### PR TITLE
loader: fix IsObjectType to return false for intrinsic type names

### DIFF
--- a/addon/Wowless/test.xml
+++ b/addon/Wowless/test.xml
@@ -172,7 +172,7 @@
     assertEquals(true, obj ~= nil)
     assertEquals('Frame', obj:GetObjectType())
     assertEquals(true, obj:IsObjectType('Frame'))
-    assertEquals(__wowless ~= nil, obj:IsObjectType('WowlessIntrinsicType')) -- TODO fix wowless
+    assertEquals(false, obj:IsObjectType('WowlessIntrinsicType'))
   </Script>
   <WowlessIntrinsicType>
     <Scripts>

--- a/wowless/modules/loader.lua
+++ b/wowless/modules/loader.lua
@@ -553,11 +553,10 @@ return function(
             log(3, 'creating intrinsic %s', e.attr.name)
             local basetype = string.lower(e.type)
             local base = uiobjecttypes.GetOrThrow(basetype)
-            local isa = base.isa
             uiobjecttypes.Add(name, {
               constructor = base.constructor,
               hostMT = base.hostMT,
-              isa = isa,
+              isa = base.isa,
               name = base.name,
               sandboxMT = base.sandboxMT,
               scripts = base.scripts,

--- a/wowless/modules/loader.lua
+++ b/wowless/modules/loader.lua
@@ -553,7 +553,7 @@ return function(
             log(3, 'creating intrinsic %s', e.attr.name)
             local basetype = string.lower(e.type)
             local base = uiobjecttypes.GetOrThrow(basetype)
-            local isa = mixin({ [name] = true }, base.isa)
+            local isa = base.isa
             uiobjecttypes.Add(name, {
               constructor = base.constructor,
               hostMT = base.hostMT,


### PR DESCRIPTION
## Summary

- `IsObjectType('WowlessIntrinsicType')` incorrectly returned `true` in wowless; the real WoW client returns `false` because `IsObjectType` only recognizes built-in C++ widget types, not dynamically-registered intrinsic names
- Fixed by removing `[name] = true` from the `isa` table when registering an intrinsic type — it now simply inherits the base type's `isa` unchanged
- Updated the test to assert `false` unconditionally, removing the `__wowless ~= nil` workaround and its TODO comment

## Test plan

- [ ] `cmake --build --preset default --target test` passes with no output

🤖 Generated with [Claude Code](https://claude.com/claude-code)