### PR TITLE
uiobjects: move type field from Lua table to C userdata

### DIFF
--- a/wowless/modules/api.lua
+++ b/wowless/modules/api.lua
@@ -133,12 +133,11 @@ return function(
     local objtype = uiobjecttypes.GetOrThrow(typename)
     log(3, 'creating %s%s', objtype.name, objname and (' named ' .. objname) or '')
     local regid = nextid()
-    local objp = uiobject.new(regid)
+    local objp = uiobject.new(regid, typename)
     local obj = setmetatable({ [0] = objp }, objtype.sandboxMT)
     local ud = objtype.constructor()
     ud.luarep = obj
     ud.name = objname
-    ud.type = typename
     userdata[regid] = ud
     setmetatable(ud, objtype.hostMT)
     DoSetParent(ud, parent)

--- a/wowless/modules/loader.lua
+++ b/wowless/modules/loader.lua
@@ -256,18 +256,18 @@ return function(
     end,
     color = function(ctx, e, parent)
       local r, g, b, a = getColor(e)
-      if uiobjecttypes.InheritsFrom(parent.type, 'texturebase') then
+      if uiobjecttypes.InheritsFrom(uiobjecttypes.GetType(parent), 'texturebase') then
         parent:SetColorTexture(r, g, b, a)
-      elseif uiobjecttypes.InheritsFrom(parent.type, 'fontinstance') then
+      elseif uiobjecttypes.InheritsFrom(uiobjecttypes.GetType(parent), 'fontinstance') then
         if ctx.shadow then
           parent:SetShadowColor(r, g, b, a)
         else
           parent:SetTextColor(r, g, b, a)
         end
-      elseif uiobjecttypes.InheritsFrom(parent.type, 'statusbar') then
+      elseif uiobjecttypes.InheritsFrom(uiobjecttypes.GetType(parent), 'statusbar') then
         parent:SetStatusBarColor(r, g, b, a)
       else
-        error('cannot apply color to ' .. parent.type)
+        error('cannot apply color to ' .. uiobjecttypes.GetType(parent))
       end
     end,
     edgetexture = function(_, e, parent)
@@ -455,7 +455,7 @@ return function(
         elseif attr.impl.method then
           local fn = obj[attr.impl.method]
           if not fn then
-            error(('missing method %q on object type %q'):format(attr.impl.method, obj.type))
+            error(('missing method %q on object type %q'):format(attr.impl.method, uiobjecttypes.GetType(obj)))
           elseif type(v) == 'table' then -- stringlist
             fn(obj, unpack(v))
           else
@@ -469,7 +469,7 @@ return function(
       end
 
       local function processAttrs(ctx, e, obj, phase)
-        local objty = obj.type
+        local objty = uiobjecttypes.GetType(obj)
         local attrs = (xmlimpls[objty] or intrinsics[objty]).attrs
         for k, v in pairs(e.attr) do
           local attr = attrs[k]

--- a/wowless/modules/region.lua
+++ b/wowless/modules/region.lua
@@ -1,3 +1,5 @@
+local uiobject = require('wowless.uiobject')
+
 return function(dirty, system, visibility)
   local IsVisible = visibility.IsVisible
   local SetDirty = dirty.SetDirty
@@ -161,22 +163,23 @@ return function(dirty, system, visibility)
 
   local function SetHeight(r, h)
     if h ~= r.height then
-      r.height = r.type == 'fontstring' and h == 0 and 1 or h
+      r.height = uiobject.type(r.luarep[0]) == 'fontstring' and h == 0 and 1 or h
       SetDirty(r)
     end
   end
 
   local function SetSize(r, w, h)
     if w ~= r.width or h ~= r.height then
-      r.width = r.type == 'fontstring' and w == 0 and 1 or w
-      r.height = r.type == 'fontstring' and h == 0 and 1 or h
+      local isfontstring = uiobject.type(r.luarep[0]) == 'fontstring'
+      r.width = isfontstring and w == 0 and 1 or w
+      r.height = isfontstring and h == 0 and 1 or h
       SetDirty(r)
     end
   end
 
   local function SetWidth(r, w)
     if w ~= r.width then
-      r.width = r.type == 'fontstring' and w == 0 and 1 or w
+      r.width = uiobject.type(r.luarep[0]) == 'fontstring' and w == 0 and 1 or w
       SetDirty(r)
     end
   end

--- a/wowless/modules/scripts.lua
+++ b/wowless/modules/scripts.lua
@@ -4,7 +4,7 @@ return function(env, log, security, uiobjecttypes)
   end
 
   local function HasScript(obj, script)
-    return uiobjecttypes.HasScript(obj.type, script:lower())
+    return uiobjecttypes.HasScript(uiobjecttypes.GetType(obj), script:lower())
   end
 
   local function HookScript(obj, name, script, bindingType)
@@ -44,7 +44,7 @@ return function(env, log, security, uiobjecttypes)
 
   local function SetScript(obj, name, script)
     if not HasScript(obj, name) then
-      error(('object type %s does not support script type %s'):format(obj.type, name))
+      error(('object type %s does not support script type %s'):format(uiobjecttypes.GetType(obj), name))
     end
     return SetScriptWithBindingType(obj, name, 1, script)
   end

--- a/wowless/modules/uiobjectloader.lua
+++ b/wowless/modules/uiobjectloader.lua
@@ -61,8 +61,8 @@ return function(datalua, funcheck, gencode, sqls, uiobjectsmodule, uiobjecttypes
       local lname = name:lower()
       local function wrap(fname, fn)
         return function(self, ...)
-          if not InheritsFrom(self.type, lname) then
-            error(('invalid self to %s.%s, got %s'):format(name, fname, tostring(self.type)))
+          if not InheritsFrom(uiobjecttypes.GetType(self), lname) then
+            error(('invalid self to %s.%s, got %s'):format(name, fname, uiobjecttypes.GetType(self)))
           end
           return fn(self, ...)
         end

--- a/wowless/modules/uiobjecttypes.lua
+++ b/wowless/modules/uiobjecttypes.lua
@@ -1,3 +1,5 @@
+local uiobject = require('wowless.uiobject')
+
 return function()
   local uiobjectTypes = {}
 
@@ -5,8 +7,12 @@ return function()
     uiobjectTypes[name] = t
   end
 
+  local function GetType(obj)
+    return uiobject.type(obj.luarep[0])
+  end
+
   local function GetObjectType(obj)
-    return uiobjectTypes[obj.type].name
+    return uiobjectTypes[GetType(obj)].name
   end
 
   local function GetOrThrow(name)
@@ -43,7 +49,7 @@ return function()
 
   local function IsObjectType(obj, ty)
     ty = string.lower(ty)
-    return uiobjectTypes[obj.type].isa[ty] or false
+    return uiobjectTypes[GetType(obj)].isa[ty] or false
   end
 
   return {
@@ -51,6 +57,7 @@ return function()
     GetObjectType = GetObjectType,
     GetOrThrow = GetOrThrow,
     GetSandboxMetatable = GetSandboxMetatable,
+    GetType = GetType,
     Has = Has,
     HasScript = HasScript,
     InheritsFrom = InheritsFrom,

--- a/wowless/uiobject.c
+++ b/wowless/uiobject.c
@@ -11,33 +11,54 @@ static const char wowless_uiobject_marker;
 struct wowless_uiobject_data {
   const void *marker;
   int id;
+  const char *type; /* interned Lua string pointer; valid for lifetime of state */
 };
+
+static const struct wowless_uiobject_data *check_data(lua_State *L, int idx) {
+  if (lua_type(L, idx) == LUA_TUSERDATA &&
+      lua_objlen(L, idx) == sizeof(struct wowless_uiobject_data)) {
+    const struct wowless_uiobject_data *ud = lua_touserdata(L, idx);
+    if (ud->marker == &wowless_uiobject_marker) {
+      return ud;
+    }
+  }
+  return NULL;
+}
 
 static int wowless_uiobject_new(lua_State *L) {
   int id = luaL_checkinteger(L, 1);
+  const char *type = luaL_checkstring(L, 2);
   struct wowless_uiobject_data *ud =
       lua_newuserdata(L, sizeof(struct wowless_uiobject_data));
   ud->marker = &wowless_uiobject_marker;
   ud->id = id;
+  ud->type = type;
   return 1;
 }
 
 static int wowless_uiobject_id(lua_State *L) {
-  if (lua_type(L, 1) == LUA_TUSERDATA &&
-      lua_objlen(L, 1) == sizeof(struct wowless_uiobject_data)) {
-    struct wowless_uiobject_data *ud = lua_touserdata(L, 1);
-    if (ud->marker == &wowless_uiobject_marker) {
-      lua_pushinteger(L, ud->id);
-      return 1;
-    }
+  const struct wowless_uiobject_data *ud = check_data(L, 1);
+  if (ud) {
+    lua_pushinteger(L, ud->id);
+    return 1;
+  }
+  return 0;
+}
+
+static int wowless_uiobject_type(lua_State *L) {
+  const struct wowless_uiobject_data *ud = check_data(L, 1);
+  if (ud) {
+    lua_pushstring(L, ud->type);
+    return 1;
   }
   return 0;
 }
 
 static const struct luaL_Reg lib[] = {
-    {"id",  wowless_uiobject_id },
-    {"new", wowless_uiobject_new},
-    {NULL,  NULL                }
+    {"id",   wowless_uiobject_id  },
+    {"new",  wowless_uiobject_new },
+    {"type", wowless_uiobject_type},
+    {NULL,   NULL                 }
 };
 
 int luaopen_wowless_uiobject(lua_State *L) {


### PR DESCRIPTION
## Summary

- Extends `wowless_uiobject_data` (from #648) with a `const char *type` field
- `uiobject.new(id, typename)` stores the type name in C; `uiobject.type(token)` retrieves it
- Removes `ud.type = typename` from `api.lua`
- Adds `uiobjecttypes.GetType(ud)` as the canonical Lua accessor; updates all call sites in `loader.lua`, `scripts.lua`, `uiobjectloader.lua`
- `region.lua` reads the type directly via `uiobject.type(r.luarep[0])`

## Test plan

- [x] `cmake --build --preset default --target test` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)