### PR TITLE
runner: modules do not escape runner.run

### DIFF
--- a/wowless/runner.lua
+++ b/wowless/runner.lua
@@ -296,12 +296,20 @@ local function simulate(cfg)
   end
   assert(issecure(), 'wowless bug: framework is tainted')
 
-  return modules,
-    {
-      done = genv.WowlessTestsDone,
-      failures = genv.WowlessTestFailures,
-      errorCount = modules.errors.GetErrorCount(),
-    }
+  local result = {
+    done = genv.WowlessTestsDone,
+    failures = genv.WowlessTestFailures,
+    errorCount = modules.errors.GetErrorCount(),
+  }
+  if cfg.profile then
+    local runner = require('wowless.runner')
+    require('wowless.profiler').write({
+      modules = modules,
+      product = cfg.product,
+      runner = runner,
+    })
+  end
+  return result
 end
 
 local function run(cfg)
@@ -311,16 +319,7 @@ local function run(cfg)
     if cfg.profile then
       debug.setprofilingenabled(true)
     end
-    local runner = require('wowless.runner')
-    local modules, result = runner.simulate(cfg)
-    if cfg.profile then
-      require('wowless.profiler').write({
-        modules = modules,
-        product = cfg.product,
-        runner = runner,
-      })
-    end
-    return result
+    return require('wowless.runner').simulate(cfg)
   ]],
     cfg
   )


### PR DESCRIPTION
## Summary

- Move the profiler call into `simulate` so `modules` stays local to that function and does not appear in the return value
- Simplify the `newstate` chunk in `run` to a single `return require('wowless.runner').simulate(cfg)`

## Test plan

- [x] Tests pass (`cmake --build --preset default --target test`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)