### PR TITLE
uiobjectloader: convert uiobjectimpl lua methods to C impl stubs

### DIFF
--- a/tools/prep.lua
+++ b/tools/prep.lua
@@ -463,7 +463,8 @@ for k, v in pairs(uiobjectdata) do
     local d = dispatch(uiobjectimplmakers, mv.impl or 'none', mv, k)
     if d.cstub then
       methods[mk] = d
-      eligible_uimethods[k .. ':' .. mk] = { k = k, mk = mk, mv = mv }
+      local uiimplkey = type(mv.impl) == 'table' and mv.impl.uiobjectimpl
+      eligible_uimethods[k .. ':' .. mk] = { k = k, mk = mk, mv = mv, impl = uiimplkey or nil }
     else
       methods[mk] = Mixin({}, d, {
         inputs = mv.inputs,
@@ -1372,68 +1373,88 @@ end
 -- UIObject method C stubs
 for key, entry in sorted(eligible_uimethods) do
   local k, mk, mv = entry.k, entry.mk, entry.mv
-  emit('static int stub_uimethod_%s_%s(lua_State *L) {', safename(k), safename(mk))
-  if mv.secureonly then
-    emit('  if (wowless_forbidden(L)) return 0;')
-  end
-  if mv.impl and mv.impl.getter then
-    emit('  wowless_implcheckuiobject_%s(L, 1);', safename(k))
-    emit('  wowless_stubcheckextraargs(L, 1, %s);', cstring(key))
-    for i, f in ipairs(mv.impl.getter) do
-      emit('  lua_getfield(L, 1, %s);', cstring(f.name))
-      local out = mv.outputs[i]
-      if out and type(out.type) == 'table' and out.type.uiobject then
-        emit('  if (!lua_isnil(L, -1)) {')
-        emit('    lua_getfield(L, -1, "luarep");')
-        emit('    lua_replace(L, -2);')
-        emit('  }')
-      end
+  if entry.impl then
+    local uiimplkey = entry.impl
+    local implimpl = dispatch(uiobjectimplimplmakers, uiobjectimpl[uiimplkey], uiimplkey)
+    local fn = implimpl.nobubblewrap and 'wowless_impl_stub_nobubblewrap' or 'wowless_impl_stub'
+    local inputs = { { type = { uiobject = k } } }
+    for _, inp in ipairs(mv.inputs or {}) do
+      table.insert(inputs, inp)
     end
-    emit('  return %d;', #mv.impl.getter)
-  elseif mv.impl and mv.impl.setter then
-    local impl_fields = mv.impl.setter
-    local inputs = mv.inputs or {}
-    emit('  wowless_implcheckuiobject_%s(L, 1);', safename(k))
-    for i, inp in ipairs(inputs) do
-      local nilable = inp.nilable or inp.default ~= nil
-      emit('  %s;', dispatch(cinputtypes, inp.type)('implcheck', nilable, i + 1))
-    end
-    emit('  wowless_stubcheckextraargs(L, %d, %s);', #impl_fields + 1, cstring(key))
-    for i, f in ipairs(impl_fields) do
-      local spec = inputs[i]
-      if spec and spec.default ~= nil then
-        emit('  if (lua_isnoneornil(L, %d)) {', i + 1)
-        if type(spec.default) == 'boolean' then
-          emit('    lua_pushboolean(L, %d);', spec.default and 1 or 0)
-        elseif type(spec.default) == 'number' then
-          emit('    lua_pushnumber(L, %g);', spec.default)
-        else
-          error('unsupported setter default type: ' .. type(spec.default))
-        end
-        emit('  } else {')
-        emit('    lua_pushvalue(L, %d);', i + 1)
-        emit('  }')
-      else
-        emit('  lua_pushvalue(L, %d);', i + 1)
-      end
-      emit('  lua_setvaluetaint(L, -1, NULL);')
-      emit('  lua_setfield(L, 1, %s);', cstring(f.name))
-    end
-    emit('  return 0;')
+    emit('static int implstub_uiimpl_%s_%s(lua_State *L) {', safename(k), safename(mk))
+    emit_implstub_body(key, {
+      inputs = inputs,
+      instride = mv.instride,
+      mayreturnnothing = mv.mayreturnnothing,
+      outputs = mv.outputs,
+      outstride = mv.outstride,
+    }, fn)
+    emit('}')
+    emit('')
   else
-    if mv.inputs ~= nil then
-      local inputs_with_self = { { type = { uiobject = k } } }
-      for _, inp in ipairs(mv.inputs) do
-        table.insert(inputs_with_self, inp)
-      end
-      emit_stub_body(key, Mixin({}, mv, { inputs = inputs_with_self }), stub_inputcheck)
-    else
-      emit('  wowless_stubcheckuiobject_%s(L, 1);', safename(k))
-      emit_stub_body(key, mv, stub_inputcheck)
+    emit('static int stub_uimethod_%s_%s(lua_State *L) {', safename(k), safename(mk))
+    if mv.secureonly then
+      emit('  if (wowless_forbidden(L)) return 0;')
     end
-  end
-  emit('}')
-  emit('')
+    if mv.impl and mv.impl.getter then
+      emit('  wowless_implcheckuiobject_%s(L, 1);', safename(k))
+      emit('  wowless_stubcheckextraargs(L, 1, %s);', cstring(key))
+      for i, f in ipairs(mv.impl.getter) do
+        emit('  lua_getfield(L, 1, %s);', cstring(f.name))
+        local out = mv.outputs[i]
+        if out and type(out.type) == 'table' and out.type.uiobject then
+          emit('  if (!lua_isnil(L, -1)) {')
+          emit('    lua_getfield(L, -1, "luarep");')
+          emit('    lua_replace(L, -2);')
+          emit('  }')
+        end
+      end
+      emit('  return %d;', #mv.impl.getter)
+    elseif mv.impl and mv.impl.setter then
+      local impl_fields = mv.impl.setter
+      local inputs = mv.inputs or {}
+      emit('  wowless_implcheckuiobject_%s(L, 1);', safename(k))
+      for i, inp in ipairs(inputs) do
+        local nilable = inp.nilable or inp.default ~= nil
+        emit('  %s;', dispatch(cinputtypes, inp.type)('implcheck', nilable, i + 1))
+      end
+      emit('  wowless_stubcheckextraargs(L, %d, %s);', #impl_fields + 1, cstring(key))
+      for i, f in ipairs(impl_fields) do
+        local spec = inputs[i]
+        if spec and spec.default ~= nil then
+          emit('  if (lua_isnoneornil(L, %d)) {', i + 1)
+          if type(spec.default) == 'boolean' then
+            emit('    lua_pushboolean(L, %d);', spec.default and 1 or 0)
+          elseif type(spec.default) == 'number' then
+            emit('    lua_pushnumber(L, %g);', spec.default)
+          else
+            error('unsupported setter default type: ' .. type(spec.default))
+          end
+          emit('  } else {')
+          emit('    lua_pushvalue(L, %d);', i + 1)
+          emit('  }')
+        else
+          emit('  lua_pushvalue(L, %d);', i + 1)
+        end
+        emit('  lua_setvaluetaint(L, -1, NULL);')
+        emit('  lua_setfield(L, 1, %s);', cstring(f.name))
+      end
+      emit('  return 0;')
+    else
+      if mv.inputs ~= nil then
+        local inputs_with_self = { { type = { uiobject = k } } }
+        for _, inp in ipairs(mv.inputs) do
+          table.insert(inputs_with_self, inp)
+        end
+        emit_stub_body(key, Mixin({}, mv, { inputs = inputs_with_self }), stub_inputcheck)
+      else
+        emit('  wowless_stubcheckuiobject_%s(L, 1);', safename(k))
+        emit_stub_body(key, mv, stub_inputcheck)
+      end
+    end
+    emit('}')
+    emit('')
+  end -- entry.impl else
 end
 
 for _, entry in ipairs(eligible) do
@@ -1640,12 +1661,32 @@ end
 emit('  {nullptr, 0, nullptr}')
 emit('};')
 emit('')
+-- UIObject impl method impldata statics
+local any_uiimpl = false
+for key, entry in sorted(eligible_uimethods) do
+  if entry.impl then
+    local k, mk, uiimplkey = entry.k, entry.mk, entry.impl
+    local implimpl = dispatch(uiobjectimplimplmakers, uiobjectimpl[uiimplkey], uiimplkey)
+    local sn = 'uiimpl_' .. safename(k) .. '_' .. safename(mk)
+    emit_stub_entry_statics(sn, { impldata = implimpl, chunkname = implimpl.src or key })
+    any_uiimpl = true
+  end
+end
+if any_uiimpl then
+  emit('')
+end
 -- UIObject method entry array
 emit('static const struct wowless_uiobject_method_entry uiobject_method_entries[] = {')
 for key, entry in sorted(eligible_uimethods) do
-  emit('  {%s, stub_uimethod_%s_%s},', cstring(key), safename(entry.k), safename(entry.mk))
+  local k, mk = entry.k, entry.mk
+  if entry.impl then
+    local sn = 'uiimpl_' .. safename(k) .. '_' .. safename(mk)
+    emit('  {%s, implstub_uiimpl_%s_%s, &impldata_%s},', cstring(key), safename(k), safename(mk), sn)
+  else
+    emit('  {%s, stub_uimethod_%s_%s, nullptr},', cstring(key), safename(k), safename(mk))
+  end
 end
-emit('  {nullptr, nullptr}')
+emit('  {nullptr, nullptr, nullptr}')
 emit('};')
 emit('')
 emit('extern "C" int luaopen_build_products_%s_stubs(lua_State *L) {', product)

--- a/wowless/modules/uiobjectloader.lua
+++ b/wowless/modules/uiobjectloader.lua
@@ -2,8 +2,7 @@ local util = require('wowless.util')
 local bubblewrap = require('wowless.bubblewrap')
 local Mixin = util.mixin
 
-return function(cgencode, cstubs, datalua, funcheck, gencode, sqls, uiobjectsmodule, uiobjecttypes)
-  local uiobjectmethodstubs = cstubs.loaduiobjectmethods(cgencode)
+return function(_cgencode, cstubs, datalua, funcheck, gencode, sqls, uiobjectsmodule, uiobjecttypes)
   local InheritsFrom = uiobjecttypes.InheritsFrom
   local UserData = uiobjectsmodule.UserData
 
@@ -60,6 +59,7 @@ return function(cgencode, cstubs, datalua, funcheck, gencode, sqls, uiobjectsmod
     return t
   end
   return function(modules)
+    local uiobjectmethodstubs = cstubs.loaduiobjectmethods(modules)
     local uiobjects = {}
     for name, cfg in pairs(datalua.uiobjects) do
       local lname = name:lower()

--- a/wowless/stubs.cpp
+++ b/wowless/stubs.cpp
@@ -128,15 +128,52 @@ static int make_uiobject_method_stub(lua_State *L) {
   return 1;
 }
 
+static int make_uiobject_impl_stub(lua_State *L) {
+  /* upvalues: 1=cgencode, 2=luafn, 3=fn ptr */
+  auto fn = reinterpret_cast<lua_CFunction>(lua_touserdata(L, lua_upvalueindex(3)));
+  lua_pushvalue(L, lua_upvalueindex(1)); /* cgencode */
+  lua_pushvalue(L, lua_upvalueindex(2)); /* luafn */
+  lua_pushcclosure(L, fn, 2);
+  return 1;
+}
+
 int wowless_load_uiobject_method_stubs(lua_State *L) {
   const auto *spec = static_cast<const wowless_uiobject_method_entry *>(
       lua_touserdata(L, lua_upvalueindex(1)));
-  /* arg 1 is cgencode directly */
+  /* arg 1 is modules; cgencode is extracted for use as upvalue */
+  lua_getfield(L, 1, "cgencode");
+  /* Stack: [modules, cgencode] */
   lua_newtable(L);
   for (const auto *e = spec; e->key; e++) {
-    lua_pushlightuserdata(L, reinterpret_cast<void *>(e->func));
-    lua_pushvalue(L, 1); /* cgencode */
-    lua_pushcclosure(L, make_uiobject_method_stub, 2);
+    if (e->impldata) {
+      const struct wowless_impl_data *d = e->impldata;
+      if (luaL_loadbuffer(L, d->impl, d->impl_len, d->chunkname) != 0) {
+        lua_error(L);
+      }
+      int nargs = 0;
+      if (d->modules) {
+        for (const char *const *m = d->modules; *m; m++, nargs++) {
+          lua_getfield(L, 1, *m);
+        }
+      }
+      if (d->sqls) {
+        lua_getfield(L, 1, "sqls");
+        int sqls_idx = lua_gettop(L);
+        for (const char *const *s = d->sqls; *s; s++, nargs++) {
+          lua_getfield(L, sqls_idx, *s);
+        }
+        lua_remove(L, sqls_idx);
+      }
+      lua_call(L, nargs, 1); /* luafn on top */
+      lua_pushvalue(L, 2);   /* cgencode */
+      lua_insert(L, -2);     /* cgencode, luafn */
+      lua_pushlightuserdata(L, reinterpret_cast<void *>(e->func));
+      lua_pushcclosure(L, make_uiobject_impl_stub, 3);
+    } else {
+      lua_pushlightuserdata(L, reinterpret_cast<void *>(e->func));
+      lua_pushvalue(L, 2); /* cgencode */
+      lua_pushcclosure(L, make_uiobject_method_stub, 2);
+    }
     lua_setfield(L, -2, e->key);
   }
   return 1;

--- a/wowless/stubs.h
+++ b/wowless/stubs.h
@@ -39,6 +39,7 @@ struct wowless_luaobject_type_entry {
 struct wowless_uiobject_method_entry {
   const char *key;
   lua_CFunction func;
+  const struct wowless_impl_data *impldata; /* NULL for pure C stub entries */
 };
 
 int wowless_load_stubs(lua_State *L);


### PR DESCRIPTION
## Summary

- Migrates `luafile` and `moduledelegate` entries in `uiobjectimpl.yaml` from Lua bubblewrap closures to C impl stubs, reusing the same `wowless_impl_data` infrastructure as global API impl stubs
- `wowless_uiobject_method_entry` gains an `impldata` field; pure-C and impl stubs are unified in one `uiobject_method_entries[]` array
- `wowless_load_uiobject_method_stubs` now takes `modules` as arg 1 (was `cgencode`) and uses a new `make_uiobject_impl_stub` factory to create unique `(cgencode, luafn)` closures per type
- Generated C stubs do self conversion via `implcheckuiobject`, all input implchecks (Font string→global, stringenum validation, uiobject/unit conversion), and uiobject output conversion via `imploutputuiobject`
- `uiobjectloader.lua`: `loaduiobjectmethods` moved inside the inner function where `modules` is available, no separate impl loader needed

## Test plan

- [x] All existing tests pass (`cmake --build --preset default --target test`)
- [x] Pre-commit hooks pass (luacheck, clang-format, stylua, build and test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)