### PR TITLE
tests: introduce captureWarnings for inline warning checking

### DIFF
--- a/addon/Wowless/test.lua
+++ b/addon/Wowless/test.lua
@@ -720,8 +720,11 @@ G.testsuite.sync = function()
           end
         end,
         ['is not a frame type'] = function()
-          assertEquals(false, (pcall(CreateFrame, 'WorldFrame')))
-          table.insert(_G.Wowless.ExpectedLuaWarnings, 'Unknown frame type: WorldFrame')
+          local warnings = G.captureWarnings(function()
+            assertEquals(false, (pcall(CreateFrame, 'WorldFrame')))
+          end)
+          assertEquals(1, #warnings)
+          assertEquals('Unknown frame type: WorldFrame', warnings[1])
         end,
       }
     end,

--- a/addon/Wowless/util.lua
+++ b/addon/Wowless/util.lua
@@ -167,7 +167,21 @@ local function sorted(t)
   end)
 end
 
+local function captureWarnings(fn)
+  local before = #G.ActualLuaWarnings
+  fn()
+  local captured = {}
+  for i = before + 1, #G.ActualLuaWarnings do
+    table.insert(captured, G.ActualLuaWarnings[i])
+  end
+  for i = #G.ActualLuaWarnings, before + 1, -1 do
+    table.remove(G.ActualLuaWarnings, i)
+  end
+  return captured
+end
+
 G.addonEnv = G
+G.captureWarnings = captureWarnings
 G.assertEquals = assertEquals
 G.assertEqualSets = assertEqualSets
 G.assertRecursivelyEqual = assertRecursivelyEqual


### PR DESCRIPTION
## Summary

- Adds `G.captureWarnings(fn)` helper to `util.lua`: runs `fn`, captures any `LUA_WARNING` events it emits, removes them from `ActualLuaWarnings`, and returns the captured list
- Migrates the WorldFrame \"is not a frame type\" test to use it, replacing the deferred `ExpectedLuaWarnings` accumulation pattern with an immediate inline check

The remaining warning tests still use the old `ExpectedLuaWarnings` mechanism and are unaffected.

## Test plan

- [ ] `cmake --build --preset default --target test` passes with no output

🤖 Generated with [Claude Code](https://claude.com/claude-code)