### PR TITLE
prep: value emitters and coutpushers return strings

### DIFF
--- a/tools/prep.lua
+++ b/tools/prep.lua
@@ -934,54 +934,44 @@ lua_value_emitters = {
 local coutpushers
 coutpushers = {
   arrayof = function(inner, val)
-    emit('  lua_createtable(L, %d, 0);', #val)
+    local t = { string.format('  lua_createtable(L, %d, 0);', #val) }
     for i, elem in ipairs(val) do
-      dispatch(coutpushers, inner, elem)
-      emit('  lua_rawseti(L, -2, %d);', i)
+      table.insert(t, dispatch(coutpushers, inner, elem))
+      table.insert(t, string.format('  lua_rawseti(L, -2, %d);', i))
     end
+    return table.concat(t, '\n')
   end,
-  boolean = function(v)
-    emit('%s', lua_value_emitters.boolean(v))
-  end,
+  boolean = lua_value_emitters.boolean,
   enum = function(_, val)
-    emit('%s', lua_value_emitters.number(val))
+    return lua_value_emitters.number(val)
   end,
-  FileAsset = function(v)
-    emit('%s', lua_value_emitters.number(v))
-  end,
-  number = function(v)
-    emit('%s', lua_value_emitters.number(v))
-  end,
-  string = function(v)
-    emit('%s', lua_value_emitters.string(v))
-  end,
-  stringenum = function(v)
-    emit('%s', lua_value_emitters.string(v))
-  end,
+  FileAsset = lua_value_emitters.number,
+  number = lua_value_emitters.number,
+  string = lua_value_emitters.string,
+  stringenum = lua_value_emitters.string,
   structure = function(name, val)
     local st = assert(structures[name], name)
     local n = 0
     for _ in pairs(val) do
       n = n + 1
     end
-    emit('  lua_createtable(L, 0, %d);', n)
+    local t = { string.format('  lua_createtable(L, 0, %d);', n) }
     for fname, fval in pairs(val) do
-      emit('%s', lua_value_emitters.string(fname))
-      dispatch(coutpushers, st.fields[fname].type, fval)
-      emit('  lua_rawset(L, -3);')
+      table.insert(t, lua_value_emitters.string(fname))
+      table.insert(t, dispatch(coutpushers, st.fields[fname].type, fval))
+      table.insert(t, '  lua_rawset(L, -3);')
     end
     if st.mixin then
-      emit('  wowless_applymixin(L, %s);', cstring(st.mixin))
+      table.insert(t, string.format('  wowless_applymixin(L, %s);', cstring(st.mixin)))
     end
+    return table.concat(t, '\n')
   end,
   luaobject = function(name, _)
-    emit('  wowless_stubcreateluaobject(L, %s);', cstring(name))
+    return string.format('  wowless_stubcreateluaobject(L, %s);', cstring(name))
   end,
-  table = function(v)
-    emit('%s', lua_value_emitters.table(v))
-  end,
+  table = lua_value_emitters.table,
   uiobject = function(name, _)
-    emit('  wowless_stubcreateuiobject(L, %s);', cstring(name))
+    return string.format('  wowless_stubcreateuiobject(L, %s);', cstring(name))
   end,
 }
 
@@ -1193,7 +1183,7 @@ for loname in sorted(luaobjectdata) do
         if val == nil then
           emit('  lua_pushnil(L);')
         else
-          dispatch(coutpushers, out.type, val)
+          emit('%s', dispatch(coutpushers, out.type, val))
         end
       end
       emit('  return %d;', #outputs)
@@ -1264,7 +1254,7 @@ local function emit_stub_body(key, cfg, inputcheck)
     if val == nil then
       emit('  lua_pushnil(L);')
     else
-      dispatch(coutpushers, out.type, val)
+      emit('%s', dispatch(coutpushers, out.type, val))
     end
   end
   emit('  return %d;', #outs)

--- a/tools/prep.lua
+++ b/tools/prep.lua
@@ -823,8 +823,11 @@ local function is_eligible(apicfg)
 end
 
 local lines = {}
+local function ins(t, fmt, ...)
+  table.insert(t, string.format(fmt, ...))
+end
 local function emit(fmt, ...)
-  table.insert(lines, string.format(fmt, ...))
+  ins(lines, fmt, ...)
 end
 
 emit('#include "wowless/typecheck.h"')
@@ -921,11 +924,12 @@ lua_value_emitters = {
     for _ in pairs(v) do
       n = n + 1
     end
-    local t = { string.format('  lua_createtable(L, 0, %d);', n) }
+    local t = {}
+    ins(t, '  lua_createtable(L, 0, %d);', n)
     for vk, vv in pairs(v) do
-      table.insert(t, dispatch(lua_value_emitters, type(vk), vk))
-      table.insert(t, dispatch(lua_value_emitters, type(vv), vv))
-      table.insert(t, '  lua_rawset(L, -3);')
+      ins(t, dispatch(lua_value_emitters, type(vk), vk))
+      ins(t, dispatch(lua_value_emitters, type(vv), vv))
+      ins(t, '  lua_rawset(L, -3);')
     end
     return table.concat(t, '\n')
   end,
@@ -934,10 +938,11 @@ lua_value_emitters = {
 local coutpushers
 coutpushers = {
   arrayof = function(inner, val)
-    local t = { string.format('  lua_createtable(L, %d, 0);', #val) }
+    local t = {}
+    ins(t, '  lua_createtable(L, %d, 0);', #val)
     for i, elem in ipairs(val) do
-      table.insert(t, dispatch(coutpushers, inner, elem))
-      table.insert(t, string.format('  lua_rawseti(L, -2, %d);', i))
+      ins(t, dispatch(coutpushers, inner, elem))
+      ins(t, '  lua_rawseti(L, -2, %d);', i)
     end
     return table.concat(t, '\n')
   end,
@@ -955,14 +960,15 @@ coutpushers = {
     for _ in pairs(val) do
       n = n + 1
     end
-    local t = { string.format('  lua_createtable(L, 0, %d);', n) }
+    local t = {}
+    ins(t, '  lua_createtable(L, 0, %d);', n)
     for fname, fval in pairs(val) do
-      table.insert(t, lua_value_emitters.string(fname))
-      table.insert(t, dispatch(coutpushers, st.fields[fname].type, fval))
-      table.insert(t, '  lua_rawset(L, -3);')
+      ins(t, lua_value_emitters.string(fname))
+      ins(t, dispatch(coutpushers, st.fields[fname].type, fval))
+      ins(t, '  lua_rawset(L, -3);')
     end
     if st.mixin then
-      table.insert(t, string.format('  wowless_applymixin(L, %s);', cstring(st.mixin)))
+      ins(t, '  wowless_applymixin(L, %s);', cstring(st.mixin))
     end
     return table.concat(t, '\n')
   end,

--- a/tools/prep.lua
+++ b/tools/prep.lua
@@ -908,25 +908,26 @@ end
 local lua_value_emitters
 lua_value_emitters = {
   boolean = function(v)
-    emit('  lua_pushboolean(L, %d);', v and 1 or 0)
+    return string.format('  lua_pushboolean(L, %d);', v and 1 or 0)
   end,
   number = function(v)
-    emit('  lua_pushnumber(L, %g);', v)
+    return string.format('  lua_pushnumber(L, %g);', v)
   end,
   string = function(v)
-    emit('  lua_pushliteral(L, %s);', cstring(v))
+    return string.format('  lua_pushliteral(L, %s);', cstring(v))
   end,
   table = function(v)
     local n = 0
     for _ in pairs(v) do
       n = n + 1
     end
-    emit('  lua_createtable(L, 0, %d);', n)
+    local t = { string.format('  lua_createtable(L, 0, %d);', n) }
     for vk, vv in pairs(v) do
-      dispatch(lua_value_emitters, type(vk), vk)
-      dispatch(lua_value_emitters, type(vv), vv)
-      emit('  lua_rawset(L, -3);')
+      table.insert(t, dispatch(lua_value_emitters, type(vk), vk))
+      table.insert(t, dispatch(lua_value_emitters, type(vv), vv))
+      table.insert(t, '  lua_rawset(L, -3);')
     end
+    return table.concat(t, '\n')
   end,
 }
 
@@ -939,14 +940,24 @@ coutpushers = {
       emit('  lua_rawseti(L, -2, %d);', i)
     end
   end,
-  boolean = lua_value_emitters.boolean,
-  enum = function(_, val)
-    lua_value_emitters.number(val)
+  boolean = function(v)
+    emit('%s', lua_value_emitters.boolean(v))
   end,
-  FileAsset = lua_value_emitters.number,
-  number = lua_value_emitters.number,
-  string = lua_value_emitters.string,
-  stringenum = lua_value_emitters.string,
+  enum = function(_, val)
+    emit('%s', lua_value_emitters.number(val))
+  end,
+  FileAsset = function(v)
+    emit('%s', lua_value_emitters.number(v))
+  end,
+  number = function(v)
+    emit('%s', lua_value_emitters.number(v))
+  end,
+  string = function(v)
+    emit('%s', lua_value_emitters.string(v))
+  end,
+  stringenum = function(v)
+    emit('%s', lua_value_emitters.string(v))
+  end,
   structure = function(name, val)
     local st = assert(structures[name], name)
     local n = 0
@@ -955,7 +966,7 @@ coutpushers = {
     end
     emit('  lua_createtable(L, 0, %d);', n)
     for fname, fval in pairs(val) do
-      lua_value_emitters.string(fname)
+      emit('%s', lua_value_emitters.string(fname))
       dispatch(coutpushers, st.fields[fname].type, fval)
       emit('  lua_rawset(L, -3);')
     end
@@ -966,7 +977,9 @@ coutpushers = {
   luaobject = function(name, _)
     emit('  wowless_stubcreateluaobject(L, %s);', cstring(name))
   end,
-  table = lua_value_emitters.table,
+  table = function(v)
+    emit('%s', lua_value_emitters.table(v))
+  end,
   uiobject = function(name, _)
     emit('  wowless_stubcreateuiobject(L, %s);', cstring(name))
   end,


### PR DESCRIPTION
## Summary

- `lua_value_emitters` functions now return strings instead of calling `emit()` directly; callers are responsible for emitting
- `coutpushers` functions follow the same pattern, restoring direct aliases to `lua_value_emitters` where applicable
- Adds `ins(t, fmt, ...)` helper (analogous to `emit` but targeting a caller-supplied table) to replace the `table.insert(t, string.format(...))` pattern in `arrayof`, `structure`, and `lua_value_emitters.table`

## Test plan

- [ ] `cmake --build --preset default --target test` passes (all pre-commit hooks including build and test passed on each commit)

🤖 Generated with [Claude Code](https://claude.com/claude-code)