### PR TITLE
pre-commit: fix markdownlint Ruby installation failure

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -29,6 +29,7 @@ repos:
   rev: v0.15.0
   hooks:
   - id: markdownlint
+    language_version: default
 - repo: https://github.com/pre-commit/mirrors-clang-format
   rev: v21.1.8
   hooks:


### PR DESCRIPTION
## Summary

- The markdownlint hook at `v0.15.0` pins `language_version: 3.3.0`, but pre-commit bundles a stale ruby-build that doesn't have a 3.3.0 definition, and the RVM binary mirror has no pre-built 3.3.0 for Ubuntu 24.04
- Setting `language_version: default` overrides the hook's pin and lets pre-commit use its own detection logic, which falls back to system Ruby when `ruby`/`gem` are in PATH

## Test plan

- [x] `pre-commit run markdownlint` installs without error and runs successfully
- [x] Full pre-commit hook suite passes (`build and test` included)

🤖 Generated with [Claude Code](https://claude.com/claude-code)