### PR TITLE
stubs: add outstride output support for impl stubs

### DIFF
--- a/tools/prep.lua
+++ b/tools/prep.lua
@@ -293,7 +293,7 @@ local function is_impl_eligible(apicfg)
   if not apicfg.impl then
     return false
   end
-  if not apicfg.instride and (apicfg.outstride or 0) == 0 then
+  if not apicfg.instride then
     local all_impl = true
     for _, inp in ipairs(apicfg.inputs or {}) do
       all_impl = all_impl and pcall(dispatch, impl_input_types, inp.type)
@@ -797,19 +797,21 @@ if args.coutput then
 
   local function simple_coutputtype(suffix)
     return function(nilable, idx)
-      return string.format('wowless_imploutput%s%s(L, %d)', nilable and 'nilable' or '', suffix, idx)
+      return string.format('wowless_imploutput%s%s(L, %s)', nilable and 'nilable' or '', suffix, idx)
     end
   end
 
   local coutputtypes = {
     boolean = simple_coutputtype('boolean'),
-    enum = simple_coutputtype('enum'),
+    enum = function(_, nilable, idx)
+      return (simple_coutputtype('enum'))(nilable, idx)
+    end,
     FileAsset = simple_coutputtype('fileasset'),
     ['function'] = simple_coutputtype('function'),
     luaobject = function(typename, nilable, idx)
       local ns = nilable and 'nilable' or ''
       local tn = cstring(typename)
-      return string.format('wowless_imploutput%sluaobject(L, %d, %s, sizeof(%s)-1)', ns, idx, tn, tn)
+      return string.format('wowless_imploutput%sluaobject(L, %s, %s, sizeof(%s)-1)', ns, idx, tn, tn)
     end,
     ['nil'] = simple_coutputtype('nil'),
     number = simple_coutputtype('number'),
@@ -819,7 +821,7 @@ if args.coutput then
     uiobject = function(typename, nilable, idx)
       local ns = nilable and 'nilable' or ''
       local tn = cstring(typename)
-      return string.format('wowless_imploutput%suiobject(L, %d, %s, sizeof(%s)-1)', ns, idx, tn, tn)
+      return string.format('wowless_imploutput%suiobject(L, %s, %s, sizeof(%s)-1)', ns, idx, tn, tn)
     end,
     unit = simple_coutputtype('unit'),
     unknown = simple_coutputtype('unknown'),
@@ -1145,9 +1147,11 @@ if args.coutput then
       local fn = impldata.nobubblewrap and 'wowless_impl_stub_nobubblewrap' or 'wowless_impl_stub'
       local v = entry.cfg
       local check_inputs = v.inputs ~= nil and (v.instride or 0) == 0
-      local check_outputs = v.outputs ~= nil and (v.outstride or 0) == 0
+      local check_outputs = v.outputs ~= nil
       local inputs = v.inputs or {}
       local outputs = v.outputs or {}
+      local outstride = v.outstride or 0
+      local nfixed = #outputs - outstride
       local nsins = #inputs
       emit('static int implstub_%s(lua_State *L) {', safename(entry.name))
       if check_inputs then
@@ -1178,20 +1182,45 @@ if args.coutput then
         if v.mayreturnnothing then
           emit('  if (ret == 0) return 0;')
         end
-        emit('  wowless_stubchecknreturns(L, ret, %d, %s);', #outputs, cstring(entry.name))
-        for i, out in ipairs(outputs) do
-          local nilable = out.nilable
-          local otype = out.type
-          if out.default ~= nil then
-            local push = dispatch(coutputdefaulttypes, type(out.default), out.default)
-            emit('  if (lua_isnil(L, %d)) {', i)
-            emit('    %s;', push)
-            emit('    lua_replace(L, %d);', i)
-            emit('  } else {')
-            emit('    %s;', dispatch(coutputtypes, otype, false, i))
+        if outstride == 0 then
+          emit('  wowless_stubchecknreturns(L, ret, %d, %s);', #outputs, cstring(entry.name))
+          for i, out in ipairs(outputs) do
+            local nilable = out.nilable
+            local otype = out.type
+            if out.default ~= nil then
+              local push = dispatch(coutputdefaulttypes, type(out.default), out.default)
+              emit('  if (lua_isnil(L, %d)) {', i)
+              emit('    %s;', push)
+              emit('    lua_replace(L, %d);', i)
+              emit('  } else {')
+              emit('    %s;', dispatch(coutputtypes, otype, false, i))
+              emit('  }')
+            else
+              emit('  %s;', dispatch(coutputtypes, otype, nilable, i))
+            end
+          end
+        else
+          if outstride > 1 then
+            emit('  if (ret < %d || (ret - %d) %% %d != 0)', nfixed, nfixed, outstride)
+            emit('    return luaL_error(L, "wrong number of return values from %%s", %s);', cstring(entry.name))
+          end
+          for i = 1, nfixed do
+            emit('  %s;', dispatch(coutputtypes, outputs[i].type, outputs[i].nilable, i))
+          end
+          if outstride > 0 then
+            emit('  for (int i = %d; i < ret; i++) {', nfixed)
+            if outstride == 1 then
+              local out = outputs[nfixed + 1]
+              emit('    %s;', dispatch(coutputtypes, out.type, out.nilable, 'i + 1'))
+            else
+              emit('    switch ((i - %d) %% %d) {', nfixed, outstride)
+              for j = 1, outstride do
+                local out = outputs[nfixed + j]
+                emit('      case %d: %s; break;', j - 1, dispatch(coutputtypes, out.type, out.nilable, 'i + 1'))
+              end
+              emit('    }')
+            end
             emit('  }')
-          else
-            emit('  %s;', dispatch(coutputtypes, otype, nilable, i))
           end
         end
         emit('  return ret;')


### PR DESCRIPTION
Enables C impl stubs for APIs that return a variable number of values in fixed-size stride groups. Previously these fell back to Lua-level wrapping.

**APIs now using C impl stubs:**
- `GetChatWindowMessages` (outstride=1, returns N strings)
- `GetAuctionItemSubClasses` / `C_AuctionHouse.GetAuctionItemSubClasses` (outstride=1, returns N numbers)
- `GetTalentPrereqs` (outstride=4, returns N×(tier, column, isLearnable, isPreviewLearnable) tuples)

**Also fixes** a latent bug where `{enum: Name}` output types were dispatched with the typename landing in the `nilable` slot, producing `wowless_imploutputnilableenum(L, 0)` (wrong nilability, wrong index). Now correctly emits `wowless_imploutputenum(L, 1)`.

Closes #554 (partial — instride and missing input types remain)

🤖 Generated with [Claude Code](https://claude.com/claude-code)