### PR TITLE
luaobjects: wire sandboximpl and funcheck into method dispatch

### DIFF
--- a/wowless/modules/luaobjects.lua
+++ b/wowless/modules/luaobjects.lua
@@ -4,6 +4,7 @@ local mixin = require('wowless.util').mixin
 return function(datalua)
   local config = datalua.config.modules and datalua.config.modules.luaobjects or {}
   local mtps = {}
+  local hostmts = {}
   local objs = setmetatable({}, { __mode = 'k' })
   local impltypes = {}
 
@@ -15,11 +16,15 @@ return function(datalua)
         return allmethods[k]
       end
       local v = datalua.luaobjects[k]
-      local methods = {}
+      local hostindex = {}
+      local sandboxindex = {}
       if v.inherits then
-        local parentmethods = createMethods(v.inherits)
-        for mk, mfn in pairs(parentmethods) do
-          methods[mk] = mfn
+        local parent = createMethods(v.inherits)
+        for mk, mfn in pairs(parent.hostindex) do
+          hostindex[mk] = mfn
+        end
+        for mk, fn in pairs(parent.sandboxindex) do
+          sandboxindex[mk] = fn
         end
       end
       for mk, mv in pairs(v.methods) do
@@ -28,12 +33,13 @@ return function(datalua)
           table.insert(args, (assert(modules[m], m)))
         end
         local mfn = assert(loadstring_untainted(mv.impl))(unpack(args))
-        methods[mk] = bubblewrap(function(u, ...)
+        hostindex[mk] = mfn
+        sandboxindex[mk] = bubblewrap(function(u, ...)
           return mfn(objs[u], ...)
         end)
       end
-      allmethods[k] = methods
-      return methods
+      allmethods[k] = { hostindex = hostindex, sandboxindex = sandboxindex }
+      return allmethods[k]
     end
 
     for k in pairs(datalua.luaobjects) do
@@ -42,19 +48,20 @@ return function(datalua)
 
     for k, v in pairs(datalua.luaobjects) do
       if not v.virtual then
-        local methods = allmethods[k]
+        local m = allmethods[k]
+        local sandboxmethods = m.sandboxindex
 
-        local mt
-        mt = {
+        local sandboxmt
+        sandboxmt = {
           __eq = function(u1, u2)
             return objs[u1].table == objs[u2].table
           end,
           __index = function(u, key)
-            return methods[key] or objs[u].table[key]
+            return sandboxmethods[key] or objs[u].table[key]
           end,
           __metatable = false,
           __newindex = function(u, key, value)
-            if methods[key] or mt[key] ~= nil then
+            if sandboxmethods[key] or sandboxmt[key] ~= nil then
               error('Attempted to assign to read-only key ' .. key)
             end
             objs[u].table[key] = value
@@ -65,8 +72,13 @@ return function(datalua)
         }
 
         local mtp = newproxy(true)
-        mixin(getmetatable(mtp), mt)
+        mixin(getmetatable(mtp), sandboxmt)
         mtps[k] = mtp
+        hostmts[k] = {
+          __index = function(t, key)
+            return m.hostindex[key] or t.table[key]
+          end,
+        }
         impltypes[k] = v.impl and modules[v.impl]
       end
     end
@@ -74,7 +86,7 @@ return function(datalua)
 
   local function make(k)
     local p = newproxy(assert(mtps[k], k))
-    local obj = { type = k, table = {}, luarep = p }
+    local obj = setmetatable({ type = k, table = {}, luarep = p }, assert(hostmts[k], k))
     objs[p] = obj
     return obj
   end

--- a/wowless/modules/luaobjects.lua
+++ b/wowless/modules/luaobjects.lua
@@ -20,12 +20,8 @@ return function(datalua)
       local sandboxindex = {}
       if v.inherits then
         local parent = createMethods(v.inherits)
-        for mk, mfn in pairs(parent.hostindex) do
-          hostindex[mk] = mfn
-        end
-        for mk, fn in pairs(parent.sandboxindex) do
-          sandboxindex[mk] = fn
-        end
+        mixin(hostindex, parent.hostindex)
+        mixin(sandboxindex, parent.sandboxindex)
       end
       for mk, mv in pairs(v.methods) do
         local args = {}

--- a/wowless/modules/luaobjects.lua
+++ b/wowless/modules/luaobjects.lua
@@ -8,6 +8,7 @@ return function(datalua)
   local impltypes = {}
 
   local function LoadTypes(modules)
+    local funcheck = modules.funcheck
     local allmethods = {}
 
     local function createMethods(k)
@@ -20,14 +21,43 @@ return function(datalua)
         mixin(sandboxindex, createMethods(v.inherits))
       end
       for mk, mv in pairs(v.methods) do
+        local fname = k .. ':' .. mk
         local args = {}
         for _, m in ipairs(mv.modules or {}) do
           table.insert(args, (assert(modules[m], m)))
         end
         local mfn = assert(loadstring_untainted(mv.impl))(unpack(args))
-        sandboxindex[mk] = bubblewrap(function(u, ...)
-          return mfn(objs[u], ...)
-        end)
+        local sandboxDispatch
+        if mv.sandboximpl then
+          local sbargs = {}
+          for _, sm in ipairs(mv.sandboxmodules or {}) do
+            table.insert(sbargs, (assert(modules[sm], sm)))
+          end
+          sandboxDispatch = assert(loadstring_untainted(mv.sandboximpl, fname))(unpack(sbargs))
+        else
+          local incheck = mv.inputs and funcheck.makeCheckInputs(fname, mv)
+          local outcheck = mv.outputs and funcheck.makeCheckOutputs(fname, mv)
+          local sandboxfn
+          if not incheck and not outcheck then
+            sandboxfn = mfn
+          elseif not incheck then
+            sandboxfn = function(...)
+              return outcheck(mfn(...))
+            end
+          elseif not outcheck then
+            sandboxfn = function(self, ...)
+              return mfn(self, incheck(...))
+            end
+          else
+            sandboxfn = function(self, ...)
+              return outcheck(mfn(self, incheck(...)))
+            end
+          end
+          sandboxDispatch = function(obj, ...)
+            return sandboxfn(objs[obj], ...)
+          end
+        end
+        sandboxindex[mk] = bubblewrap(sandboxDispatch)
       end
       allmethods[k] = sandboxindex
       return sandboxindex

--- a/wowless/modules/luaobjects.lua
+++ b/wowless/modules/luaobjects.lua
@@ -15,12 +15,9 @@ return function(datalua)
         return allmethods[k]
       end
       local v = datalua.luaobjects[k]
-      local hostindex = {}
       local sandboxindex = {}
       if v.inherits then
-        local parent = createMethods(v.inherits)
-        mixin(hostindex, parent.hostindex)
-        mixin(sandboxindex, parent.sandboxindex)
+        mixin(sandboxindex, createMethods(v.inherits))
       end
       for mk, mv in pairs(v.methods) do
         local args = {}
@@ -28,13 +25,12 @@ return function(datalua)
           table.insert(args, (assert(modules[m], m)))
         end
         local mfn = assert(loadstring_untainted(mv.impl))(unpack(args))
-        hostindex[mk] = mfn
         sandboxindex[mk] = bubblewrap(function(u, ...)
           return mfn(objs[u], ...)
         end)
       end
-      allmethods[k] = { hostindex = hostindex, sandboxindex = sandboxindex }
-      return allmethods[k]
+      allmethods[k] = sandboxindex
+      return sandboxindex
     end
 
     for k in pairs(datalua.luaobjects) do
@@ -43,8 +39,7 @@ return function(datalua)
 
     for k, v in pairs(datalua.luaobjects) do
       if not v.virtual then
-        local m = allmethods[k]
-        local sandboxmethods = m.sandboxindex
+        local sandboxmethods = allmethods[k]
 
         local sandboxmt
         sandboxmt = {

--- a/wowless/modules/luaobjects.lua
+++ b/wowless/modules/luaobjects.lua
@@ -4,7 +4,6 @@ local mixin = require('wowless.util').mixin
 return function(datalua)
   local config = datalua.config.modules and datalua.config.modules.luaobjects or {}
   local mtps = {}
-  local hostmts = {}
   local objs = setmetatable({}, { __mode = 'k' })
   local impltypes = {}
 
@@ -70,11 +69,6 @@ return function(datalua)
         local mtp = newproxy(true)
         mixin(getmetatable(mtp), sandboxmt)
         mtps[k] = mtp
-        hostmts[k] = {
-          __index = function(t, key)
-            return m.hostindex[key] or t.table[key]
-          end,
-        }
         impltypes[k] = v.impl and modules[v.impl]
       end
     end
@@ -82,7 +76,7 @@ return function(datalua)
 
   local function make(k)
     local p = newproxy(assert(mtps[k], k))
-    local obj = setmetatable({ type = k, table = {}, luarep = p }, assert(hostmts[k], k))
+    local obj = { type = k, table = {}, luarep = p }
     objs[p] = obj
     return obj
   end


### PR DESCRIPTION
## Summary

- Methods with a `sandboximpl` (generated by `stubby` in prep.lua for all non-impl stub methods) now use it for sandbox dispatch instead of silently calling the no-op host impl
- Methods without `sandboximpl` fall back to `funcheck` `makeCheckInputs`/`makeCheckOutputs` around the host impl, with `self` coercion via `objs[u]` — mirrors the uiobjectloader dispatch pattern
- `funcheck` is accessed via `modules.funcheck` inside `LoadTypes` to avoid the cycle `luaobjects → funcheck → typecheck → luaobjects`

## Test plan

- [x] All existing tests pass
- [x] `methodpartition` test still passes — bubblewrap done before inheritance copying so shared methods keep the same function object

🤖 Generated with [Claude Code](https://claude.com/claude-code)