### PR TITLE
luaobjects: eliminate luarep

### DIFF
--- a/addon/Wowless/luaobjects.lua
+++ b/addon/Wowless/luaobjects.lua
@@ -77,9 +77,6 @@ local function checkLuaObject(ty, o)
         seen[fn] = k
       end
     end,
-    field_luarep = function()
-      assertEquals(_G.__wowless and o or nil, o.luarep)
-    end,
     field_type = function()
       assertEquals(nil, o.type)
     end,

--- a/tools/prep.lua
+++ b/tools/prep.lua
@@ -107,7 +107,7 @@ local specDefault = (function()
       return ('gencode.CreateUIObject(%q).luarep'):format(ty.uiobject:lower())
     end
     if ty.luaobject then
-      return ('gencode.CreateLuaObject(%q).luarep'):format(ty.luaobject)
+      return ('gencode.CreateLuaObject(%q)'):format(ty.luaobject)
     end
     error('unexpected type: ' .. prettywrite(ty, true))
   end
@@ -1206,11 +1206,11 @@ if args.coutput then
     emit('}')
     emit('')
     emit('static void wowless_imploutputluaobject_%s(lua_State *L, int idx) {', safename(loname))
-    emit('  wowless_imploutputluaobject(L, idx, %d);', tid)
+    emit('  wowless_imploutputluaobject(L, idx, %d, %s);', tid, cstring(loname))
     emit('}')
     emit('')
     emit('static void wowless_imploutputnilableluaobject_%s(lua_State *L, int idx) {', safename(loname))
-    emit('  wowless_imploutputnilableluaobject(L, idx, %d);', tid)
+    emit('  wowless_imploutputnilableluaobject(L, idx, %d, %s);', tid, cstring(loname))
     emit('}')
     emit('')
   end

--- a/wowless/modules/cgencode.lua
+++ b/wowless/modules/cgencode.lua
@@ -12,7 +12,7 @@ return function(addons, api, events, log, luaobjects, uiobjects, units)
   end
 
   local function CreateLuaObject(typename)
-    return luaobjects.Create(typename).luarep
+    return luaobjects.CreateProxy(typename, luaobjects.Create(typename))
   end
 
   local function CreateUiObject(typename)
@@ -37,6 +37,7 @@ return function(addons, api, events, log, luaobjects, uiobjects, units)
     GetUnit = units.GetUnit,
     Coerce = luaobjects.Coerce,
     CreateLuaObject = CreateLuaObject,
+    CreateProxy = luaobjects.CreateProxy,
     CreateUiObject = CreateUiObject,
     log = log,
   }

--- a/wowless/modules/gencode.lua
+++ b/wowless/modules/gencode.lua
@@ -26,9 +26,13 @@ return function(api, env, log, luaobjects, typecheck)
     end
   end
 
+  local function CreateLuaObject(typename)
+    return luaobjects.CreateProxy(typename, luaobjects.Create(typename))
+  end
+
   return {
     Check = Check,
-    CreateLuaObject = luaobjects.Create,
+    CreateLuaObject = CreateLuaObject,
     CreateUIObject = api.CreateUIObject,
     hlist = hlist,
     Mixin = env.mixin,

--- a/wowless/modules/luaobjects.lua
+++ b/wowless/modules/luaobjects.lua
@@ -70,9 +70,8 @@ return function(cstubs, datalua)
 
   local function make(k)
     local typeid = assert(typeids[k], k)
-    local env = {}
-    local p = luaobject.new(typeid, metatables[k], env)
-    env.luarep = p
+    local env = { typeid }
+    luaobject.new(typeid, metatables[k], env)
     return env
   end
 
@@ -96,14 +95,14 @@ return function(cstubs, datalua)
   end
 
   local function CreateProxy(typename, obj)
-    assert(obj and obj.luarep, 'not a luaobject')
+    assert(type(obj) == 'table', 'not a luaobject env')
     local typeid = assert(typeids[typename], typename)
     local np = luaobject.new(typeid, metatables[typename], obj)
     return np
   end
 
   local function IsType(typename, obj)
-    return type(obj) == 'table' and luaobject.gettypeid(obj.luarep) == typeids[typename]
+    return type(obj) == 'table' and obj[1] == typeids[typename]
   end
 
   local function UserData(p)

--- a/wowless/modules/typecheck.lua
+++ b/wowless/modules/typecheck.lua
@@ -262,7 +262,7 @@ return function(addons, datalua, env, luaobjects, uiobjects, uiobjecttypes, unit
     elseif spec.type.luaobject then
       if isout then
         if luaobjects.IsType(spec.type.luaobject, value) then
-          return value.luarep
+          return luaobjects.CreateProxy(spec.type.luaobject, value)
         else
           return nil, 'is not of luaobject type ' .. spec.type.luaobject
         end

--- a/wowless/typecheck.h
+++ b/wowless/typecheck.h
@@ -716,23 +716,31 @@ static inline void wowless_imploutputnilabletable(lua_State *L, int idx) {
 }
 
 static inline void wowless_imploutputluaobject(lua_State *L, int idx,
-                                               int typeid_val) {
+                                               int typeid_val,
+                                               std::string_view tname) {
   idx = lua_absindex(L, idx);
   if (lua_type(L, idx) == LUA_TTABLE) {
-    lua_getfield(L, idx, "luarep");
-    if (wowless_isluaobject(L, -1, typeid_val)) {
+    lua_rawgeti(L, idx, 1);
+    bool ok = lua_type(L, -1) == LUA_TNUMBER &&
+              (int)lua_tointeger(L, -1) == typeid_val;
+    lua_pop(L, 1);
+    if (ok) {
+      lua_getfield(L, lua_upvalueindex(1), "CreateProxy");
+      lua_pushlstring(L, tname.data(), tname.size());
+      lua_pushvalue(L, idx);
+      lua_call(L, 2, 1);
       lua_replace(L, idx);
       return;
     }
-    lua_pop(L, 1);
   }
   wowless_outputtyperror(L, idx, "luaobject");
 }
 
 static inline void wowless_imploutputnilableluaobject(lua_State *L, int idx,
-                                                      int typeid_val) {
+                                                      int typeid_val,
+                                                      std::string_view tname) {
   if (!lua_isnoneornil(L, idx)) {
-    wowless_imploutputluaobject(L, idx, typeid_val);
+    wowless_imploutputluaobject(L, idx, typeid_val, tname);
   }
 }
 


### PR DESCRIPTION
Store the typeid at env[1] (array part) instead of a named field, and create a fresh proxy on output rather than reading back a stored luarep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)