### PR TITLE
stubs: add uiobject to impl_input_types

### DIFF
--- a/data/modules.yaml
+++ b/data/modules.yaml
@@ -32,6 +32,7 @@ cgencode:
     events:
     log:
     luaobjects:
+    uiobjects:
     uiobjecttypes:
     units:
 clog:

--- a/tools/prep.lua
+++ b/tools/prep.lua
@@ -275,6 +275,7 @@ local impl_input_types = {
   structure = nop,
   table = nop,
   uiAddon = nop,
+  uiobject = nop,
   unit = nop,
   unknown = nop,
 }
@@ -1016,6 +1017,8 @@ if args.coutput then
     emit('static bool wowless_isnilableuiobject_%s(lua_State *L, int idx);', safename(uname))
     emit('static void wowless_stubcheckuiobject_%s(lua_State *L, int idx);', safename(uname))
     emit('static void wowless_stubchecknilableuiobject_%s(lua_State *L, int idx);', safename(uname))
+    emit('static void wowless_implcheckuiobject_%s(lua_State *L, int idx);', safename(uname))
+    emit('static void wowless_implchecknilableuiobject_%s(lua_State *L, int idx);', safename(uname))
   end
   emit('')
 
@@ -1075,6 +1078,14 @@ if args.coutput then
     emit('')
     emit('static void wowless_stubchecknilableuiobject_%s(lua_State *L, int idx) {', safename(uname))
     emit('  if (!wowless_isnilableuiobject_%s(L, idx)) luaL_typerror(L, idx, "uiobject");', safename(uname))
+    emit('}')
+    emit('')
+    emit('static void wowless_implcheckuiobject_%s(lua_State *L, int idx) {', safename(uname))
+    emit('  wowless_implcheckuiobject(L, idx, %d);', uitype_bits[uname])
+    emit('}')
+    emit('')
+    emit('static void wowless_implchecknilableuiobject_%s(lua_State *L, int idx) {', safename(uname))
+    emit('  wowless_implchecknilableuiobject(L, idx, %d);', uitype_bits[uname])
     emit('}')
     emit('')
   end

--- a/wowless/modules/cgencode.lua
+++ b/wowless/modules/cgencode.lua
@@ -1,6 +1,6 @@
 local bubblewrap = require('wowless.bubblewrap')
 
-return function(addons, api, events, log, luaobjects, uiobjecttypes, units)
+return function(addons, api, events, log, luaobjects, uiobjects, uiobjecttypes, units)
   local stringenums = require('runtime.stringenums')
 
   local function CheckStringEnum(value, enumname)
@@ -58,7 +58,10 @@ return function(addons, api, events, log, luaobjects, uiobjecttypes, units)
     events.SendEvent('ADDON_ACTION_FORBIDDEN', taint, 'UNKNOWN()')
   end
 
+  -- Index 1 is accessed from C via lua_rawgeti for a hot-path array-part lookup
+  -- (no hashing). Keep uiobjects.userdata first; string keys below can shift freely.
   return {
+    uiobjects.userdata,
     CheckStringEnum = CheckStringEnum,
     FireProtected = bubblewrap(FireProtected),
     GetUiAddon = GetUiAddon,

--- a/wowless/typecheck.h
+++ b/wowless/typecheck.h
@@ -524,6 +524,37 @@ static inline void wowless_implchecknilableluaobject(lua_State *L, int idx,
   }
 }
 
+static inline void wowless_implcheckuiobject(lua_State *L, int idx,
+                                             int type_bit) {
+  idx = lua_absindex(L, idx);
+  lua_rawgeti(L, idx, 0);
+  if (lua_type(L, -1) == LUA_TUSERDATA &&
+      lua_objlen(L, -1) == sizeof(struct wowless_uiobject_data)) {
+    const struct wowless_uiobject_data *ud =
+        (const struct wowless_uiobject_data *)lua_touserdata(L, -1);
+    if (ud->marker == &wowless_uiobject_marker &&
+        ((ud->uitype->isa_mask >> type_bit) & 1)) {
+      int id = ud->id;
+      /* cgencode[1] is uiobjects.userdata (integer-keyed by ud->id); both
+       * lookups hit the array part directly — keep uiobjects.userdata at
+       * index 1 in cgencode's return table. */
+      lua_rawgeti(L, lua_upvalueindex(1), 1);
+      lua_rawgeti(L, -1, id);
+      lua_replace(L, idx);
+      lua_pop(L, 2);
+      return;
+    }
+  }
+  luaL_typerror(L, idx, "uiobject");
+}
+
+static inline void wowless_implchecknilableuiobject(lua_State *L, int idx,
+                                                    int type_bit) {
+  if (!lua_isnoneornil(L, idx)) {
+    wowless_implcheckuiobject(L, idx, type_bit);
+  }
+}
+
 static inline void wowless_imploutputoneornil(lua_State *L, int idx) {
   if (!lua_isnil(L, idx) &&
       !(lua_type(L, idx) == LUA_TNUMBER && lua_tonumber(L, idx) == 1)) {


### PR DESCRIPTION
Closes #623.

## Summary
- Add `uiobjects` back to `cgencode` module deps and expose `uiobjects.userdata` at integer index 1 of the return table; C uses `lua_rawgeti(..., 1)` (array-part lookup, no hashing) instead of a string key
- Add `wowless_implcheckuiobject` / `wowless_implchecknilableuiobject` to `typecheck.h`: reads `ud->id` and `ud->uitype->isa_mask` directly in C (no Lua callback), then does two `lua_rawgeti` array-part lookups to replace the stack slot with the internal object
- Add `uiobject` to `impl_input_types` in `prep.lua` to mark it eligible for impl C wrappers
- Emit per-type `implcheckuiobject_xxx` / `implchecknilableuiobject_xxx` forward declarations and definitions alongside the existing `stubcheck` variants, passing `uitype_bits[uname]` as the type bit

## Test plan
- [ ] `cmake --build --preset default --target test` passes with no output

🤖 Generated with [Claude Code](https://claude.com/claude-code)