### PR TITLE
stubs: add oneornil output support for impl stubs

### DIFF
--- a/tools/prep.lua
+++ b/tools/prep.lua
@@ -813,7 +813,7 @@ if args.coutput then
     end,
     ['nil'] = simple_coutputtype('nil'),
     number = simple_coutputtype('number'),
-    oneornil = simple_coutputtype('unknown'),
+    oneornil = simple_coutputtype('oneornil'),
     string = simple_coutputtype('string'),
     table = simple_coutputtype('table'),
     uiobject = function(typename, nilable, idx)

--- a/wowless/typecheck.h
+++ b/wowless/typecheck.h
@@ -505,6 +505,17 @@ static inline void wowless_implchecknilablenil(lua_State *L, int idx) {
   wowless_stubchecknil(L, idx);
 }
 
+static inline void wowless_imploutputoneornil(lua_State *L, int idx) {
+  if (!lua_isnil(L, idx) &&
+      !(lua_type(L, idx) == LUA_TNUMBER && lua_tonumber(L, idx) == 1)) {
+    wowless_outputtyperror(L, idx, "1 or nil");
+  }
+}
+
+static inline void wowless_imploutputnilableoneornil(lua_State *L, int idx) {
+  wowless_imploutputoneornil(L, idx);
+}
+
 static inline void wowless_imploutputnil(lua_State *L, int idx) {
   if (!lua_isnil(L, idx)) {
     wowless_outputtyperror(L, idx, "nil");


### PR DESCRIPTION
Adds `wowless_imploutputoneornil` to `typecheck.h`: validates that a C impl stub output is either `nil` or the number `1`, matching the Lua-level `oneornil` typecheck semantics. Wires it up in `coutputtypes` in `prep.lua` (was previously mapped to the no-op `unknown`).

Closes #554 (partial)

🤖 Generated with [Claude Code](https://claude.com/claude-code)