### PR TITLE
stubs: add uiobject output support for impl stubs

### DIFF
--- a/tools/prep.lua
+++ b/tools/prep.lua
@@ -285,6 +285,7 @@ local impl_output_types = {
   oneornil = nop,
   string = nop,
   table = nop,
+  uiobject = nop,
   unit = nop,
 }
 
@@ -815,6 +816,11 @@ if args.coutput then
     oneornil = simple_coutputtype('unknown'),
     string = simple_coutputtype('string'),
     table = simple_coutputtype('table'),
+    uiobject = function(typename, nilable, idx)
+      local ns = nilable and 'nilable' or ''
+      local tn = cstring(typename)
+      return string.format('wowless_imploutput%suiobject(L, %d, %s, sizeof(%s)-1)', ns, idx, tn, tn)
+    end,
     unit = simple_coutputtype('unit'),
     unknown = simple_coutputtype('unknown'),
   }
@@ -1159,6 +1165,11 @@ if args.coutput then
         local inputcheck = v.usage and usagecheck or check
         for i, inp in ipairs(inputs) do
           emit('  %s', inputcheck(inp, i))
+        end
+        if v.usage then
+          for i, inp in ipairs(inputs) do
+            emit('  %s', check(inp, i))
+          end
         end
         emit('  wowless_stubcheckextraargs(L, %d, %s);', nsins, cstring(entry.name))
       end

--- a/wowless/modules/cgencode.lua
+++ b/wowless/modules/cgencode.lua
@@ -31,6 +31,13 @@ return function(addons, api, events, log, luaobjects, uiobjects, uiobjecttypes, 
     return internal.luarep
   end
 
+  local function ImplOutputUiObject(internal, typename)
+    if type(internal) ~= 'table' or not uiobjecttypes.IsObjectType(internal, typename) then
+      error('impl output type error: expected uiobject ' .. typename)
+    end
+    return internal.luarep
+  end
+
   local function GetUiAddon(value)
     return addons.addons[tonumber(value) or tostring(value):lower()]
   end
@@ -50,6 +57,7 @@ return function(addons, api, events, log, luaobjects, uiobjects, uiobjecttypes, 
     GetUiAddon = GetUiAddon,
     GetUnit = units.GetUnit,
     ImplOutputLuaObject = ImplOutputLuaObject,
+    ImplOutputUiObject = ImplOutputUiObject,
     CreateLuaObject = CreateLuaObject,
     CreateUiObject = CreateUiObject,
     IsLuaObject = IsLuaObject,

--- a/wowless/typecheck.h
+++ b/wowless/typecheck.h
@@ -651,6 +651,25 @@ static inline void wowless_imploutputnilableluaobject(lua_State *L, int idx,
   }
 }
 
+static inline void wowless_imploutputuiobject(lua_State *L, int idx,
+                                              const char *typename,
+                                              size_t typenamelen) {
+  idx = lua_absindex(L, idx);
+  lua_getfield(L, lua_upvalueindex(1), "ImplOutputUiObject");
+  lua_pushvalue(L, idx);
+  lua_pushlstring(L, typename, typenamelen);
+  lua_call(L, 2, 1);
+  lua_replace(L, idx);
+}
+
+static inline void wowless_imploutputnilableuiobject(lua_State *L, int idx,
+                                                     const char *typename,
+                                                     size_t typenamelen) {
+  if (!lua_isnoneornil(L, idx)) {
+    wowless_imploutputuiobject(L, idx, typename, typenamelen);
+  }
+}
+
 static inline void wowless_stubcheckextraargs(lua_State *L, int nsins,
                                               const char *fname) {
   if (lua_gettop(L) > nsins) {


### PR DESCRIPTION
## Summary

- Adds `uiobject` to `impl_output_types` so APIs returning uiobjects can be handled as C impl stubs
- Adds `uiobject` to `coutputtypes` in prep.lua with C codegen calling `wowless_imploutputuiobject`
- Adds `ImplOutputUiObject` to `cgencode.lua` and `wowless_imploutputuiobject`/`wowless_imploutputnilableuiobject` to `typecheck.h`
- Fixes a latent coercion bug in the impl stub generator: when using the `usage` check path, inputs were validated but not coerced (e.g. numbers weren't converted to strings before calling the impl); adds a coercion pass after the usage checks

Mirrors the luaobject output support added in #609.

## Test plan

- [x] `cmake --build --preset default --target test` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)