### PR TITLE
build: convert C++ to C

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,24 +4,12 @@ set(CMAKE_TOOLCHAIN_FILE
     ${CMAKE_CURRENT_SOURCE_DIR}/vcpkg/scripts/buildsystems/vcpkg.cmake
     CACHE STRING "Vcpkg toolchain file")
 
-project(wowless LANGUAGES C CXX)
-
-set(CMAKE_CXX_STANDARD 17)
-set(CMAKE_CXX_STANDARD_REQUIRED ON)
+project(wowless LANGUAGES C)
 
 include(CheckCCompilerFlag)
 check_c_compiler_flag(-ffast-math HAVE_FFAST_MATH)
 if(HAVE_FFAST_MATH)
   add_compile_options(-ffast-math)
-endif()
-
-include(CheckCXXCompilerFlag)
-check_cxx_compiler_flag(-fno-exceptions HAVE_FNO_EXCEPTIONS)
-check_cxx_compiler_flag(/EH- HAVE_EH_MINUS)
-if(HAVE_FNO_EXCEPTIONS)
-  add_compile_options($<$<COMPILE_LANGUAGE:CXX>:-fno-exceptions>)
-elseif(HAVE_EH_MINUS)
-  add_compile_options($<$<COMPILE_LANGUAGE:CXX>:/EH->)
 endif()
 
 set(elune_SOURCE_DIR vendor/elune)
@@ -502,11 +490,11 @@ add_lua_executable(
 foreach(product ${products})
   add_custom_command(
     OUTPUT stamp/${product}.txt
-    BYPRODUCTS runtime/${product}.lua generated/${product}_stubs.cpp
+    BYPRODUCTS runtime/${product}.lua generated/${product}_stubs.c
     COMMAND
       prep ${product} --sqls ${CMAKE_CURRENT_BINARY_DIR}/runtime/sqls.yaml
       --output ${CMAKE_CURRENT_BINARY_DIR}/generated/${product}.lua --coutput
-      ${CMAKE_CURRENT_BINARY_DIR}/generated/${product}_stubs.cpp
+      ${CMAKE_CURRENT_BINARY_DIR}/generated/${product}_stubs.c
     COMMAND
       ${CMAKE_COMMAND} -E copy_if_different
       ${CMAKE_CURRENT_BINARY_DIR}/generated/${product}.lua
@@ -523,7 +511,7 @@ foreach(product ${products})
         build.products.${product}.stubs=c)
   target_sources(
     datalua_${product}
-    PRIVATE ${CMAKE_CURRENT_BINARY_DIR}/generated/${product}_stubs.cpp)
+    PRIVATE ${CMAKE_CURRENT_BINARY_DIR}/generated/${product}_stubs.c)
   add_dependencies(datalua_${product} datalua_${product}_lua)
   list(APPEND dataluas datalua_${product})
 endforeach()
@@ -883,7 +871,7 @@ target_sources(
           wowless/luaobject.c
           wowless/modules/encodingutil.c
           wowless/secure.c
-          wowless/stubs.cpp
+          wowless/stubs.c
           wowless/uiobject.c)
 
 add_lua_executable(

--- a/tools/prep.lua
+++ b/tools/prep.lua
@@ -749,11 +749,11 @@ if args.coutput then
       return function(verb, nilable, idx)
         local effective_verb = verb == 'implcheck' and 'stubcheck' or verb
         return string.format(
-          'wowless_%s%sarrayof<%s>(L, %s)',
+          'wowless_%s%sarrayof(L, %s, %s)',
           effective_verb,
           nilable and 'nilable' or '',
-          check_name,
-          idx
+          idx,
+          check_name
         )
       end
     end,
@@ -806,7 +806,7 @@ if args.coutput then
     arrayof = function(inner, nilable, idx)
       local inner_fn = dispatch(cinputtypes, inner)
       local check_name = inner_fn('stubcheck', false, 0):match('^(.-)%(')
-      return string.format('wowless_stubcheck%sarrayof<%s>(L, %s)', nilable and 'nilable' or '', check_name, idx)
+      return string.format('wowless_stubcheck%sarrayof(L, %s, %s)', nilable and 'nilable' or '', idx, check_name)
     end,
     boolean = simple_coutputtype('boolean'),
     enum = function(_, nilable, idx)
@@ -1498,14 +1498,14 @@ if args.coutput then
         for _, m in ipairs(mods) do
           table.insert(parts, cstring(m))
         end
-        emit('static const char *const implmods_%s[] = {%s, nullptr};', sn, table.concat(parts, ', '))
+        emit('static const char *const implmods_%s[] = {%s, NULL};', sn, table.concat(parts, ', '))
       end
       if #sqls_list > 0 then
         local parts = {}
         for _, s in ipairs(sqls_list) do
           table.insert(parts, cstring(s))
         end
-        emit('static const char *const implsqls_%s[] = {%s, nullptr};', sn, table.concat(parts, ', '))
+        emit('static const char *const implsqls_%s[] = {%s, NULL};', sn, table.concat(parts, ', '))
       end
       emit(
         'static const wowless_impl_data impldata_%s = {%s, %d, %s, %s, %s};',
@@ -1513,8 +1513,8 @@ if args.coutput then
         cstring(impldata.impl),
         #impldata.impl,
         cstring(entry.chunkname),
-        #mods > 0 and ('implmods_' .. sn) or 'nullptr',
-        #sqls_list > 0 and ('implsqls_' .. sn) or 'nullptr'
+        #mods > 0 and ('implmods_' .. sn) or 'NULL',
+        #sqls_list > 0 and ('implsqls_' .. sn) or 'NULL'
       )
     end
   end
@@ -1522,10 +1522,10 @@ if args.coutput then
   local function emit_stub_entry(indent, name, entry)
     if entry.impldata then
       local impldata = entry.impldata
-      local func = impldata.nowrap and 'nullptr' or ('implstub_' .. entry.sn)
+      local func = impldata.nowrap and 'NULL' or ('implstub_' .. entry.sn)
       emit('%s{%s, %s, %d, &impldata_%s},', indent, cstring(name), func, entry.secureonly and 1 or 0, entry.sn)
     else
-      emit('%s{%s, stub_%s, %d, nullptr},', indent, cstring(name), entry.sn, entry.secureonly and 1 or 0)
+      emit('%s{%s, stub_%s, %d, NULL},', indent, cstring(name), entry.sn, entry.secureonly and 1 or 0)
     end
   end
 
@@ -1545,7 +1545,7 @@ if args.coutput then
   for name, entry in sorted(global_entries) do
     emit_stub_entry('  ', name, entry)
   end
-  emit('  {nullptr, nullptr, 0, nullptr}')
+  emit('  {NULL, NULL, 0, NULL}')
   emit('};')
   emit('')
 
@@ -1554,7 +1554,7 @@ if args.coutput then
     for name, entry in sorted(ns_entries[ns]) do
       emit_stub_entry('  ', name, entry)
     end
-    emit('  {nullptr, nullptr, 0, nullptr}')
+    emit('  {NULL, NULL, 0, NULL}')
     emit('};')
     emit('')
   end
@@ -1563,11 +1563,11 @@ if args.coutput then
   for ns in sorted(ns_entries) do
     emit('  {%s, stubs_ns_%s},', cstring(ns), safename(ns))
   end
-  emit('  {nullptr, nullptr}')
+  emit('  {NULL, NULL}')
   emit('};')
   emit('')
 
-  emit('static const wowless_stubs_spec stubs_spec = {')
+  emit('static wowless_stubs_spec stubs_spec = {')
   emit('  stubs_global,')
   emit('  stubs_ns,')
   emit('};')
@@ -1579,9 +1579,9 @@ if args.coutput then
       for mname in sorted(lodata.methods or {}) do
         local sn = string.format('lomethod_%s_%s', safename(loname), safename(mname))
         local impl_src = string.format('return (...).methods[%q]', mname)
-        emit('static const char *const implmods_%s[] = {%s, nullptr};', sn, cstring(lodata.impl))
+        emit('static const char *const implmods_%s[] = {%s, NULL};', sn, cstring(lodata.impl))
         emit(
-          'static const wowless_impl_data impldata_%s = {%s, %d, %s, implmods_%s, nullptr};',
+          'static const wowless_impl_data impldata_%s = {%s, %d, %s, implmods_%s, NULL};',
           sn,
           cstring(impl_src),
           #impl_src,
@@ -1607,38 +1607,38 @@ if args.coutput then
     else
       for mname in sorted(lodata.methods or {}) do
         local sn = string.format('lomethod_%s_%s', safename(loname), safename(mname))
-        emit('  {%s, stub_%s, 0, nullptr},', cstring(mname), sn)
+        emit('  {%s, stub_%s, 0, NULL},', cstring(mname), sn)
       end
     end
-    emit('  {nullptr, nullptr, 0, nullptr}')
+    emit('  {NULL, NULL, 0, NULL}')
     emit('};')
     emit('')
   end
 
   -- Luaobject type registry (all types including virtual, for method stub sharing)
-  emit('static const wowless_luaobject_type_entry lo_types[] = {')
+  emit('static wowless_luaobject_type_entry lo_types[] = {')
   for loname in sorted(luaobjectdata) do
     emit('  {%s, %d, lo_methods_%s},', cstring(loname), luaobject_typeids[loname], safename(loname))
   end
-  emit('  {nullptr, 0, nullptr}')
+  emit('  {NULL, 0, NULL}')
   emit('};')
   emit('')
   -- UIObject method entry array
-  emit('static const struct wowless_uiobject_method_entry uiobject_method_entries[] = {')
+  emit('static struct wowless_uiobject_method_entry uiobject_method_entries[] = {')
   for key, entry in sorted(eligible_uimethods) do
     emit('  {%s, stub_uimethod_%s_%s},', cstring(key), safename(entry.k), safename(entry.mk))
   end
-  emit('  {nullptr, nullptr}')
+  emit('  {NULL, NULL}')
   emit('};')
   emit('')
-  emit('extern "C" int luaopen_build_products_%s_stubs(lua_State *L) {', product)
+  emit('int luaopen_build_products_%s_stubs(lua_State *L) {', product)
   emit('  lua_newtable(L);')
-  emit('  lua_pushlightuserdata(L, static_cast<void *>(const_cast<wowless_stubs_spec *>(&stubs_spec)));')
+  emit('  lua_pushlightuserdata(L, (void *)&stubs_spec);')
   emit('  lua_pushcclosure(L, wowless_load_stubs, 1);')
   emit('  lua_setfield(L, -2, "load");')
   emit('  lua_pushcfunction(L, wowless_uiobject_new);')
   emit('  lua_setfield(L, -2, "new");')
-  emit('  lua_pushlightuserdata(L, static_cast<void *>(const_cast<wowless_luaobject_type_entry *>(lo_types)));')
+  emit('  lua_pushlightuserdata(L, (void *)lo_types);')
   emit('  lua_pushcclosure(L, wowless_load_luaobject_stubs, 1);')
   emit('  lua_setfield(L, -2, "loadluaobjects");')
   emit('  lua_pushlightuserdata(L, (void *)uiobject_method_entries);')

--- a/wowless/stubs.c
+++ b/wowless/stubs.c
@@ -1,9 +1,7 @@
-extern "C" {
 #include "wowless/stubs.h"
 
 #include "lauxlib.h"
 #include "wowless/bubblewrap.h"
-}
 
 int wowless_impl_stub(lua_State *L) {
   lua_pushvalue(L, lua_upvalueindex(2));
@@ -101,8 +99,8 @@ void wowless_stub_log_extra_args(lua_State *L, const char *fname) {
 }
 
 int wowless_load_luaobject_stubs(lua_State *L) {
-  const auto *spec = static_cast<const wowless_luaobject_type_entry *>(
-      lua_touserdata(L, lua_upvalueindex(1)));
+  const wowless_luaobject_type_entry *spec =
+      lua_touserdata(L, lua_upvalueindex(1));
   lua_getfield(L, 1, "cgencode");
   lua_insert(L, 1);
   /* Stack: [cgencode, modules] */
@@ -113,7 +111,8 @@ int wowless_load_luaobject_stubs(lua_State *L) {
     lua_pushinteger(L, t->type_id);
     lua_setfield(L, -2, "typeid");
     load_entries(L, t->methods);
-    /* Stack: [cgencode, modules, result, type_info, sandbox_methods, host_methods] */
+    /* Stack: [cgencode, modules, result, type_info, sandbox_methods,
+     * host_methods] */
     lua_pop(L, 1); /* discard host_methods */
     lua_setfield(L, -2, "methods");
     lua_setfield(L, -2, t->type_name);
@@ -122,19 +121,19 @@ int wowless_load_luaobject_stubs(lua_State *L) {
 }
 
 static int make_uiobject_method_stub(lua_State *L) {
-  auto fn = reinterpret_cast<lua_CFunction>(lua_touserdata(L, lua_upvalueindex(1)));
+  lua_CFunction fn = (lua_CFunction)lua_touserdata(L, lua_upvalueindex(1));
   lua_pushvalue(L, lua_upvalueindex(2)); /* cgencode */
   lua_pushcclosure(L, fn, 1);
   return 1;
 }
 
 int wowless_load_uiobject_method_stubs(lua_State *L) {
-  const auto *spec = static_cast<const wowless_uiobject_method_entry *>(
-      lua_touserdata(L, lua_upvalueindex(1)));
+  const wowless_uiobject_method_entry *spec =
+      lua_touserdata(L, lua_upvalueindex(1));
   /* arg 1 is cgencode directly */
   lua_newtable(L);
-  for (const auto *e = spec; e->key; e++) {
-    lua_pushlightuserdata(L, reinterpret_cast<void *>(e->func));
+  for (const wowless_uiobject_method_entry *e = spec; e->key; e++) {
+    lua_pushlightuserdata(L, (void *)e->func);
     lua_pushvalue(L, 1); /* cgencode */
     lua_pushcclosure(L, make_uiobject_method_stub, 2);
     lua_setfield(L, -2, e->key);
@@ -143,8 +142,7 @@ int wowless_load_uiobject_method_stubs(lua_State *L) {
 }
 
 int wowless_load_stubs(lua_State *L) {
-  const auto *spec =
-      static_cast<const wowless_stubs_spec *>(lua_touserdata(L, lua_upvalueindex(1)));
+  const wowless_stubs_spec *spec = lua_touserdata(L, lua_upvalueindex(1));
   lua_getfield(L, 1, "cgencode");
   lua_insert(L, 1);
   load_entries(L, spec->global);

--- a/wowless/stubs.h
+++ b/wowless/stubs.h
@@ -5,41 +5,41 @@
 
 #include "lua.h"
 
-struct wowless_impl_data {
+typedef struct wowless_impl_data {
   const char *impl;
   size_t impl_len;
   const char *chunkname;
   const char *const *modules; /* NULL-terminated array, or NULL */
   const char *const *sqls;    /* NULL-terminated array, or NULL */
-};
+} wowless_impl_data;
 
-struct wowless_stub_entry {
+typedef struct wowless_stub_entry {
   const char *name;
   lua_CFunction func;
   int secureonly;
-  const struct wowless_impl_data *impldata; /* NULL for C stub entries */
-};
+  const wowless_impl_data *impldata; /* NULL for C stub entries */
+} wowless_stub_entry;
 
-struct wowless_ns_entry {
+typedef struct wowless_ns_entry {
   const char *ns;
-  const struct wowless_stub_entry *entries;
-};
+  const wowless_stub_entry *entries;
+} wowless_ns_entry;
 
-struct wowless_stubs_spec {
-  const struct wowless_stub_entry *global;
-  const struct wowless_ns_entry *ns;
-};
+typedef struct wowless_stubs_spec {
+  const wowless_stub_entry *global;
+  const wowless_ns_entry *ns;
+} wowless_stubs_spec;
 
-struct wowless_luaobject_type_entry {
+typedef struct wowless_luaobject_type_entry {
   const char *type_name;
   int type_id;
-  const struct wowless_stub_entry *methods;
-};
+  const wowless_stub_entry *methods;
+} wowless_luaobject_type_entry;
 
-struct wowless_uiobject_method_entry {
+typedef struct wowless_uiobject_method_entry {
   const char *key;
   lua_CFunction func;
-};
+} wowless_uiobject_method_entry;
 
 int wowless_load_stubs(lua_State *L);
 int wowless_load_luaobject_stubs(lua_State *L);

--- a/wowless/typecheck.h
+++ b/wowless/typecheck.h
@@ -1,15 +1,13 @@
 #ifndef WOWLESS_TYPECHECK_H
 #define WOWLESS_TYPECHECK_H
 
-extern "C" {
+#include <stdbool.h>
+
 #include "lauxlib.h"
 #include "lua.h"
 #include "wowless/luaobject.h"
 #include "wowless/stubs.h"
 #include "wowless/uiobject.h"
-}
-
-#include <string_view>
 
 static inline int wowless_forbidden(lua_State *L) {
   const char *taint = lua_getstacktaint(L);
@@ -355,14 +353,14 @@ static inline void wowless_stubchecknilablenil(lua_State *L, int idx) {
 }
 
 static inline bool wowless_isstringenum(lua_State *L, int idx,
-                                        std::string_view enumname) {
+                                        const char *enumname) {
   idx = lua_absindex(L, idx);
   if (lua_type(L, idx) != LUA_TSTRING) {
     return false;
   }
   lua_getfield(L, lua_upvalueindex(1), "CheckStringEnum");
   lua_pushvalue(L, idx);
-  lua_pushlstring(L, enumname.data(), enumname.size());
+  lua_pushstring(L, enumname);
   lua_call(L, 2, 1);
   int result = lua_toboolean(L, -1);
   lua_pop(L, 1);
@@ -370,12 +368,12 @@ static inline bool wowless_isstringenum(lua_State *L, int idx,
 }
 
 static inline bool wowless_isnilablestringenum(lua_State *L, int idx,
-                                               std::string_view enumname) {
+                                               const char *enumname) {
   return lua_isnoneornil(L, idx) || wowless_isstringenum(L, idx, enumname);
 }
 
 static inline void wowless_stubcheckstringenum(lua_State *L, int idx,
-                                               std::string_view enumname) {
+                                               const char *enumname) {
   if (!wowless_isstringenum(L, idx, enumname)) {
     if (lua_type(L, idx) != LUA_TSTRING) {
       luaL_checktype(L, idx, LUA_TSTRING);
@@ -385,8 +383,8 @@ static inline void wowless_stubcheckstringenum(lua_State *L, int idx,
   }
 }
 
-static inline void wowless_stubchecknilablestringenum(
-    lua_State *L, int idx, std::string_view enumname) {
+static inline void wowless_stubchecknilablestringenum(lua_State *L, int idx,
+                                                      const char *enumname) {
   if (!wowless_isnilablestringenum(L, idx, enumname)) {
     if (lua_type(L, idx) != LUA_TSTRING) {
       luaL_checktype(L, idx, LUA_TSTRING);
@@ -397,16 +395,15 @@ static inline void wowless_stubchecknilablestringenum(
 }
 
 static inline void wowless_stubcreateluaobject(lua_State *L,
-                                               std::string_view tname) {
+                                               const char *tname) {
   lua_getfield(L, lua_upvalueindex(1), "CreateLuaObject");
-  lua_pushlstring(L, tname.data(), tname.size());
+  lua_pushstring(L, tname);
   lua_call(L, 1, 1);
 }
 
-static inline void wowless_stubcreateuiobject(lua_State *L,
-                                              std::string_view tname) {
+static inline void wowless_stubcreateuiobject(lua_State *L, const char *tname) {
   lua_getfield(L, lua_upvalueindex(1), "CreateUiObject");
-  lua_pushlstring(L, tname.data(), tname.size());
+  lua_pushstring(L, tname);
   lua_call(L, 1, 1);
 }
 
@@ -737,7 +734,7 @@ static inline void wowless_imploutputnilabletable(lua_State *L, int idx) {
 
 static inline void wowless_imploutputluaobject(lua_State *L, int idx,
                                                int typeid_val,
-                                               std::string_view tname) {
+                                               const char *tname) {
   idx = lua_absindex(L, idx);
   if (lua_type(L, idx) == LUA_TTABLE) {
     lua_rawgeti(L, idx, 1);
@@ -746,7 +743,7 @@ static inline void wowless_imploutputluaobject(lua_State *L, int idx,
     lua_pop(L, 1);
     if (ok) {
       lua_getfield(L, lua_upvalueindex(1), "CreateProxy");
-      lua_pushlstring(L, tname.data(), tname.size());
+      lua_pushstring(L, tname);
       lua_pushvalue(L, idx);
       lua_call(L, 2, 1);
       lua_replace(L, idx);
@@ -758,7 +755,7 @@ static inline void wowless_imploutputluaobject(lua_State *L, int idx,
 
 static inline void wowless_imploutputnilableluaobject(lua_State *L, int idx,
                                                       int typeid_val,
-                                                      std::string_view tname) {
+                                                      const char *tname) {
   if (!lua_isnoneornil(L, idx)) {
     wowless_imploutputluaobject(L, idx, typeid_val, tname);
   }
@@ -830,22 +827,22 @@ static inline void wowless_applymixin(lua_State *L, const char *mixin_name) {
   lua_pop(L, 1);
 }
 
-template <void Check(lua_State *, int)>
-static void wowless_stubcheckarrayof(lua_State *L, int idx) {
+static void wowless_stubcheckarrayof(lua_State *L, int idx,
+                                     void (*check)(lua_State *, int)) {
   idx = lua_absindex(L, idx);
   wowless_stubchecktable(L, idx);
-  int n = static_cast<int>(lua_objlen(L, idx));
+  int n = (int)lua_objlen(L, idx);
   for (int i = 1; i <= n; i++) {
     lua_rawgeti(L, idx, i);
-    Check(L, -1);
+    check(L, -1);
     lua_pop(L, 1);
   }
 }
 
-template <void Check(lua_State *, int)>
-static void wowless_stubchecknilablearrayof(lua_State *L, int idx) {
+static void wowless_stubchecknilablearrayof(lua_State *L, int idx,
+                                            void (*check)(lua_State *, int)) {
   if (!lua_isnoneornil(L, idx)) {
-    wowless_stubcheckarrayof<Check>(L, idx);
+    wowless_stubcheckarrayof(L, idx, check);
   }
 }
 


### PR DESCRIPTION
## Summary

- Removes all C++ from the project; `CMakeLists.txt` now declares `LANGUAGES C` only
- `wowless/stubs.cpp` → `wowless/stubs.c`: drop `extern "C"` wrapper, replace `auto`/`static_cast`/`reinterpret_cast` with explicit types and C-style casts
- `wowless/typecheck.h`: drop `extern "C"` wrapper and `#include <string_view>`; add `#include <stdbool.h>`; replace `std::string_view` params with `const char *` and `.data()`/`.size()` calls with `lua_pushstring`; convert the two `template` functions (`wowless_stubcheckarrayof` / `wowless_stubchecknilablearrayof`) to take a function-pointer parameter instead
- `wowless/stubs.h`: add typedefs for all struct types so generated `.c` files can reference them without the `struct` keyword
- `tools/prep.lua`: emit `NULL` instead of `nullptr`, drop `extern "C"` and C++ casts from the `luaopen_` entry point, emit arrayof checks with function-pointer argument syntax, rename output extension to `.c`

## Test plan

- [x] All pre-commit hooks pass (clang-format, luacheck, build and test)
- [x] No `.cpp` files remain outside `vendor/` and `build/`
- [x] `grep` for `extern "C"`, `std::`, `string_view`, `template`, `nullptr` finds nothing in project source

🤖 Generated with [Claude Code](https://claude.ai/claude-code)