### PR TITLE
stubs: first-pass C++ modernization

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -879,7 +879,7 @@ target_sources(
   PRIVATE wowless/bubblewrap.c
           wowless/debug.c
           wowless/ext.c
-          wowless/modules/ctypecheck.c
+          wowless/modules/ctypecheck.cpp
           wowless/modules/encodingutil.c
           wowless/secure.c
           wowless/stubs.cpp)

--- a/tools/prep.lua
+++ b/tools/prep.lua
@@ -772,7 +772,7 @@ if args.coutput then
     luaobject = function(name)
       return function(verb, nilable, idx)
         local ns = nilable and 'nilable' or ''
-        return string.format('wowless_%s%sluaobject(L, %s, %s, %d)', verb, ns, idx, cstring(name), #name)
+        return string.format('wowless_%s%sluaobject(L, %s, %s)', verb, ns, idx, cstring(name))
       end
     end,
     number = simple_cinputtype('number'),
@@ -821,8 +821,7 @@ if args.coutput then
     ['function'] = simple_coutputtype('function'),
     luaobject = function(typename, nilable, idx)
       local ns = nilable and 'nilable' or ''
-      local tn = cstring(typename)
-      return string.format('wowless_imploutput%sluaobject(L, %s, %s, sizeof(%s)-1)', ns, idx, tn, tn)
+      return string.format('wowless_imploutput%sluaobject(L, %s, %s)', ns, idx, cstring(typename))
     end,
     ['nil'] = simple_coutputtype('nil'),
     number = simple_coutputtype('number'),
@@ -834,8 +833,7 @@ if args.coutput then
     table = simple_coutputtype('table'),
     uiobject = function(typename, nilable, idx)
       local ns = nilable and 'nilable' or ''
-      local tn = cstring(typename)
-      return string.format('wowless_imploutput%suiobject(L, %s, %s, sizeof(%s)-1)', ns, idx, tn, tn)
+      return string.format('wowless_imploutput%suiobject(L, %s, %s)', ns, idx, cstring(typename))
     end,
     unit = simple_coutputtype('unit'),
     unknown = simple_coutputtype('unknown'),
@@ -959,11 +957,11 @@ if args.coutput then
       end
     end,
     luaobject = function(name, _)
-      emit('  wowless_stubcreateluaobject(L, %s, %d);', cstring(name), #name)
+      emit('  wowless_stubcreateluaobject(L, %s);', cstring(name))
     end,
     table = lua_value_emitters.table,
     uiobject = function(name, _)
-      emit('  wowless_stubcreateuiobject(L, %s, %d);', cstring(name), #name)
+      emit('  wowless_stubcreateuiobject(L, %s);', cstring(name))
     end,
   }
 
@@ -975,8 +973,8 @@ if args.coutput then
     emit('')
   end
   for sename in sorted(stringenums) do
-    emit('static int wowless_isstringenum_%s(lua_State *L, int idx);', safename(sename))
-    emit('static int wowless_isnilablestringenum_%s(lua_State *L, int idx);', safename(sename))
+    emit('static bool wowless_isstringenum_%s(lua_State *L, int idx);', safename(sename))
+    emit('static bool wowless_isnilablestringenum_%s(lua_State *L, int idx);', safename(sename))
     emit('static void wowless_stubcheckstringenum_%s(lua_State *L, int idx);', safename(sename))
     emit('static void wowless_stubchecknilablestringenum_%s(lua_State *L, int idx);', safename(sename))
   end
@@ -984,8 +982,8 @@ if args.coutput then
     emit('')
   end
   for uname in sorted(uiobjectdata) do
-    emit('static int wowless_isuiobject_%s(lua_State *L, int idx);', safename(uname))
-    emit('static int wowless_isnilableuiobject_%s(lua_State *L, int idx);', safename(uname))
+    emit('static bool wowless_isuiobject_%s(lua_State *L, int idx);', safename(uname))
+    emit('static bool wowless_isnilableuiobject_%s(lua_State *L, int idx);', safename(uname))
     emit('static void wowless_stubcheckuiobject_%s(lua_State *L, int idx);', safename(uname))
     emit('static void wowless_stubchecknilableuiobject_%s(lua_State *L, int idx);', safename(uname))
   end
@@ -1016,32 +1014,32 @@ if args.coutput then
   end
 
   for sename in sorted(stringenums) do
-    emit('static int wowless_isstringenum_%s(lua_State *L, int idx) {', safename(sename))
-    emit('  return wowless_isstringenum(L, idx, %s, %d);', cstring(sename), #sename)
+    emit('static bool wowless_isstringenum_%s(lua_State *L, int idx) {', safename(sename))
+    emit('  return wowless_isstringenum(L, idx, %s);', cstring(sename))
     emit('}')
     emit('')
-    emit('static int wowless_isnilablestringenum_%s(lua_State *L, int idx) {', safename(sename))
-    emit('  return wowless_isnilablestringenum(L, idx, %s, %d);', cstring(sename), #sename)
+    emit('static bool wowless_isnilablestringenum_%s(lua_State *L, int idx) {', safename(sename))
+    emit('  return wowless_isnilablestringenum(L, idx, %s);', cstring(sename))
     emit('}')
     emit('')
     emit('static void wowless_stubcheckstringenum_%s(lua_State *L, int idx) {', safename(sename))
-    emit('  wowless_stubcheckstringenum(L, idx, %s, %d);', cstring(sename), #sename)
+    emit('  wowless_stubcheckstringenum(L, idx, %s);', cstring(sename))
     emit('}')
     emit('')
     emit('static void wowless_stubchecknilablestringenum_%s(lua_State *L, int idx) {', safename(sename))
-    emit('  wowless_stubchecknilablestringenum(L, idx, %s, %d);', cstring(sename), #sename)
+    emit('  wowless_stubchecknilablestringenum(L, idx, %s);', cstring(sename))
     emit('}')
     emit('')
   end
 
   for uname in sorted(uiobjectdata) do
     local target = uname:lower()
-    emit('static int wowless_isuiobject_%s(lua_State *L, int idx) {', safename(uname))
-    emit('  return wowless_isuiobject(L, idx, %s, %d);', cstring(target), #target)
+    emit('static bool wowless_isuiobject_%s(lua_State *L, int idx) {', safename(uname))
+    emit('  return wowless_isuiobject(L, idx, %s);', cstring(target))
     emit('}')
     emit('')
-    emit('static int wowless_isnilableuiobject_%s(lua_State *L, int idx) {', safename(uname))
-    emit('  return wowless_isnilableuiobject(L, idx, %s, %d);', cstring(target), #target)
+    emit('static bool wowless_isnilableuiobject_%s(lua_State *L, int idx) {', safename(uname))
+    emit('  return wowless_isnilableuiobject(L, idx, %s);', cstring(target))
     emit('}')
     emit('')
     emit('static void wowless_stubcheckuiobject_%s(lua_State *L, int idx) {', safename(uname))
@@ -1287,23 +1285,23 @@ if args.coutput then
         for _, m in ipairs(mods) do
           table.insert(parts, cstring(m))
         end
-        emit('static const char *const implmods_%s[] = {%s, NULL};', sn, table.concat(parts, ', '))
+        emit('static const char *const implmods_%s[] = {%s, nullptr};', sn, table.concat(parts, ', '))
       end
       if #sqls_list > 0 then
         local parts = {}
         for _, s in ipairs(sqls_list) do
           table.insert(parts, cstring(s))
         end
-        emit('static const char *const implsqls_%s[] = {%s, NULL};', sn, table.concat(parts, ', '))
+        emit('static const char *const implsqls_%s[] = {%s, nullptr};', sn, table.concat(parts, ', '))
       end
       emit(
-        'static const struct wowless_impl_data impldata_%s = {%s, %d, %s, %s, %s};',
+        'static const wowless_impl_data impldata_%s = {%s, %d, %s, %s, %s};',
         sn,
         cstring(impldata.impl),
         #impldata.impl,
         cstring(entry.chunkname),
-        #mods > 0 and ('implmods_' .. sn) or 'NULL',
-        #sqls_list > 0 and ('implsqls_' .. sn) or 'NULL'
+        #mods > 0 and ('implmods_' .. sn) or 'nullptr',
+        #sqls_list > 0 and ('implsqls_' .. sn) or 'nullptr'
       )
     end
   end
@@ -1311,10 +1309,10 @@ if args.coutput then
   local function emit_stub_entry(indent, name, entry)
     if entry.impldata then
       local impldata = entry.impldata
-      local func = impldata.nowrap and 'NULL' or ('implstub_' .. entry.sn)
+      local func = impldata.nowrap and 'nullptr' or ('implstub_' .. entry.sn)
       emit('%s{%s, %s, %d, &impldata_%s},', indent, cstring(name), func, entry.secureonly and 1 or 0, entry.sn)
     else
-      emit('%s{%s, stub_%s, %d, NULL},', indent, cstring(name), entry.sn, entry.secureonly and 1 or 0)
+      emit('%s{%s, stub_%s, %d, nullptr},', indent, cstring(name), entry.sn, entry.secureonly and 1 or 0)
     end
   end
 
@@ -1330,39 +1328,39 @@ if args.coutput then
     emit('')
   end
 
-  emit('static const struct wowless_stub_entry stubs_global[] = {')
+  emit('static const wowless_stub_entry stubs_global[] = {')
   for name, entry in sorted(global_entries) do
     emit_stub_entry('  ', name, entry)
   end
-  emit('  {NULL, NULL, 0, NULL}')
+  emit('  {nullptr, nullptr, 0, nullptr}')
   emit('};')
   emit('')
 
   for ns in sorted(ns_entries) do
-    emit('static const struct wowless_stub_entry stubs_ns_%s[] = {', safename(ns))
+    emit('static const wowless_stub_entry stubs_ns_%s[] = {', safename(ns))
     for name, entry in sorted(ns_entries[ns]) do
       emit_stub_entry('  ', name, entry)
     end
-    emit('  {NULL, NULL, 0, NULL}')
+    emit('  {nullptr, nullptr, 0, nullptr}')
     emit('};')
     emit('')
   end
 
-  emit('static const struct wowless_ns_entry stubs_ns[] = {')
+  emit('static const wowless_ns_entry stubs_ns[] = {')
   for ns in sorted(ns_entries) do
     emit('  {%s, stubs_ns_%s},', cstring(ns), safename(ns))
   end
-  emit('  {NULL, NULL}')
+  emit('  {nullptr, nullptr}')
   emit('};')
   emit('')
 
-  emit('static const struct wowless_stubs_spec stubs_spec = {')
+  emit('static const wowless_stubs_spec stubs_spec = {')
   emit('  stubs_global,')
   emit('  stubs_ns,')
   emit('};')
   emit('')
   emit('extern "C" int luaopen_build_products_%s_stubs(lua_State *L) {', product)
-  emit('  lua_pushlightuserdata(L, (void *)&stubs_spec);')
+  emit('  lua_pushlightuserdata(L, static_cast<void *>(const_cast<wowless_stubs_spec *>(&stubs_spec)));')
   emit('  lua_pushcclosure(L, wowless_load_stubs, 1);')
   emit('  return 1;')
   emit('}')

--- a/wowless/modules/ctypecheck.cpp
+++ b/wowless/modules/ctypecheck.cpp
@@ -1,6 +1,3 @@
-#include "lauxlib.h"
-#include "lua.h"
-#include "wowless/stubs.h"
 #include "wowless/typecheck.h"
 
 /*
@@ -75,12 +72,12 @@ SIMPLE_CHECKER(imploutputnilabletable, wowless_imploutputnilabletable)
  * This works directly because wowless_stubcheck* already reads upvalue 1 as
  * cgencode.
  */
-#define TYPED_CHECKER(name, call)                      \
-  static int ctypecheck_##name(lua_State *L) {         \
-    size_t len;                                        \
-    const char *tname = luaL_checklstring(L, 2, &len); \
-    call(L, 1, tname, len);                            \
-    return 0;                                          \
+#define TYPED_CHECKER(name, call)                                    \
+  static int ctypecheck_##name(lua_State *L) {                       \
+    size_t len;                                                      \
+    const char *tname = luaL_checklstring(L, 2, &len);               \
+    call(L, 1, std::string_view{tname, len});                        \
+    return 0;                                                        \
   }
 
 TYPED_CHECKER(stubcheckstringenum, wowless_stubcheckstringenum)
@@ -167,7 +164,7 @@ static int make_module(lua_State *L) {
   return 1;
 }
 
-int luaopen_wowless_modules_ctypecheck(lua_State *L) {
+extern "C" int luaopen_wowless_modules_ctypecheck(lua_State *L) {
   lua_pushcfunction(L, make_module);
   return 1;
 }

--- a/wowless/stubs.cpp
+++ b/wowless/stubs.cpp
@@ -101,13 +101,12 @@ void wowless_stub_log_extra_args(lua_State *L, const char *fname) {
 }
 
 int wowless_load_stubs(lua_State *L) {
-  const struct wowless_stubs_spec *spec =
-      (const struct wowless_stubs_spec *)lua_touserdata(L, lua_upvalueindex(1));
-  const struct wowless_ns_entry *ns;
+  const auto *spec =
+      static_cast<const wowless_stubs_spec *>(lua_touserdata(L, lua_upvalueindex(1)));
   lua_getfield(L, 1, "cgencode");
   lua_insert(L, 1);
   load_entries(L, spec->global);
-  for (ns = spec->ns; ns->ns; ns++) {
+  for (const wowless_ns_entry *ns = spec->ns; ns->ns; ns++) {
     load_entries(L, ns->entries);
     lua_setfield(L, -3, ns->ns);
     lua_pushnil(L);

--- a/wowless/typecheck.h
+++ b/wowless/typecheck.h
@@ -1,15 +1,13 @@
 #ifndef WOWLESS_TYPECHECK_H
 #define WOWLESS_TYPECHECK_H
 
-#ifdef __cplusplus
 extern "C" {
-#endif
 #include "lauxlib.h"
 #include "lua.h"
 #include "wowless/stubs.h"
-#ifdef __cplusplus
 }
-#endif
+
+#include <string_view>
 
 static inline int wowless_forbidden(lua_State *L) {
   const char *taint = lua_getstacktaint(L);
@@ -22,11 +20,11 @@ static inline int wowless_forbidden(lua_State *L) {
   return 0;
 }
 
-static inline int wowless_isnumber(lua_State *L, int idx) {
+static inline bool wowless_isnumber(lua_State *L, int idx) {
   return lua_isnumber(L, idx);
 }
 
-static inline int wowless_isnilablenumber(lua_State *L, int idx) {
+static inline bool wowless_isnilablenumber(lua_State *L, int idx) {
   return lua_isnoneornil(L, idx) || lua_isnumber(L, idx);
 }
 
@@ -90,11 +88,11 @@ static inline void wowless_stubchecknilableenum(lua_State *L, int idx) {
   wowless_stubchecknilablenumber(L, idx);
 }
 
-static inline int wowless_isstring(lua_State *L, int idx) {
+static inline bool wowless_isstring(lua_State *L, int idx) {
   return lua_isstring(L, idx);
 }
 
-static inline int wowless_isnilablestring(lua_State *L, int idx) {
+static inline bool wowless_isnilablestring(lua_State *L, int idx) {
   return lua_isnoneornil(L, idx) || lua_isstring(L, idx);
 }
 
@@ -110,11 +108,11 @@ static inline void wowless_stubchecknilablestring(lua_State *L, int idx) {
   }
 }
 
-static inline int wowless_isfileasset(lua_State *L, int idx) {
+static inline bool wowless_isfileasset(lua_State *L, int idx) {
   return wowless_isstring(L, idx);
 }
 
-static inline int wowless_isnilablefileasset(lua_State *L, int idx) {
+static inline bool wowless_isnilablefileasset(lua_State *L, int idx) {
   return wowless_isnilablestring(L, idx);
 }
 
@@ -126,11 +124,13 @@ static inline void wowless_stubchecknilablefileasset(lua_State *L, int idx) {
   wowless_stubchecknilablestring(L, idx);
 }
 
-static inline int wowless_isboolean(lua_State *L, int idx) {
+static inline bool wowless_isboolean(lua_State *L, int idx) {
   return !lua_isnoneornil(L, idx);
 }
 
-static inline int wowless_isnilableboolean(lua_State *L, int idx) { return 1; }
+static inline bool wowless_isnilableboolean(lua_State *L, int idx) {
+  return true;
+}
 
 static inline void wowless_stubcheckboolean(lua_State *L, int idx) {
   if (!wowless_isboolean(L, idx)) {
@@ -140,11 +140,11 @@ static inline void wowless_stubcheckboolean(lua_State *L, int idx) {
 
 static inline void wowless_stubchecknilableboolean(lua_State *L, int idx) {}
 
-static inline int wowless_isfunction(lua_State *L, int idx) {
+static inline bool wowless_isfunction(lua_State *L, int idx) {
   return lua_type(L, idx) == LUA_TFUNCTION;
 }
 
-static inline int wowless_isnilablefunction(lua_State *L, int idx) {
+static inline bool wowless_isnilablefunction(lua_State *L, int idx) {
   int t = lua_type(L, idx);
   return t == LUA_TFUNCTION || t == LUA_TNIL || t == LUA_TNONE;
 }
@@ -161,11 +161,11 @@ static inline void wowless_stubchecknilablefunction(lua_State *L, int idx) {
   }
 }
 
-static inline int wowless_isunit(lua_State *L, int idx) {
+static inline bool wowless_isunit(lua_State *L, int idx) {
   return lua_type(L, idx) == LUA_TSTRING;
 }
 
-static inline int wowless_isnilableunit(lua_State *L, int idx) {
+static inline bool wowless_isnilableunit(lua_State *L, int idx) {
   int t = lua_type(L, idx);
   return t == LUA_TSTRING || t == LUA_TNIL || t == LUA_TNONE;
 }
@@ -182,11 +182,11 @@ static inline void wowless_stubchecknilableunit(lua_State *L, int idx) {
   }
 }
 
-static inline int wowless_isuiaddon(lua_State *L, int idx) {
+static inline bool wowless_isuiaddon(lua_State *L, int idx) {
   return wowless_isstring(L, idx);
 }
 
-static inline int wowless_isnilableuiaddon(lua_State *L, int idx) {
+static inline bool wowless_isnilableuiaddon(lua_State *L, int idx) {
   return wowless_isnilablestring(L, idx);
 }
 
@@ -198,11 +198,11 @@ static inline void wowless_stubchecknilableuiaddon(lua_State *L, int idx) {
   wowless_stubchecknilablestring(L, idx);
 }
 
-static inline int wowless_istable(lua_State *L, int idx) {
+static inline bool wowless_istable(lua_State *L, int idx) {
   return lua_type(L, idx) == LUA_TTABLE;
 }
 
-static inline int wowless_isnilabletable(lua_State *L, int idx) {
+static inline bool wowless_isnilabletable(lua_State *L, int idx) {
   int t = lua_type(L, idx);
   return t == LUA_TTABLE || t == LUA_TNIL || t == LUA_TNONE;
 }
@@ -219,92 +219,86 @@ static inline void wowless_stubchecknilabletable(lua_State *L, int idx) {
   }
 }
 
-static inline int wowless_isluaobject(lua_State *L, int idx, const char *tname,
-                                      size_t typenamelen) {
+static inline bool wowless_isluaobject(lua_State *L, int idx,
+                                       std::string_view tname) {
   idx = lua_absindex(L, idx);
   if (lua_type(L, idx) != LUA_TUSERDATA) {
-    return 0;
+    return false;
   }
   lua_getfield(L, lua_upvalueindex(1), "IsLuaObject");
   lua_pushvalue(L, idx);
-  lua_pushlstring(L, tname, typenamelen);
+  lua_pushlstring(L, tname.data(), tname.size());
   lua_call(L, 2, 1);
   int result = lua_toboolean(L, -1);
   lua_pop(L, 1);
   return result;
 }
 
-static inline int wowless_isnilableluaobject(lua_State *L, int idx,
-                                             const char *tname,
-                                             size_t typenamelen) {
-  return lua_isnoneornil(L, idx) ||
-         wowless_isluaobject(L, idx, tname, typenamelen);
+static inline bool wowless_isnilableluaobject(lua_State *L, int idx,
+                                              std::string_view tname) {
+  return lua_isnoneornil(L, idx) || wowless_isluaobject(L, idx, tname);
 }
 
 static inline void wowless_stubcheckluaobject(lua_State *L, int idx,
-                                              const char *tname,
-                                              size_t typenamelen) {
-  if (!wowless_isluaobject(L, idx, tname, typenamelen)) {
+                                              std::string_view tname) {
+  if (!wowless_isluaobject(L, idx, tname)) {
     luaL_typerror(L, idx, "luaobject");
   }
 }
 
 static inline void wowless_stubchecknilableluaobject(lua_State *L, int idx,
-                                                     const char *tname,
-                                                     size_t typenamelen) {
-  if (!wowless_isnilableluaobject(L, idx, tname, typenamelen)) {
+                                                     std::string_view tname) {
+  if (!wowless_isnilableluaobject(L, idx, tname)) {
     luaL_typerror(L, idx, "luaobject");
   }
 }
 
-static inline int wowless_isuiobject(lua_State *L, int idx, const char *tname,
-                                     size_t typenamelen) {
+static inline bool wowless_isuiobject(lua_State *L, int idx,
+                                      std::string_view tname) {
   idx = lua_absindex(L, idx);
   if (lua_type(L, idx) != LUA_TTABLE) {
-    return 0;
+    return false;
   }
   lua_rawgeti(L, idx, 0);
   if (lua_type(L, -1) != LUA_TUSERDATA) {
     lua_pop(L, 1);
-    return 0;
+    return false;
   }
   lua_getfield(L, lua_upvalueindex(1), "IsUiObject");
   lua_insert(L, -2);
-  lua_pushlstring(L, tname, typenamelen);
+  lua_pushlstring(L, tname.data(), tname.size());
   lua_call(L, 2, 1);
   int result = lua_toboolean(L, -1);
   lua_pop(L, 1);
   return result;
 }
 
-static inline int wowless_isnilableuiobject(lua_State *L, int idx,
-                                            const char *tname,
-                                            size_t typenamelen) {
-  return lua_isnoneornil(L, idx) ||
-         wowless_isuiobject(L, idx, tname, typenamelen);
+static inline bool wowless_isnilableuiobject(lua_State *L, int idx,
+                                             std::string_view tname) {
+  return lua_isnoneornil(L, idx) || wowless_isuiobject(L, idx, tname);
 }
 
 static inline void wowless_stubcheckuiobject(lua_State *L, int idx,
-                                             const char *tname,
-                                             size_t typenamelen) {
-  if (!wowless_isuiobject(L, idx, tname, typenamelen)) {
+                                             std::string_view tname) {
+  if (!wowless_isuiobject(L, idx, tname)) {
     luaL_typerror(L, idx, "uiobject");
   }
 }
 
 static inline void wowless_stubchecknilableuiobject(lua_State *L, int idx,
-                                                    const char *tname,
-                                                    size_t typenamelen) {
-  if (!wowless_isnilableuiobject(L, idx, tname, typenamelen)) {
+                                                    std::string_view tname) {
+  if (!wowless_isnilableuiobject(L, idx, tname)) {
     luaL_typerror(L, idx, "uiobject");
   }
 }
 
-static inline int wowless_isunknown(lua_State *L, int idx) {
+static inline bool wowless_isunknown(lua_State *L, int idx) {
   return !lua_isnoneornil(L, idx);
 }
 
-static inline int wowless_isnilableunknown(lua_State *L, int idx) { return 1; }
+static inline bool wowless_isnilableunknown(lua_State *L, int idx) {
+  return true;
+}
 
 static inline void wowless_stubcheckunknown(lua_State *L, int idx) {
   if (!wowless_isunknown(L, idx)) {
@@ -314,11 +308,11 @@ static inline void wowless_stubcheckunknown(lua_State *L, int idx) {
 
 static inline void wowless_stubchecknilableunknown(lua_State *L, int idx) {}
 
-static inline int wowless_isnil(lua_State *L, int idx) {
+static inline bool wowless_isnil(lua_State *L, int idx) {
   return lua_isnoneornil(L, idx);
 }
 
-static inline int wowless_isnilablenil(lua_State *L, int idx) {
+static inline bool wowless_isnilablenil(lua_State *L, int idx) {
   return wowless_isnil(L, idx);
 }
 
@@ -332,33 +326,29 @@ static inline void wowless_stubchecknilablenil(lua_State *L, int idx) {
   wowless_stubchecknil(L, idx);
 }
 
-static inline int wowless_isstringenum(lua_State *L, int idx,
-                                       const char *enumname,
-                                       size_t enumnamelen) {
+static inline bool wowless_isstringenum(lua_State *L, int idx,
+                                        std::string_view enumname) {
   idx = lua_absindex(L, idx);
   if (lua_type(L, idx) != LUA_TSTRING) {
-    return 0;
+    return false;
   }
   lua_getfield(L, lua_upvalueindex(1), "CheckStringEnum");
   lua_pushvalue(L, idx);
-  lua_pushlstring(L, enumname, enumnamelen);
+  lua_pushlstring(L, enumname.data(), enumname.size());
   lua_call(L, 2, 1);
   int result = lua_toboolean(L, -1);
   lua_pop(L, 1);
   return result;
 }
 
-static inline int wowless_isnilablestringenum(lua_State *L, int idx,
-                                              const char *enumname,
-                                              size_t enumnamelen) {
-  return lua_isnoneornil(L, idx) ||
-         wowless_isstringenum(L, idx, enumname, enumnamelen);
+static inline bool wowless_isnilablestringenum(lua_State *L, int idx,
+                                               std::string_view enumname) {
+  return lua_isnoneornil(L, idx) || wowless_isstringenum(L, idx, enumname);
 }
 
 static inline void wowless_stubcheckstringenum(lua_State *L, int idx,
-                                               const char *enumname,
-                                               size_t enumnamelen) {
-  if (!wowless_isstringenum(L, idx, enumname, enumnamelen)) {
+                                               std::string_view enumname) {
+  if (!wowless_isstringenum(L, idx, enumname)) {
     if (lua_type(L, idx) != LUA_TSTRING) {
       luaL_checktype(L, idx, LUA_TSTRING);
     } else {
@@ -367,10 +357,9 @@ static inline void wowless_stubcheckstringenum(lua_State *L, int idx,
   }
 }
 
-static inline void wowless_stubchecknilablestringenum(lua_State *L, int idx,
-                                                      const char *enumname,
-                                                      size_t enumnamelen) {
-  if (!wowless_isnilablestringenum(L, idx, enumname, enumnamelen)) {
+static inline void wowless_stubchecknilablestringenum(
+    lua_State *L, int idx, std::string_view enumname) {
+  if (!wowless_isnilablestringenum(L, idx, enumname)) {
     if (lua_type(L, idx) != LUA_TSTRING) {
       luaL_checktype(L, idx, LUA_TSTRING);
     } else {
@@ -379,17 +368,17 @@ static inline void wowless_stubchecknilablestringenum(lua_State *L, int idx,
   }
 }
 
-static inline void wowless_stubcreateluaobject(lua_State *L, const char *tname,
-                                               size_t typenamelen) {
+static inline void wowless_stubcreateluaobject(lua_State *L,
+                                               std::string_view tname) {
   lua_getfield(L, lua_upvalueindex(1), "CreateLuaObject");
-  lua_pushlstring(L, tname, typenamelen);
+  lua_pushlstring(L, tname.data(), tname.size());
   lua_call(L, 1, 1);
 }
 
-static inline void wowless_stubcreateuiobject(lua_State *L, const char *tname,
-                                              size_t typenamelen) {
+static inline void wowless_stubcreateuiobject(lua_State *L,
+                                              std::string_view tname) {
   lua_getfield(L, lua_upvalueindex(1), "CreateUiObject");
-  lua_pushlstring(L, tname, typenamelen);
+  lua_pushlstring(L, tname.data(), tname.size());
   lua_call(L, 1, 1);
 }
 
@@ -519,21 +508,19 @@ static inline void wowless_implcheckany(lua_State *L, int idx) {}
 static inline void wowless_implchecknilableany(lua_State *L, int idx) {}
 
 static inline void wowless_implcheckluaobject(lua_State *L, int idx,
-                                              const char *tname,
-                                              size_t typenamelen) {
+                                              std::string_view tname) {
   idx = lua_absindex(L, idx);
   lua_getfield(L, lua_upvalueindex(1), "ImplInputLuaObject");
   lua_pushvalue(L, idx);
-  lua_pushlstring(L, tname, typenamelen);
+  lua_pushlstring(L, tname.data(), tname.size());
   lua_call(L, 2, 1);
   lua_replace(L, idx);
 }
 
 static inline void wowless_implchecknilableluaobject(lua_State *L, int idx,
-                                                     const char *tname,
-                                                     size_t typenamelen) {
+                                                     std::string_view tname) {
   if (!lua_isnoneornil(L, idx)) {
-    wowless_implcheckluaobject(L, idx, tname, typenamelen);
+    wowless_implcheckluaobject(L, idx, tname);
   }
 }
 
@@ -676,40 +663,36 @@ static inline void wowless_imploutputnilabletable(lua_State *L, int idx) {
 }
 
 static inline void wowless_imploutputluaobject(lua_State *L, int idx,
-                                               const char *tname,
-                                               size_t typenamelen) {
+                                               std::string_view tname) {
   idx = lua_absindex(L, idx);
   lua_getfield(L, lua_upvalueindex(1), "ImplOutputLuaObject");
   lua_pushvalue(L, idx);
-  lua_pushlstring(L, tname, typenamelen);
+  lua_pushlstring(L, tname.data(), tname.size());
   lua_call(L, 2, 1);
   lua_replace(L, idx);
 }
 
 static inline void wowless_imploutputnilableluaobject(lua_State *L, int idx,
-                                                      const char *tname,
-                                                      size_t typenamelen) {
+                                                      std::string_view tname) {
   if (!lua_isnoneornil(L, idx)) {
-    wowless_imploutputluaobject(L, idx, tname, typenamelen);
+    wowless_imploutputluaobject(L, idx, tname);
   }
 }
 
 static inline void wowless_imploutputuiobject(lua_State *L, int idx,
-                                              const char *tname,
-                                              size_t typenamelen) {
+                                              std::string_view tname) {
   idx = lua_absindex(L, idx);
   lua_getfield(L, lua_upvalueindex(1), "ImplOutputUiObject");
   lua_pushvalue(L, idx);
-  lua_pushlstring(L, tname, typenamelen);
+  lua_pushlstring(L, tname.data(), tname.size());
   lua_call(L, 2, 1);
   lua_replace(L, idx);
 }
 
 static inline void wowless_imploutputnilableuiobject(lua_State *L, int idx,
-                                                     const char *tname,
-                                                     size_t typenamelen) {
+                                                     std::string_view tname) {
   if (!lua_isnoneornil(L, idx)) {
-    wowless_imploutputuiobject(L, idx, tname, typenamelen);
+    wowless_imploutputuiobject(L, idx, tname);
   }
 }
 
@@ -750,12 +733,11 @@ static inline void wowless_applymixin(lua_State *L, const char *mixin_name) {
   lua_pop(L, 1);
 }
 
-#ifdef __cplusplus
 template <void Check(lua_State *, int)>
 static void wowless_stubcheckarrayof(lua_State *L, int idx) {
   idx = lua_absindex(L, idx);
   wowless_stubchecktable(L, idx);
-  int n = (int)lua_objlen(L, idx);
+  int n = static_cast<int>(lua_objlen(L, idx));
   for (int i = 1; i <= n; i++) {
     lua_rawgeti(L, idx, i);
     Check(L, -1);
@@ -769,6 +751,5 @@ static void wowless_stubchecknilablearrayof(lua_State *L, int idx) {
     wowless_stubcheckarrayof<Check>(L, idx);
   }
 }
-#endif
 
 #endif /* WOWLESS_TYPECHECK_H */


### PR DESCRIPTION
## Summary

- Rename `ctypecheck.c` → `ctypecheck.cpp`; add `extern "C"` on `luaopen_wowless_modules_ctypecheck`
- `typecheck.h`: remove `#ifdef __cplusplus` guards (file is now C++ only), add `#include <string_view>`, convert all `(const char*, size_t)` typed-name parameters to `std::string_view`, change `is*` predicate return types from `int` to `bool`
- `stubs.cpp`: `static_cast` instead of C-style cast, drop redundant `struct` keyword, move `ns` variable into `for` loop
- `prep.lua`: emit `nullptr` instead of `NULL`, drop hardcoded string lengths (string literals construct `string_view` with compile-time-known length via `__builtin_strlen`), emit `bool` return types for generated `is*` wrappers, drop redundant `struct` keyword in emitted type names

## Test plan

- [x] `cmake --build --preset default --target test` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)