### PR TITLE
stubs: implement type as cfunc wowless_type

### DIFF
--- a/data/impl.yaml
+++ b/data/impl.yaml
@@ -680,8 +680,6 @@ tonumber:
   stdlib: tonumber
 tostring:
   stdlib: tostring
-type:
-  stdlib: type
 UnitClass:
   impl:
     sqls:

--- a/data/products/wow/apis.yaml
+++ b/data/products/wow/apis.yaml
@@ -38557,7 +38557,14 @@ TurnRightStart:
 TurnRightStop:
   protected: true
 type:
-  impl: type
+  cfunc: wowless_type
+  inputs:
+  - name: value
+    nilable: true
+    type: unknown
+  outputs:
+  - name: typename
+    type: string
 UninviteUnit:
 UnitAffectingCombat:
   inputs:

--- a/data/products/wow_anniversary/apis.yaml
+++ b/data/products/wow_anniversary/apis.yaml
@@ -24365,7 +24365,14 @@ TurnRightStart:
 TurnRightStop:
   protected: true
 type:
-  impl: type
+  cfunc: wowless_type
+  inputs:
+  - name: value
+    nilable: true
+    type: unknown
+  outputs:
+  - name: typename
+    type: string
 UninviteUnit:
 UnitAffectingCombat:
   inputs:

--- a/data/products/wow_beta/apis.yaml
+++ b/data/products/wow_beta/apis.yaml
@@ -38491,7 +38491,14 @@ TurnRightStart:
 TurnRightStop:
   protected: true
 type:
-  impl: type
+  cfunc: wowless_type
+  inputs:
+  - name: value
+    nilable: true
+    type: unknown
+  outputs:
+  - name: typename
+    type: string
 UninviteUnit:
 UnitAffectingCombat:
   inputs:

--- a/data/products/wow_classic/apis.yaml
+++ b/data/products/wow_classic/apis.yaml
@@ -23738,7 +23738,14 @@ TurnRightStart:
 TurnRightStop:
   protected: true
 type:
-  impl: type
+  cfunc: wowless_type
+  inputs:
+  - name: value
+    nilable: true
+    type: unknown
+  outputs:
+  - name: typename
+    type: string
 UninviteUnit:
 UnitAffectingCombat:
   inputs:

--- a/data/products/wow_classic_era/apis.yaml
+++ b/data/products/wow_classic_era/apis.yaml
@@ -22584,7 +22584,14 @@ TurnRightStart:
 TurnRightStop:
   protected: true
 type:
-  impl: type
+  cfunc: wowless_type
+  inputs:
+  - name: value
+    nilable: true
+    type: unknown
+  outputs:
+  - name: typename
+    type: string
 UninviteUnit:
 UnitAffectingCombat:
   inputs:

--- a/data/products/wow_classic_era_ptr/apis.yaml
+++ b/data/products/wow_classic_era_ptr/apis.yaml
@@ -24365,7 +24365,14 @@ TurnRightStart:
 TurnRightStop:
   protected: true
 type:
-  impl: type
+  cfunc: wowless_type
+  inputs:
+  - name: value
+    nilable: true
+    type: unknown
+  outputs:
+  - name: typename
+    type: string
 UninviteUnit:
 UnitAffectingCombat:
   inputs:

--- a/data/products/wow_classic_ptr/apis.yaml
+++ b/data/products/wow_classic_ptr/apis.yaml
@@ -23738,7 +23738,14 @@ TurnRightStart:
 TurnRightStop:
   protected: true
 type:
-  impl: type
+  cfunc: wowless_type
+  inputs:
+  - name: value
+    nilable: true
+    type: unknown
+  outputs:
+  - name: typename
+    type: string
 UninviteUnit:
 UnitAffectingCombat:
   inputs:

--- a/data/products/wowt/apis.yaml
+++ b/data/products/wowt/apis.yaml
@@ -39012,7 +39012,14 @@ TurnRightStart:
 TurnRightStop:
   protected: true
 type:
-  impl: type
+  cfunc: wowless_type
+  inputs:
+  - name: value
+    nilable: true
+    type: unknown
+  outputs:
+  - name: typename
+    type: string
 UninviteUnit:
 UnitAffectingCombat:
   inputs:

--- a/data/products/wowxptr/apis.yaml
+++ b/data/products/wowxptr/apis.yaml
@@ -38491,7 +38491,14 @@ TurnRightStart:
 TurnRightStop:
   protected: true
 type:
-  impl: type
+  cfunc: wowless_type
+  inputs:
+  - name: value
+    nilable: true
+    type: unknown
+  outputs:
+  - name: typename
+    type: string
 UninviteUnit:
 UnitAffectingCombat:
   inputs:

--- a/data/schemas/function.yaml
+++ b/data/schemas/function.yaml
@@ -1,6 +1,8 @@
 name: function
 type:
   record:
+    cfunc:
+      type: string
     impl:
       type:
         ref:

--- a/spec/data/apis_spec.lua
+++ b/spec/data/apis_spec.lua
@@ -9,7 +9,7 @@ describe('apis', function()
         describe(name, function()
           it('is not stubbed if provided by elune', function()
             if _G[name] then
-              assert.Truthy(api.impl)
+              assert.Truthy(api.impl or api.cfunc)
             end
           end)
           it('has outputs if it has inputs', function()

--- a/tools/prep.lua
+++ b/tools/prep.lua
@@ -1163,75 +1163,77 @@ if args.coutput then
 
   for _, entry in ipairs(eligible) do
     local k, v = entry.name, entry.cfg
-    emit('static int stub_%s(lua_State *L) {', safename(k))
-    if v.protected then
-      emit('  if (wowless_forbidden(L)) return 0;')
-    end
-    local allinps = v.inputs or {}
-    local instride = v.instride or 0
-    local nsins = #allinps - instride
-    local function check(inp, idx)
-      local nilable = inp.nilable or inp.default ~= nil
-      return dispatch(cinputtypes, inp.type)('stubcheck', nilable, idx) .. ';'
-    end
-    local function usagecheck(inp, idx)
-      local nilable = inp.nilable or inp.default ~= nil
-      return ('if (!%s) return luaL_error(L, %s);'):format(
-        dispatch(cinputtypes, inp.type)('is', nilable, idx),
-        cstring('Usage: ' .. v.usage)
-      )
-    end
-    local inputcheck = v.usage and usagecheck or check
-    for i = 1, nsins do
-      emit('  %s', inputcheck(allinps[i], i))
-    end
-    if instride > 0 then
-      emit('  int i, n = lua_gettop(L);')
-      emit('  for (i = %d; i <= n; i += %d) {', nsins + 1, instride)
-      for j = nsins + 1, #allinps do
-        emit('    %s', inputcheck(allinps[j], 'i + ' .. (j - nsins - 1)))
+    if not v.cfunc then
+      emit('static int stub_%s(lua_State *L) {', safename(k))
+      if v.protected then
+        emit('  if (wowless_forbidden(L)) return 0;')
       end
-      emit('  }')
-    end
-    if v.inputs ~= nil and instride == 0 then
-      emit('  wowless_stubcheckextraargs(L, %d, %s);', nsins, cstring(k))
-    end
-    local allouts = not v.stubnothing and v.outputs or {}
-    local outstride = v.outstride or 0
-    local nonstride = #allouts - outstride
-    local stuboutstrides = v.stuboutstrides
-    local outs
-    if stuboutstrides ~= nil then
-      outs = {}
-      for i = 1, nonstride do
-        table.insert(outs, allouts[i])
+      local allinps = v.inputs or {}
+      local instride = v.instride or 0
+      local nsins = #allinps - instride
+      local function check(inp, idx)
+        local nilable = inp.nilable or inp.default ~= nil
+        return dispatch(cinputtypes, inp.type)('stubcheck', nilable, idx) .. ';'
       end
-      for _ = 1, stuboutstrides do
-        for j = nonstride + 1, #allouts do
-          table.insert(outs, allouts[j])
+      local function usagecheck(inp, idx)
+        local nilable = inp.nilable or inp.default ~= nil
+        return ('if (!%s) return luaL_error(L, %s);'):format(
+          dispatch(cinputtypes, inp.type)('is', nilable, idx),
+          cstring('Usage: ' .. v.usage)
+        )
+      end
+      local inputcheck = v.usage and usagecheck or check
+      for i = 1, nsins do
+        emit('  %s', inputcheck(allinps[i], i))
+      end
+      if instride > 0 then
+        emit('  int i, n = lua_gettop(L);')
+        emit('  for (i = %d; i <= n; i += %d) {', nsins + 1, instride)
+        for j = nsins + 1, #allinps do
+          emit('    %s', inputcheck(allinps[j], 'i + ' .. (j - nsins - 1)))
+        end
+        emit('  }')
+      end
+      if v.inputs ~= nil and instride == 0 then
+        emit('  wowless_stubcheckextraargs(L, %d, %s);', nsins, cstring(k))
+      end
+      local allouts = not v.stubnothing and v.outputs or {}
+      local outstride = v.outstride or 0
+      local nonstride = #allouts - outstride
+      local stuboutstrides = v.stuboutstrides
+      local outs
+      if stuboutstrides ~= nil then
+        outs = {}
+        for i = 1, nonstride do
+          table.insert(outs, allouts[i])
+        end
+        for _ = 1, stuboutstrides do
+          for j = nonstride + 1, #allouts do
+            table.insert(outs, allouts[j])
+          end
+        end
+      else
+        outs = allouts
+      end
+      for _, out in ipairs(outs) do
+        local val
+        if out.stub ~= nil then
+          val = out.stub
+        elseif out.default ~= nil then
+          val = out.default
+        elseif not out.nilable or out.stubnotnil then
+          val = dispatch(coutdefaults, out.type)
+        end
+        if val == nil then
+          emit('  lua_pushnil(L);')
+        else
+          dispatch(coutpushers, out.type, val)
         end
       end
-    else
-      outs = allouts
+      emit('  return %d;', #outs)
+      emit('}')
+      emit('')
     end
-    for _, out in ipairs(outs) do
-      local val
-      if out.stub ~= nil then
-        val = out.stub
-      elseif out.default ~= nil then
-        val = out.default
-      elseif not out.nilable or out.stubnotnil then
-        val = dispatch(coutdefaults, out.type)
-      end
-      if val == nil then
-        emit('  lua_pushnil(L);')
-      else
-        dispatch(coutpushers, out.type, val)
-      end
-    end
-    emit('  return %d;', #outs)
-    emit('}')
-    emit('')
   end
 
   local coutputdefaulttypes = {
@@ -1359,9 +1361,11 @@ if args.coutput then
       if not ns_entries[ns] then
         ns_entries[ns] = {}
       end
-      ns_entries[ns][shortname] = { sn = safename(entry.name), secureonly = not not entry.cfg.secureonly }
+      ns_entries[ns][shortname] =
+        { cfunc = entry.cfg.cfunc, sn = safename(entry.name), secureonly = not not entry.cfg.secureonly }
     else
-      global_entries[entry.name] = { sn = safename(entry.name), secureonly = not not entry.cfg.secureonly }
+      global_entries[entry.name] =
+        { cfunc = entry.cfg.cfunc, sn = safename(entry.name), secureonly = not not entry.cfg.secureonly }
     end
   end
   for _, entry in ipairs(eligible_impls) do
@@ -1420,6 +1424,8 @@ if args.coutput then
       local impldata = entry.impldata
       local func = impldata.nowrap and 'nullptr' or ('implstub_' .. entry.sn)
       emit('%s{%s, %s, %d, &impldata_%s},', indent, cstring(name), func, entry.secureonly and 1 or 0, entry.sn)
+    elseif entry.cfunc then
+      emit('%s{%s, %s, %d, nullptr},', indent, cstring(name), entry.cfunc, entry.secureonly and 1 or 0)
     else
       emit('%s{%s, stub_%s, %d, nullptr},', indent, cstring(name), entry.sn, entry.secureonly and 1 or 0)
     end

--- a/wowless/typecheck.h
+++ b/wowless/typecheck.h
@@ -819,4 +819,10 @@ static void wowless_stubchecknilablearrayof(lua_State *L, int idx) {
   }
 }
 
+static int wowless_type(lua_State *L) {
+  luaL_checkany(L, 1);
+  lua_pushstring(L, lua_typename(L, lua_type(L, 1)));
+  return 1;
+}
+
 #endif /* WOWLESS_TYPECHECK_H */


### PR DESCRIPTION
## Summary

- Removes `type` from the impl/fenv-table pathway (`stdlib: type` in `impl.yaml`)
- Adds `wowless_type` in `typecheck.h` as a hand-coded C function (`luaL_checkany` + `lua_typename`)
- Introduces a `cfunc` field to the function schema and `prep.lua` generator: APIs with `cfunc` get the named C function as their stub entry instead of a generated body
- Updates all 9 product `apis.yaml` files to use `cfunc: wowless_type` with proper `unknown`/`string` input/output types
- Updates `spec/data/apis_spec.lua` to accept `cfunc` alongside `impl` as a valid override for elune-provided globals

## Test plan

- [ ] `cmake --build --preset default --target test` passes (all hooks + tests green)
- [ ] `build/generated/wowt_stubs.cpp` contains `{"type", wowless_type, 0, nullptr}` in `stubs_global`

🤖 Generated with [Claude Code](https://claude.com/claude-code)