### PR TITLE
gha: use VCPKG_APPLOCAL_DEPS to copy DLLs on Windows

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -98,7 +98,4 @@ jobs:
         restore-keys: vcpkg-${{ runner.os }}
     - uses: lukka/get-cmake@v4.3.2
     - run: cmake --preset default
-    - if: runner.os == 'Windows'
-      run: echo "${{ github.workspace }}/build/vcpkg_installed/x64-windows/bin" >> $env:GITHUB_PATH
-      shell: pwsh
     - run: cmake --build --preset default --target all test --verbose

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -14,7 +14,8 @@
       "binaryDir": "${sourceDir}/build",
       "cacheVariables": {
         "CMAKE_BUILD_TYPE": "Release",
-        "CMAKE_EXPORT_COMPILE_COMMANDS": true
+        "CMAKE_EXPORT_COMPILE_COMMANDS": true,
+        "VCPKG_APPLOCAL_DEPS": true
       },
       "generator": "Ninja",
       "name": "default"


### PR DESCRIPTION
## Summary

- Enables `VCPKG_APPLOCAL_DEPS=true` in `CMakePresets.json` so vcpkg's CMake toolchain automatically copies required DLLs next to each built target on Windows (no-op on Linux/macOS)
- Removes the Windows-specific `GITHUB_PATH` manipulation step from the `buildpreset` CI job
- The `buildpreset` job is now uniform across all platforms

## Test plan

- [ ] CI `buildpreset` job passes on Windows, Linux, and macOS without the PATH step

🤖 Generated with [Claude Code](https://claude.com/claude-code)