### PR TITLE
gha: add buildpreset job

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -72,3 +72,33 @@ jobs:
     - uses: lukka/get-cmake@v4.3.2
     - run: cmake -B build -G "${{ matrix.config.generator }}"
     - run: cmake --build build --verbose
+  buildpreset:
+    strategy:
+      fail-fast: false
+      matrix:
+        config:
+        - name: Linux
+          os: ubuntu-latest
+        - name: MacOS
+          os: macos-latest
+        - name: Windows
+          os: windows-latest
+    runs-on: ${{ matrix.config.os }}
+    steps:
+    - if: ${{ matrix.config.os == 'ubuntu-latest' }}
+      run: sudo apt-get install autoconf-archive libltdl-dev
+    - uses: actions/checkout@v6
+      with:
+        submodules: true
+    - run: mkdir ${{ env.VCPKG_DEFAULT_BINARY_CACHE }}
+    - uses: actions/cache@v5
+      with:
+        path: ${{ env.VCPKG_DEFAULT_BINARY_CACHE }}
+        key: vcpkg-${{ runner.os }}-${{ github.run_id }}
+        restore-keys: vcpkg-${{ runner.os }}
+    - uses: lukka/get-cmake@v4.3.2
+    - run: cmake --preset default
+    - if: runner.os == 'Windows'
+      run: echo "${{ github.workspace }}/build/vcpkg_installed/x64-windows/bin" >> $env:GITHUB_PATH
+      shell: pwsh
+    - run: cmake --build --preset default --target all test --verbose

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -13,6 +13,7 @@
     {
       "binaryDir": "${sourceDir}/build",
       "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Release",
         "CMAKE_C_FLAGS": "-DNDEBUG -ffast-math -O3",
         "CMAKE_EXPORT_COMPILE_COMMANDS": true
       },

--- a/addon/Wowless/luaobjects.lua
+++ b/addon/Wowless/luaobjects.lua
@@ -84,7 +84,7 @@ local function checkLuaObject(ty, o)
       if config.tostring_metamethod then
         assert(tostring(o):match('^' .. ty .. ': 0x[0-9a-f]+$'))
       else
-        assert(tostring(o):match('^userdata: 0x[0-9a-f]+$'))
+        assert(tostring(o):match('^userdata: 0[xX]?%x+$'))
       end
     end,
     type = function()

--- a/tools/yaml2lua.lua
+++ b/tools/yaml2lua.lua
@@ -1,4 +1,18 @@
+-- pl.pretty uses string.format('%d') for integers, which overflows 32-bit
+-- long on Windows (LLP64 ABI). Patch it to use '%.0f' instead, which uses
+-- double arithmetic and handles values up to 2^53 correctly on all platforms.
+local _fmt = string.format
+string.format = function(s, ...) -- luacheck: ignore
+  if s == '%d' then
+    local v = select(1, ...)
+    if type(v) == 'number' and (v >= 2 ^ 31 or v < -(2 ^ 31)) then
+      return _fmt('%.0f', v)
+    end
+  end
+  return _fmt(s, ...)
+end
 local t = assert(require('wowapi.yaml').parseFile(arg[1]))
 local s = 'return ' .. require('pl.pretty').write(t)
+string.format = _fmt -- luacheck: ignore
 assert(require('pl.dir').makepath(require('pl.path').dirname(arg[2])))
 assert(require('pl.file').write(arg[2], s))

--- a/wowapi/data.lua
+++ b/wowapi/data.lua
@@ -1,7 +1,7 @@
 local extLoaders = {
   sql = require('pl.file').read,
   yaml = function(f)
-    return require('build.' .. f:sub(1, -6):gsub('/', '.'))
+    return require('build.' .. f:sub(1, -6):gsub('[/\\]', '.'))
   end,
 }
 

--- a/wowless/modules/api.lua
+++ b/wowless/modules/api.lua
@@ -79,7 +79,7 @@ return function(
     name = ''
     local parent = frame.parent
     while parent do
-      local key = parentkey.GetParentKey(frame) or string.match(tostring(frame), '^table: 0x0*(.*)$'):lower()
+      local key = parentkey.GetParentKey(frame) or tostring(frame):gsub('^%S+ 0x?0*', ''):lower()
       name = key .. (name == '' and '' or ('.' .. name))
       local parentName = parent.name
       if parentName == 'UIParent' then

--- a/wowless/modules/luaobjects.lua
+++ b/wowless/modules/luaobjects.lua
@@ -60,7 +60,7 @@ return function(datalua)
             objs[u].table[key] = value
           end,
           __tostring = config.tostring_metamethod and function(u)
-            return k .. ': ' .. tostring(objs[u].table):sub(8)
+            return k .. ': 0x' .. tostring(objs[u].table):gsub('^%S+ 0x?0*', ''):lower()
           end or nil,
         }
 

--- a/wowless/util.lua
+++ b/wowless/util.lua
@@ -32,7 +32,7 @@ local readfile = (function()
   local function resolve(p)
     local c = cache
     local dd = ''
-    p = p:gsub('^%a:', '') -- strip Windows drive letter
+    p = p:gsub('\\', '/'):gsub('^%a:', '') -- normalize separators and strip Windows drive letter
     for k in p:gmatch('[^/]+') do
       assert(type(c) == 'table', dd .. ' is not a directory')
       dd = dd .. '/' .. k

--- a/wowless/util.lua
+++ b/wowless/util.lua
@@ -25,11 +25,14 @@ local readfile = (function()
       end
     end
   end
+  local path = require('path')
+  local rootdir = path.currentdir():match('^(%a:)') or ''
   local cache = {}
-  dirtab('', cache)
+  dirtab(rootdir, cache)
   local function resolve(p)
     local c = cache
     local dd = ''
+    p = p:gsub('^%a:', '') -- strip Windows drive letter
     for k in p:gmatch('[^/]+') do
       assert(type(c) == 'table', dd .. ' is not a directory')
       dd = dd .. '/' .. k
@@ -56,7 +59,6 @@ local readfile = (function()
     end
     return content
   end
-  local path = require('path')
   return function(filename)
     local fullname = path.normalize(path.join(path.currentdir(), filename))
     return getContent(resolve(fullname:lower()))


### PR DESCRIPTION
Revives and fixes PR #463 by adding a `buildpreset` job that builds and
runs tests using cmake presets on Linux, macOS, and Windows.

## Changes

- `util.lua`: fix readfile filesystem cache and backslash path normalization on Windows
- `tools/yaml2lua.lua`, `wowapi/data.lua`, `wowless/modules/api.lua`: fix Windows-specific runtime failures (integer overflow in pl.pretty, backslash module paths, tostring pattern assuming `0x` prefix)
- `wowless/modules/luaobjects.lua`, `addon/Wowless/luaobjects.lua`: fix tostring patterns for cross-platform address formatting
- `CMakePresets.json`: set `CMAKE_BUILD_TYPE=Release` so vcpkg selects release DLLs on Windows
- `.github/workflows/test.yml`: add `buildpreset` job; on Windows, add vcpkg `x64-windows/bin` to PATH so runtests.exe can find its DLLs

<!-- issue #463 -->

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>