### PR TITLE
prep: support permissive bit in C input type checks

### DIFF
--- a/data/products/wow_classic_era/docs.yaml
+++ b/data/products/wow_classic_era/docs.yaml
@@ -454,7 +454,8 @@ lies:
             type:
               _change:
                 from: string
-                to: unknown
+                to:
+                  stringenum: WrapMode
           3:
             _add:
               default: CLAMP
@@ -463,7 +464,8 @@ lies:
             type:
               _change:
                 from: string
-                to: unknown
+                to:
+                  stringenum: WrapMode
           4:
             _add:
               default: LINEAR

--- a/data/products/wow_classic_era/uiobjects.yaml
+++ b/data/products/wow_classic_era/uiobjects.yaml
@@ -8041,10 +8041,14 @@ TextureBase:
         type: string
       - default: CLAMP
         name: wrapModeHorizontal
-        type: unknown
+        permissive: true
+        type:
+          stringenum: WrapMode
       - default: CLAMP
         name: wrapModeVertical
-        type: unknown
+        permissive: true
+        type:
+          stringenum: WrapMode
       - default: LINEAR
         name: filterMode
         type:

--- a/tools/prep.lua
+++ b/tools/prep.lua
@@ -1068,7 +1068,26 @@ local function emit_stub_body(key, cfg, inputcheck)
   emit('  return %d;', #outs)
 end
 
+local function cpermissive(inp, idx)
+  local is_check = dispatch(cinputtypes, inp.type)('is', false, idx)
+  local t = type(inp.default)
+  local push
+  if t == 'boolean' then
+    push = ('lua_pushboolean(L, %s)'):format(inp.default and '1' or '0')
+  elseif t == 'number' then
+    push = ('lua_pushnumber(L, %g)'):format(inp.default)
+  elseif t == 'string' then
+    push = ('lua_pushstring(L, %s)'):format(cstring(inp.default))
+  else
+    error('unsupported permissive default type: ' .. t)
+  end
+  return ('if (!lua_isnoneornil(L, %d) && !%s) { %s; lua_replace(L, %d); }'):format(idx, is_check, push, idx)
+end
+
 local function stub_inputcheck(inp, idx)
+  if inp.permissive then
+    return cpermissive(inp, idx)
+  end
   local nilable = inp.nilable or inp.default ~= nil
   return dispatch(cinputtypes, inp.type)('stubcheck', nilable, idx) .. ';'
 end
@@ -1096,6 +1115,9 @@ local function emit_implstub_body(name, v, fn)
   local nsins = #inputs - instride
   if check_inputs then
     local function check(inp, idx)
+      if inp.permissive then
+        return cpermissive(inp, idx)
+      end
       local nilable = inp.nilable or inp.default ~= nil
       return dispatch(cinputtypes, inp.type)('implcheck', nilable, idx) .. ';'
     end


### PR DESCRIPTION
## Summary

- Adds `cpermissive()` helper in `prep.lua` that generates C code to replace a mismatched argument with its default value instead of erroring — matching the Lua `typecheck.lua` behavior for `permissive: true` inputs
- Applies in both `stub_inputcheck` (regular stubs) and the `check` closure inside `emit_implstub_body` (impl stubs)
- Reverts the incorrect `wow_classic_era` SetTexture workaround (`type: unknown`) back to the correct `permissive: true` + `stringenum: WrapMode` spec

## Background

When PR #684 converted `uiobjectimpl` methods to C stubs, the generated C stubs did strict type enforcement. Era's `SetTexture` passes a boolean tile flag for `wrapModeHorizontal`/`wrapModeVertical` (old pre-WrapMode API). The spec correctly had `permissive: true` on those params — the Lua typecheck path silently used the default on mismatch — but the C stub path ignored the flag and errored.

The previous fix changed the type to `unknown`, discarding the type documentation. This fix instead implements the `permissive` semantics in C.

## Test plan

- [ ] All existing tests pass (`cmake --build --preset default --target test`)
- [ ] Era runs clean (SetTexture no longer errors on boolean tile args)
- [ ] Other products with permissive params (retail, classic, wowt, etc.) continue to work

🤖 Generated with [Claude Code](https://claude.ai/claude-code)