### PR TITLE
stubs: handle stringenums entirely in C with static registry

### DIFF
--- a/tools/prep.lua
+++ b/tools/prep.lua
@@ -7,8 +7,6 @@ local args = (function()
   return parser:parse()
 end)()
 
-local product = args.product
-
 local deps = {} -- accumulated during runtime
 
 local function parseYaml(f)
@@ -23,6 +21,7 @@ local prettywrite = require('tools.prettywrite')
 local Mixin = require('wowless.util').mixin
 local sorted = require('pl.tablex').sort
 
+local product = args.product
 local globals = parseYaml('data/products/' .. product .. '/globals.yaml')
 local structures = parseYaml('data/products/' .. product .. '/structures.yaml')
 local stringenums = parseYaml('data/stringenums.yaml')
@@ -215,6 +214,7 @@ local impl_input_types = {
   luaobject = nop,
   number = nop,
   string = nop,
+  stringenum = nop,
   structure = nop,
   table = nop,
   uiAddon = nop,
@@ -238,6 +238,7 @@ impl_output_types = {
   number = nop,
   oneornil = nop,
   string = nop,
+  stringenum = nop,
   structure = nop,
   table = nop,
   uiobject = nop,
@@ -773,8 +774,19 @@ if args.coutput then
     number = simple_cinputtype('number'),
     string = simple_cinputtype('string'),
     stringenum = function(name)
+      local n = 0
+      for _ in pairs(stringenums[name]) do
+        n = n + 1
+      end
       return function(verb, nilable, idx)
-        return string.format('wowless_%s%sstringenum_%s(L, %s)', verb, nilable and 'nilable' or '', safename(name), idx)
+        return string.format(
+          'wowless_%s%sstringenum(L, %s, wowless_stringenum_%s_values, %d)',
+          verb,
+          nilable and 'nilable' or '',
+          idx,
+          safename(name),
+          n
+        )
       end
     end,
     structure = function(name)
@@ -822,6 +834,20 @@ if args.coutput then
     number = simple_coutputtype('number'),
     oneornil = simple_coutputtype('oneornil'),
     string = simple_coutputtype('string'),
+    stringenum = function(name, nilable, idx)
+      local n = 0
+      for _ in pairs(stringenums[name]) do
+        n = n + 1
+      end
+      local ns = nilable and 'nilable' or ''
+      return string.format(
+        'wowless_imploutput%sstringenum(L, %s, wowless_stringenum_%s_values, %d)',
+        ns,
+        idx,
+        safename(name),
+        n
+      )
+    end,
     structure = function(name, nilable, idx)
       return string.format('wowless_stubcheck%sstruct_%s(L, %s)', nilable and 'nilable' or '', safename(name), idx)
     end,
@@ -1006,11 +1032,21 @@ if args.coutput then
   if next(structures) then
     emit('')
   end
-  for sename in sorted(stringenums) do
-    emit('static bool wowless_isstringenum_%s(lua_State *L, int idx);', safename(sename))
-    emit('static bool wowless_isnilablestringenum_%s(lua_State *L, int idx);', safename(sename))
-    emit('static void wowless_stubcheckstringenum_%s(lua_State *L, int idx);', safename(sename))
-    emit('static void wowless_stubchecknilablestringenum_%s(lua_State *L, int idx);', safename(sename))
+  for sename, sevalues in sorted(stringenums) do
+    local values = {}
+    for k in pairs(sevalues) do
+      values[#values + 1] = k
+    end
+    table.sort(values)
+    local entries = {}
+    for _, v in ipairs(values) do
+      entries[#entries + 1] = cstring(v)
+    end
+    emit(
+      'static const char * const wowless_stringenum_%s_values[] = {%s};',
+      safename(sename),
+      table.concat(entries, ', ')
+    )
   end
   if next(stringenums) then
     emit('')
@@ -1054,25 +1090,6 @@ if args.coutput then
     emit('  if (!lua_isnoneornil(L, idx)) {')
     emit('    wowless_stubcheckstruct_%s(L, idx);', safename(sname))
     emit('  }')
-    emit('}')
-    emit('')
-  end
-
-  for sename in sorted(stringenums) do
-    emit('static bool wowless_isstringenum_%s(lua_State *L, int idx) {', safename(sename))
-    emit('  return wowless_isstringenum(L, idx, %s);', cstring(sename))
-    emit('}')
-    emit('')
-    emit('static bool wowless_isnilablestringenum_%s(lua_State *L, int idx) {', safename(sename))
-    emit('  return wowless_isnilablestringenum(L, idx, %s);', cstring(sename))
-    emit('}')
-    emit('')
-    emit('static void wowless_stubcheckstringenum_%s(lua_State *L, int idx) {', safename(sename))
-    emit('  wowless_stubcheckstringenum(L, idx, %s);', cstring(sename))
-    emit('}')
-    emit('')
-    emit('static void wowless_stubchecknilablestringenum_%s(lua_State *L, int idx) {', safename(sename))
-    emit('  wowless_stubchecknilablestringenum(L, idx, %s);', cstring(sename))
     emit('}')
     emit('')
   end

--- a/wowless/modules/cgencode.lua
+++ b/wowless/modules/cgencode.lua
@@ -1,16 +1,6 @@
 local bubblewrap = require('wowless.bubblewrap')
 
 return function(addons, api, events, log, luaobjects, uiobjects, units)
-  local stringenums = require('runtime.stringenums')
-
-  local function CheckStringEnum(value, enumname)
-    local evalues = stringenums[enumname]
-    if not evalues then
-      error('internal error: unknown string enum: ' .. enumname)
-    end
-    return evalues[value:upper()]
-  end
-
   local function CreateLuaObject(typename)
     return luaobjects.CreateProxy(typename, luaobjects.Create(typename))
   end
@@ -31,7 +21,6 @@ return function(addons, api, events, log, luaobjects, uiobjects, units)
   -- lookups (no hashing). Keep uiobjects.userdata at 1.
   return {
     uiobjects.userdata,
-    CheckStringEnum = CheckStringEnum,
     FireProtected = bubblewrap(FireProtected),
     GetUiAddon = GetUiAddon,
     GetUnit = units.GetUnit,

--- a/wowless/typecheck.h
+++ b/wowless/typecheck.h
@@ -9,6 +9,14 @@ extern "C" {
 #include "wowless/uiobject.h"
 }
 
+#include <string.h>
+#ifdef _MSC_VER
+#define wowless_strcasecmp _stricmp
+#else
+#include <strings.h>
+#define wowless_strcasecmp strcasecmp
+#endif
+
 #include <string_view>
 
 static inline int wowless_forbidden(lua_State *L) {
@@ -354,29 +362,42 @@ static inline void wowless_stubchecknilablenil(lua_State *L, int idx) {
   wowless_stubchecknil(L, idx);
 }
 
+static inline bool wowless_stringenum_check(const char *s,
+                                            const char *const *values, int n) {
+  int lo = 0, hi = n - 1;
+  while (lo <= hi) {
+    int mid = (lo + hi) / 2;
+    int cmp = wowless_strcasecmp(s, values[mid]);
+    if (cmp == 0) {
+      return true;
+    }
+    if (cmp < 0) {
+      hi = mid - 1;
+    } else {
+      lo = mid + 1;
+    }
+  }
+  return false;
+}
+
 static inline bool wowless_isstringenum(lua_State *L, int idx,
-                                        std::string_view enumname) {
-  idx = lua_absindex(L, idx);
+                                        const char *const *values, int n) {
   if (lua_type(L, idx) != LUA_TSTRING) {
     return false;
   }
-  lua_getfield(L, lua_upvalueindex(1), "CheckStringEnum");
-  lua_pushvalue(L, idx);
-  lua_pushlstring(L, enumname.data(), enumname.size());
-  lua_call(L, 2, 1);
-  int result = lua_toboolean(L, -1);
-  lua_pop(L, 1);
-  return result;
+  return wowless_stringenum_check(lua_tostring(L, idx), values, n);
 }
 
 static inline bool wowless_isnilablestringenum(lua_State *L, int idx,
-                                               std::string_view enumname) {
-  return lua_isnoneornil(L, idx) || wowless_isstringenum(L, idx, enumname);
+                                               const char *const *values,
+                                               int n) {
+  return lua_isnoneornil(L, idx) || wowless_isstringenum(L, idx, values, n);
 }
 
 static inline void wowless_stubcheckstringenum(lua_State *L, int idx,
-                                               std::string_view enumname) {
-  if (!wowless_isstringenum(L, idx, enumname)) {
+                                               const char *const *values,
+                                               int n) {
+  if (!wowless_isstringenum(L, idx, values, n)) {
     if (lua_type(L, idx) != LUA_TSTRING) {
       luaL_checktype(L, idx, LUA_TSTRING);
     } else {
@@ -385,14 +406,80 @@ static inline void wowless_stubcheckstringenum(lua_State *L, int idx,
   }
 }
 
-static inline void wowless_stubchecknilablestringenum(
-    lua_State *L, int idx, std::string_view enumname) {
-  if (!wowless_isnilablestringenum(L, idx, enumname)) {
+static inline void wowless_stubchecknilablestringenum(lua_State *L, int idx,
+                                                      const char *const *values,
+                                                      int n) {
+  if (!wowless_isnilablestringenum(L, idx, values, n)) {
     if (lua_type(L, idx) != LUA_TSTRING) {
       luaL_checktype(L, idx, LUA_TSTRING);
     } else {
       luaL_argerror(L, idx, "invalid string enum value");
     }
+  }
+}
+
+static inline void wowless_implcheckstringenum(lua_State *L, int idx,
+                                               const char *const *values,
+                                               int n) {
+  if (lua_type(L, idx) != LUA_TSTRING) {
+    luaL_typerror(L, idx, lua_typename(L, LUA_TSTRING));
+    return;
+  }
+  const char *s = lua_tostring(L, idx);
+  int lo = 0, hi = n - 1;
+  while (lo <= hi) {
+    int mid = (lo + hi) / 2;
+    int cmp = wowless_strcasecmp(s, values[mid]);
+    if (cmp == 0) {
+      lua_pushstring(L, values[mid]);
+      lua_replace(L, idx);
+      return;
+    }
+    if (cmp < 0) {
+      hi = mid - 1;
+    } else {
+      lo = mid + 1;
+    }
+  }
+  luaL_argerror(L, idx, "invalid string enum value");
+}
+
+static inline void wowless_implchecknilablestringenum(lua_State *L, int idx,
+                                                      const char *const *values,
+                                                      int n) {
+  if (!lua_isnoneornil(L, idx)) {
+    wowless_implcheckstringenum(L, idx, values, n);
+  }
+}
+
+static inline void wowless_imploutputstringenum(lua_State *L, int idx,
+                                                const char *const *values,
+                                                int n) {
+  if (lua_type(L, idx) != LUA_TSTRING) {
+    luaL_typerror(L, idx, lua_typename(L, LUA_TSTRING));
+    return;
+  }
+  const char *s = lua_tostring(L, idx);
+  int lo = 0, hi = n - 1;
+  while (lo <= hi) {
+    int mid = (lo + hi) / 2;
+    int cmp = strcmp(s, values[mid]);
+    if (cmp == 0) {
+      return;
+    }
+    if (cmp < 0) {
+      hi = mid - 1;
+    } else {
+      lo = mid + 1;
+    }
+  }
+  luaL_argerror(L, idx, "invalid string enum value");
+}
+
+static inline void wowless_imploutputnilablestringenum(
+    lua_State *L, int idx, const char *const *values, int n) {
+  if (!lua_isnoneornil(L, idx)) {
+    wowless_imploutputstringenum(L, idx, values, n);
   }
 }
 


### PR DESCRIPTION
## Summary

Eliminates all Lua involvement from stringenum validation in C stubs. Previously every stringenum check called back into the Lua `cgencode` module via `CheckStringEnum`, requiring Lua stack manipulation and a table lookup.

`prep.lua` now emits a sorted `const char *const` array for each enum directly into the per-product generated `_stubs.cpp`. The generic check functions in `typecheck.h` take `(values, n)` and use binary search.

Three check flavors added for stringenums:

- **stubcheck**: reject non-string or string not in the enum
- **implcheck**: accept any case, normalize stack value to canonical (uppercase) case; error if not in enum
- **imploutput**: require exact case match (`strcmp`); error otherwise

Also removes `CheckStringEnum` and the `runtime.stringenums` dependency from `cgencode.lua`.

Portability: `strcasecmp` is POSIX-only; a `wowless_strcasecmp` shim maps to `_stricmp` on MSVC.

## Test plan

- [x] `cmake --build --preset default --target test` passes with no output
- [x] `bin/run.sh wow_classic_era` runs clean
- [x] CI passes on Linux, macOS, and Windows (MSVC)

🤖 Generated with [Claude Code](https://claude.com/claude-code)