### PR TITLE
stubs: reimplement imploutput uiobjects in C without Lua calls

### DIFF
--- a/data/modules.yaml
+++ b/data/modules.yaml
@@ -33,7 +33,6 @@ cgencode:
     log:
     luaobjects:
     uiobjects:
-    uiobjecttypes:
     units:
 clog:
   deps:

--- a/tools/prep.lua
+++ b/tools/prep.lua
@@ -864,7 +864,7 @@ if args.coutput then
     table = simple_coutputtype('table'),
     uiobject = function(typename, nilable, idx)
       local ns = nilable and 'nilable' or ''
-      return string.format('wowless_imploutput%suiobject(L, %s, %s)', ns, idx, cstring(typename))
+      return string.format('wowless_imploutput%suiobject(L, %s, %d)', ns, idx, assert(uitype_bits[typename], typename))
     end,
     unit = simple_coutputtype('unit'),
     unknown = simple_coutputtype('unknown'),

--- a/wowless/modules/api.lua
+++ b/wowless/modules/api.lua
@@ -136,6 +136,7 @@ return function(
     local objp = new(regid, objtype.ctype)
     local obj = setmetatable({ [0] = objp }, objtype.sandboxMT)
     local ud = objtype.constructor()
+    ud[0] = objp
     ud.luarep = obj
     ud.name = objname
     ud.type = typename

--- a/wowless/modules/api.lua
+++ b/wowless/modules/api.lua
@@ -136,7 +136,7 @@ return function(
     local objp = new(regid, objtype.ctype)
     local obj = setmetatable({ [0] = objp }, objtype.sandboxMT)
     local ud = objtype.constructor()
-    ud[0] = objp
+    ud[1] = objp
     ud.luarep = obj
     ud.name = objname
     ud.type = typename

--- a/wowless/modules/cgencode.lua
+++ b/wowless/modules/cgencode.lua
@@ -1,6 +1,6 @@
 local bubblewrap = require('wowless.bubblewrap')
 
-return function(addons, api, events, log, luaobjects, uiobjects, uiobjecttypes, units)
+return function(addons, api, events, log, luaobjects, uiobjects, units)
   local stringenums = require('runtime.stringenums')
 
   local function CheckStringEnum(value, enumname)
@@ -43,13 +43,6 @@ return function(addons, api, events, log, luaobjects, uiobjects, uiobjecttypes, 
     return internal.luarep
   end
 
-  local function ImplOutputUiObject(internal, typename)
-    if type(internal) ~= 'table' or not uiobjecttypes.IsObjectType(internal, typename) then
-      error('impl output type error: expected uiobject ' .. typename)
-    end
-    return internal.luarep
-  end
-
   local function GetUiAddon(value)
     return addons.addons[tonumber(value) or tostring(value):lower()]
   end
@@ -68,7 +61,6 @@ return function(addons, api, events, log, luaobjects, uiobjects, uiobjecttypes, 
     GetUnit = units.GetUnit,
     ImplInputLuaObject = ImplInputLuaObject,
     ImplOutputLuaObject = ImplOutputLuaObject,
-    ImplOutputUiObject = ImplOutputUiObject,
     CreateLuaObject = CreateLuaObject,
     CreateUiObject = CreateUiObject,
     IsLuaObject = IsLuaObject,

--- a/wowless/runner.lua
+++ b/wowless/runner.lua
@@ -319,7 +319,8 @@ local function run(cfg)
     for _, obj in pairs(modules.uiobjects.userdata) do
       assert(UserData(obj.luarep) == obj)
       for k, v in pairs(obj) do
-        assert(type(v) ~= 'table' or (k ~= 'luarep') == not UserData(v), k)
+        local ud = type(v) == 'table' and UserData(v)
+        assert(not ud or (k == 'luarep') == (ud ~= v), k)
       end
     end
     assert(issecure(), 'wowless bug: framework is tainted')

--- a/wowless/runner.lua
+++ b/wowless/runner.lua
@@ -319,8 +319,7 @@ local function run(cfg)
     for _, obj in pairs(modules.uiobjects.userdata) do
       assert(UserData(obj.luarep) == obj)
       for k, v in pairs(obj) do
-        local ud = type(v) == 'table' and UserData(v)
-        assert(not ud or (k == 'luarep') == (ud ~= v), k)
+        assert(type(v) ~= 'table' or (k ~= 'luarep') == not UserData(v), k)
       end
     end
     assert(issecure(), 'wowless bug: framework is tainted')

--- a/wowless/typecheck.h
+++ b/wowless/typecheck.h
@@ -713,19 +713,35 @@ static inline void wowless_imploutputnilableluaobject(lua_State *L, int idx,
 }
 
 static inline void wowless_imploutputuiobject(lua_State *L, int idx,
-                                              std::string_view tname) {
+                                              int type_bit) {
   idx = lua_absindex(L, idx);
-  lua_getfield(L, lua_upvalueindex(1), "ImplOutputUiObject");
-  lua_pushvalue(L, idx);
-  lua_pushlstring(L, tname.data(), tname.size());
-  lua_call(L, 2, 1);
-  lua_replace(L, idx);
+  if (lua_type(L, idx) == LUA_TTABLE) {
+    lua_getfield(L, idx, "luarep");
+    if (lua_type(L, -1) == LUA_TTABLE) {
+      lua_rawgeti(L, -1, 0);
+      bool ok = false;
+      if (lua_type(L, -1) == LUA_TUSERDATA &&
+          lua_objlen(L, -1) == sizeof(struct wowless_uiobject_data)) {
+        const struct wowless_uiobject_data *ud =
+            (const struct wowless_uiobject_data *)lua_touserdata(L, -1);
+        ok = ud->marker == &wowless_uiobject_marker &&
+             ((ud->uitype->isa_mask >> type_bit) & 1);
+      }
+      lua_pop(L, 1);
+      if (ok) {
+        lua_replace(L, idx);
+        return;
+      }
+    }
+    lua_pop(L, 1);
+  }
+  wowless_outputtyperror(L, idx, "uiobject");
 }
 
 static inline void wowless_imploutputnilableuiobject(lua_State *L, int idx,
-                                                     std::string_view tname) {
+                                                     int type_bit) {
   if (!lua_isnoneornil(L, idx)) {
-    wowless_imploutputuiobject(L, idx, tname);
+    wowless_imploutputuiobject(L, idx, type_bit);
   }
 }
 

--- a/wowless/typecheck.h
+++ b/wowless/typecheck.h
@@ -716,7 +716,7 @@ static inline void wowless_imploutputuiobject(lua_State *L, int idx,
                                               int type_bit) {
   idx = lua_absindex(L, idx);
   if (lua_type(L, idx) == LUA_TTABLE) {
-    lua_rawgeti(L, idx, 0);
+    lua_rawgeti(L, idx, 1);
     if (lua_type(L, -1) == LUA_TUSERDATA &&
         lua_objlen(L, -1) == sizeof(struct wowless_uiobject_data)) {
       const struct wowless_uiobject_data *ud =

--- a/wowless/typecheck.h
+++ b/wowless/typecheck.h
@@ -716,19 +716,15 @@ static inline void wowless_imploutputuiobject(lua_State *L, int idx,
                                               int type_bit) {
   idx = lua_absindex(L, idx);
   if (lua_type(L, idx) == LUA_TTABLE) {
-    lua_getfield(L, idx, "luarep");
-    if (lua_type(L, -1) == LUA_TTABLE) {
-      lua_rawgeti(L, -1, 0);
-      bool ok = false;
-      if (lua_type(L, -1) == LUA_TUSERDATA &&
-          lua_objlen(L, -1) == sizeof(struct wowless_uiobject_data)) {
-        const struct wowless_uiobject_data *ud =
-            (const struct wowless_uiobject_data *)lua_touserdata(L, -1);
-        ok = ud->marker == &wowless_uiobject_marker &&
-             ((ud->uitype->isa_mask >> type_bit) & 1);
-      }
-      lua_pop(L, 1);
-      if (ok) {
+    lua_rawgeti(L, idx, 0);
+    if (lua_type(L, -1) == LUA_TUSERDATA &&
+        lua_objlen(L, -1) == sizeof(struct wowless_uiobject_data)) {
+      const struct wowless_uiobject_data *ud =
+          (const struct wowless_uiobject_data *)lua_touserdata(L, -1);
+      if (ud->marker == &wowless_uiobject_marker &&
+          ((ud->uitype->isa_mask >> type_bit) & 1)) {
+        lua_pop(L, 1);
+        lua_getfield(L, idx, "luarep");
         lua_replace(L, idx);
         return;
       }


### PR DESCRIPTION
## Summary

- `wowless_imploutputuiobject` validates by checking `internal[1]` (the C userdata stored on the host rep) directly via the `isa_mask` bit, symmetric with `wowless_implcheckuiobject` on the input side — no Lua calls
- `api.lua` stores `objp` at `ud[1]` so the host rep has its own direct path to the C userdata, independent of the sandbox rep's `[0]`; using `[1]` (not `[0]`) keeps `UserData(internal)` returning nil so the runner invariant remains simple
- `ImplOutputUiObject` and its `uiobjecttypes` dependency removed from `cgencode.lua`
- `prep.lua` emits integer type bits instead of string typenames for uiobject outputs
- Runner invariant reverted to original form: `(k ~= 'luarep') == not UserData(v)`

## Test plan

- [x] `cmake --build --preset default --target test` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)