### PR TITLE
prep: convert setter uiobject methods to C impl stubs

### DIFF
--- a/tools/prep.lua
+++ b/tools/prep.lua
@@ -1310,7 +1310,6 @@ if args.coutput then
         emit('  %s;', dispatch(cinputtypes, inp.type)('stubcheck', nilable, i + 1))
       end
       emit('  wowless_stubcheckextraargs(L, %d, %s);', #impl_fields + 1, cstring(key))
-      emit('  const char *intaint = wowless_bubblewrap_cstub_enter(L);')
       emit('  wowless_implcheckuiobject_%s(L, 1);', safename(k))
       for i, f in ipairs(impl_fields) do
         local spec = inputs[i]
@@ -1332,9 +1331,9 @@ if args.coutput then
         else
           emit('  lua_pushvalue(L, %d);', i + 1)
         end
+        emit('  lua_setvaluetaint(L, -1, NULL);')
         emit('  lua_setfield(L, 1, %s);', cstring(f.name))
       end
-      emit('  wowless_bubblewrap_cstub_exit(L, intaint);')
       emit('  return 0;')
     else
       emit('  wowless_stubcheckuiobject_%s(L, 1);', safename(k))

--- a/tools/prep.lua
+++ b/tools/prep.lua
@@ -396,29 +396,7 @@ local uiobjectimplmakers = {
       modules = {},
     }
   end,
-  setter = function(impl, mv, k)
-    -- sandbox impl: original code with gencode.Check converting sandbox reps to internal uds
-    local sb = { 'local gencode=...;' }
-    table.insert(sb, string.format('local selfspec={name="self",type={uiobject=%q}};', k))
-    for i in ipairs(impl) do
-      table.insert(sb, 'local spec' .. i .. '=' .. prettywrite(mv.inputs[i], true) .. ';')
-    end
-    table.insert(sb, 'return function(obj')
-    for _, f in ipairs(impl) do
-      table.insert(sb, ',')
-      table.insert(sb, f.name)
-    end
-    table.insert(sb, ')local self=gencode.Check(selfspec,obj);')
-    for i, f in ipairs(impl) do
-      table.insert(sb, 'self.')
-      table.insert(sb, f.name)
-      table.insert(sb, '=gencode.Check(spec')
-      table.insert(sb, tostring(i))
-      table.insert(sb, ',')
-      table.insert(sb, f.name)
-      table.insert(sb, ');')
-    end
-    table.insert(sb, 'end')
+  setter = function(impl, mv)
     -- host impl: direct field assignment, applying defaults for optional args
     local t = { 'return function(self' }
     for _, f in ipairs(impl) do
@@ -440,10 +418,9 @@ local uiobjectimplmakers = {
     end
     table.insert(t, 'end')
     return {
+      cstub = true,
       impl = table.concat(t),
       modules = {},
-      sandboximpl = table.concat(sb),
-      sandboxmodules = { 'gencode' },
     }
   end,
   settexture = function(impl, _, k)
@@ -1324,6 +1301,41 @@ if args.coutput then
         end
       end
       emit('  return %d;', #mv.impl.getter)
+    elseif mv.impl and mv.impl.setter then
+      local impl_fields = mv.impl.setter
+      local inputs = mv.inputs or {}
+      emit('  wowless_stubcheckuiobject_%s(L, 1);', safename(k))
+      for i, inp in ipairs(inputs) do
+        local nilable = inp.nilable or inp.default ~= nil
+        emit('  %s;', dispatch(cinputtypes, inp.type)('stubcheck', nilable, i + 1))
+      end
+      emit('  wowless_stubcheckextraargs(L, %d, %s);', #impl_fields + 1, cstring(key))
+      emit('  const char *intaint = wowless_bubblewrap_cstub_enter(L);')
+      emit('  wowless_implcheckuiobject_%s(L, 1);', safename(k))
+      for i, f in ipairs(impl_fields) do
+        local spec = inputs[i]
+        if spec and type(spec.type) == 'table' and spec.type.uiobject then
+          emit('  wowless_implcheckuiobject_%s(L, %d);', safename(spec.type.uiobject), i + 1)
+        end
+        if spec and spec.default ~= nil then
+          emit('  if (lua_isnoneornil(L, %d)) {', i + 1)
+          if type(spec.default) == 'boolean' then
+            emit('    lua_pushboolean(L, %d);', spec.default and 1 or 0)
+          elseif type(spec.default) == 'number' then
+            emit('    lua_pushnumber(L, %g);', spec.default)
+          else
+            error('unsupported setter default type: ' .. type(spec.default))
+          end
+          emit('  } else {')
+          emit('    lua_pushvalue(L, %d);', i + 1)
+          emit('  }')
+        else
+          emit('  lua_pushvalue(L, %d);', i + 1)
+        end
+        emit('  lua_setfield(L, 1, %s);', cstring(f.name))
+      end
+      emit('  wowless_bubblewrap_cstub_exit(L, intaint);')
+      emit('  return 0;')
     else
       emit('  wowless_stubcheckuiobject_%s(L, 1);', safename(k))
       emit_stub_body(key, mv, 1, stub_inputcheck)

--- a/tools/prep.lua
+++ b/tools/prep.lua
@@ -756,9 +756,10 @@ if args.coutput then
         n = n + 1
       end
       return function(verb, nilable, idx)
+        local effective_verb = verb == 'implcheck' and 'stubcheck' or verb
         return string.format(
           'wowless_%s%sstringenum(L, %s, wowless_stringenum_%s_values, %d)',
-          verb,
+          effective_verb,
           nilable and 'nilable' or '',
           idx,
           safename(name),
@@ -1304,18 +1305,14 @@ if args.coutput then
     elseif mv.impl and mv.impl.setter then
       local impl_fields = mv.impl.setter
       local inputs = mv.inputs or {}
-      emit('  wowless_stubcheckuiobject_%s(L, 1);', safename(k))
+      emit('  wowless_implcheckuiobject_%s(L, 1);', safename(k))
       for i, inp in ipairs(inputs) do
         local nilable = inp.nilable or inp.default ~= nil
-        emit('  %s;', dispatch(cinputtypes, inp.type)('stubcheck', nilable, i + 1))
+        emit('  %s;', dispatch(cinputtypes, inp.type)('implcheck', nilable, i + 1))
       end
       emit('  wowless_stubcheckextraargs(L, %d, %s);', #impl_fields + 1, cstring(key))
-      emit('  wowless_implcheckuiobject_%s(L, 1);', safename(k))
       for i, f in ipairs(impl_fields) do
         local spec = inputs[i]
-        if spec and type(spec.type) == 'table' and spec.type.uiobject then
-          emit('  wowless_implcheckuiobject_%s(L, %d);', safename(spec.type.uiobject), i + 1)
-        end
         if spec and spec.default ~= nil then
           emit('  if (lua_isnoneornil(L, %d)) {', i + 1)
           if type(spec.default) == 'boolean' then

--- a/tools/prep.lua
+++ b/tools/prep.lua
@@ -756,10 +756,9 @@ if args.coutput then
         n = n + 1
       end
       return function(verb, nilable, idx)
-        local effective_verb = verb == 'implcheck' and 'stubcheck' or verb
         return string.format(
           'wowless_%s%sstringenum(L, %s, wowless_stringenum_%s_values, %d)',
-          effective_verb,
+          verb,
           nilable and 'nilable' or '',
           idx,
           safename(name),

--- a/tools/prep.lua
+++ b/tools/prep.lua
@@ -1307,6 +1307,13 @@ if args.coutput then
       emit('  wowless_implcheckuiobject_%s(L, 1);', safename(k))
       for i, inp in ipairs(inputs) do
         local nilable = inp.nilable or inp.default ~= nil
+        -- Font objects can be passed as global name strings (typecheck.lua special case)
+        if type(inp.type) == 'table' and inp.type.uiobject == 'Font' then
+          emit('  if (lua_type(L, %d) == LUA_TSTRING) {', i + 1)
+          emit('    lua_getglobal(L, lua_tostring(L, %d));', i + 1)
+          emit('    lua_replace(L, %d);', i + 1)
+          emit('  }')
+        end
         emit('  %s;', dispatch(cinputtypes, inp.type)('implcheck', nilable, i + 1))
       end
       emit('  wowless_stubcheckextraargs(L, %d, %s);', #impl_fields + 1, cstring(key))

--- a/wowless/typecheck.h
+++ b/wowless/typecheck.h
@@ -4,6 +4,7 @@
 extern "C" {
 #include "lauxlib.h"
 #include "lua.h"
+#include "wowless/bubblewrap.h"
 #include "wowless/luaobject.h"
 #include "wowless/stubs.h"
 #include "wowless/uiobject.h"

--- a/wowless/typecheck.h
+++ b/wowless/typecheck.h
@@ -4,7 +4,6 @@
 extern "C" {
 #include "lauxlib.h"
 #include "lua.h"
-#include "wowless/bubblewrap.h"
 #include "wowless/luaobject.h"
 #include "wowless/stubs.h"
 #include "wowless/uiobject.h"


### PR DESCRIPTION
## Summary

Converts 129 UIObject setter methods from bubblewrap+pcall Lua closures to native C stub functions, using the same factory pattern as the getter stubs from #676.

Key design decisions:

- **Taint**: instead of switching the whole Lua state to host mode via `cstub_enter`/`cstub_exit`, setter stubs call `lua_setvaluetaint(L, -1, NULL)` on each value before `lua_setfield`. This strips taint only from the local stack copy; the caller's variable retains its taint, and `setobj2t` writes `NULL` taint into the host table slot.
- **Type checking and coercion**: uses `implcheck` variants for all inputs so primitive types (number, boolean, string) are coerced in place before the field write, and UIObject inputs are converted from sandbox proxy to host rep in the same pass.
- **Font string names**: Font objects can be passed as global name strings (a WoW compat pattern); the stub resolves the string via `lua_getglobal` before the implcheck, matching the old `gencode.Check` behavior.
- **Self**: `wowless_implcheckuiobject_TYPE(L, 1)` validates and converts self to host rep; no separate stubcheck needed since implcheck subsumes it.

## Test plan

- [x] `cmake --build --preset default --target test` passes with no output
- [x] `bin/run.sh wow_classic_era` runs clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)