### PR TITLE
stubs: remove tostring input type, replace with any

### DIFF
--- a/data/products/wow/apis.yaml
+++ b/data/products/wow/apis.yaml
@@ -32192,7 +32192,7 @@ CreateForbiddenFrame:
     type: string
   - name: name
     nilable: true
-    type: tostring
+    type: any
   - name: parent
     nilable: true
     type:
@@ -32214,7 +32214,7 @@ CreateFrame:
     type: string
   - name: name
     nilable: true
-    type: tostring
+    type: any
   - name: parent
     nilable: true
     type:

--- a/data/products/wow_anniversary/apis.yaml
+++ b/data/products/wow_anniversary/apis.yaml
@@ -17314,7 +17314,7 @@ CreateForbiddenFrame:
     type: string
   - name: name
     nilable: true
-    type: tostring
+    type: any
   - name: parent
     nilable: true
     type:
@@ -17336,7 +17336,7 @@ CreateFrame:
     type: string
   - name: name
     nilable: true
-    type: tostring
+    type: any
   - name: parent
     nilable: true
     type:

--- a/data/products/wow_beta/apis.yaml
+++ b/data/products/wow_beta/apis.yaml
@@ -32136,7 +32136,7 @@ CreateForbiddenFrame:
     type: string
   - name: name
     nilable: true
-    type: tostring
+    type: any
   - name: parent
     nilable: true
     type:
@@ -32158,7 +32158,7 @@ CreateFrame:
     type: string
   - name: name
     nilable: true
-    type: tostring
+    type: any
   - name: parent
     nilable: true
     type:

--- a/data/products/wow_classic/apis.yaml
+++ b/data/products/wow_classic/apis.yaml
@@ -16605,7 +16605,7 @@ CreateForbiddenFrame:
     type: string
   - name: name
     nilable: true
-    type: tostring
+    type: any
   - name: parent
     nilable: true
     type:
@@ -16627,7 +16627,7 @@ CreateFrame:
     type: string
   - name: name
     nilable: true
-    type: tostring
+    type: any
   - name: parent
     nilable: true
     type:

--- a/data/products/wow_classic_era/apis.yaml
+++ b/data/products/wow_classic_era/apis.yaml
@@ -15587,7 +15587,7 @@ CreateForbiddenFrame:
     type: string
   - name: name
     nilable: true
-    type: tostring
+    type: any
   - name: parent
     nilable: true
     type:
@@ -15609,7 +15609,7 @@ CreateFrame:
     type: string
   - name: name
     nilable: true
-    type: tostring
+    type: any
   - name: parent
     nilable: true
     type:

--- a/data/products/wow_classic_era_ptr/apis.yaml
+++ b/data/products/wow_classic_era_ptr/apis.yaml
@@ -17314,7 +17314,7 @@ CreateForbiddenFrame:
     type: string
   - name: name
     nilable: true
-    type: tostring
+    type: any
   - name: parent
     nilable: true
     type:
@@ -17336,7 +17336,7 @@ CreateFrame:
     type: string
   - name: name
     nilable: true
-    type: tostring
+    type: any
   - name: parent
     nilable: true
     type:

--- a/data/products/wow_classic_ptr/apis.yaml
+++ b/data/products/wow_classic_ptr/apis.yaml
@@ -16605,7 +16605,7 @@ CreateForbiddenFrame:
     type: string
   - name: name
     nilable: true
-    type: tostring
+    type: any
   - name: parent
     nilable: true
     type:
@@ -16627,7 +16627,7 @@ CreateFrame:
     type: string
   - name: name
     nilable: true
-    type: tostring
+    type: any
   - name: parent
     nilable: true
     type:

--- a/data/products/wowt/apis.yaml
+++ b/data/products/wowt/apis.yaml
@@ -32643,7 +32643,7 @@ CreateForbiddenFrame:
     type: string
   - name: name
     nilable: true
-    type: tostring
+    type: any
   - name: parent
     nilable: true
     type:
@@ -32665,7 +32665,7 @@ CreateFrame:
     type: string
   - name: name
     nilable: true
-    type: tostring
+    type: any
   - name: parent
     nilable: true
     type:

--- a/data/products/wowxptr/apis.yaml
+++ b/data/products/wowxptr/apis.yaml
@@ -32136,7 +32136,7 @@ CreateForbiddenFrame:
     type: string
   - name: name
     nilable: true
-    type: tostring
+    type: any
   - name: parent
     nilable: true
     type:
@@ -32158,7 +32158,7 @@ CreateFrame:
     type: string
   - name: name
     nilable: true
-    type: tostring
+    type: any
   - name: parent
     nilable: true
     type:

--- a/data/schemas/type.yaml
+++ b/data/schemas/type.yaml
@@ -27,7 +27,6 @@ type:
         schema: structure
     table: tag
     TextureAsset: tag
-    tostring: tag
     uiAddon: tag
     uiobject:
       ref:

--- a/spec/wowless/modules/typecheck_align_spec.lua
+++ b/spec/wowless/modules/typecheck_align_spec.lua
@@ -150,7 +150,6 @@ describe('typecheck align', function()
     any = { ltype = 'any', sections = {} },
     gender = { ltype = 'gender', sections = {} },
     oneornil = { ltype = 'oneornil', sections = {} },
-    tostring = { ltype = 'tostring', sections = {} },
     structure = { ltype = { structure = 'TestStruct' }, sections = {} },
     arrayof = { ltype = { arrayof = 'number' }, sections = {} },
   }

--- a/wowless/modules/typecheck.lua
+++ b/wowless/modules/typecheck.lua
@@ -103,10 +103,6 @@ return function(addons, datalua, env, luaobjects, uiobjects, uiobjecttypes, unit
     table = function(value)
       return luatypecheck('table', value)
     end,
-    tostring = function(value)
-      local v = type(value) == 'number' and tostring(value) or value
-      return type(v) == 'string' and v or nil
-    end,
     uiAddon = function(value)
       if type(value) ~= 'string' and type(value) ~= 'number' then
         return nil, true

--- a/wowless/typecheck.h
+++ b/wowless/typecheck.h
@@ -527,22 +527,24 @@ static inline void wowless_implchecknilableluaobject(lua_State *L, int idx,
 static inline void wowless_implcheckuiobject(lua_State *L, int idx,
                                              int type_bit) {
   idx = lua_absindex(L, idx);
-  lua_rawgeti(L, idx, 0);
-  if (lua_type(L, -1) == LUA_TUSERDATA &&
-      lua_objlen(L, -1) == sizeof(struct wowless_uiobject_data)) {
-    const struct wowless_uiobject_data *ud =
-        (const struct wowless_uiobject_data *)lua_touserdata(L, -1);
-    if (ud->marker == &wowless_uiobject_marker &&
-        ((ud->uitype->isa_mask >> type_bit) & 1)) {
-      int id = ud->id;
-      /* cgencode[1] is uiobjects.userdata (integer-keyed by ud->id); both
-       * lookups hit the array part directly — keep uiobjects.userdata at
-       * index 1 in cgencode's return table. */
-      lua_rawgeti(L, lua_upvalueindex(1), 1);
-      lua_rawgeti(L, -1, id);
-      lua_replace(L, idx);
-      lua_pop(L, 2);
-      return;
+  if (lua_type(L, idx) == LUA_TTABLE) {
+    lua_rawgeti(L, idx, 0);
+    if (lua_type(L, -1) == LUA_TUSERDATA &&
+        lua_objlen(L, -1) == sizeof(struct wowless_uiobject_data)) {
+      const struct wowless_uiobject_data *ud =
+          (const struct wowless_uiobject_data *)lua_touserdata(L, -1);
+      if (ud->marker == &wowless_uiobject_marker &&
+          ((ud->uitype->isa_mask >> type_bit) & 1)) {
+        int id = ud->id;
+        /* cgencode[1] is uiobjects.userdata (integer-keyed by ud->id); both
+         * lookups hit the array part directly — keep uiobjects.userdata at
+         * index 1 in cgencode's return table. */
+        lua_rawgeti(L, lua_upvalueindex(1), 1);
+        lua_rawgeti(L, -1, id);
+        lua_replace(L, idx);
+        lua_pop(L, 2);
+        return;
+      }
     }
   }
   luaL_typerror(L, idx, "uiobject");


### PR DESCRIPTION
## Summary

- Removes the `tostring` type entirely from the type system; the two `CreateFrame`/`CreateForbiddenFrame` `name` parameters that used it now use `any`
- This makes those APIs `impl_input_eligible`, giving them C implstubs
- Fixes a pre-existing bug in `wowless_implcheckuiobject`: `lua_rawgeti` was called on an unchecked value, crashing (SIGSEGV) instead of raising a Lua error when a non-table was passed as a uiobject argument (e.g. a string frame name in a pcall test). The fix nests the happy path inside a `lua_type == LUA_TTABLE` guard, matching the surrounding style.

## Test plan

- [ ] Pre-commit hook (`build and test`) passes
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)