### PR TITLE
loader: intrinsics are not new uiobject types (#655)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -876,6 +876,7 @@ lua2c(
   wowless.modules.fontinstance=${CMAKE_CURRENT_SOURCE_DIR}/wowless/modules/fontinstance.lua
   wowless.modules.funtainer=${CMAKE_CURRENT_SOURCE_DIR}/wowless/modules/funtainer.lua
   wowless.modules.gencode=${CMAKE_CURRENT_SOURCE_DIR}/wowless/modules/gencode.lua
+  wowless.modules.intrinsics=${CMAKE_CURRENT_SOURCE_DIR}/wowless/modules/intrinsics.lua
   wowless.modules.loader=${CMAKE_CURRENT_SOURCE_DIR}/wowless/modules/loader.lua
   wowless.modules.luaobjects=${CMAKE_CURRENT_SOURCE_DIR}/wowless/modules/luaobjects.lua
   wowless.modules.macrotext=${CMAKE_CURRENT_SOURCE_DIR}/wowless/modules/macrotext.lua

--- a/data/modules.yaml
+++ b/data/modules.yaml
@@ -7,6 +7,7 @@ api:
     datalua:
     env:
     events:
+    intrinsics:
     log:
     loglevel:
     parentkey:
@@ -81,6 +82,9 @@ funtainer:
 gencode:
   deps:
     api:
+intrinsics:
+  deps:
+    log:
 loader:
   deps:
     addons:
@@ -89,6 +93,7 @@ loader:
     datalua:
     env:
     events:
+    intrinsics:
     loadercfg:
     log:
     loglevel:

--- a/wowless/modules/api.lua
+++ b/wowless/modules/api.lua
@@ -27,9 +27,10 @@ return function(
     end
   end)()
 
+  local GetIntrinsic = uiobjecttypes.GetIntrinsic
   local GetObjectType = uiobjecttypes.GetObjectType
+  local HasType = uiobjecttypes.Has
   local InheritsFrom = uiobjecttypes.InheritsFrom
-  local IsIntrinsicType = uiobjecttypes.IsIntrinsicType
   local IsObjectType = uiobjecttypes.IsObjectType
   local IsVisible = visibility.IsVisible
   local RunScript = scripts.RunScript
@@ -214,17 +215,22 @@ return function(
 
   local function CreateFrame(type, name, parent, templateNames, id)
     local ltype = string.lower(type)
-    if not IsIntrinsicType(ltype) or not InheritsFrom(ltype, 'frame') then
+    local intrinsicEntry = GetIntrinsic(ltype)
+    local basetype = intrinsicEntry and intrinsicEntry.basetype or ltype
+    if not HasType(basetype) or not InheritsFrom(basetype, 'frame') then
       if datalua.config.runtime.warners[ltype] then
         SendEvent('LUA_WARNING', 'Unknown frame type: ' .. type)
       end
       error('CreateFrame: Unknown frame type \'' .. type .. '\'', 0)
     end
     local tmpls = {}
+    if intrinsicEntry then
+      table.insert(tmpls, intrinsicEntry.template)
+    end
     for templateName in string.gmatch(templateNames or '', '[^, ]+') do
       table.insert(tmpls, templates.GetTemplateOrThrow(templateName))
     end
-    return CreateUIObject(ltype, name, parent, nil, tmpls, id)
+    return CreateUIObject(basetype, name, parent, nil, tmpls, id)
   end
 
   local function CreateChildUIObject(typename, self, name, inherits, layer, sublevel)

--- a/wowless/modules/api.lua
+++ b/wowless/modules/api.lua
@@ -5,6 +5,7 @@ return function(
   datalua,
   env,
   events,
+  intrinsics,
   log,
   loglevel,
   parentkey,
@@ -27,7 +28,7 @@ return function(
     end
   end)()
 
-  local GetIntrinsic = uiobjecttypes.GetIntrinsic
+  local GetIntrinsic = intrinsics.Get
   local GetObjectType = uiobjecttypes.GetObjectType
   local HasType = uiobjecttypes.Has
   local InheritsFrom = uiobjecttypes.InheritsFrom

--- a/wowless/modules/intrinsics.lua
+++ b/wowless/modules/intrinsics.lua
@@ -1,0 +1,20 @@
+return function(log)
+  local intrinsicTypes = {}
+
+  local function Add(name, basetype, template)
+    if intrinsicTypes[name] then
+      log(1, 'overwriting intrinsic %s', name)
+    end
+    log(3, 'creating intrinsic %s', name)
+    intrinsicTypes[name] = { basetype = basetype, template = template }
+  end
+
+  local function Get(name)
+    return intrinsicTypes[name]
+  end
+
+  return {
+    Add = Add,
+    Get = Get,
+  }
+end

--- a/wowless/modules/loader.lua
+++ b/wowless/modules/loader.lua
@@ -5,6 +5,7 @@ return function(
   datalua,
   envmodule,
   events,
+  intrinsics,
   loadercfg,
   log,
   loglevel,
@@ -592,7 +593,7 @@ return function(
 
       function loadElement(ctx, e, parent)
         local ltype = string.lower(e.type)
-        local intrinsicEntry = uiobjecttypes.GetIntrinsic(ltype)
+        local intrinsicEntry = intrinsics.Get(ltype)
         -- uiobject types and intrinsic types share the same xml element namespace.
         if uiobjecttypes.Has(ltype) or intrinsicEntry or e.type == 'worldframe' then
           ctx = not e.attr.intrinsic and ctx or mixin({}, ctx, { intrinsic = true })
@@ -610,13 +611,9 @@ return function(
             assert(virtual ~= false, 'intrinsics cannot be explicitly non-virtual: ' .. e.type)
             assert(e.attr.name, 'cannot create anonymous intrinsic')
             local name = string.lower(e.attr.name)
-            if uiobjecttypes.GetIntrinsic(name) then
-              log(1, 'overwriting intrinsic %s', e.attr.name)
-            end
-            log(3, 'creating intrinsic %s', e.attr.name)
             local basetype = intrinsicEntry and intrinsicEntry.basetype or ltype
             uiobjecttypes.GetOrThrow(basetype) -- validate basetype exists
-            uiobjecttypes.AddIntrinsic(name, basetype, template)
+            intrinsics.Add(name, basetype, template)
           else
             if (ltype == 'font' and e.attr.name) or (virtual and not ctx.ignoreVirtual) then
               assert(e.attr.name, 'cannot create anonymous template')

--- a/wowless/modules/loader.lua
+++ b/wowless/modules/loader.lua
@@ -30,7 +30,6 @@ return function(
   local parseXml = xml
   local util = require('wowless.util')
   local mixin = util.mixin
-  local intrinsics = {}
   local readFile = util.readfile
   local bindings = bindingsmodule.bindings
   local securemixins = {}
@@ -519,7 +518,7 @@ return function(
 
       local function processAttrs(ctx, e, obj, phase)
         local objty = obj.type
-        local attrs = (xmlimpls[objty] or intrinsics[objty]).attrs
+        local attrs = xmlimpls[objty].attrs
         for k, v in pairs(e.attr) do
           local attr = attrs[k]
           if attr and phase == attr.phase then
@@ -592,8 +591,10 @@ return function(
       end
 
       function loadElement(ctx, e, parent)
-        -- This assumes that uiobject types and xml types are the same "space" of strings.
-        if uiobjecttypes.IsIntrinsicType(e.type) or e.type == 'worldframe' then
+        local ltype = string.lower(e.type)
+        local intrinsicEntry = uiobjecttypes.GetIntrinsic(ltype)
+        -- uiobject types and intrinsic types share the same xml element namespace.
+        if uiobjecttypes.Has(ltype) or intrinsicEntry or e.type == 'worldframe' then
           ctx = not e.attr.intrinsic and ctx or mixin({}, ctx, { intrinsic = true })
           local template = {
             inherits = e.attr.inherits,
@@ -609,25 +610,14 @@ return function(
             assert(virtual ~= false, 'intrinsics cannot be explicitly non-virtual: ' .. e.type)
             assert(e.attr.name, 'cannot create anonymous intrinsic')
             local name = string.lower(e.attr.name)
-            if uiobjecttypes.Has(name) then
+            if uiobjecttypes.GetIntrinsic(name) then
               log(1, 'overwriting intrinsic %s', e.attr.name)
             end
             log(3, 'creating intrinsic %s', e.attr.name)
-            local basetype = string.lower(e.type)
-            local base = uiobjecttypes.GetOrThrow(basetype)
-            uiobjecttypes.Add(name, {
-              constructor = base.constructor,
-              ctype = base.ctype,
-              hostMT = base.hostMT,
-              isa = base.isa,
-              name = base.name,
-              sandboxMT = base.sandboxMT,
-              scripts = base.scripts,
-              template = template,
-            })
-            intrinsics[name] = xmlimpls[basetype]
+            local basetype = intrinsicEntry and intrinsicEntry.basetype or ltype
+            uiobjecttypes.GetOrThrow(basetype) -- validate basetype exists
+            uiobjecttypes.AddIntrinsic(name, basetype, template)
           else
-            local ltype = string.lower(e.type)
             if (ltype == 'font' and e.attr.name) or (virtual and not ctx.ignoreVirtual) then
               assert(e.attr.name, 'cannot create anonymous template')
               templates.SetTemplate(e.attr.name, template)
@@ -637,10 +627,12 @@ return function(
               if virtual and ctx.ignoreVirtual then
                 log(1, 'ignoring virtual on %s', tostring(name))
               end
-              local ety = e.type == 'worldframe' and 'frame' or e.type
+              local basetype = intrinsicEntry and intrinsicEntry.basetype
+                or (e.type == 'worldframe' and 'frame' or ltype)
               local env = ctx.useAddonEnv and addonEnv or ctx.useSecureEnv and secureenv or genv
-              local objParent = uiobjecttypes.InheritsFrom(ety, 'parentedobjectbase') and parent or nil
-              return api.CreateUIObject(ety, name, objParent, env, { template }, nil, ctx.layer, ctx.sublevel)
+              local tmpls = intrinsicEntry and { intrinsicEntry.template, template } or { template }
+              local objParent = uiobjecttypes.InheritsFrom(basetype, 'parentedobjectbase') and parent or nil
+              return api.CreateUIObject(basetype, name, objParent, env, tmpls, nil, ctx.layer, ctx.sublevel)
             end
           end
         else

--- a/wowless/modules/uiobjecttypes.lua
+++ b/wowless/modules/uiobjecttypes.lua
@@ -1,17 +1,8 @@
 return function()
   local uiobjectTypes = {}
-  local intrinsicTypeMap = {}
 
   local function Add(name, t)
     uiobjectTypes[name] = t
-  end
-
-  local function AddIntrinsic(name, basetype, template)
-    intrinsicTypeMap[name] = { basetype = basetype, template = template }
-  end
-
-  local function GetIntrinsic(name)
-    return intrinsicTypeMap[name]
   end
 
   local function GetObjectType(obj)
@@ -53,8 +44,6 @@ return function()
 
   return {
     Add = Add,
-    AddIntrinsic = AddIntrinsic,
-    GetIntrinsic = GetIntrinsic,
     GetObjectType = GetObjectType,
     GetOrThrow = GetOrThrow,
     GetSandboxMetatable = GetSandboxMetatable,

--- a/wowless/modules/uiobjecttypes.lua
+++ b/wowless/modules/uiobjecttypes.lua
@@ -1,8 +1,17 @@
 return function()
   local uiobjectTypes = {}
+  local intrinsicTypeMap = {}
 
   local function Add(name, t)
     uiobjectTypes[name] = t
+  end
+
+  local function AddIntrinsic(name, basetype, template)
+    intrinsicTypeMap[name] = { basetype = basetype, template = template }
+  end
+
+  local function GetIntrinsic(name)
+    return intrinsicTypeMap[name]
   end
 
   local function GetObjectType(obj)
@@ -37,10 +46,6 @@ return function()
     return t.isa[b]
   end
 
-  local function IsIntrinsicType(t)
-    return uiobjectTypes[string.lower(t)] ~= nil
-  end
-
   local function IsObjectType(obj, ty)
     ty = string.lower(ty)
     return uiobjectTypes[obj.type].isa[ty] or false
@@ -48,13 +53,14 @@ return function()
 
   return {
     Add = Add,
+    AddIntrinsic = AddIntrinsic,
+    GetIntrinsic = GetIntrinsic,
     GetObjectType = GetObjectType,
     GetOrThrow = GetOrThrow,
     GetSandboxMetatable = GetSandboxMetatable,
     Has = Has,
     HasScript = HasScript,
     InheritsFrom = InheritsFrom,
-    IsIntrinsicType = IsIntrinsicType,
     IsObjectType = IsObjectType,
   }
 end


### PR DESCRIPTION
## Summary

- Moves intrinsic type mappings (name → basetype + template) out of `uiobjectTypes` into a separate `intrinsicTypeMap` in `uiobjecttypes.lua`, so the set of UIObject types is fixed per product and unchanged at runtime
- Intrinsic-of-intrinsic definitions correctly resolve to the ultimate real base type (e.g. `WowlessEvenMoreIntrinsicType` → `WowlessIntrinsicType` → `frame`)
- `CreateFrame` and XML `loadElement` look up intrinsics via `GetIntrinsic` and use the real basetype, prepending the intrinsic template before any user-specified templates
- Removes the now-unused `IsIntrinsicType` export and the local `intrinsics` table in `loader.lua`

Closes #655

## Test plan

- [x] All existing tests pass (`cmake --build --preset default --target test`)
- [x] `GetObjectType()` on an intrinsic-based frame returns the real type (`'Frame'`, not the intrinsic name) — already verified by existing test at `addon/Wowless/test.xml:173`
- [x] `IsObjectType('WowlessIntrinsicType')` returns `false` — verified by existing test at `addon/Wowless/test.xml:175`

🤖 Generated with [Claude Code](https://claude.com/claude-code)