### PR TITLE
luaobjects: implement luaobject creation in C for output stubs #523

### DIFF
--- a/tools/prep.lua
+++ b/tools/prep.lua
@@ -651,6 +651,9 @@ if args.coutput then
       end
       return result
     end,
+    luaobject = function(name)
+      return name
+    end,
     table = function()
       return {}
     end,
@@ -806,6 +809,9 @@ if args.coutput then
       if st.mixin then
         emit('  wowless_applymixin(L, %s);', cstring(st.mixin))
       end
+    end,
+    luaobject = function(name, _val)
+      emit('  wowless_luaobject_make(L, %s, %d);', cstring(name), #name)
     end,
     table = lua_value_emitters.table,
   }

--- a/wowless/luaobject.c
+++ b/wowless/luaobject.c
@@ -1,7 +1,10 @@
+#include "wowless/luaobject.h"
+
 #include "lauxlib.h"
 #include "lua.h"
 
 #define LUAOBJECT_KEY_PREFIX "wowless.luaobject."
+#define LUAOBJECT_OBJS_KEY "wowless.luaobject.objs"
 
 /* luaobject.register(typename, metatable)
  * Registers a luaobject type by storing the metatable in the registry
@@ -14,6 +17,17 @@ static int luaobject_register(lua_State *L) {
   lua_pushvalue(L, 1);
   lua_concat(L, 2);
   lua_pushvalue(L, 2);
+  lua_rawset(L, LUA_REGISTRYINDEX);
+  return 0;
+}
+
+/* luaobject.register_objs(objs)
+ * Stores the module-private objs weak table in the registry so C can reach it.
+ */
+static int luaobject_register_objs(lua_State *L) {
+  luaL_checktype(L, 1, LUA_TTABLE);
+  lua_pushliteral(L, LUAOBJECT_OBJS_KEY);
+  lua_pushvalue(L, 1);
   lua_rawset(L, LUA_REGISTRYINDEX);
   return 0;
 }
@@ -36,10 +50,70 @@ static int luaobject_new(lua_State *L) {
   return 1;
 }
 
+/* luaobject_make_internal(L, name, namelen)
+ * Creates a userdata, builds the backing { type, table, luarep } table,
+ * registers it in objs, and leaves ud, backing on the stack.
+ */
+static void luaobject_make_internal(lua_State *L, const char *name,
+                                    size_t namelen) {
+  /* look up metatable from registry */
+  lua_pushliteral(L, LUAOBJECT_KEY_PREFIX);
+  lua_pushlstring(L, name, namelen);
+  lua_concat(L, 2);
+  lua_rawget(L, LUA_REGISTRYINDEX); /* mt */
+  if (!lua_istable(L, -1)) {
+    luaL_error(L, "unknown luaobject type: %.*s", (int)namelen, name);
+  }
+
+  /* create userdata and attach metatable; stack: mt, ud */
+  lua_newuserdata(L, 0);
+  lua_pushvalue(L, -2);
+  lua_setmetatable(L, -2);
+  lua_remove(L, -2); /* stack: ud */
+
+  /* create backing table { type=name, table={}, luarep=ud } */
+  lua_createtable(L, 0, 3); /* stack: ud, backing */
+  lua_pushlstring(L, name, namelen);
+  lua_setfield(L, -2, "type");
+  lua_createtable(L, 0, 0);
+  lua_setfield(L, -2, "table");
+  lua_pushvalue(L, -2);          /* ud */
+  lua_setfield(L, -2, "luarep"); /* stack: ud, backing */
+
+  /* objs[ud] = backing */
+  lua_pushliteral(L, LUAOBJECT_OBJS_KEY);
+  lua_rawget(L, LUA_REGISTRYINDEX); /* stack: ud, backing, objs */
+  lua_pushvalue(L, -3);             /* ud */
+  lua_pushvalue(L, -3);             /* backing */
+  lua_rawset(L, -3);                /* objs[ud] = backing */
+  lua_pop(L, 1);                    /* pop objs; stack: ud, backing */
+}
+
+/* wowless_luaobject_make(L, name, namelen)
+ * Creates a luaobject and leaves the userdata on the stack (for C stubs).
+ */
+void wowless_luaobject_make(lua_State *L, const char *name, size_t namelen) {
+  luaobject_make_internal(L, name, namelen);
+  lua_pop(L, 1); /* pop backing; stack: ud */
+}
+
+/* luaobject.make(typename)
+ * Creates a luaobject and returns the backing table (for Lua callers).
+ */
+static int luaobject_make(lua_State *L) {
+  size_t namelen;
+  const char *name = luaL_checklstring(L, 1, &namelen);
+  luaobject_make_internal(L, name, namelen);
+  lua_remove(L, -2); /* remove ud; stack: backing */
+  return 1;
+}
+
 static const struct luaL_Reg luaobjectlib[] = {
-    {"new",      luaobject_new     },
-    {"register", luaobject_register},
-    {NULL,       NULL              },
+    {"make",          luaobject_make         },
+    {"new",           luaobject_new          },
+    {"register",      luaobject_register     },
+    {"register_objs", luaobject_register_objs},
+    {NULL,            NULL                   },
 };
 
 int luaopen_wowless_luaobject(lua_State *L) {

--- a/wowless/luaobject.h
+++ b/wowless/luaobject.h
@@ -1,0 +1,10 @@
+#ifndef WOWLESS_LUAOBJECT_H
+#define WOWLESS_LUAOBJECT_H
+
+#include <stddef.h>
+
+#include "lua.h"
+
+void wowless_luaobject_make(lua_State *L, const char *name, size_t namelen);
+
+#endif /* WOWLESS_LUAOBJECT_H */

--- a/wowless/modules/luaobjects.lua
+++ b/wowless/modules/luaobjects.lua
@@ -4,6 +4,7 @@ local luaobject = require('wowless.luaobject')
 return function(datalua)
   local config = datalua.config.modules and datalua.config.modules.luaobjects or {}
   local objs = setmetatable({}, { __mode = 'k' })
+  luaobject.register_objs(objs)
   local impltypes = {}
 
   local function LoadTypes(modules)
@@ -69,16 +70,9 @@ return function(datalua)
     end
   end
 
-  local function make(k)
-    local p = luaobject.new(k)
-    local obj = { type = k, table = {}, luarep = p }
-    objs[p] = obj
-    return obj
-  end
-
   local function Create(k, ...)
     local impl = impltypes[k]
-    local obj = make(k)
+    local obj = luaobject.make(k)
     if impl and impl.construct then
       impl.construct(obj, ...)
     end
@@ -88,7 +82,7 @@ return function(datalua)
   local function Coerce(k, value)
     local impl = impltypes[k]
     if impl and impl.coerce then
-      local obj = make(k)
+      local obj = luaobject.make(k)
       if impl.coerce(obj, value) then
         return obj
       end

--- a/wowless/typecheck.h
+++ b/wowless/typecheck.h
@@ -3,6 +3,7 @@
 
 #include "lauxlib.h"
 #include "lua.h"
+#include "wowless/luaobject.h"
 
 static inline void wowless_stubcheckenum(lua_State *L, int idx) {
   if (lua_type(L, idx) != LUA_TNUMBER) {


### PR DESCRIPTION
## Summary

- Add `wowless_luaobject_make` (C, leaves userdata on stack for generated stubs) and `luaobject.make` (Lua-callable, returns backing table) to `luaobject.c`, sharing a common internal helper
- Add `luaobject.register_objs` to expose the `objs` weak table to C at init time
- Add `wowless/luaobject.h` declaring `wowless_luaobject_make`; included by `typecheck.h`
- Remove local `make()` from `luaobjects.lua`; `Create`/`Coerce` now call `luaobject.make`
- Add `luaobject` to `coutdefaults`/`coutpushers` in `prep.lua`, making APIs with luaobject outputs eligible for C stubs

## Test plan
- [x] All existing tests pass (`cmake --build --preset default --target test`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)