### PR TITLE
stubs: output type checking for string/number impl stubs

### DIFF
--- a/tools/prep.lua
+++ b/tools/prep.lua
@@ -259,6 +259,21 @@ local function ensureimpl(k)
   return impls[k]
 end
 
+local function is_output_eligible(out)
+  local t = out.type
+  if type(t) ~= 'string' then
+    return false
+  end
+  return t == 'nil'
+    or t == 'oneornil'
+    or t == 'unknown'
+    or t == 'string'
+    or t == 'unit'
+    or t == 'number'
+    or t == 'enum'
+    or t == 'FileAsset'
+end
+
 local function is_impl_eligible(apicfg)
   if not apicfg.impl then
     return false
@@ -268,7 +283,19 @@ local function is_impl_eligible(apicfg)
   if not has_inputs and not has_outputs then
     return true
   end
-  return ensureimpl(apicfg.impl).nowrap
+  local impl = ensureimpl(apicfg.impl)
+  if impl.nowrap then
+    return true
+  end
+  if impl.nobubblewrap and (apicfg.outstride or 0) == 0 then
+    for _, out in ipairs(apicfg.outputs or {}) do
+      if not is_output_eligible(out) then
+        return false
+      end
+    end
+    return true
+  end
+  return false
 end
 
 local function mkapi(apicfg)
@@ -693,6 +720,14 @@ if args.coutput then
     end,
   }
 
+  local coutputtypes = {
+    enum = 'number',
+    FileAsset = 'number',
+    number = 'number',
+    string = 'string',
+    unit = 'string',
+  }
+
   local used_structures = {}
   local used_arrayofs = {}
   local used_luaobjects = {}
@@ -1050,7 +1085,7 @@ if args.coutput then
       local fn = impldata.nobubblewrap and 'wowless_impl_stub_nobubblewrap' or 'wowless_impl_stub'
       local v = entry.cfg
       local check_inputs = v.inputs ~= nil and (v.instride or 0) == 0
-      local check_outputs = v.outputs ~= nil and #v.outputs == 0
+      local check_outputs = v.outputs ~= nil and (v.outstride or 0) == 0
       emit('static int implstub_%s(lua_State *L) {', safename(entry.name))
       if check_inputs then
         emit('  wowless_stubcheckextraargs(L, 0, %s);', cstring(entry.name))
@@ -1058,6 +1093,13 @@ if args.coutput then
       if check_outputs then
         emit('  int ret = %s(L);', fn)
         emit('  wowless_stubchecknreturns(L, ret, %d, %s);', #v.outputs, cstring(entry.name))
+        for i, out in ipairs(v.outputs) do
+          local nilable = out.nilable or out.default ~= nil
+          local ct = type(out.type) == 'string' and coutputtypes[out.type]
+          if ct then
+            emit('  wowless_stuboutput%s%s(L, %d);', nilable and 'nilable' or '', ct, i)
+          end
+        end
         emit('  return ret;')
       else
         emit('  return %s(L);', fn)

--- a/wowless/typecheck.h
+++ b/wowless/typecheck.h
@@ -217,6 +217,36 @@ static inline void wowless_stubcreateuiobject(lua_State *L,
   lua_call(L, 1, 1);
 }
 
+static inline void wowless_stuboutputstring(lua_State *L, int idx) {
+  if (lua_type(L, idx) != LUA_TSTRING) {
+    luaL_error(L, "output %d: string expected, got %s", idx,
+               luaL_typename(L, idx));
+  }
+}
+
+static inline void wowless_stuboutputnilablestring(lua_State *L, int idx) {
+  int t = lua_type(L, idx);
+  if (t != LUA_TSTRING && t != LUA_TNIL && t != LUA_TNONE) {
+    luaL_error(L, "output %d: string or nil expected, got %s", idx,
+               luaL_typename(L, idx));
+  }
+}
+
+static inline void wowless_stuboutputnumber(lua_State *L, int idx) {
+  if (lua_type(L, idx) != LUA_TNUMBER) {
+    luaL_error(L, "output %d: number expected, got %s", idx,
+               luaL_typename(L, idx));
+  }
+}
+
+static inline void wowless_stuboutputnilablenumber(lua_State *L, int idx) {
+  int t = lua_type(L, idx);
+  if (t != LUA_TNUMBER && t != LUA_TNIL && t != LUA_TNONE) {
+    luaL_error(L, "output %d: number or nil expected, got %s", idx,
+               luaL_typename(L, idx));
+  }
+}
+
 static inline void wowless_stubcheckextraargs(lua_State *L, int nsins,
                                               const char *fname) {
   if (lua_gettop(L) > nsins) {


### PR DESCRIPTION
Closes #554 (partial — strings and numbers only, no outstride).

## Changes

### `wowless/typecheck.h`
Add four new inline output checkers using `luaL_error` (strict, no coercion):
- `wowless_stuboutputstring` / `wowless_stuboutputnilablestring` — requires `LUA_TSTRING`
- `wowless_stuboutputnumber` / `wowless_stuboutputnilablenumber` — requires `LUA_TNUMBER`

### `tools/prep.lua`
- Add `coutputtypes` dispatch table: `string`/`unit` → `string`, `number`/`enum`/`FileAsset` → `number`
- Expand `is_impl_eligible`: allow `nobubblewrap` impls when `(outstride or 0) == 0` and all outputs are string/number/nil/unknown types
- Update `implstub` generation: change `check_outputs` condition from `#outputs == 0` to `(outstride or 0) == 0`; emit per-output `wowless_stuboutput*` calls for string/number outputs (nil/unknown/other types are no-ops)

## Out of scope (deferred to follow-up)
- `outstride` output handling
- boolean, function, table, structure, arrayof output types
- uiobject/luaobject output coercion
- stringenum output checking

🤖 Generated with [Claude Code](https://claude.com/claude-code)