### PR TITLE
data: declare global/product file lists in datafiles.yaml

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -334,6 +334,7 @@ function(yaml2lua basename)
     DEPENDS yaml2lua ${input})
 endfunction()
 
+yaml2lua(datafiles)
 yaml2lua(families)
 yaml2lua(gametypes)
 yaml2lua(modules)
@@ -673,6 +674,7 @@ list(
   build
   config
   cvars
+  datafiles
   docs
   doctable
   events
@@ -703,6 +705,7 @@ endforeach()
 
 lua2c(
   wowapischema
+  build.data.datafiles=runtime/datafiles.lua
   build.data.families=runtime/families.lua
   build.data.gametypes=runtime/gametypes.lua
   build.data.impl=runtime/impl.lua

--- a/data/datafiles.yaml
+++ b/data/datafiles.yaml
@@ -1,0 +1,23 @@
+global:
+- families
+- gametypes
+- impl
+- modules
+- products
+- scripttypes
+- sql
+- stringenums
+- test
+- uiobjectimpl
+product:
+- apis
+- build
+- config
+- cvars
+- docs
+- events
+- globals
+- luaobjects
+- structures
+- uiobjects
+- xml

--- a/data/schemas/datafiles.yaml
+++ b/data/schemas/datafiles.yaml
@@ -1,0 +1,11 @@
+name: datafiles
+type:
+  record:
+    global:
+      required: true
+      type:
+        sequenceof: string
+    product:
+      required: true
+      type:
+        sequenceof: string

--- a/spec/data/schema_coverage_spec.lua
+++ b/spec/data/schema_coverage_spec.lua
@@ -110,19 +110,7 @@ end
 local used = {}
 local products = require('build.data.products')
 
-local globalFiles = {
-  'families',
-  'gametypes',
-  'impl',
-  'modules',
-  'products',
-  'scripttypes',
-  'sql',
-  'stringenums',
-  'test',
-  'uiobjectimpl',
-}
-for _, name in ipairs(globalFiles) do
+for _, name in ipairs(wdata.datafiles.global) do
   trackType(wdata.schemas[name].type, wdata[name], name, used)
 end
 
@@ -132,21 +120,8 @@ for _, s in pairs(wdata.schemas) do
   trackType(schemaSchemaType, s, 'schema', used)
 end
 
-local productFiles = {
-  'apis',
-  'build',
-  'config',
-  'cvars',
-  'docs',
-  'events',
-  'globals',
-  'luaobjects',
-  'structures',
-  'uiobjects',
-  'xml',
-}
 for _, p in ipairs(products) do
-  for _, name in ipairs(productFiles) do
+  for _, name in ipairs(wdata.datafiles.product) do
     trackType(wdata.schemas[name].type, wdata[name][p], name, used)
   end
 end

--- a/wowapi/data.lua
+++ b/wowapi/data.lua
@@ -36,11 +36,10 @@ local function perproduct(f)
   end
 end
 
+local datafiles = extLoaders.yaml('data/datafiles.yaml')
+
 local fns = {
-  apis = perproduct('apis'),
-  build = perproduct('build'),
-  config = perproduct('config'),
-  cvars = perproduct('cvars'),
+  datafiles = global('datafiles'),
   enums = function()
     local t = {}
     for _, d in ipairs(require('pl.dir').getdirectories('data/products')) do
@@ -48,25 +47,14 @@ local fns = {
     end
     return t
   end,
-  docs = perproduct('docs'),
-  events = perproduct('events'),
-  families = global('families'),
-  gametypes = global('gametypes'),
-  globals = perproduct('globals'),
-  impl = global('impl'),
-  luaobjects = perproduct('luaobjects'),
-  modules = global('modules'),
-  products = global('products'),
   schemas = loaddir('schemas', 'yaml'),
-  scripttypes = global('scripttypes'),
-  sql = global('sql'),
-  stringenums = global('stringenums'),
-  structures = perproduct('structures'),
-  test = global('test'),
-  uiobjectimpl = global('uiobjectimpl'),
-  uiobjects = perproduct('uiobjects'),
-  xml = perproduct('xml'),
 }
+for _, name in ipairs(datafiles.global) do
+  fns[name] = global(name)
+end
+for _, name in ipairs(datafiles.product) do
+  fns[name] = perproduct(name)
+end
 
 return setmetatable({}, {
   __index = function(t, k)


### PR DESCRIPTION
## Summary

- Introduces `data/datafiles.yaml` as the single source of truth for which data files are global-scoped vs per-product-scoped, with a matching schema at `data/schemas/datafiles.yaml`
- `wowapi/data.lua` now builds its `fns` table from the manifest at load time instead of hardcoding each entry
- `spec/data/schema_coverage_spec.lua` iterates `wdata.datafiles.global` / `wdata.datafiles.product` instead of its own duplicate tables
- Also fixes a latent bug: `build`, `config`, `docs`, and `globals` were in the coverage spec's `productFiles` list but were missing from `data.lua`'s `fns`, which would have caused runtime errors; they're now properly declared in `datafiles.yaml` and loaded as `perproduct` entries

Adding a new data file now requires only editing `datafiles.yaml` + a `yaml2lua` + `lua2c` entry in CMakeLists — no Lua list-sync needed.

## Test plan

- [ ] CI: schema coverage test passes (all known fields are exercised)
- [ ] CI: existing data validation tests pass
- [ ] Manual: verify `wdata.datafiles` is accessible in a busted session