### PR TITLE
tools: replace pl.pretty.write with custom table serializer

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -338,7 +338,7 @@ target_sources(wowlessyaml PRIVATE wowapi/cyaml.c)
 target_link_libraries(wowlessyaml PRIVATE yaml)
 
 add_lua_executable(yaml2lua ${CMAKE_CURRENT_SOURCE_DIR}/tools/yaml2lua.lua
-                   penlight wowlessyaml)
+                   penlight toolsutil wowlessyaml)
 add_lua_executable(lua2yaml ${CMAKE_CURRENT_SOURCE_DIR}/tools/lua2yaml.lua
                    penlight wowlessyaml)
 
@@ -358,7 +358,10 @@ yaml2lua(modules)
 yaml2lua(products)
 yaml2lua(stringenums)
 
-lua2c(toolsutil tools.util=${CMAKE_CURRENT_SOURCE_DIR}/tools/util.lua)
+lua2c(toolsprettywrite
+      tools.prettywrite=${CMAKE_CURRENT_SOURCE_DIR}/tools/prettywrite.lua)
+lua2c(toolsutil tools.util=${CMAKE_CURRENT_SOURCE_DIR}/tools/util.lua
+      toolsprettywrite=p)
 
 add_lua_executable(sqls ${CMAKE_CURRENT_SOURCE_DIR}/tools/sqls.lua penlight
                    toolsutil wowlessyaml)
@@ -848,7 +851,8 @@ lua2c(
   wowless.profiler=${CMAKE_CURRENT_SOURCE_DIR}/wowless/profiler.lua
   wowless.runner=${CMAKE_CURRENT_SOURCE_DIR}/wowless/runner.lua
   wowless.secure=c
-  wowless.xml=${CMAKE_CURRENT_SOURCE_DIR}/wowless/xml.lua)
+  wowless.xml=${CMAKE_CURRENT_SOURCE_DIR}/wowless/xml.lua
+  toolsprettywrite=p)
 target_sources(
   wowlesslib
   PRIVATE wowless/bubblewrap.c
@@ -955,6 +959,7 @@ add_lua_executable(
   penlight
   runtimegametypes
   runtimeproducts
+  toolsprettywrite
   toolstedit
   tsort
   wowapischema
@@ -1033,6 +1038,7 @@ set(specs
     spec/data/xml_spec.lua
     spec/data/yaml_spec.lua
     spec/elune_spec.lua
+    spec/tools/prettywrite_spec.lua
     spec/tools/tedit_spec.lua
     spec/wowapi/schema_spec.lua
     spec/wowapi/yaml_spec.lua

--- a/spec/tools/prettywrite_spec.lua
+++ b/spec/tools/prettywrite_spec.lua
@@ -1,0 +1,57 @@
+describe('prettywrite', function()
+  local prettywrite = require('tools.prettywrite')
+
+  local cases = {
+    { 'false', false, 'false' },
+    { 'true', true, 'true' },
+    { 'integer', 42, '42' },
+    { 'negative integer', -7, '-7' },
+    { 'large integer', 2147483648, '2147483648' },
+    { 'float', 1.5, tostring(1.5) },
+    { 'string', 'hello', '"hello"' },
+    { 'string with quotes', 'say "hi"', '"say \\"hi\\""' },
+    { 'empty table', {}, '{}' },
+  }
+
+  local inline_cases = {
+    { 'array', { 1, 2, 3 }, '{1, 2, 3}' },
+    { 'map', { a = 1, b = 2 }, '{a = 1, b = 2}' },
+    { 'non-identifier key', { ['foo-bar'] = 1 }, '{["foo-bar"] = 1}' },
+    { 'numeric non-array key', { [0] = 1 }, '{[0] = 1}' },
+    { 'sorted keys', { c = 3, a = 1, b = 2 }, '{a = 1, b = 2, c = 3}' },
+    { 'keyword key', { ['and'] = 1 }, '{["and"] = 1}' },
+  }
+
+  local multiline_cases = {
+    { 'array', { 1, 2 }, '{\n  1,\n  2,\n}' },
+    { 'map', { a = 1, b = 2 }, '{\n  a = 1,\n  b = 2,\n}' },
+    { 'nested', { x = { y = 1 } }, '{\n  x = {\n    y = 1,\n  },\n}' },
+  }
+
+  for _, c in ipairs(cases) do
+    it(c[1], function()
+      assert.equal(c[3], prettywrite(c[2]))
+    end)
+  end
+
+  describe('inline', function()
+    for _, c in ipairs(inline_cases) do
+      it(c[1], function()
+        assert.equal(c[3], prettywrite(c[2], true))
+      end)
+    end
+  end)
+
+  describe('multiline', function()
+    for _, c in ipairs(multiline_cases) do
+      it(c[1], function()
+        assert.equal(c[3], prettywrite(c[2]))
+      end)
+    end
+  end)
+
+  it('roundtrip', function()
+    local t = { a = 1, b = { 2, 3 }, c = true }
+    assert.same(t, assert(loadstring('return ' .. prettywrite(t)))())
+  end)
+end)

--- a/tools/gentest.lua
+++ b/tools/gentest.lua
@@ -311,7 +311,7 @@ end)()
 local function doit(k, p)
   if ptablemap[k] then
     local nn, tt = ptablemap[k](p)
-    return '_G.WowlessData.' .. nn .. ' = ' .. require('pl.pretty').write(tt) .. '\n'
+    return '_G.WowlessData.' .. nn .. ' = ' .. require('tools.prettywrite')(tt) .. '\n'
   elseif k == 'product' then
     return ('_G.WowlessData = { product = %q }'):format(p)
   elseif k == 'toc' then

--- a/tools/prep.lua
+++ b/tools/prep.lua
@@ -19,7 +19,7 @@ local function readFile(f)
   deps[f] = true
   return (assert(require('pl.file').read(f)))
 end
-local plprettywrite = require('pl.pretty').write
+local prettywrite = require('tools.prettywrite')
 local Mixin = require('wowless.util').mixin
 local sorted = require('pl.tablex').sort
 
@@ -34,7 +34,7 @@ local function valstr(value)
   elseif ty == 'string' then
     return string.format('%q', value)
   elseif ty == 'table' then
-    return plprettywrite(value, '')
+    return prettywrite(value, true)
   else
     error('unsupported stub value type ' .. ty)
   end
@@ -109,7 +109,7 @@ local specDefault = (function()
     if ty.luaobject then
       return ('gencode.CreateLuaObject(%q).luarep'):format(ty.luaobject)
     end
-    error('unexpected type: ' .. require('pl.pretty').write(ty))
+    error('unexpected type: ' .. prettywrite(ty, true))
   end
   return specDefault
 end)()
@@ -144,7 +144,7 @@ local function stubby(mv, skip0)
   local ins = mv.inputs or {}
   local nsins = #ins - (mv.instride or 0)
   for i = 1, #ins do
-    table.insert(t, 'local spec' .. i .. '=' .. plprettywrite(mv.inputs[i], '') .. ';')
+    table.insert(t, 'local spec' .. i .. '=' .. prettywrite(mv.inputs[i], true) .. ';')
   end
   table.insert(t, 'return function(')
   local a = {}
@@ -432,7 +432,7 @@ local uiobjectimplmakers = {
   getter = function(impl, mv)
     local t = { 'local gencode=...;' }
     for i in ipairs(impl) do
-      table.insert(t, 'local spec' .. i .. '=' .. plprettywrite(mv.outputs[i], '') .. ';')
+      table.insert(t, 'local spec' .. i .. '=' .. prettywrite(mv.outputs[i], true) .. ';')
     end
     table.insert(t, 'return function(self)return ')
     for i, f in ipairs(impl) do
@@ -450,7 +450,7 @@ local uiobjectimplmakers = {
   setter = function(impl, mv)
     local t = { 'local gencode=...;' }
     for i in ipairs(impl) do
-      table.insert(t, 'local spec' .. i .. '=' .. plprettywrite(mv.inputs[i], '') .. ';')
+      table.insert(t, 'local spec' .. i .. '=' .. prettywrite(mv.inputs[i], true) .. ';')
     end
     table.insert(t, 'return function(self')
     for _, f in ipairs(impl) do

--- a/tools/prettywrite.lua
+++ b/tools/prettywrite.lua
@@ -1,0 +1,89 @@
+local function prettywrite(v, inline)
+  local function isid(s)
+    return type(s) == 'string'
+      and s:match('^[%a_][%w_]*$')
+      and not ({
+        ['and'] = 1,
+        ['break'] = 1,
+        ['do'] = 1,
+        ['else'] = 1,
+        ['elseif'] = 1,
+        ['end'] = 1,
+        ['false'] = 1,
+        ['for'] = 1,
+        ['function'] = 1,
+        ['goto'] = 1,
+        ['if'] = 1,
+        ['in'] = 1,
+        ['local'] = 1,
+        ['nil'] = 1,
+        ['not'] = 1,
+        ['or'] = 1,
+        ['repeat'] = 1,
+        ['return'] = 1,
+        ['then'] = 1,
+        ['true'] = 1,
+        ['until'] = 1,
+        ['while'] = 1,
+      })[s]
+  end
+  local function numstr(n)
+    if n == math.floor(n) and math.abs(n) < 2 ^ 53 then
+      return string.format('%.0f', n)
+    end
+    return tostring(n)
+  end
+  local function rec(x, depth)
+    local t = type(x)
+    if t == 'boolean' then
+      return tostring(x)
+    elseif t == 'number' then
+      return numstr(x)
+    elseif t == 'string' then
+      return string.format('%q', x)
+    elseif t == 'table' then
+      local parts = {}
+      local n = 0
+      for i = 1, math.huge do
+        if x[i] == nil then
+          break
+        end
+        n = i
+        table.insert(parts, rec(x[i], depth + 1))
+      end
+      local keys = {}
+      for k in pairs(x) do
+        if not (type(k) == 'number' and k >= 1 and k <= n and k == math.floor(k)) then
+          table.insert(keys, k)
+        end
+      end
+      table.sort(keys, function(a, b)
+        return tostring(a) < tostring(b)
+      end)
+      for _, k in ipairs(keys) do
+        local kstr
+        if isid(k) then
+          kstr = k .. ' = ' .. rec(x[k], depth + 1)
+        else
+          kstr = '[' .. rec(k, depth + 1) .. '] = ' .. rec(x[k], depth + 1)
+        end
+        table.insert(parts, kstr)
+      end
+      if #parts == 0 then
+        return '{}'
+      end
+      if inline then
+        return '{' .. table.concat(parts, ', ') .. '}'
+      else
+        local indent = string.rep('  ', depth + 1)
+        local closing = string.rep('  ', depth)
+        return '{\n' .. indent .. table.concat(parts, ',\n' .. indent) .. ',\n' .. closing .. '}'
+      end
+    else
+      error('unsupported type ' .. t)
+    end
+  end
+  return rec(v, 0)
+end
+
+return prettywrite

--- a/tools/util.lua
+++ b/tools/util.lua
@@ -1,5 +1,7 @@
+local prettywrite = require('tools.prettywrite')
+
 local function returntable(t)
-  return 'return ' .. require('pl.pretty').write(t) .. '\n'
+  return 'return ' .. prettywrite(t) .. '\n'
 end
 
 local function writeifchanged(f, c)

--- a/tools/yaml2lua.lua
+++ b/tools/yaml2lua.lua
@@ -1,18 +1,4 @@
--- pl.pretty uses string.format('%d') for integers, which overflows 32-bit
--- long on Windows (LLP64 ABI). Patch it to use '%.0f' instead, which uses
--- double arithmetic and handles values up to 2^53 correctly on all platforms.
-local _fmt = string.format
-string.format = function(s, ...) -- luacheck: ignore
-  if s == '%d' then
-    local v = select(1, ...)
-    if type(v) == 'number' and (v >= 2 ^ 31 or v < -(2 ^ 31)) then
-      return _fmt('%.0f', v)
-    end
-  end
-  return _fmt(s, ...)
-end
 local t = assert(require('wowapi.yaml').parseFile(arg[1]))
-local s = 'return ' .. require('pl.pretty').write(t)
-string.format = _fmt -- luacheck: ignore
+local tu = require('tools.util')
 assert(require('pl.dir').makepath(require('pl.path').dirname(arg[2])))
-assert(require('pl.file').write(arg[2], s))
+assert(require('pl.file').write(arg[2], tu.returntable(t)))

--- a/wowless/env.lua
+++ b/wowless/env.lua
@@ -3,7 +3,7 @@ local deepcopy = require('pl.tablex').deepcopy
 
 local function dump(uiobjects)
   local function d(x)
-    io.write(require('pl.pretty').write(x))
+    io.write(require('tools.prettywrite')(x))
     io.write('\n')
   end
   return function(...)
@@ -68,7 +68,7 @@ local function init(modules, lite)
         y = y,
       }
     end
-    io.write(require('pl.pretty').write({
+    io.write(require('tools.prettywrite')({
       bottom = r.bottom,
       debugname = r:GetDebugName(),
       height = r.height,

--- a/wowless/modules/loader.lua
+++ b/wowless/modules/loader.lua
@@ -910,7 +910,7 @@ return function(
   end
 
   local function saveAllVariables()
-    local w = require('pl.pretty').write
+    local w = require('tools.prettywrite')
     for _, v in pairs(addonData) do
       if v.loaded then
         local t = {}
@@ -920,7 +920,7 @@ return function(
             if val ~= nil then
               table.insert(t, var)
               table.insert(t, ' = ')
-              table.insert(t, type(val) == 'table' and w(val, '  ', true) or tostring(val))
+              table.insert(t, type(val) == 'table' and w(val) or tostring(val))
               table.insert(t, '\n')
             end
           end


### PR DESCRIPTION
Removes `pl.pretty` from all Lua table serialization in the tools layer and replaces it with a custom `prettywrite()` function in `tools/util.lua`.

The immediate motivation is `yaml2lua.lua`, which had a `string.format` monkey-patch hack to work around `pl.pretty`'s use of `%d` for integers — which overflows a 32-bit `long` on Windows (LLP64 ABI) for values ≥ 2³¹. The new serializer uses `%.0f` for integer-valued numbers, which uses double arithmetic and is correct on all platforms up to 2⁵³.

## Changes

- **`tools/util.lua`**: Add `prettywrite(v, inline)` — handles booleans, numbers, strings, and tables (arrays in order, maps with sorted keys, nested with 2-space indentation). Inline mode produces `{k = v, ...}` on one line. Export it alongside `returntable`, which now uses it internally.
- **`tools/yaml2lua.lua`**: Remove the 14-line `string.format` monkey-patch. Now just calls `tu.returntable(t)`.
- **`tools/prep.lua`**: Replace `plprettywrite = require('pl.pretty').write` with `prettywrite = require('tools.util').prettywrite`. The `valstr` table case uses inline mode.
- **`tools/gentest.lua`**: Use `require('tools.util').prettywrite(tt)` for WowlessData table output.