### PR TITLE
cmake: drop redundant -O3 and -DNDEBUG from CMAKE_C_FLAGS

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -14,7 +14,7 @@
       "binaryDir": "${sourceDir}/build",
       "cacheVariables": {
         "CMAKE_BUILD_TYPE": "Release",
-        "CMAKE_C_FLAGS": "-DNDEBUG -ffast-math -O3",
+        "CMAKE_C_FLAGS": "-ffast-math",
         "CMAKE_EXPORT_COMPILE_COMMANDS": true
       },
       "generator": "Ninja",


### PR DESCRIPTION
## Summary

- `CMAKE_BUILD_TYPE=Release` already implies `-O3 -DNDEBUG` via CMake's default `CMAKE_C_FLAGS_RELEASE`
- Remove those two flags from the explicit `CMAKE_C_FLAGS`, keeping only `-ffast-math` which is genuinely additive

## Test plan

- [ ] CI build passes with the reduced flags

---
_Generated by [Claude Code](https://claude.ai/code/session_01L3uwRhMNzfRCug5xjdwbqP)_