### PR TITLE
cmake: set hidden visibility preset for all targets

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,6 +24,10 @@ elseif(HAVE_EH_MINUS)
   add_compile_options($<$<COMPILE_LANGUAGE:CXX>:/EH->)
 endif()
 
+set(CMAKE_C_VISIBILITY_PRESET hidden)
+set(CMAKE_CXX_VISIBILITY_PRESET hidden)
+set(CMAKE_VISIBILITY_INLINES_HIDDEN ON)
+
 set(elune_SOURCE_DIR vendor/elune)
 set(elune_BINARY_DIR ${CMAKE_BINARY_DIR}/_deps/elune-build)
 add_library(


### PR DESCRIPTION
Sets CMAKE_C_VISIBILITY_PRESET, CMAKE_CXX_VISIBILITY_PRESET, and
CMAKE_VISIBILITY_INLINES_HIDDEN globally before any target is created,
applying -fvisibility=hidden to all compilation units on GCC/Clang

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>