### PR TITLE
events: replace funcheck-based echecks with prep-generated C

### DIFF
--- a/data/modules.yaml
+++ b/data/modules.yaml
@@ -62,8 +62,8 @@ eventqueue:
     events:
 events:
   deps:
+    cstubs:
     datalua:
-    funcheck:
     log:
     loglevel:
     scripts:

--- a/tools/prep.lua
+++ b/tools/prep.lua
@@ -1652,6 +1652,41 @@ end
 emit('  {nullptr, nullptr}')
 emit('};')
 emit('')
+for k, e in sorted(events) do
+  local payload = e.payload
+  local stride = e.stride or 0
+  local nfixed = #payload - stride
+  emit('static int eventcheck_%s(lua_State *L) {', safename(k))
+  emit('  int n = lua_gettop(L);')
+  if stride > 1 then
+    emit('  if (n < %d || (n - %d) %% %d != 0) {', nfixed, nfixed, stride)
+    emit(
+      '    return luaL_error(L, "wrong number of return values to %%q: want stride %d, got %%d", %s, n);',
+      stride,
+      cstring(k)
+    )
+    emit('  }')
+  elseif stride == 0 then
+    emit('  wowless_stubchecknreturns(L, n, %d, %s);', nfixed, cstring(k))
+  end
+  for i = 1, nfixed do
+    local out = payload[i]
+    local nilable = out.nilable
+    emit('  %s;', dispatch(coutputtypes, out.type, nilable, i))
+  end
+  if stride > 0 then
+    emit('  for (int i = %d; i < n; i += %d) {', nfixed, stride)
+    for j = 1, stride do
+      local out = payload[nfixed + j]
+      local nilable = out.nilable
+      emit('    %s;', dispatch(coutputtypes, out.type, nilable, string.format('i + %d', j)))
+    end
+    emit('  }')
+  end
+  emit('  return n;')
+  emit('}')
+  emit('')
+end
 emit('extern "C" int luaopen_build_products_%s_stubs(lua_State *L) {', product)
 emit('  lua_newtable(L);')
 emit('  lua_pushlightuserdata(L, static_cast<void *>(const_cast<wowless_stubs_spec *>(&stubs_spec)));')
@@ -1665,6 +1700,12 @@ emit('  lua_setfield(L, -2, "loadluaobjects");')
 emit('  lua_pushlightuserdata(L, (void *)uiobject_method_entries);')
 emit('  lua_pushcclosure(L, wowless_load_uiobject_method_stubs, 1);')
 emit('  lua_setfield(L, -2, "loaduiobjectmethods");')
+emit('  lua_newtable(L);')
+for k in sorted(events) do
+  emit('  lua_pushcfunction(L, eventcheck_%s);', safename(k))
+  emit('  lua_setfield(L, -2, %s);', cstring(k))
+end
+emit('  lua_setfield(L, -2, "eventchecks");')
 emit('  return 1;')
 emit('}')
 

--- a/wowless/modules/events.lua
+++ b/wowless/modules/events.lua
@@ -1,5 +1,5 @@
 local hlist = require('wowless.hlist')
-return function(datalua, funcheck, log, loglevel, scripts, security)
+return function(cstubs, datalua, log, loglevel, scripts, security)
   local allregs = hlist()
   local regs = {}
   local cbregs = {}
@@ -112,17 +112,7 @@ return function(datalua, funcheck, log, loglevel, scripts, security)
     return unpack(GetFramesRegisteredForEvent(event))
   end
 
-  local echecks = setmetatable({}, {
-    __index = function(t, k)
-      local e = datalua.events[k]
-      local v = funcheck.makeCheckOutputs(k, {
-        outputs = e.payload,
-        outstride = e.stride,
-      })
-      t[k] = v
-      return v
-    end,
-  })
+  local echecks = cstubs.eventchecks
 
   local function DoSendEvent(event, ...)
     for _, reg in ipairs(GetFramesRegisteredForEvent(event)) do


### PR DESCRIPTION
## Summary

- Generates a `static int eventcheck_<NAME>` C function per event in the existing `_stubs.cpp`, validating arg count and types using the existing `wowless_imploutput*` helpers from `typecheck.h`
- Exposes them as a `eventchecks` sub-table in the stubs module's `luaopen` (keyed by event name)
- Replaces the lazy `setmetatable`-based `echecks` in `events.lua` with a direct reference to `cstubs.eventchecks`
- Removes `funcheck` as a dependency of `events` (replaced by `cstubs`)

## Test plan

- [x] All existing tests pass (`cmake --build --preset default --target test`)
- [x] Pre-commit hooks pass (build and test, luacheck, StyLua, yamlfmt)

🤖 Generated with [Claude Code](https://claude.com/claude-code)