### PR TITLE
typecheck: use static inline to fix linker errors

### DIFF
--- a/wowless/typecheck.h
+++ b/wowless/typecheck.h
@@ -4,11 +4,11 @@
 #include "lauxlib.h"
 #include "lua.h"
 
-inline void wowless_stubchecknumber(lua_State *L, int idx) {
+static inline void wowless_stubchecknumber(lua_State *L, int idx) {
   luaL_checknumber(L, idx);
 }
 
-inline void wowless_stubchecknilablenumber(lua_State *L, int idx) {
+static inline void wowless_stubchecknilablenumber(lua_State *L, int idx) {
   switch (lua_type(L, idx)) {
     case LUA_TSTRING:
       luaL_checknumber(L, idx);
@@ -22,13 +22,13 @@ inline void wowless_stubchecknilablenumber(lua_State *L, int idx) {
   }
 }
 
-inline void wowless_stubcheckstring(lua_State *L, int idx) {
+static inline void wowless_stubcheckstring(lua_State *L, int idx) {
   if (!lua_isstring(L, idx)) {
     luaL_typerror(L, idx, lua_typename(L, LUA_TSTRING));
   }
 }
 
-inline void wowless_stubchecknilablestring(lua_State *L, int idx) {
+static inline void wowless_stubchecknilablestring(lua_State *L, int idx) {
   switch (lua_type(L, idx)) {
     case LUA_TNONE:
     case LUA_TNIL:


### PR DESCRIPTION
## Summary

- `inline` in C99 is only an "inline hint" — no external symbol definition is emitted, so the linker fails when the compiler doesn't inline a call
- Change all four helpers in `wowless/typecheck.h` to `static inline`, which gives each translation unit its own copy and eliminates the need for an external symbol

Fixes the undefined symbol errors seen on macOS and Linux CI for `wowless_stubchecknumber`, `wowless_stubchecknilablenumber`, `wowless_stubcheckstring`, and `wowless_stubchecknilablestring`.

## Test plan

- [ ] CI build passes on macOS and Linux

🤖 Generated with [Claude Code](https://claude.com/claude-code)