### PR TITLE
toc: parse SavedVariables into array fields

### DIFF
--- a/data/test/GetAddOnMetadata.lua
+++ b/data/test/GetAddOnMetadata.lua
@@ -6,7 +6,7 @@ local kv = {
 local knil = {
   Dependencies = false,
   Interface = true,
-  SavedVariables = false,
+  SavedVariables = true,
   WowlessNonsense = true,
 }
 local tests = {}

--- a/spec/wowless/toc_spec.lua
+++ b/spec/wowless/toc_spec.lua
@@ -25,6 +25,16 @@ describe('wowless.toc', function()
           assert.same({ Key = 'Value' }, toc.attrs)
           assert.same({ 'aaa', 'bbb', 'ccc' }, toc.files)
         end)
+        it('handles SavedVariables field', function()
+          local lines = {
+            '## SavedVariables: Foo, Bar Baz',
+            '## Key: Value',
+          }
+          local toc = parse(gametype, table.concat(lines, '\n'))
+          assert.same({ 'Foo', 'Bar', 'Baz' }, toc.savedvariables)
+          assert.same({ Key = 'Value' }, toc.attrs)
+          assert.Nil(toc.attrs.SavedVariables)
+        end)
         it('handles Interface field', function()
           local lines = {
             '## Interface: 120001',

--- a/wowless/modules/loader.lua
+++ b/wowless/modules/loader.lua
@@ -928,8 +928,8 @@ return function(
     for _, v in pairs(addonData) do
       if v.loaded then
         local t = {}
-        for _, attr in ipairs({ 'SavedVariables', 'SavedVariablesPerCharacter' }) do
-          for var in (v.attrs[attr] or ''):gmatch('[^, ]+') do
+        for _, attr in ipairs({ 'savedvariables', 'savedvariablespercharacter' }) do
+          for _, var in ipairs(v[attr] or {}) do
             local val = genv[var]
             if val ~= nil then
               table.insert(t, var)

--- a/wowless/toc.lua
+++ b/wowless/toc.lua
@@ -60,6 +60,12 @@ local function parse(gametype, content)
       if key then
         if key == 'Interface' then
           toc.interface = tonumber(value)
+        elseif key == 'SavedVariables' or key == 'SavedVariablesPerCharacter' then
+          local arr = {}
+          for var in value:gmatch('[^, ]+') do
+            table.insert(arr, var)
+          end
+          toc[key:lower()] = arr
         else
           toc.attrs[key] = value
         end


### PR DESCRIPTION
## Summary

- `toc.lua`: Parse `SavedVariables` and `SavedVariablesPerCharacter` TOC keys into array fields (`toc.savedvariables`, `toc.savedvariablespercharacter`) instead of leaving them as raw comma-separated strings in `attrs`
- `loader.lua`: Update `saveAllVariables` to iterate the new arrays via `ipairs` instead of gmatch-parsing attr strings
- `toc_spec.lua`: Add test covering array parsing and removal from `attrs`
- `GetAddOnMetadata.lua`: Fix test — `SavedVariables` no longer appears in `attrs`, so `GetAddOnMetadata` now correctly returns nil (matching real WoW behavior)

## Test plan

- [ ] `cmake --build --preset default --target test` passes with no output
- [ ] New `toc_spec` test verifies `SavedVariables: Foo, Bar Baz` parses to `{ 'Foo', 'Bar', 'Baz' }` and is absent from `attrs`
- [ ] `GetAddOnMetadata` test for `SavedVariables` now expects nil on wowless (was a known discrepancy tracked via issue #581)

🤖 Generated with [Claude Code](https://claude.com/claude-code)