### PR TITLE
uiobjects: replace newproxy identity token with C full userdata

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -872,6 +872,7 @@ lua2c(
   wowless.profiler=${CMAKE_CURRENT_SOURCE_DIR}/wowless/profiler.lua
   wowless.runner=${CMAKE_CURRENT_SOURCE_DIR}/wowless/runner.lua
   wowless.secure=c
+  wowless.uiobject=c
   wowless.xml=${CMAKE_CURRENT_SOURCE_DIR}/wowless/xml.lua
   toolsprettywrite=p)
 target_sources(
@@ -882,7 +883,8 @@ target_sources(
           wowless/modules/ctypecheck.cpp
           wowless/modules/encodingutil.c
           wowless/secure.c
-          wowless/stubs.cpp)
+          wowless/stubs.cpp
+          wowless/uiobject.c)
 
 add_lua_executable(
   wowless

--- a/wowless/modules/api.lua
+++ b/wowless/modules/api.lua
@@ -1,4 +1,5 @@
 local hlist = require('wowless.hlist')
+local uiobject = require('wowless.uiobject')
 
 return function(
   datalua,
@@ -17,6 +18,13 @@ return function(
   local genv = env.genv
   local secureenv = env.secureenv
   local userdata = uiobjects.userdata
+  local nextid = (function()
+    local n = 0
+    return function()
+      n = n + 1
+      return n
+    end
+  end)()
 
   local InheritsFrom = uiobjecttypes.InheritsFrom
   local IsIntrinsicType = uiobjecttypes.IsIntrinsicType
@@ -124,13 +132,14 @@ return function(
     end
     local objtype = uiobjecttypes.GetOrThrow(typename)
     log(3, 'creating %s%s', objtype.name, objname and (' named ' .. objname) or '')
-    local objp = newproxy(nil)
+    local regid = nextid()
+    local objp = uiobject.new(regid)
     local obj = setmetatable({ [0] = objp }, objtype.sandboxMT)
     local ud = objtype.constructor()
     ud.luarep = obj
     ud.name = objname
     ud.type = typename
-    userdata[objp] = ud
+    userdata[regid] = ud
     setmetatable(ud, objtype.hostMT)
     DoSetParent(ud, parent)
     if InheritsFrom(typename, 'frame') then

--- a/wowless/modules/cgencode.lua
+++ b/wowless/modules/cgencode.lua
@@ -55,7 +55,7 @@ return function(addons, api, events, log, luaobjects, uiobjects, uiobjecttypes, 
   end
 
   local function IsUiObject(ud, typename)
-    local internal = uiobjects.userdata[ud]
+    local internal = uiobjects.UserData(ud)
     return internal and uiobjecttypes.IsObjectType(internal, typename)
   end
 

--- a/wowless/modules/uiobjects.lua
+++ b/wowless/modules/uiobjects.lua
@@ -3,15 +3,7 @@ local uiobject = require('wowless.uiobject')
 return function()
   local userdata = {}
   local function UserData(obj)
-    if type(obj) ~= 'table' then
-      return nil
-    end
-    local token = rawget(obj, 0)
-    if token == nil then
-      return nil
-    end
-    local id = uiobject.id(token)
-    return id and userdata[id]
+    return userdata[uiobject.id(rawget(obj, 0))]
   end
   return {
     userdata = userdata,

--- a/wowless/modules/uiobjects.lua
+++ b/wowless/modules/uiobjects.lua
@@ -3,7 +3,7 @@ local uiobject = require('wowless.uiobject')
 return function()
   local userdata = {}
   local function UserData(obj)
-    return userdata[uiobject.id(rawget(obj, 0))]
+    return userdata[uiobject.id(obj[0])]
   end
   return {
     userdata = userdata,

--- a/wowless/modules/uiobjects.lua
+++ b/wowless/modules/uiobjects.lua
@@ -1,7 +1,17 @@
+local uiobject = require('wowless.uiobject')
+
 return function()
   local userdata = {}
   local function UserData(obj)
-    return userdata[obj[0]]
+    if type(obj) ~= 'table' then
+      return nil
+    end
+    local token = rawget(obj, 0)
+    if token == nil then
+      return nil
+    end
+    local id = uiobject.id(token)
+    return id and userdata[id]
   end
   return {
     userdata = userdata,

--- a/wowless/typecheck.h
+++ b/wowless/typecheck.h
@@ -264,8 +264,9 @@ static inline bool wowless_isuiobject(lua_State *L, int idx,
     lua_pop(L, 1);
     return false;
   }
+  lua_pop(L, 1);
   lua_getfield(L, lua_upvalueindex(1), "IsUiObject");
-  lua_insert(L, -2);
+  lua_pushvalue(L, idx);
   lua_pushlstring(L, tname.data(), tname.size());
   lua_call(L, 2, 1);
   int result = lua_toboolean(L, -1);

--- a/wowless/uiobject.c
+++ b/wowless/uiobject.c
@@ -23,11 +23,17 @@ static int wowless_uiobject_new(lua_State *L) {
 }
 
 static int wowless_uiobject_id(lua_State *L) {
-  if (lua_type(L, 1) != LUA_TUSERDATA) goto fail;
-  if (lua_objlen(L, 1) != sizeof(struct wowless_uiobject_data)) goto fail;
+  if (lua_type(L, 1) != LUA_TUSERDATA) {
+    goto fail;
+  }
+  if (lua_objlen(L, 1) != sizeof(struct wowless_uiobject_data)) {
+    goto fail;
+  }
   {
     struct wowless_uiobject_data *ud = lua_touserdata(L, 1);
-    if (ud->marker != &wowless_uiobject_marker) goto fail;
+    if (ud->marker != &wowless_uiobject_marker) {
+      goto fail;
+    }
     lua_pushinteger(L, ud->id);
     return 1;
   }

--- a/wowless/uiobject.c
+++ b/wowless/uiobject.c
@@ -1,0 +1,49 @@
+#include "lauxlib.h"
+#include "lua.h"
+
+/*
+ * Stored at the start of every uiobject token userdata.
+ * Its address acts as an in-memory marker so we can identify our userdata
+ * without needing a metatable (keeping getmetatable(token) == nil).
+ */
+static const char wowless_uiobject_marker;
+
+struct wowless_uiobject_data {
+  const void *marker;
+  int id;
+};
+
+static int wowless_uiobject_new(lua_State *L) {
+  int id = luaL_checkinteger(L, 1);
+  struct wowless_uiobject_data *ud =
+      lua_newuserdata(L, sizeof(struct wowless_uiobject_data));
+  ud->marker = &wowless_uiobject_marker;
+  ud->id = id;
+  return 1;
+}
+
+static int wowless_uiobject_id(lua_State *L) {
+  if (lua_type(L, 1) != LUA_TUSERDATA) goto fail;
+  if (lua_objlen(L, 1) != sizeof(struct wowless_uiobject_data)) goto fail;
+  {
+    struct wowless_uiobject_data *ud = lua_touserdata(L, 1);
+    if (ud->marker != &wowless_uiobject_marker) goto fail;
+    lua_pushinteger(L, ud->id);
+    return 1;
+  }
+fail:
+  lua_pushnil(L);
+  return 1;
+}
+
+static const struct luaL_Reg lib[] = {
+    {"id",  wowless_uiobject_id },
+    {"new", wowless_uiobject_new},
+    {NULL,  NULL                }
+};
+
+int luaopen_wowless_uiobject(lua_State *L) {
+  lua_newtable(L);
+  luaL_register(L, NULL, lib);
+  return 1;
+}

--- a/wowless/uiobject.c
+++ b/wowless/uiobject.c
@@ -23,23 +23,15 @@ static int wowless_uiobject_new(lua_State *L) {
 }
 
 static int wowless_uiobject_id(lua_State *L) {
-  if (lua_type(L, 1) != LUA_TUSERDATA) {
-    goto fail;
-  }
-  if (lua_objlen(L, 1) != sizeof(struct wowless_uiobject_data)) {
-    goto fail;
-  }
-  {
+  if (lua_type(L, 1) == LUA_TUSERDATA &&
+      lua_objlen(L, 1) == sizeof(struct wowless_uiobject_data)) {
     struct wowless_uiobject_data *ud = lua_touserdata(L, 1);
-    if (ud->marker != &wowless_uiobject_marker) {
-      goto fail;
+    if (ud->marker == &wowless_uiobject_marker) {
+      lua_pushinteger(L, ud->id);
+      return 1;
     }
-    lua_pushinteger(L, ud->id);
-    return 1;
   }
-fail:
-  lua_pushnil(L);
-  return 1;
+  return 0;
 }
 
 static const struct luaL_Reg lib[] = {


### PR DESCRIPTION
## Summary

- Introduces `wowless/uiobject.c`: a new C module with `new(id)` (creates a full userdata storing an integer ID) and `id(ud)` (extracts the integer, or nil if not a wowless uiobject token)
- The identity token at `obj[0]` changes from `newproxy(nil)` to this C full userdata — the sandbox object itself remains a Lua table
- The integer ID is used as the key in the host-side `userdata` table, making object identity state-independent (prerequisite for eventual two-Lua-state separation)
- The C userdata uses an in-memory struct marker (`const void *marker` field pointing to a static address) for identification, so `getmetatable(obj[0])` remains `nil`

## Test plan

- [ ] All existing tests pass (`cmake --build --preset default --target test`)
- [ ] All pre-commit hooks pass (`pre-commit run -a`)
- [ ] `type(frame)` still returns `'table'`
- [ ] `getmetatable(frame[0])` still returns `nil`

🤖 Generated with [Claude Code](https://claude.com/claude-code)