### PR TITLE
modules: introduce cstubs module to abstract product-specific stubs loading

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -831,6 +831,7 @@ lua2c(
   wowless.modules.calendar=${CMAKE_CURRENT_SOURCE_DIR}/wowless/modules/calendar.lua
   wowless.modules.cgencode=${CMAKE_CURRENT_SOURCE_DIR}/wowless/modules/cgencode.lua
   wowless.modules.clog=${CMAKE_CURRENT_SOURCE_DIR}/wowless/modules/clog.lua
+  wowless.modules.cstubs=${CMAKE_CURRENT_SOURCE_DIR}/wowless/modules/cstubs.lua
   wowless.modules.ctypecheck=c
   wowless.modules.cvars=${CMAKE_CURRENT_SOURCE_DIR}/wowless/modules/cvars.lua
   wowless.modules.datetime=${CMAKE_CURRENT_SOURCE_DIR}/wowless/modules/datetime.lua

--- a/data/modules.yaml
+++ b/data/modules.yaml
@@ -3,6 +3,7 @@ addons:
     datalua:
 api:
   deps:
+    cstubs:
     datalua:
     env:
     events:
@@ -32,6 +33,9 @@ clog:
   deps:
     datalua:
     log:
+cstubs:
+  deps:
+    datalua:
 ctypecheck:
   deps:
     cgencode:

--- a/wowless/env.lua
+++ b/wowless/env.lua
@@ -20,8 +20,7 @@ end
 
 local function init(modules, lite)
   modules.log(1, 'loading functions')
-  local stubs = require('build.products.' .. modules.datalua.product .. '.stubs')
-  local impls, secureimpls = stubs.load(modules)
+  local impls, secureimpls = modules.cstubs.load(modules)
   modules.log(1, 'functions loaded')
   Mixin(modules.env.genv, deepcopy(impls))
   Mixin(modules.env.genv, deepcopy(modules.datalua.globals))

--- a/wowless/modules/api.lua
+++ b/wowless/modules/api.lua
@@ -1,6 +1,7 @@
 local hlist = require('wowless.hlist')
 
 return function(
+  cstubs,
   datalua,
   env,
   events,
@@ -13,7 +14,7 @@ return function(
   uiobjecttypes,
   visibility
 )
-  local new = require('build.products.' .. datalua.product .. '.stubs').new
+  local new = cstubs.new
   local frames = hlist()
   local genv = env.genv
   local secureenv = env.secureenv

--- a/wowless/modules/cstubs.lua
+++ b/wowless/modules/cstubs.lua
@@ -1,0 +1,3 @@
+return function(datalua)
+  return require('build.products.' .. datalua.product .. '.stubs')
+end


### PR DESCRIPTION
## Summary

- Adds a new `wowless.modules.cstubs` module that encapsulates `require('build.products.' .. product .. '.stubs')`, taking `datalua` as its only dependency
- `wowless/modules/api.lua` now receives `cstubs` as an injected dependency instead of calling `require` inline
- `wowless/env.lua` now uses `modules.cstubs.load(modules)` instead of constructing the require path itself
- Registers the new module in `CMakeLists.txt` and `data/modules.yaml`

## Test plan

- [x] All existing tests pass (`cmake --build --preset default --target test`)
- [x] All pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)