### PR TITLE
prep/uiobjectloader: separate host/sandbox coercion for generated methods

### DIFF
--- a/data/modules.yaml
+++ b/data/modules.yaml
@@ -84,6 +84,7 @@ gencode:
     log:
     luaobjects:
     typecheck:
+    uiobjects:
 loader:
   deps:
     addons:

--- a/data/modules.yaml
+++ b/data/modules.yaml
@@ -84,7 +84,6 @@ gencode:
     log:
     luaobjects:
     typecheck:
-    uiobjects:
 loader:
   deps:
     addons:

--- a/data/uiobjectimpl.yaml
+++ b/data/uiobjectimpl.yaml
@@ -27,8 +27,6 @@ Button/SetButtonState:
   luafile:
 Button/SetDisabledAtlas:
   luafile:
-    modules:
-      uiobjects:
 Button/SetEnabled:
   luafile:
 Button/SetFontString:
@@ -39,16 +37,10 @@ Button/SetFormattedText:
   luafile:
 Button/SetHighlightAtlas:
   luafile:
-    modules:
-      uiobjects:
 Button/SetNormalAtlas:
   luafile:
-    modules:
-      uiobjects:
 Button/SetPushedAtlas:
   luafile:
-    modules:
-      uiobjects:
 Button/SetText:
   luafile:
 CheckButton/SetChecked:

--- a/data/uiobjectimpl.yaml
+++ b/data/uiobjectimpl.yaml
@@ -51,8 +51,6 @@ Button/SetPushedAtlas:
       uiobjects:
 Button/SetText:
   luafile:
-    modules:
-      uiobjects:
 CheckButton/SetChecked:
   luafile:
 EditBox/Disable:

--- a/data/uiobjects/Button/SetDisabledAtlas.lua
+++ b/data/uiobjects/Button/SetDisabledAtlas.lua
@@ -1,6 +1,6 @@
 return function(self, atlas)
   if not self.disabledTexture then
-    self:SetDisabledTexture(self:CreateTexture().luarep)
+    self:SetDisabledTexture(self:CreateTexture())
   end
   self.disabledTexture:SetAtlas(atlas)
 end

--- a/data/uiobjects/Button/SetDisabledAtlas.lua
+++ b/data/uiobjects/Button/SetDisabledAtlas.lua
@@ -5,5 +5,5 @@ return function(self, atlas)
     t = self:CreateTexture()
     self:SetDisabledTexture(t)
   end
-  uiobjects.UserData(t):SetAtlas(atlas)
+  (uiobjects.UserData(t) or t):SetAtlas(atlas)
 end

--- a/data/uiobjects/Button/SetDisabledAtlas.lua
+++ b/data/uiobjects/Button/SetDisabledAtlas.lua
@@ -1,9 +1,6 @@
-local uiobjects = ...
 return function(self, atlas)
-  local t = self:GetDisabledTexture()
-  if not t then
-    t = self:CreateTexture()
-    self:SetDisabledTexture(t)
+  if not self.disabledTexture then
+    self:SetDisabledTexture(self:CreateTexture().luarep)
   end
-  (uiobjects.UserData(t) or t):SetAtlas(atlas)
+  self.disabledTexture:SetAtlas(atlas)
 end

--- a/data/uiobjects/Button/SetHighlightAtlas.lua
+++ b/data/uiobjects/Button/SetHighlightAtlas.lua
@@ -5,5 +5,5 @@ return function(self, atlas)
     t = self:CreateTexture()
     self:SetHighlightTexture(t)
   end
-  uiobjects.UserData(t):SetAtlas(atlas)
+  (uiobjects.UserData(t) or t):SetAtlas(atlas)
 end

--- a/data/uiobjects/Button/SetHighlightAtlas.lua
+++ b/data/uiobjects/Button/SetHighlightAtlas.lua
@@ -1,6 +1,6 @@
 return function(self, atlas)
   if not self.highlightTexture then
-    self:SetHighlightTexture(self:CreateTexture().luarep)
+    self:SetHighlightTexture(self:CreateTexture())
   end
   self.highlightTexture:SetAtlas(atlas)
 end

--- a/data/uiobjects/Button/SetHighlightAtlas.lua
+++ b/data/uiobjects/Button/SetHighlightAtlas.lua
@@ -1,9 +1,6 @@
-local uiobjects = ...
 return function(self, atlas)
-  local t = self:GetHighlightTexture()
-  if not t then
-    t = self:CreateTexture()
-    self:SetHighlightTexture(t)
+  if not self.highlightTexture then
+    self:SetHighlightTexture(self:CreateTexture().luarep)
   end
-  (uiobjects.UserData(t) or t):SetAtlas(atlas)
+  self.highlightTexture:SetAtlas(atlas)
 end

--- a/data/uiobjects/Button/SetNormalAtlas.lua
+++ b/data/uiobjects/Button/SetNormalAtlas.lua
@@ -1,9 +1,6 @@
-local uiobjects = ...
 return function(self, atlas)
-  local t = self:GetNormalTexture()
-  if not t then
-    t = self:CreateTexture()
-    self:SetNormalTexture(t)
+  if not self.normalTexture then
+    self:SetNormalTexture(self:CreateTexture().luarep)
   end
-  (uiobjects.UserData(t) or t):SetAtlas(atlas)
+  self.normalTexture:SetAtlas(atlas)
 end

--- a/data/uiobjects/Button/SetNormalAtlas.lua
+++ b/data/uiobjects/Button/SetNormalAtlas.lua
@@ -5,5 +5,5 @@ return function(self, atlas)
     t = self:CreateTexture()
     self:SetNormalTexture(t)
   end
-  uiobjects.UserData(t):SetAtlas(atlas)
+  (uiobjects.UserData(t) or t):SetAtlas(atlas)
 end

--- a/data/uiobjects/Button/SetNormalAtlas.lua
+++ b/data/uiobjects/Button/SetNormalAtlas.lua
@@ -1,6 +1,6 @@
 return function(self, atlas)
   if not self.normalTexture then
-    self:SetNormalTexture(self:CreateTexture().luarep)
+    self:SetNormalTexture(self:CreateTexture())
   end
   self.normalTexture:SetAtlas(atlas)
 end

--- a/data/uiobjects/Button/SetPushedAtlas.lua
+++ b/data/uiobjects/Button/SetPushedAtlas.lua
@@ -1,6 +1,6 @@
 return function(self, atlas)
   if not self.pushedTexture then
-    self:SetPushedTexture(self:CreateTexture().luarep)
+    self:SetPushedTexture(self:CreateTexture())
   end
   self.pushedTexture:SetAtlas(atlas)
 end

--- a/data/uiobjects/Button/SetPushedAtlas.lua
+++ b/data/uiobjects/Button/SetPushedAtlas.lua
@@ -1,9 +1,6 @@
-local uiobjects = ...
 return function(self, atlas)
-  local t = self:GetPushedTexture()
-  if not t then
-    t = self:CreateTexture()
-    self:SetPushedTexture(t)
+  if not self.pushedTexture then
+    self:SetPushedTexture(self:CreateTexture().luarep)
   end
-  (uiobjects.UserData(t) or t):SetAtlas(atlas)
+  self.pushedTexture:SetAtlas(atlas)
 end

--- a/data/uiobjects/Button/SetPushedAtlas.lua
+++ b/data/uiobjects/Button/SetPushedAtlas.lua
@@ -5,5 +5,5 @@ return function(self, atlas)
     t = self:CreateTexture()
     self:SetPushedTexture(t)
   end
-  uiobjects.UserData(t):SetAtlas(atlas)
+  (uiobjects.UserData(t) or t):SetAtlas(atlas)
 end

--- a/data/uiobjects/Button/SetText.lua
+++ b/data/uiobjects/Button/SetText.lua
@@ -1,5 +1,4 @@
-local uiobjects = ...
 return function(self, text)
-  self.fontstring = self.fontstring or uiobjects.UserData(self:CreateFontString())
+  self.fontstring = self.fontstring or self:CreateFontString()
   self.fontstring:SetText(text)
 end

--- a/tools/prep.lua
+++ b/tools/prep.lua
@@ -140,43 +140,44 @@ local function ensuresql(k)
 end
 
 local function stubby(mv, skip0)
-  local t = { 'local gencode=...;' }
   local ins = mv.inputs or {}
   local nsins = #ins - (mv.instride or 0)
+  -- sandbox impl: original code with gencode.Check input validation and specDefault outputs
+  local sb = { 'local gencode=...;' }
   for i = 1, #ins do
-    table.insert(t, 'local spec' .. i .. '=' .. prettywrite(mv.inputs[i], true) .. ';')
+    table.insert(sb, 'local spec' .. i .. '=' .. prettywrite(mv.inputs[i], true) .. ';')
   end
-  table.insert(t, 'return function(')
-  local a = {}
+  table.insert(sb, 'return function(')
+  local sba = {}
   if skip0 then
-    table.insert(a, '_')
+    table.insert(sba, '_')
   end
   for i = 1, nsins do
-    table.insert(a, 'arg' .. i)
+    table.insert(sba, 'arg' .. i)
   end
   if mv.instride then
-    table.insert(a, '...')
+    table.insert(sba, '...')
   end
-  table.insert(t, table.concat(a, ','))
-  table.insert(t, ')')
+  table.insert(sb, table.concat(sba, ','))
+  table.insert(sb, ')')
   for i = 1, nsins do
-    table.insert(t, 'gencode.Check(spec' .. i .. ',arg' .. i .. ');')
+    table.insert(sb, 'gencode.Check(spec' .. i .. ',arg' .. i .. ');')
   end
   if mv.instride then
-    table.insert(t, 'for i=1,select("#",...),' .. mv.instride .. ' do ')
-    table.insert(t, 'local arg' .. nsins + 1)
+    table.insert(sb, 'for i=1,select("#",...),' .. mv.instride .. ' do ')
+    table.insert(sb, 'local arg' .. nsins + 1)
     for i = nsins + 2, #ins do
-      table.insert(t, ',arg' .. i)
+      table.insert(sb, ',arg' .. i)
     end
-    table.insert(t, '=select(i,...);')
+    table.insert(sb, '=select(i,...);')
     for i = nsins + 1, #ins do
-      table.insert(t, 'gencode.Check(spec' .. i .. ',arg' .. i .. ');')
+      table.insert(sb, 'gencode.Check(spec' .. i .. ',arg' .. i .. ');')
     end
-    table.insert(t, 'end ')
+    table.insert(sb, 'end ')
   end
   local outs = mv.outputs or {}
   if #outs > 0 and not mv.stubnothing then
-    table.insert(t, 'return ')
+    table.insert(sb, 'return ')
     local rets = {}
     local nonstride = #outs - (mv.outstride or 0)
     for i = 1, nonstride do
@@ -187,12 +188,16 @@ local function stubby(mv, skip0)
         table.insert(rets, specDefault(outs[j]))
       end
     end
-    table.insert(t, table.concat(rets, ','))
+    table.insert(sb, table.concat(rets, ','))
   end
-  table.insert(t, ' end')
+  table.insert(sb, ' end')
+  -- host impl: simple no-op
+  local impl = 'return function(' .. (skip0 and '_' or '') .. ',...) end'
   return {
-    impl = table.concat(t),
-    modules = { 'gencode' },
+    impl = impl,
+    modules = {},
+    sandboximpl = table.concat(sb),
+    sandboxmodules = { 'gencode' },
     secureonly = mv.secureonly,
   }
 end
@@ -434,50 +439,83 @@ local uiobjectimplimplmakers = {
 }
 local uiobjectimplmakers = {
   getter = function(impl, mv)
-    local t = { 'local gencode=...;' }
+    -- sandbox impl: original code with gencode.Check converting internal uds to luarep
+    local sb = { 'local gencode=...;' }
     for i in ipairs(impl) do
-      table.insert(t, 'local spec' .. i .. '=' .. prettywrite(mv.outputs[i], true) .. ';')
+      table.insert(sb, 'local spec' .. i .. '=' .. prettywrite(mv.outputs[i], true) .. ';')
     end
-    table.insert(t, 'return function(self)return ')
+    table.insert(sb, 'return function(self)return ')
     for i, f in ipairs(impl) do
-      table.insert(t, (i == 1 and '' or ',') .. 'gencode.Check(spec' .. i .. ',self.' .. f.name .. ',true)')
+      table.insert(sb, (i == 1 and '' or ',') .. 'gencode.Check(spec' .. i .. ',self.' .. f.name .. ',true)')
     end
-    table.insert(t, 'end')
+    table.insert(sb, 'end')
+    -- host impl: simple direct field access
+    local t = { 'return function(self)return ' }
+    for i, f in ipairs(impl) do
+      table.insert(t, (i == 1 and '' or ',') .. 'self.' .. f.name)
+    end
+    table.insert(t, ' end')
     return {
       impl = table.concat(t),
-      modules = { 'gencode' },
+      modules = {},
+      sandboximpl = table.concat(sb),
+      sandboxmodules = { 'gencode' },
     }
   end,
   none = function(mv)
     return stubby(mv, true)
   end,
   setter = function(impl, mv)
-    local t = { 'local gencode=...;' }
+    -- sandbox impl: original code with gencode.Check converting sandbox reps to internal uds
+    local sb = { 'local gencode=...;' }
     for i in ipairs(impl) do
-      table.insert(t, 'local spec' .. i .. '=' .. prettywrite(mv.inputs[i], true) .. ';')
+      table.insert(sb, 'local spec' .. i .. '=' .. prettywrite(mv.inputs[i], true) .. ';')
     end
-    table.insert(t, 'return function(self')
+    table.insert(sb, 'return function(self')
+    for _, f in ipairs(impl) do
+      table.insert(sb, ',')
+      table.insert(sb, f.name)
+    end
+    table.insert(sb, ')')
+    for i, f in ipairs(impl) do
+      table.insert(sb, 'self.')
+      table.insert(sb, f.name)
+      table.insert(sb, '=gencode.Check(spec')
+      table.insert(sb, tostring(i))
+      table.insert(sb, ',')
+      table.insert(sb, f.name)
+      table.insert(sb, ');')
+    end
+    table.insert(sb, 'end')
+    -- host impl: direct field assignment, applying defaults for optional args
+    local t = { 'return function(self' }
     for _, f in ipairs(impl) do
       table.insert(t, ',')
       table.insert(t, f.name)
     end
     table.insert(t, ')')
     for i, f in ipairs(impl) do
+      local spec = mv.inputs[i]
       table.insert(t, 'self.')
       table.insert(t, f.name)
-      table.insert(t, '=gencode.Check(spec')
-      table.insert(t, tostring(i))
-      table.insert(t, ',')
-      table.insert(t, f.name)
-      table.insert(t, ');')
+      table.insert(t, '=')
+      if spec and spec.default ~= nil then
+        table.insert(t, f.name .. '~=nil and ' .. f.name .. ' or ' .. valstr(spec.default))
+      else
+        table.insert(t, f.name)
+      end
+      table.insert(t, ';')
     end
     table.insert(t, 'end')
     return {
       impl = table.concat(t),
-      modules = { 'gencode' },
+      modules = {},
+      sandboximpl = table.concat(sb),
+      sandboxmodules = { 'gencode' },
     }
   end,
-  settexture = function(impl, mv)
+  settexture = function(impl)
+    -- host impl: uses gencode.ToTexture which handles internal uds directly
     local t = { 'local gencode=...;return function(self,tex)' }
     table.insert(t, 'local t=gencode.ToTexture(self,tex,self.')
     table.insert(t, impl.field)
@@ -495,10 +533,32 @@ local uiobjectimplmakers = {
       table.insert(t, 'return true;')
     end
     table.insert(t, 'end')
+    -- sandbox impl: handles sandbox texture reps via uiobjects.UserData
+    local sb = { 'local gencode,uiobjects=...;return function(self,tex)local t;' }
+    table.insert(sb, 'if type(tex)=="string" or type(tex)=="number" then ')
+    table.insert(sb, 't=self.')
+    table.insert(sb, impl.field)
+    table.insert(sb, ' or self:CreateTexture();t:SetTexture(tex);')
+    table.insert(sb, 'elseif tex~=nil then t=uiobjects.UserData(tex);end ')
+    table.insert(sb, 'if t then gencode.SetParent(t,self);if t:GetNumPoints()==0 then t:SetAllPoints()end t:SetShown(')
+    table.insert(sb, impl.shown or 'true')
+    table.insert(sb, ');')
+    if impl.extra then
+      table.insert(sb, impl.extra)
+      table.insert(sb, ';')
+    end
+    table.insert(sb, 'end self.')
+    table.insert(sb, impl.field)
+    table.insert(sb, '=t;')
+    if impl['return'] then
+      table.insert(sb, 'return true;')
+    end
+    table.insert(sb, 'end')
     return {
       impl = table.concat(t),
-      inputs = mv.inputs,
       modules = { 'gencode' },
+      sandboximpl = table.concat(sb),
+      sandboxmodules = { 'gencode', 'uiobjects' },
     }
   end,
   uiobjectimpl = function(impl, mv)

--- a/tools/prep.lua
+++ b/tools/prep.lua
@@ -477,7 +477,7 @@ local uiobjectimplmakers = {
       modules = { 'gencode' },
     }
   end,
-  settexture = function(impl)
+  settexture = function(impl, mv)
     local t = { 'local gencode=...;return function(self,tex)' }
     table.insert(t, 'local t=gencode.ToTexture(self,tex,self.')
     table.insert(t, impl.field)
@@ -497,6 +497,7 @@ local uiobjectimplmakers = {
     table.insert(t, 'end')
     return {
       impl = table.concat(t),
+      inputs = mv.inputs,
       modules = { 'gencode' },
     }
   end,

--- a/tools/prep.lua
+++ b/tools/prep.lua
@@ -444,7 +444,7 @@ local uiobjectimplmakers = {
     for i in ipairs(impl) do
       table.insert(sb, 'local spec' .. i .. '=' .. prettywrite(mv.outputs[i], true) .. ';')
     end
-    table.insert(sb, 'return function(self)return ')
+    table.insert(sb, 'return function(obj)local self=gencode.UserData(obj);return ')
     for i, f in ipairs(impl) do
       table.insert(sb, (i == 1 and '' or ',') .. 'gencode.Check(spec' .. i .. ',self.' .. f.name .. ',true)')
     end
@@ -471,12 +471,12 @@ local uiobjectimplmakers = {
     for i in ipairs(impl) do
       table.insert(sb, 'local spec' .. i .. '=' .. prettywrite(mv.inputs[i], true) .. ';')
     end
-    table.insert(sb, 'return function(self')
+    table.insert(sb, 'return function(obj')
     for _, f in ipairs(impl) do
       table.insert(sb, ',')
       table.insert(sb, f.name)
     end
-    table.insert(sb, ')')
+    table.insert(sb, ')local self=gencode.UserData(obj);')
     for i, f in ipairs(impl) do
       table.insert(sb, 'self.')
       table.insert(sb, f.name)
@@ -534,12 +534,12 @@ local uiobjectimplmakers = {
     end
     table.insert(t, 'end')
     -- sandbox impl: handles sandbox texture reps via uiobjects.UserData
-    local sb = { 'local gencode,uiobjects=...;return function(self,tex)local t;' }
+    local sb = { 'local gencode=...;return function(obj,tex)local self=gencode.UserData(obj);local t;' }
     table.insert(sb, 'if type(tex)=="string" or type(tex)=="number" then ')
     table.insert(sb, 't=self.')
     table.insert(sb, impl.field)
     table.insert(sb, ' or self:CreateTexture();t:SetTexture(tex);')
-    table.insert(sb, 'elseif tex~=nil then t=uiobjects.UserData(tex);end ')
+    table.insert(sb, 'elseif tex~=nil then t=gencode.UserData(tex);end ')
     table.insert(sb, 'if t then gencode.SetParent(t,self);if t:GetNumPoints()==0 then t:SetAllPoints()end t:SetShown(')
     table.insert(sb, impl.shown or 'true')
     table.insert(sb, ');')
@@ -558,7 +558,7 @@ local uiobjectimplmakers = {
       impl = table.concat(t),
       modules = { 'gencode' },
       sandboximpl = table.concat(sb),
-      sandboxmodules = { 'gencode', 'uiobjects' },
+      sandboxmodules = { 'gencode' },
     }
   end,
   uiobjectimpl = function(impl, mv)

--- a/tools/prep.lua
+++ b/tools/prep.lua
@@ -191,13 +191,10 @@ local function stubby(mv, skip0)
     table.insert(sb, table.concat(rets, ','))
   end
   table.insert(sb, ' end')
-  -- host impl: simple no-op
-  local impl = 'return function(' .. (skip0 and '_' or '') .. ',...) end'
   return {
-    impl = impl,
-    modules = {},
-    sandboximpl = table.concat(sb),
-    sandboxmodules = { 'gencode' },
+    hostimpl = 'return function(...) end',
+    impl = table.concat(sb),
+    modules = { 'gencode' },
     secureonly = mv.secureonly,
   }
 end
@@ -456,10 +453,9 @@ local uiobjectimplmakers = {
     end
     table.insert(t, ' end')
     return {
-      impl = table.concat(t),
-      modules = {},
-      sandboximpl = table.concat(sb),
-      sandboxmodules = { 'gencode' },
+      hostimpl = table.concat(t),
+      impl = table.concat(sb),
+      modules = { 'gencode' },
     }
   end,
   none = function(mv)
@@ -508,10 +504,9 @@ local uiobjectimplmakers = {
     end
     table.insert(t, 'end')
     return {
-      impl = table.concat(t),
-      modules = {},
-      sandboximpl = table.concat(sb),
-      sandboxmodules = { 'gencode' },
+      hostimpl = table.concat(t),
+      impl = table.concat(sb),
+      modules = { 'gencode' },
     }
   end,
   settexture = function(impl)
@@ -555,10 +550,10 @@ local uiobjectimplmakers = {
     end
     table.insert(sb, 'end')
     return {
-      impl = table.concat(t),
-      modules = { 'gencode' },
-      sandboximpl = table.concat(sb),
-      sandboxmodules = { 'gencode', 'uiobjects' },
+      hostimpl = table.concat(t),
+      hostmodules = { 'gencode' },
+      impl = table.concat(sb),
+      modules = { 'gencode', 'uiobjects' },
     }
   end,
   uiobjectimpl = function(impl, mv)

--- a/tools/prep.lua
+++ b/tools/prep.lua
@@ -191,10 +191,13 @@ local function stubby(mv, skip0)
     table.insert(sb, table.concat(rets, ','))
   end
   table.insert(sb, ' end')
+  -- host impl: simple no-op
+  local impl = 'return function(' .. (skip0 and '_' or '') .. ',...) end'
   return {
-    hostimpl = 'return function(...) end',
-    impl = table.concat(sb),
-    modules = { 'gencode' },
+    impl = impl,
+    modules = {},
+    sandboximpl = table.concat(sb),
+    sandboxmodules = { 'gencode' },
     secureonly = mv.secureonly,
   }
 end
@@ -453,9 +456,10 @@ local uiobjectimplmakers = {
     end
     table.insert(t, ' end')
     return {
-      hostimpl = table.concat(t),
-      impl = table.concat(sb),
-      modules = { 'gencode' },
+      impl = table.concat(t),
+      modules = {},
+      sandboximpl = table.concat(sb),
+      sandboxmodules = { 'gencode' },
     }
   end,
   none = function(mv)
@@ -504,9 +508,10 @@ local uiobjectimplmakers = {
     end
     table.insert(t, 'end')
     return {
-      hostimpl = table.concat(t),
-      impl = table.concat(sb),
-      modules = { 'gencode' },
+      impl = table.concat(t),
+      modules = {},
+      sandboximpl = table.concat(sb),
+      sandboxmodules = { 'gencode' },
     }
   end,
   settexture = function(impl)
@@ -550,10 +555,10 @@ local uiobjectimplmakers = {
     end
     table.insert(sb, 'end')
     return {
-      hostimpl = table.concat(t),
-      hostmodules = { 'gencode' },
-      impl = table.concat(sb),
-      modules = { 'gencode', 'uiobjects' },
+      impl = table.concat(t),
+      modules = { 'gencode' },
+      sandboximpl = table.concat(sb),
+      sandboxmodules = { 'gencode', 'uiobjects' },
     }
   end,
   uiobjectimpl = function(impl, mv)

--- a/wowless/modules/gencode.lua
+++ b/wowless/modules/gencode.lua
@@ -21,8 +21,11 @@ return function(api, env, log, luaobjects, typecheck, uiobjects)
       local t = obj or parent:CreateTexture()
       t:SetTexture(tex)
       return t
-    else
-      return tex and uiobjects.UserData(tex)
+    elseif tex then
+      if tex[0] then
+        return uiobjects.UserData(tex)
+      end
+      return tex
     end
   end
 

--- a/wowless/modules/gencode.lua
+++ b/wowless/modules/gencode.lua
@@ -22,7 +22,7 @@ return function(api, env, log, luaobjects, typecheck, uiobjects)
       t:SetTexture(tex)
       return t
     else
-      return tex and (uiobjects.UserData(tex) or tex)
+      return tex and uiobjects.UserData(tex)
     end
   end
 

--- a/wowless/modules/gencode.lua
+++ b/wowless/modules/gencode.lua
@@ -1,6 +1,6 @@
 local hlist = require('wowless.hlist')
 
-return function(api, env, log, luaobjects, typecheck, uiobjects)
+return function(api, env, log, luaobjects, typecheck)
   local function Check(spec, v, isout)
     local vv, errmsg, iswarn = typecheck(spec, v, isout)
     if errmsg then
@@ -21,10 +21,7 @@ return function(api, env, log, luaobjects, typecheck, uiobjects)
       local t = obj or parent:CreateTexture()
       t:SetTexture(tex)
       return t
-    elseif tex then
-      if tex[0] then
-        return uiobjects.UserData(tex)
-      end
+    else
       return tex
     end
   end

--- a/wowless/modules/gencode.lua
+++ b/wowless/modules/gencode.lua
@@ -1,6 +1,6 @@
 local hlist = require('wowless.hlist')
 
-return function(api, env, log, luaobjects, typecheck)
+return function(api, env, log, luaobjects, typecheck, uiobjects)
   local function Check(spec, v, isout)
     local vv, errmsg, iswarn = typecheck(spec, v, isout)
     if errmsg then
@@ -34,5 +34,6 @@ return function(api, env, log, luaobjects, typecheck)
     Mixin = env.mixin,
     SetParent = api.SetParent,
     ToTexture = ToTexture,
+    UserData = uiobjects.UserData,
   }
 end

--- a/wowless/modules/gencode.lua
+++ b/wowless/modules/gencode.lua
@@ -18,11 +18,11 @@ return function(api, env, log, luaobjects, typecheck, uiobjects)
 
   local function ToTexture(parent, tex, obj)
     if type(tex) == 'string' or type(tex) == 'number' then
-      local t = obj or uiobjects.UserData(parent:CreateTexture())
+      local t = obj or parent:CreateTexture()
       t:SetTexture(tex)
       return t
     else
-      return tex and uiobjects.UserData(tex)
+      return tex and (uiobjects.UserData(tex) or tex)
     end
   end
 

--- a/wowless/modules/loader.lua
+++ b/wowless/modules/loader.lua
@@ -307,7 +307,7 @@ return function(
     maskedtexture = function(_, e, parent)
       local t = navigate(parent.parent and parent.parent.luarep, e.attr.childkey)
       if t then
-        uiobjects.UserData(t):AddMaskTexture(parent.luarep)
+        uiobjects.UserData(t):AddMaskTexture(parent)
       else
         log(1, 'cannot find maskedtexture childkey %s', e.attr.childkey)
       end
@@ -594,7 +594,7 @@ return function(
             local obj = loadElement(ctx, elt, parent)
             -- TODO find if this if needs to be broader to everything here including kids
             if parent:IsObjectType(impl.call.parenttype) then
-              parent[impl.call.parentmethod](parent, obj.luarep)
+              parent[impl.call.parentmethod](parent, obj)
             end
           elseif impl == 'transparent' or impl == 'loadstring' then
             local ctxmix = mixin({}, ctx)

--- a/wowless/modules/typecheck.lua
+++ b/wowless/modules/typecheck.lua
@@ -103,6 +103,20 @@ return function(addons, datalua, env, luaobjects, uiobjects, uiobjecttypes, unit
     table = function(value)
       return luatypecheck('table', value)
     end,
+    TextureAsset = function(value, isout)
+      if isout then
+        return nil, true
+      end
+      local ty = type(value)
+      if ty == 'string' or ty == 'number' then
+        return value
+      end
+      if ty == 'table' then
+        local ud = uiobjects.UserData(value)
+        return ud, not ud
+      end
+      return nil, true
+    end,
     uiAddon = function(value)
       if type(value) ~= 'string' and type(value) ~= 'number' then
         return nil, true

--- a/wowless/modules/uiobjectloader.lua
+++ b/wowless/modules/uiobjectloader.lua
@@ -24,10 +24,8 @@ return function(datalua, funcheck, gencode, sqls, uiobjectsmodule, uiobjecttypes
           Mixin(hostindex, r.hostindex)
           Mixin(sandboxindex, r.sandboxindex)
         end
-        for n, m in pairs(ty.mixin) do -- do this last in case of overrides
-          hostindex[n] = m.hostfn
-          sandboxindex[n] = m.sandboxDispatch
-        end
+        Mixin(hostindex, ty.hostindex) -- do this last in case of overrides
+        Mixin(sandboxindex, ty.sandboxindex)
         result[lk] = {
           constructor = ty.constructor,
           ctype = ty.cfg.uitype_bit,
@@ -82,7 +80,8 @@ return function(datalua, funcheck, gencode, sqls, uiobjectsmodule, uiobjecttypes
           return orig()
         end
       end
-      local mixin = {}
+      local hostindex = {}
+      local sandboxindex = {}
       for mname, method in pairs(cfg.methods) do
         local fname = name .. ':' .. mname
         local incheck = method.inputs and funcheck.makeCheckInputs(fname, method)
@@ -129,13 +128,15 @@ return function(datalua, funcheck, gencode, sqls, uiobjectsmodule, uiobjecttypes
             return sandboxfn(UserData(obj), ...)
           end
         end
-        mixin[mname] = { hostfn = hostfn, sandboxDispatch = sandboxDispatch }
+        hostindex[mname] = hostfn
+        sandboxindex[mname] = sandboxDispatch
       end
       uiobjects[name] = {
         cfg = cfg,
         constructor = constructor,
+        hostindex = hostindex,
         inherits = cfg.inherits,
-        mixin = mixin,
+        sandboxindex = sandboxindex,
         scripts = cfg.scripts,
       }
     end

--- a/wowless/modules/uiobjectloader.lua
+++ b/wowless/modules/uiobjectloader.lua
@@ -51,6 +51,10 @@ return function(datalua, funcheck, gencode, sqls, uiobjectsmodule, uiobjecttypes
           sandboxfn = function(...)
             return outcheck(fn(...))
           end
+        elseif not outcheck then
+          sandboxfn = function(self, ...)
+            return fn(self, incheck(...))
+          end
         else
           sandboxfn = function(self, ...)
             return outcheck(fn(self, incheck(...)))

--- a/wowless/modules/uiobjectloader.lua
+++ b/wowless/modules/uiobjectloader.lua
@@ -42,15 +42,14 @@ return function(datalua, funcheck, gencode, sqls, uiobjectsmodule, uiobjecttypes
       local hostIndex = {}
       local sandboxIndex = {}
       for n, m in pairs(v.metaindex) do
-        hostIndex[n] = m.fn
-        local sandboxDispatchFn
-        if m.fn ~= m.sandboxfn then
+        local fn, incheck, outcheck = m.fn, m.incheck, m.outcheck
+        hostIndex[n] = fn
+        if m.sandboxfn then
           local sf = m.sandboxfn
-          sandboxDispatchFn = function(obj, ...)
+          sandboxIndex[n] = bubblewrap(function(obj, ...)
             return sf(UserData(obj), ...)
-          end
+          end)
         else
-          local fn, incheck, outcheck = m.fn, m.incheck, m.outcheck
           local sandboxfn
           if not incheck and not outcheck then
             sandboxfn = fn
@@ -67,11 +66,10 @@ return function(datalua, funcheck, gencode, sqls, uiobjectsmodule, uiobjecttypes
               return outcheck(fn(self, incheck(...)))
             end
           end
-          sandboxDispatchFn = function(obj, ...)
+          sandboxIndex[n] = bubblewrap(function(obj, ...)
             return sandboxfn(UserData(obj), ...)
-          end
+          end)
         end
-        sandboxIndex[n] = bubblewrap(sandboxDispatchFn)
       end
       t[k] = {
         constructor = v.constructor,
@@ -121,17 +119,17 @@ return function(datalua, funcheck, gencode, sqls, uiobjectsmodule, uiobjecttypes
         for _, sql in ipairs(method.sqls or {}) do
           table.insert(args, (assert(sqls[sql], sql)))
         end
-        local sandboxbasefn = wrap(fname, mkfn(unpack(args)))
-        local basefn = sandboxbasefn
-        if method.hostimpl then
-          local hmkfn = assert(loadstring_untainted(method.hostimpl, src), fname)
-          local hargs = {}
-          for _, hm in ipairs(method.hostmodules or {}) do
-            table.insert(hargs, (assert(modules[hm], hm)))
+        local basefn = wrap(fname, mkfn(unpack(args)))
+        local sandboxbasefn = nil
+        if method.sandboximpl then
+          local sbmkfn = assert(loadstring_untainted(method.sandboximpl, src), fname)
+          local sbargs = {}
+          for _, sm in ipairs(method.sandboxmodules or {}) do
+            table.insert(sbargs, (assert(modules[sm], sm)))
           end
-          basefn = wrap(fname, hmkfn(unpack(hargs)))
+          sandboxbasefn = wrap(fname, sbmkfn(unpack(sbargs)))
         end
-        mixin[mname] = { fn = basefn, sandboxfn = sandboxbasefn, incheck = incheck, outcheck = outcheck }
+        mixin[mname] = { fn = basefn, incheck = incheck, outcheck = outcheck, sandboxfn = sandboxbasefn }
       end
       uiobjects[name] = {
         cfg = cfg,

--- a/wowless/modules/uiobjectloader.lua
+++ b/wowless/modules/uiobjectloader.lua
@@ -42,14 +42,15 @@ return function(datalua, funcheck, gencode, sqls, uiobjectsmodule, uiobjecttypes
       local hostIndex = {}
       local sandboxIndex = {}
       for n, m in pairs(v.metaindex) do
-        local fn, incheck, outcheck = m.fn, m.incheck, m.outcheck
-        hostIndex[n] = fn
-        if m.sandboxfn then
+        hostIndex[n] = m.fn
+        local sandboxDispatchFn
+        if m.fn ~= m.sandboxfn then
           local sf = m.sandboxfn
-          sandboxIndex[n] = bubblewrap(function(obj, ...)
+          sandboxDispatchFn = function(obj, ...)
             return sf(UserData(obj), ...)
-          end)
+          end
         else
+          local fn, incheck, outcheck = m.fn, m.incheck, m.outcheck
           local sandboxfn
           if not incheck and not outcheck then
             sandboxfn = fn
@@ -66,10 +67,11 @@ return function(datalua, funcheck, gencode, sqls, uiobjectsmodule, uiobjecttypes
               return outcheck(fn(self, incheck(...)))
             end
           end
-          sandboxIndex[n] = bubblewrap(function(obj, ...)
+          sandboxDispatchFn = function(obj, ...)
             return sandboxfn(UserData(obj), ...)
-          end)
+          end
         end
+        sandboxIndex[n] = bubblewrap(sandboxDispatchFn)
       end
       t[k] = {
         constructor = v.constructor,
@@ -119,17 +121,17 @@ return function(datalua, funcheck, gencode, sqls, uiobjectsmodule, uiobjecttypes
         for _, sql in ipairs(method.sqls or {}) do
           table.insert(args, (assert(sqls[sql], sql)))
         end
-        local basefn = wrap(fname, mkfn(unpack(args)))
-        local sandboxbasefn = nil
-        if method.sandboximpl then
-          local sbmkfn = assert(loadstring_untainted(method.sandboximpl, src), fname)
-          local sbargs = {}
-          for _, sm in ipairs(method.sandboxmodules or {}) do
-            table.insert(sbargs, (assert(modules[sm], sm)))
+        local sandboxbasefn = wrap(fname, mkfn(unpack(args)))
+        local basefn = sandboxbasefn
+        if method.hostimpl then
+          local hmkfn = assert(loadstring_untainted(method.hostimpl, src), fname)
+          local hargs = {}
+          for _, hm in ipairs(method.hostmodules or {}) do
+            table.insert(hargs, (assert(modules[hm], hm)))
           end
-          sandboxbasefn = wrap(fname, sbmkfn(unpack(sbargs)))
+          basefn = wrap(fname, hmkfn(unpack(hargs)))
         end
-        mixin[mname] = { fn = basefn, incheck = incheck, outcheck = outcheck, sandboxfn = sandboxbasefn }
+        mixin[mname] = { fn = basefn, sandboxfn = sandboxbasefn, incheck = incheck, outcheck = outcheck }
       end
       uiobjects[name] = {
         cfg = cfg,

--- a/wowless/modules/uiobjectloader.lua
+++ b/wowless/modules/uiobjectloader.lua
@@ -39,16 +39,31 @@ return function(datalua, funcheck, gencode, sqls, uiobjectsmodule, uiobjecttypes
     end
     local t = {}
     for k, v in pairs(result) do
+      local hostIndex = {}
       local sandboxIndex = {}
-      for n, f in pairs(v.metaindex) do
+      for n, m in pairs(v.metaindex) do
+        local fn, incheck, outcheck = m.fn, m.incheck, m.outcheck
+        hostIndex[n] = fn
+        local sandboxfn
+        if not incheck and not outcheck then
+          sandboxfn = fn
+        elseif not incheck then
+          sandboxfn = function(...)
+            return outcheck(fn(...))
+          end
+        else
+          sandboxfn = function(self, ...)
+            return outcheck(fn(self, incheck(...)))
+          end
+        end
         sandboxIndex[n] = bubblewrap(function(obj, ...)
-          return f(UserData(obj), ...)
+          return sandboxfn(UserData(obj), ...)
         end)
       end
       t[k] = {
         constructor = v.constructor,
         ctype = v.ctype,
-        hostMT = { __index = v.metaindex },
+        hostMT = { __index = hostIndex }, -- issue #657
         isa = v.isa,
         name = v.name,
         sandboxMT = { __index = sandboxIndex },
@@ -94,19 +109,7 @@ return function(datalua, funcheck, gencode, sqls, uiobjectsmodule, uiobjecttypes
           table.insert(args, (assert(sqls[sql], sql)))
         end
         local basefn = wrap(fname, mkfn(unpack(args)))
-        local outfn
-        if not incheck and not outcheck then
-          outfn = basefn
-        elseif not incheck then
-          outfn = function(...)
-            return outcheck(basefn(...))
-          end
-        else
-          outfn = function(self, ...)
-            return outcheck(basefn(self, incheck(...)))
-          end
-        end
-        mixin[mname] = outfn
+        mixin[mname] = { fn = basefn, incheck = incheck, outcheck = outcheck }
       end
       uiobjects[name] = {
         cfg = cfg,

--- a/wowless/modules/uiobjectloader.lua
+++ b/wowless/modules/uiobjectloader.lua
@@ -103,10 +103,7 @@ return function(datalua, funcheck, gencode, sqls, uiobjectsmodule, uiobjecttypes
           for _, sm in ipairs(method.sandboxmodules or {}) do
             table.insert(sbargs, (assert(modules[sm], sm)))
           end
-          local sbfn = wrap(fname, sbmkfn(unpack(sbargs)))
-          sandboxDispatch = function(obj, ...)
-            return sbfn(UserData(obj), ...)
-          end
+          sandboxDispatch = sbmkfn(unpack(sbargs))
         else
           local sandboxfn
           if not incheck and not outcheck then

--- a/wowless/modules/uiobjectloader.lua
+++ b/wowless/modules/uiobjectloader.lua
@@ -14,22 +14,27 @@ return function(datalua, funcheck, gencode, sqls, uiobjectsmodule, uiobjecttypes
         local ty = types[k]
         local isa = { [lk] = true }
         local scripts = Mixin({}, ty.scripts or {})
-        local metaindex = {}
+        local hostindex = {}
+        local sandboxindex = {}
         for inh in pairs(ty.inherits) do
           flattenOne(inh)
-          Mixin(isa, result[string.lower(inh)].isa)
-          Mixin(scripts, result[string.lower(inh)].scripts)
-          for mk, mv in pairs(result[string.lower(inh)].metaindex) do
-            metaindex[mk] = mv
-          end
+          local r = result[string.lower(inh)]
+          Mixin(isa, r.isa)
+          Mixin(scripts, r.scripts)
+          Mixin(hostindex, r.hostindex)
+          Mixin(sandboxindex, r.sandboxindex)
         end
-        Mixin(metaindex, ty.mixin) -- do this last in case of overrides
+        for n, m in pairs(ty.mixin) do -- do this last in case of overrides
+          hostindex[n] = m.hostfn
+          sandboxindex[n] = m.sandboxDispatch
+        end
         result[lk] = {
           constructor = ty.constructor,
           ctype = ty.cfg.uitype_bit,
+          hostindex = hostindex,
           isa = isa,
-          metaindex = metaindex,
           name = ty.cfg.objectType or k,
+          sandboxindex = sandboxindex,
           scripts = scripts,
         }
       end
@@ -39,45 +44,17 @@ return function(datalua, funcheck, gencode, sqls, uiobjectsmodule, uiobjecttypes
     end
     local t = {}
     for k, v in pairs(result) do
-      local hostIndex = {}
-      local sandboxIndex = {}
-      for n, m in pairs(v.metaindex) do
-        local fn, incheck, outcheck = m.fn, m.incheck, m.outcheck
-        hostIndex[n] = fn
-        if m.sandboxfn then
-          local sf = m.sandboxfn
-          sandboxIndex[n] = bubblewrap(function(obj, ...)
-            return sf(UserData(obj), ...)
-          end)
-        else
-          local sandboxfn
-          if not incheck and not outcheck then
-            sandboxfn = fn
-          elseif not incheck then
-            sandboxfn = function(...)
-              return outcheck(fn(...))
-            end
-          elseif not outcheck then
-            sandboxfn = function(self, ...)
-              return fn(self, incheck(...))
-            end
-          else
-            sandboxfn = function(self, ...)
-              return outcheck(fn(self, incheck(...)))
-            end
-          end
-          sandboxIndex[n] = bubblewrap(function(obj, ...)
-            return sandboxfn(UserData(obj), ...)
-          end)
-        end
+      local sandboxMTindex = {}
+      for n, fn in pairs(v.sandboxindex) do
+        sandboxMTindex[n] = bubblewrap(fn)
       end
       t[k] = {
         constructor = v.constructor,
         ctype = v.ctype,
-        hostMT = { __index = hostIndex }, -- issue #657
+        hostMT = { __index = v.hostindex }, -- issue #657
         isa = v.isa,
         name = v.name,
-        sandboxMT = { __index = sandboxIndex },
+        sandboxMT = { __index = sandboxMTindex },
         scripts = v.scripts,
       }
     end
@@ -119,17 +96,40 @@ return function(datalua, funcheck, gencode, sqls, uiobjectsmodule, uiobjecttypes
         for _, sql in ipairs(method.sqls or {}) do
           table.insert(args, (assert(sqls[sql], sql)))
         end
-        local basefn = wrap(fname, mkfn(unpack(args)))
-        local sandboxbasefn = nil
+        local hostfn = wrap(fname, mkfn(unpack(args)))
+        local sandboxDispatch
         if method.sandboximpl then
           local sbmkfn = assert(loadstring_untainted(method.sandboximpl, src), fname)
           local sbargs = {}
           for _, sm in ipairs(method.sandboxmodules or {}) do
             table.insert(sbargs, (assert(modules[sm], sm)))
           end
-          sandboxbasefn = wrap(fname, sbmkfn(unpack(sbargs)))
+          local sbfn = wrap(fname, sbmkfn(unpack(sbargs)))
+          sandboxDispatch = function(obj, ...)
+            return sbfn(UserData(obj), ...)
+          end
+        else
+          local sandboxfn
+          if not incheck and not outcheck then
+            sandboxfn = hostfn
+          elseif not incheck then
+            sandboxfn = function(...)
+              return outcheck(hostfn(...))
+            end
+          elseif not outcheck then
+            sandboxfn = function(self, ...)
+              return hostfn(self, incheck(...))
+            end
+          else
+            sandboxfn = function(self, ...)
+              return outcheck(hostfn(self, incheck(...)))
+            end
+          end
+          sandboxDispatch = function(obj, ...)
+            return sandboxfn(UserData(obj), ...)
+          end
         end
-        mixin[mname] = { fn = basefn, incheck = incheck, outcheck = outcheck, sandboxfn = sandboxbasefn }
+        mixin[mname] = { hostfn = hostfn, sandboxDispatch = sandboxDispatch }
       end
       uiobjects[name] = {
         cfg = cfg,

--- a/wowless/modules/uiobjectloader.lua
+++ b/wowless/modules/uiobjectloader.lua
@@ -44,25 +44,32 @@ return function(datalua, funcheck, gencode, sqls, uiobjectsmodule, uiobjecttypes
       for n, m in pairs(v.metaindex) do
         local fn, incheck, outcheck = m.fn, m.incheck, m.outcheck
         hostIndex[n] = fn
-        local sandboxfn
-        if not incheck and not outcheck then
-          sandboxfn = fn
-        elseif not incheck then
-          sandboxfn = function(...)
-            return outcheck(fn(...))
-          end
-        elseif not outcheck then
-          sandboxfn = function(self, ...)
-            return fn(self, incheck(...))
-          end
+        if m.sandboxfn then
+          local sf = m.sandboxfn
+          sandboxIndex[n] = bubblewrap(function(obj, ...)
+            return sf(UserData(obj), ...)
+          end)
         else
-          sandboxfn = function(self, ...)
-            return outcheck(fn(self, incheck(...)))
+          local sandboxfn
+          if not incheck and not outcheck then
+            sandboxfn = fn
+          elseif not incheck then
+            sandboxfn = function(...)
+              return outcheck(fn(...))
+            end
+          elseif not outcheck then
+            sandboxfn = function(self, ...)
+              return fn(self, incheck(...))
+            end
+          else
+            sandboxfn = function(self, ...)
+              return outcheck(fn(self, incheck(...)))
+            end
           end
+          sandboxIndex[n] = bubblewrap(function(obj, ...)
+            return sandboxfn(UserData(obj), ...)
+          end)
         end
-        sandboxIndex[n] = bubblewrap(function(obj, ...)
-          return sandboxfn(UserData(obj), ...)
-        end)
       end
       t[k] = {
         constructor = v.constructor,
@@ -113,7 +120,16 @@ return function(datalua, funcheck, gencode, sqls, uiobjectsmodule, uiobjecttypes
           table.insert(args, (assert(sqls[sql], sql)))
         end
         local basefn = wrap(fname, mkfn(unpack(args)))
-        mixin[mname] = { fn = basefn, incheck = incheck, outcheck = outcheck }
+        local sandboxbasefn = nil
+        if method.sandboximpl then
+          local sbmkfn = assert(loadstring_untainted(method.sandboximpl, src), fname)
+          local sbargs = {}
+          for _, sm in ipairs(method.sandboxmodules or {}) do
+            table.insert(sbargs, (assert(modules[sm], sm)))
+          end
+          sandboxbasefn = wrap(fname, sbmkfn(unpack(sbargs)))
+        end
+        mixin[mname] = { fn = basefn, incheck = incheck, outcheck = outcheck, sandboxfn = sandboxbasefn }
       end
       uiobjects[name] = {
         cfg = cfg,


### PR DESCRIPTION
## Summary

- Adds `sandboximpl` generation to `prep.lua` for getter, setter, settexture, and stub methods on UIObjects, so sandbox calls get input/output type checking while host calls use direct field access
- Separates host and sandbox method dispatch in `uiobjectloader`: sandbox methods now go through a `sandboxDispatch` wrapper that coerces the proxy to its internal UserData representation before calling the method
- Generated sandboximpls coerce `self` internally via `gencode.UserData(obj)`, eliminating the wrapper closure on the sandboximpl path in `uiobjectloader`
- Adds `uiobjects` as a dependency of `gencode` so `gencode.UserData` is available in sandbox-facing generated code

## Test plan

- [x] All existing tests pass (`cmake --build --preset default --target test`)
- [x] Addon test suite completes (`WowlessTestsDone = true`, no failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)