### PR TITLE
prep: load uiobject cstub host impls from C

### DIFF
--- a/tools/prep.lua
+++ b/tools/prep.lua
@@ -253,7 +253,6 @@ local uiobjectimplmakers = {
     }
   end,
   setter = function(impl, mv)
-    -- host impl: direct field assignment, applying defaults for optional args
     local t = { 'return function(self' }
     for _, f in ipairs(impl) do
       table.insert(t, ',')
@@ -318,8 +317,8 @@ for k, v in pairs(uiobjectdata) do
   for mk, mv in pairs(v.methods) do
     local d = dispatch(uiobjectimplmakers, mv.impl or 'none', mv, k)
     if d.cstub then
-      methods[mk] = d
-      eligible_uimethods[k .. ':' .. mk] = { k = k, mk = mk, mv = mv }
+      methods[mk] = { cstub = true }
+      eligible_uimethods[k .. ':' .. mk] = { impl = d.impl, k = k, mk = mk, mv = mv }
     else
       methods[mk] = Mixin({}, d, {
         inputs = mv.inputs,
@@ -1426,12 +1425,25 @@ end
 emit('  {nullptr, 0, nullptr}')
 emit('};')
 emit('')
+-- UIObject host impl data statics
+for key, entry in sorted(eligible_uimethods) do
+  local sn = safename(entry.k) .. '_' .. safename(entry.mk)
+  emit(
+    'static const wowless_impl_data host_impldata_%s = {%s, %d, %s, nullptr, nullptr};',
+    sn,
+    cstring(entry.impl),
+    #entry.impl,
+    cstring(key)
+  )
+end
+emit('')
 -- UIObject method entry array
 emit('static const struct wowless_uiobject_method_entry uiobject_method_entries[] = {')
 for key, entry in sorted(eligible_uimethods) do
-  emit('  {%s, stub_uimethod_%s_%s},', cstring(key), safename(entry.k), safename(entry.mk))
+  local sn = safename(entry.k) .. '_' .. safename(entry.mk)
+  emit('  {%s, stub_uimethod_%s_%s, &host_impldata_%s},', cstring(key), safename(entry.k), safename(entry.mk), sn)
 end
-emit('  {nullptr, nullptr}')
+emit('  {nullptr, nullptr, nullptr}')
 emit('};')
 emit('')
 for k, e in sorted(eventcfg) do

--- a/wowless/modules/uiobjectloader.lua
+++ b/wowless/modules/uiobjectloader.lua
@@ -3,7 +3,7 @@ local bubblewrap = require('wowless.bubblewrap')
 local Mixin = util.mixin
 
 return function(cgencode, cstubs, datalua, funcheck, gencode, sqls, uiobjectsmodule, uiobjecttypes)
-  local uiobjectmethodstubs = cstubs.loaduiobjectmethods(cgencode)
+  local uiobjectmethodstubs, uiobjecthostimpls = cstubs.loaduiobjectmethods(cgencode)
   local InheritsFrom = uiobjecttypes.InheritsFrom
   local UserData = uiobjectsmodule.UserData
 
@@ -87,20 +87,22 @@ return function(cgencode, cstubs, datalua, funcheck, gencode, sqls, uiobjectsmod
         local fname = name .. ':' .. mname
         local incheck = method.inputs and funcheck.makeCheckInputs(fname, method)
         local outcheck = method.outputs and funcheck.makeCheckOutputs(fname, method)
-        local src = method.src or fname
-        local mkfn = assert(loadstring_untainted(method.impl, src), fname)
-        local args = {}
-        for _, m in ipairs(method.modules or {}) do
-          table.insert(args, (assert(modules[m], m)))
-        end
-        for _, sql in ipairs(method.sqls or {}) do
-          table.insert(args, (assert(sqls[sql], sql)))
-        end
-        local rawfn = mkfn(unpack(args))
+        local rawfn
         local sandboxFactory
         if method.cstub then
           sandboxFactory = uiobjectmethodstubs[fname]
+          rawfn = uiobjecthostimpls[fname]
         else
+          local src = method.src or fname
+          local mkfn = assert(loadstring_untainted(method.impl, src), fname)
+          local args = {}
+          for _, m in ipairs(method.modules or {}) do
+            table.insert(args, (assert(modules[m], m)))
+          end
+          for _, sql in ipairs(method.sqls or {}) do
+            table.insert(args, (assert(sqls[sql], sql)))
+          end
+          rawfn = mkfn(unpack(args))
           local wrappedfn = wrap(fname, rawfn)
           local sandboxfn
           if not incheck and not outcheck then

--- a/wowless/stubs.cpp
+++ b/wowless/stubs.cpp
@@ -132,14 +132,21 @@ int wowless_load_uiobject_method_stubs(lua_State *L) {
   const auto *spec = static_cast<const wowless_uiobject_method_entry *>(
       lua_touserdata(L, lua_upvalueindex(1)));
   /* arg 1 is cgencode directly */
-  lua_newtable(L);
+  lua_newtable(L); /* sandbox factories */
+  lua_newtable(L); /* host Lua functions */
   for (const auto *e = spec; e->key; e++) {
     lua_pushlightuserdata(L, reinterpret_cast<void *>(e->func));
     lua_pushvalue(L, 1); /* cgencode */
     lua_pushcclosure(L, make_uiobject_method_stub, 2);
-    lua_setfield(L, -2, e->key);
+    lua_setfield(L, -3, e->key); /* into sandbox table */
+    const struct wowless_impl_data *d = e->host;
+    if (luaL_loadbuffer(L, d->impl, d->impl_len, d->chunkname) != 0) {
+      lua_error(L);
+    }
+    lua_call(L, 0, 1);
+    lua_setfield(L, -2, e->key); /* into host table */
   }
-  return 1;
+  return 2;
 }
 
 int wowless_load_eventcheck_stubs(lua_State *L) {

--- a/wowless/stubs.h
+++ b/wowless/stubs.h
@@ -39,6 +39,8 @@ struct wowless_luaobject_type_entry {
 struct wowless_uiobject_method_entry {
   const char *key;
   lua_CFunction func;
+  const struct wowless_impl_data
+      *host; /* NULL-terminated host impl, loaded as Lua function */
 };
 
 int wowless_load_stubs(lua_State *L);


### PR DESCRIPTION
## Summary

- Embed the Lua impl strings for `getter`/`setter`/`none` cstub methods as `wowless_impl_data` in the generated C file rather than shipping them in the Lua data
- `wowless_load_uiobject_method_stubs` now returns two tables: sandbox factories (existing behavior) and host Lua functions loaded via `luaL_loadbuffer` + call
- `uiobjectloader` consumes the host table directly instead of calling `loadstring_untainted` on `method.impl`; the Lua data for cstub methods no longer contains `impl` or `modules`

## Test plan

- [x] All existing tests pass (`cmake --build --preset default --target test`)
- [x] Pre-commit hooks pass (clang-format, StyLua, luacheck, build and test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)