### PR TITLE
test: schema coverage failure for manual inspection

### DIFF
--- a/data/schemas/gametypes.yaml
+++ b/data/schemas/gametypes.yaml
@@ -12,3 +12,5 @@ type:
           type:
             ref:
               schema: family
+        uncovered_test_field:
+          type: string


### PR DESCRIPTION
Intentional failure to test the schema coverage CI check.

Adds an `uncovered_test_field` to the `gametypes` schema record that no data instance populates, so the coverage test should report:

```
gametypes.__val.uncovered_test_field
  ✗ FAILED: false
```

Do not merge — for manual inspection only.