### PR TITLE
prep: support structure type outputs in C stub generation

### DIFF
--- a/tools/prep.lua
+++ b/tools/prep.lua
@@ -541,6 +541,25 @@ if args.coutput then
     string = function()
       return ''
     end,
+    structure = function(name)
+      local st = assert(structures[name], name)
+      assert(not st.mixin, 'mixin structure not supported in C stubs: ' .. name)
+      local result = {}
+      for fname, field in pairs(st.fields) do
+        local fval
+        if field.stub ~= nil then
+          fval = field.stub
+        elseif field.default ~= nil then
+          fval = field.default
+        elseif not field.nilable or field.stubnotnil then
+          fval = dispatch(coutdefaults, field.type)
+        end
+        if fval ~= nil then
+          result[fname] = fval
+        end
+      end
+      return result
+    end,
     table = function()
       return {}
     end,
@@ -649,6 +668,9 @@ if args.coutput then
     end,
     number = lua_value_emitters.number,
     string = lua_value_emitters.string,
+    structure = function(_, val)
+      lua_value_emitters.table(val)
+    end,
     table = lua_value_emitters.table,
   }
 


### PR DESCRIPTION
## Summary

- Adds `structure` to `coutdefaults`: recursively computes a plain Lua table of default field values, applying the same `stub`/`default`/`nilable`/type-dispatch logic used for output specs
- Adds `structure` to `coutpushers`: delegates to the existing `lua_value_emitters.table` since the value is already a plain Lua table at that point
- Structures with a `mixin` field (like `ColorMixin`) are rejected in `coutdefaults.structure` via `assert`. Because the handler is called recursively for nested structure fields, any API whose output transitively references a mixin structure will fail the `pcall` in `is_eligible` and remain as a Lua stub (where `gencode.Mixin` applies the methods correctly)

## Test plan

- [x] `cmake --build --preset default --target test` passes
- [x] `bin/run.sh wow -e1` runs without error

🤖 Generated with [Claude Code](https://claude.com/claude-code)