### PR TITLE
luaobjects: migrate metatable construction to C

### DIFF
--- a/wowless/luaobject.c
+++ b/wowless/luaobject.c
@@ -1,5 +1,7 @@
 #include "wowless/luaobject.h"
 
+#include <stdint.h>
+#include <stdio.h>
 #include <string.h>
 
 #include "lauxlib.h"
@@ -73,8 +75,10 @@ static int luaobject_newindex(lua_State *L) {
 /* upvalue 1: typename string */
 static int luaobject_tostring(lua_State *L) {
   lua_getfenv(L, 1);
-  lua_pushfstring(L, "%s: %p", lua_tostring(L, lua_upvalueindex(1)),
-                  lua_topointer(L, -1));
+  char buf[64];
+  snprintf(buf, sizeof(buf), "%s: 0x%llx", lua_tostring(L, lua_upvalueindex(1)),
+           (unsigned long long)(uintptr_t)lua_topointer(L, -1));
+  lua_pushstring(L, buf);
   return 1;
 }
 

--- a/wowless/luaobject.c
+++ b/wowless/luaobject.c
@@ -78,8 +78,8 @@ static int luaobject_tostring(lua_State *L) {
   return 1;
 }
 
-void wowless_luaobject_register_mt(lua_State *L, int mt_idx, int type_id,
-                                   int methods_idx, const char *typename_str) {
+void wowless_luaobject_make_mt(lua_State *L, int methods_idx,
+                               const char *typename_str) {
   lua_newtable(L); /* metatable */
   lua_pushcfunction(L, luaobject_eq);
   lua_setfield(L, -2, "__eq");
@@ -96,7 +96,6 @@ void wowless_luaobject_register_mt(lua_State *L, int mt_idx, int type_id,
     lua_pushcclosure(L, luaobject_tostring, 1);
     lua_setfield(L, -2, "__tostring");
   }
-  lua_rawseti(L, mt_idx, type_id);
 }
 
 /* upvalue 1: metatables (type_id -> metatable) */

--- a/wowless/luaobject.c
+++ b/wowless/luaobject.c
@@ -1,5 +1,7 @@
 #include "wowless/luaobject.h"
 
+#include <string.h>
+
 #include "lauxlib.h"
 #include "lua.h"
 
@@ -18,15 +20,6 @@ static int wowless_luaobject_getenv(lua_State *L) {
   return 0;
 }
 
-static int wowless_luaobject_gettypeid(lua_State *L) {
-  const struct wowless_luaobject_data *ud = wowless_toluaobject(L, 1);
-  if (ud) {
-    lua_pushinteger(L, ud->type_id);
-    return 1;
-  }
-  return 0;
-}
-
 static int luaobject_eq(lua_State *L) {
   lua_getfenv(L, 1);
   lua_getfenv(L, 2);
@@ -34,25 +27,14 @@ static int luaobject_eq(lua_State *L) {
   return 1;
 }
 
-/* upvalue 1: state table (cache, typenames, readonly, mt) */
-
+/* upvalue 1: methods */
 static int luaobject_index(lua_State *L) {
-  const struct wowless_luaobject_data *ud = wowless_toluaobject(L, 1);
-  if (ud) {
-    lua_getfield(L, lua_upvalueindex(1), "cache");
-    lua_rawgeti(L, -1, ud->type_id);
-    if (!lua_isnil(L, -1)) {
-      lua_pushvalue(L, 2);
-      lua_rawget(L, -2);
-      if (!lua_isnil(L, -1)) {
-        return 1;
-      }
-      lua_pop(L, 2);
-    } else {
-      lua_pop(L, 1);
-    }
-    lua_pop(L, 1); /* pop cache */
+  lua_pushvalue(L, 2);
+  lua_rawget(L, lua_upvalueindex(1));
+  if (!lua_isnil(L, -1)) {
+    return 1;
   }
+  lua_pop(L, 1);
   lua_getfenv(L, 1);
   lua_getfield(L, -1, "table");
   lua_pushvalue(L, 2);
@@ -60,33 +42,25 @@ static int luaobject_index(lua_State *L) {
   return 1;
 }
 
+/* upvalue 1: methods */
 static int luaobject_newindex(lua_State *L) {
-  const struct wowless_luaobject_data *ud = wowless_toluaobject(L, 1);
-  if (ud) {
-    lua_getfield(L, lua_upvalueindex(1), "cache");
-    lua_rawgeti(L, -1, ud->type_id);
-    lua_remove(L, -2); /* remove cache, keep methods */
-    if (!lua_isnil(L, -1)) {
-      lua_pushvalue(L, 2);
-      lua_rawget(L, -2);
-      if (!lua_isnil(L, -1)) {
-        lua_pop(L, 2);
-        return luaL_error(L, "Attempted to assign to read-only key %s",
-                          lua_tostring(L, 2));
+  lua_pushvalue(L, 2);
+  lua_rawget(L, lua_upvalueindex(1));
+  if (!lua_isnil(L, -1)) {
+    lua_pop(L, 1);
+    return luaL_error(L, "Attempted to assign to read-only key %s",
+                      lua_tostring(L, 2));
+  }
+  lua_pop(L, 1);
+  static const char *const metamethod_keys[] = {
+      "__eq", "__index", "__metatable", "__newindex", "__tostring", NULL};
+  const char *key = lua_tostring(L, 2);
+  if (key) {
+    for (const char *const *k = metamethod_keys; *k; k++) {
+      if (strcmp(key, *k) == 0) {
+        return luaL_error(L, "Attempted to assign to read-only key %s", key);
       }
-      lua_pop(L, 1); /* pop nil result */
     }
-    lua_pop(L, 1); /* pop methods or nil */
-    lua_getfield(L, lua_upvalueindex(1), "readonly");
-    lua_pushvalue(L, 2);
-    lua_rawget(L, -2);
-    lua_remove(L, -2); /* remove readonly table */
-    if (!lua_isnil(L, -1)) {
-      lua_pop(L, 1);
-      return luaL_error(L, "Attempted to assign to read-only key %s",
-                        lua_tostring(L, 2));
-    }
-    lua_pop(L, 1); /* pop nil */
   }
   lua_getfenv(L, 1);
   lua_getfield(L, -1, "table");
@@ -96,37 +70,39 @@ static int luaobject_newindex(lua_State *L) {
   return 0;
 }
 
+/* upvalue 1: typename string */
 static int luaobject_tostring(lua_State *L) {
-  const struct wowless_luaobject_data *ud = wowless_toluaobject(L, 1);
-  if (ud) {
-    lua_getfield(L, lua_upvalueindex(1), "typenames");
-    lua_rawgeti(L, -1, ud->type_id);
-    if (lua_type(L, -1) == LUA_TSTRING) {
-      const char *tn = lua_tostring(L, -1);
-      lua_getfenv(L, 1);
-      lua_pushfstring(L, "%s: %p", tn, lua_topointer(L, -1));
-      return 1;
-    }
-  }
-  return 0;
+  lua_getfenv(L, 1);
+  lua_pushfstring(L, "%s: %p", lua_tostring(L, lua_upvalueindex(1)),
+                  lua_topointer(L, -1));
+  return 1;
 }
 
+/* upvalue 1: cache (type_id -> metatable) */
 static int luaobject_register_mt(lua_State *L) {
   int type_id = luaL_checkinteger(L, 1);
   luaL_checktype(L, 2, LUA_TTABLE); /* methods */
-  lua_getfield(L, lua_upvalueindex(1), "cache");
+  lua_newtable(L);                  /* metatable */
+  lua_pushcfunction(L, luaobject_eq);
+  lua_setfield(L, -2, "__eq");
   lua_pushvalue(L, 2);
-  lua_rawseti(L, -2, type_id);
-  lua_pop(L, 1);
+  lua_pushcclosure(L, luaobject_index, 1);
+  lua_setfield(L, -2, "__index");
+  lua_pushboolean(L, 0);
+  lua_setfield(L, -2, "__metatable");
+  lua_pushvalue(L, 2);
+  lua_pushcclosure(L, luaobject_newindex, 1);
+  lua_setfield(L, -2, "__newindex");
   if (lua_type(L, 3) == LUA_TSTRING) {
-    lua_getfield(L, lua_upvalueindex(1), "typenames");
     lua_pushvalue(L, 3);
-    lua_rawseti(L, -2, type_id);
-    lua_pop(L, 1);
+    lua_pushcclosure(L, luaobject_tostring, 1);
+    lua_setfield(L, -2, "__tostring");
   }
+  lua_rawseti(L, lua_upvalueindex(1), type_id);
   return 0;
 }
 
+/* upvalue 1: cache (type_id -> metatable) */
 static int wowless_luaobject_new(lua_State *L) {
   int type_id = luaL_checkinteger(L, 1);
   luaL_checktype(L, 2, LUA_TTABLE); /* env */
@@ -135,62 +111,19 @@ static int wowless_luaobject_new(lua_State *L) {
           L, sizeof(struct wowless_luaobject_data));
   ud->marker = &wowless_luaobject_marker;
   ud->type_id = type_id;
-  lua_getfield(L, lua_upvalueindex(1), "mt");
+  lua_rawgeti(L, lua_upvalueindex(1), type_id);
   lua_setmetatable(L, -2);
   lua_pushvalue(L, 2);
   lua_setfenv(L, -2);
   return 1;
 }
 
-static int wowless_luaobject_makemt(lua_State *L) {
-  int tostring_enabled = lua_toboolean(L, 1);
-  lua_newtable(L); /* shared metatable */
-  lua_pushcfunction(L, luaobject_eq);
-  lua_setfield(L, -2, "__eq");
-  lua_pushvalue(L, lua_upvalueindex(1));
-  lua_pushcclosure(L, luaobject_index, 1);
-  lua_setfield(L, -2, "__index");
-  lua_pushboolean(L, 0);
-  lua_setfield(L, -2, "__metatable");
-  lua_pushvalue(L, lua_upvalueindex(1));
-  lua_pushcclosure(L, luaobject_newindex, 1);
-  lua_setfield(L, -2, "__newindex");
-  if (tostring_enabled) {
-    lua_pushvalue(L, lua_upvalueindex(1));
-    lua_pushcclosure(L, luaobject_tostring, 1);
-    lua_setfield(L, -2, "__tostring");
-  }
-  lua_setfield(L, lua_upvalueindex(1), "mt");
-  lua_getfield(L, lua_upvalueindex(1), "readonly");
-  static const char *const always_readonly[] = {
-      "__eq", "__index", "__metatable", "__newindex", NULL};
-  for (const char *const *k = always_readonly; *k; k++) {
-    lua_pushboolean(L, 1);
-    lua_setfield(L, -2, *k);
-  }
-  if (tostring_enabled) {
-    lua_pushboolean(L, 1);
-    lua_setfield(L, -2, "__tostring");
-  }
-  lua_pop(L, 1); /* pop readonly */
-  return 0;
-}
-
 int luaopen_wowless_luaobject(lua_State *L) {
   lua_newtable(L); /* module */
   lua_pushcfunction(L, wowless_luaobject_getenv);
   lua_setfield(L, -2, "getenv");
-  lua_pushcfunction(L, wowless_luaobject_gettypeid);
-  lua_setfield(L, -2, "gettypeid");
 
-  lua_newtable(L); /* state */
-  lua_newtable(L);
-  lua_setfield(L, -2, "cache");
-  lua_newtable(L);
-  lua_setfield(L, -2, "typenames");
-  lua_newtable(L);
-  lua_setfield(L, -2, "readonly");
-  /* state["mt"] is set by makemt */
+  lua_newtable(L); /* cache: type_id -> metatable */
 
   lua_pushvalue(L, -1);
   lua_pushcclosure(L, luaobject_register_mt, 1);
@@ -200,10 +133,6 @@ int luaopen_wowless_luaobject(lua_State *L) {
   lua_pushcclosure(L, wowless_luaobject_new, 1);
   lua_setfield(L, -3, "new");
 
-  lua_pushvalue(L, -1);
-  lua_pushcclosure(L, wowless_luaobject_makemt, 1);
-  lua_setfield(L, -3, "makemt");
-
-  lua_pop(L, 1); /* pop state */
+  lua_pop(L, 1); /* pop cache */
   return 1;
 }

--- a/wowless/luaobject.c
+++ b/wowless/luaobject.c
@@ -78,31 +78,28 @@ static int luaobject_tostring(lua_State *L) {
   return 1;
 }
 
-/* upvalue 1: cache (type_id -> metatable) */
-static int luaobject_register_mt(lua_State *L) {
-  int type_id = luaL_checkinteger(L, 1);
-  luaL_checktype(L, 2, LUA_TTABLE); /* methods */
-  lua_newtable(L);                  /* metatable */
+void wowless_luaobject_register_mt(lua_State *L, int mt_idx, int type_id,
+                                   int methods_idx, const char *typename_str) {
+  lua_newtable(L); /* metatable */
   lua_pushcfunction(L, luaobject_eq);
   lua_setfield(L, -2, "__eq");
-  lua_pushvalue(L, 2);
+  lua_pushvalue(L, methods_idx);
   lua_pushcclosure(L, luaobject_index, 1);
   lua_setfield(L, -2, "__index");
   lua_pushboolean(L, 0);
   lua_setfield(L, -2, "__metatable");
-  lua_pushvalue(L, 2);
+  lua_pushvalue(L, methods_idx);
   lua_pushcclosure(L, luaobject_newindex, 1);
   lua_setfield(L, -2, "__newindex");
-  if (lua_type(L, 3) == LUA_TSTRING) {
-    lua_pushvalue(L, 3);
+  if (typename_str) {
+    lua_pushstring(L, typename_str);
     lua_pushcclosure(L, luaobject_tostring, 1);
     lua_setfield(L, -2, "__tostring");
   }
-  lua_rawseti(L, lua_upvalueindex(1), type_id);
-  return 0;
+  lua_rawseti(L, mt_idx, type_id);
 }
 
-/* upvalue 1: cache (type_id -> metatable) */
+/* upvalue 1: metatables (type_id -> metatable) */
 static int wowless_luaobject_new(lua_State *L) {
   int type_id = luaL_checkinteger(L, 1);
   luaL_checktype(L, 2, LUA_TTABLE); /* env */
@@ -123,16 +120,12 @@ int luaopen_wowless_luaobject(lua_State *L) {
   lua_pushcfunction(L, wowless_luaobject_getenv);
   lua_setfield(L, -2, "getenv");
 
-  lua_newtable(L); /* cache: type_id -> metatable */
-
+  lua_newtable(L); /* metatables: type_id -> metatable */
   lua_pushvalue(L, -1);
-  lua_pushcclosure(L, luaobject_register_mt, 1);
-  lua_setfield(L, -3, "register_mt");
+  lua_setfield(L, -3, "metatables");
 
-  lua_pushvalue(L, -1);
   lua_pushcclosure(L, wowless_luaobject_new, 1);
-  lua_setfield(L, -3, "new");
+  lua_setfield(L, -2, "new");
 
-  lua_pop(L, 1); /* pop cache */
   return 1;
 }

--- a/wowless/luaobject.c
+++ b/wowless/luaobject.c
@@ -27,31 +27,183 @@ static int wowless_luaobject_gettypeid(lua_State *L) {
   return 0;
 }
 
+static int luaobject_eq(lua_State *L) {
+  lua_getfenv(L, 1);
+  lua_getfenv(L, 2);
+  lua_pushboolean(L, lua_rawequal(L, -2, -1));
+  return 1;
+}
+
+/* upvalue 1: state table (cache, typenames, readonly, mt) */
+
+static int luaobject_index(lua_State *L) {
+  const struct wowless_luaobject_data *ud = wowless_toluaobject(L, 1);
+  if (ud) {
+    lua_getfield(L, lua_upvalueindex(1), "cache");
+    lua_rawgeti(L, -1, ud->type_id);
+    if (!lua_isnil(L, -1)) {
+      lua_pushvalue(L, 2);
+      lua_rawget(L, -2);
+      if (!lua_isnil(L, -1)) {
+        return 1;
+      }
+      lua_pop(L, 2);
+    } else {
+      lua_pop(L, 1);
+    }
+    lua_pop(L, 1); /* pop cache */
+  }
+  lua_getfenv(L, 1);
+  lua_getfield(L, -1, "table");
+  lua_pushvalue(L, 2);
+  lua_rawget(L, -2);
+  return 1;
+}
+
+static int luaobject_newindex(lua_State *L) {
+  const struct wowless_luaobject_data *ud = wowless_toluaobject(L, 1);
+  if (ud) {
+    lua_getfield(L, lua_upvalueindex(1), "cache");
+    lua_rawgeti(L, -1, ud->type_id);
+    lua_remove(L, -2); /* remove cache, keep methods */
+    if (!lua_isnil(L, -1)) {
+      lua_pushvalue(L, 2);
+      lua_rawget(L, -2);
+      if (!lua_isnil(L, -1)) {
+        lua_pop(L, 2);
+        return luaL_error(L, "Attempted to assign to read-only key %s",
+                          lua_tostring(L, 2));
+      }
+      lua_pop(L, 1); /* pop nil result */
+    }
+    lua_pop(L, 1); /* pop methods or nil */
+    lua_getfield(L, lua_upvalueindex(1), "readonly");
+    lua_pushvalue(L, 2);
+    lua_rawget(L, -2);
+    lua_remove(L, -2); /* remove readonly table */
+    if (!lua_isnil(L, -1)) {
+      lua_pop(L, 1);
+      return luaL_error(L, "Attempted to assign to read-only key %s",
+                        lua_tostring(L, 2));
+    }
+    lua_pop(L, 1); /* pop nil */
+  }
+  lua_getfenv(L, 1);
+  lua_getfield(L, -1, "table");
+  lua_pushvalue(L, 2);
+  lua_pushvalue(L, 3);
+  lua_rawset(L, -3);
+  return 0;
+}
+
+static int luaobject_tostring(lua_State *L) {
+  const struct wowless_luaobject_data *ud = wowless_toluaobject(L, 1);
+  if (ud) {
+    lua_getfield(L, lua_upvalueindex(1), "typenames");
+    lua_rawgeti(L, -1, ud->type_id);
+    if (lua_type(L, -1) == LUA_TSTRING) {
+      const char *tn = lua_tostring(L, -1);
+      lua_getfenv(L, 1);
+      lua_pushfstring(L, "%s: %p", tn, lua_topointer(L, -1));
+      return 1;
+    }
+  }
+  return 0;
+}
+
+static int luaobject_register_mt(lua_State *L) {
+  int type_id = luaL_checkinteger(L, 1);
+  luaL_checktype(L, 2, LUA_TTABLE); /* methods */
+  lua_getfield(L, lua_upvalueindex(1), "cache");
+  lua_pushvalue(L, 2);
+  lua_rawseti(L, -2, type_id);
+  lua_pop(L, 1);
+  if (lua_type(L, 3) == LUA_TSTRING) {
+    lua_getfield(L, lua_upvalueindex(1), "typenames");
+    lua_pushvalue(L, 3);
+    lua_rawseti(L, -2, type_id);
+    lua_pop(L, 1);
+  }
+  return 0;
+}
+
 static int wowless_luaobject_new(lua_State *L) {
   int type_id = luaL_checkinteger(L, 1);
-  luaL_checktype(L, 2, LUA_TTABLE);
-  luaL_checktype(L, 3, LUA_TTABLE);
+  luaL_checktype(L, 2, LUA_TTABLE); /* env */
   struct wowless_luaobject_data *ud =
       (struct wowless_luaobject_data *)lua_newuserdata(
           L, sizeof(struct wowless_luaobject_data));
   ud->marker = &wowless_luaobject_marker;
   ud->type_id = type_id;
-  lua_pushvalue(L, 2);
+  lua_getfield(L, lua_upvalueindex(1), "mt");
   lua_setmetatable(L, -2);
-  lua_pushvalue(L, 3);
+  lua_pushvalue(L, 2);
   lua_setfenv(L, -2);
   return 1;
 }
 
-static const struct luaL_Reg lib[] = {
-    {"getenv",    wowless_luaobject_getenv   },
-    {"gettypeid", wowless_luaobject_gettypeid},
-    {"new",       wowless_luaobject_new      },
-    {NULL,        NULL                       }
-};
+static int wowless_luaobject_makemt(lua_State *L) {
+  int tostring_enabled = lua_toboolean(L, 1);
+  lua_newtable(L); /* shared metatable */
+  lua_pushcfunction(L, luaobject_eq);
+  lua_setfield(L, -2, "__eq");
+  lua_pushvalue(L, lua_upvalueindex(1));
+  lua_pushcclosure(L, luaobject_index, 1);
+  lua_setfield(L, -2, "__index");
+  lua_pushboolean(L, 0);
+  lua_setfield(L, -2, "__metatable");
+  lua_pushvalue(L, lua_upvalueindex(1));
+  lua_pushcclosure(L, luaobject_newindex, 1);
+  lua_setfield(L, -2, "__newindex");
+  if (tostring_enabled) {
+    lua_pushvalue(L, lua_upvalueindex(1));
+    lua_pushcclosure(L, luaobject_tostring, 1);
+    lua_setfield(L, -2, "__tostring");
+  }
+  lua_setfield(L, lua_upvalueindex(1), "mt");
+  lua_getfield(L, lua_upvalueindex(1), "readonly");
+  static const char *const always_readonly[] = {
+      "__eq", "__index", "__metatable", "__newindex", NULL};
+  for (const char *const *k = always_readonly; *k; k++) {
+    lua_pushboolean(L, 1);
+    lua_setfield(L, -2, *k);
+  }
+  if (tostring_enabled) {
+    lua_pushboolean(L, 1);
+    lua_setfield(L, -2, "__tostring");
+  }
+  lua_pop(L, 1); /* pop readonly */
+  return 0;
+}
 
 int luaopen_wowless_luaobject(lua_State *L) {
+  lua_newtable(L); /* module */
+  lua_pushcfunction(L, wowless_luaobject_getenv);
+  lua_setfield(L, -2, "getenv");
+  lua_pushcfunction(L, wowless_luaobject_gettypeid);
+  lua_setfield(L, -2, "gettypeid");
+
+  lua_newtable(L); /* state */
   lua_newtable(L);
-  luaL_register(L, NULL, lib);
+  lua_setfield(L, -2, "cache");
+  lua_newtable(L);
+  lua_setfield(L, -2, "typenames");
+  lua_newtable(L);
+  lua_setfield(L, -2, "readonly");
+  /* state["mt"] is set by makemt */
+
+  lua_pushvalue(L, -1);
+  lua_pushcclosure(L, luaobject_register_mt, 1);
+  lua_setfield(L, -3, "register_mt");
+
+  lua_pushvalue(L, -1);
+  lua_pushcclosure(L, wowless_luaobject_new, 1);
+  lua_setfield(L, -3, "new");
+
+  lua_pushvalue(L, -1);
+  lua_pushcclosure(L, wowless_luaobject_makemt, 1);
+  lua_setfield(L, -3, "makemt");
+
+  lua_pop(L, 1); /* pop state */
   return 1;
 }

--- a/wowless/luaobject.h
+++ b/wowless/luaobject.h
@@ -29,7 +29,7 @@ static inline bool wowless_isluaobject(lua_State *L, int idx, int type_id) {
   return ud && ud->type_id == type_id;
 }
 
-void wowless_luaobject_register_mt(lua_State *L, int mt_idx, int type_id,
-                                   int methods_idx, const char *typename_str);
+void wowless_luaobject_make_mt(lua_State *L, int methods_idx,
+                               const char *typename_str);
 
 #endif /* WOWLESS_LUAOBJECT_H */

--- a/wowless/luaobject.h
+++ b/wowless/luaobject.h
@@ -29,4 +29,7 @@ static inline bool wowless_isluaobject(lua_State *L, int idx, int type_id) {
   return ud && ud->type_id == type_id;
 }
 
+void wowless_luaobject_register_mt(lua_State *L, int mt_idx, int type_id,
+                                   int methods_idx, const char *typename_str);
+
 #endif /* WOWLESS_LUAOBJECT_H */

--- a/wowless/modules/luaobjects.lua
+++ b/wowless/modules/luaobjects.lua
@@ -3,45 +3,13 @@ local luaobject = require('wowless.luaobject')
 return function(cstubs, datalua)
   local config = datalua.config.modules and datalua.config.modules.luaobjects or {}
   local typeids = {}
-  local methods_by_typeid = {}
-  local typename_by_typeid = {}
   local impltypes = {}
 
-  local shared_mt
-  shared_mt = {
-    __eq = function(u1, u2)
-      return luaobject.getenv(u1) == luaobject.getenv(u2)
-    end,
-    __index = function(u, key)
-      local methods = methods_by_typeid[luaobject.gettypeid(u)]
-      return methods[key] or luaobject.getenv(u).table[key]
-    end,
-    __metatable = false,
-    __newindex = function(u, key, value)
-      local methods = methods_by_typeid[luaobject.gettypeid(u)]
-      if methods[key] or shared_mt[key] ~= nil then
-        error('Attempted to assign to read-only key ' .. key)
-      end
-      luaobject.getenv(u).table[key] = value
-    end,
-    __tostring = config.tostring_metamethod and function(u)
-      local k = typename_by_typeid[luaobject.gettypeid(u)]
-      return k .. ': 0x' .. tostring(luaobject.getenv(u)):gsub('^%S+ 0x?0*', ''):lower()
-    end or nil,
-  }
-
   local function LoadTypes(modules)
-    local type_stubs = cstubs.loadluaobjects(modules)
-
+    local type_stubs = cstubs.loadluaobjects(modules, luaobject, config.tostring_metamethod)
     for k, ts in pairs(type_stubs) do
       typeids[k] = ts.typeid
-      local v = datalua.luaobjects[k]
-      if not v.virtual then
-        methods_by_typeid[ts.typeid] = ts.methods
-        typename_by_typeid[ts.typeid] = k
-      end
     end
-
     for k, v in pairs(datalua.luaobjects) do
       if v.impl and not v.virtual then
         impltypes[k] = modules[v.impl]
@@ -71,8 +39,7 @@ return function(cstubs, datalua)
   local function CreateProxy(obj)
     assert(type(obj) == 'table', 'not a luaobject env')
     local typeid = assert(obj[1], 'not a luaobject env')
-    local np = luaobject.new(typeid, shared_mt, obj)
-    return np
+    return luaobject.new(typeid, obj)
   end
 
   local function IsType(typename, obj)

--- a/wowless/stubs.cpp
+++ b/wowless/stubs.cpp
@@ -3,6 +3,7 @@ extern "C" {
 
 #include "lauxlib.h"
 #include "wowless/bubblewrap.h"
+#include "wowless/luaobject.h"
 }
 
 int wowless_impl_stub(lua_State *L) {
@@ -132,21 +133,14 @@ int wowless_load_luaobject_stubs(lua_State *L) {
   lua_getfield(L, 1, "cgencode");
   lua_insert(L, 1);
   /* Stack: [cgencode=1, modules=2, luaobject=3, bool=4] */
-  lua_getfield(L, 3, "register_mt");
-  /* Stack: [cgencode=1, modules=2, luaobject=3, bool=4, register_mt=5] */
+  lua_getfield(L, 3, "metatables");
+  /* Stack: [cgencode=1, modules=2, luaobject=3, bool=4, metatables=5] */
   lua_newtable(L); /* dedup=6 */
   lua_newtable(L); /* result=7 */
   for (const wowless_luaobject_type_entry *t = spec; t->type_name; t++) {
     load_entries_dedup(L, t->methods, 6); /* pushes methods=8 */
-    lua_pushvalue(L, 5);                 /* register_mt */
-    lua_pushinteger(L, t->type_id);
-    lua_pushvalue(L, 8); /* methods */
-    if (tostring_enabled) {
-      lua_pushstring(L, t->type_name);
-    } else {
-      lua_pushnil(L);
-    }
-    lua_call(L, 3, 0);
+    wowless_luaobject_register_mt(L, 5, t->type_id, 8,
+                                  tostring_enabled ? t->type_name : nullptr);
     lua_pop(L, 1); /* pop methods=8 */
     lua_newtable(L);
     lua_pushinteger(L, t->type_id);

--- a/wowless/stubs.cpp
+++ b/wowless/stubs.cpp
@@ -132,9 +132,6 @@ int wowless_load_luaobject_stubs(lua_State *L) {
   lua_getfield(L, 1, "cgencode");
   lua_insert(L, 1);
   /* Stack: [cgencode=1, modules=2, luaobject=3, bool=4] */
-  lua_getfield(L, 3, "makemt");
-  lua_pushboolean(L, tostring_enabled ? 1 : 0);
-  lua_call(L, 1, 0);
   lua_getfield(L, 3, "register_mt");
   /* Stack: [cgencode=1, modules=2, luaobject=3, bool=4, register_mt=5] */
   lua_newtable(L); /* dedup=6 */

--- a/wowless/stubs.cpp
+++ b/wowless/stubs.cpp
@@ -139,8 +139,8 @@ int wowless_load_luaobject_stubs(lua_State *L) {
   lua_newtable(L); /* result=7 */
   for (const wowless_luaobject_type_entry *t = spec; t->type_name; t++) {
     load_entries_dedup(L, t->methods, 6); /* pushes methods=8 */
-    wowless_luaobject_register_mt(L, 5, t->type_id, 8,
-                                  tostring_enabled ? t->type_name : nullptr);
+    wowless_luaobject_make_mt(L, 8, tostring_enabled ? t->type_name : nullptr);
+    lua_rawseti(L, 5, t->type_id);
     lua_pop(L, 1); /* pop methods=8 */
     lua_newtable(L);
     lua_pushinteger(L, t->type_id);

--- a/wowless/stubs.cpp
+++ b/wowless/stubs.cpp
@@ -127,22 +127,36 @@ static void load_entries_dedup(lua_State *L, const struct wowless_stub_entry *e,
 int wowless_load_luaobject_stubs(lua_State *L) {
   const auto *spec = static_cast<const wowless_luaobject_type_entry *>(
       lua_touserdata(L, lua_upvalueindex(1)));
+  /* arg 1: modules, arg 2: luaobject module, arg 3: tostring_enabled */
+  bool tostring_enabled = lua_toboolean(L, 3);
   lua_getfield(L, 1, "cgencode");
   lua_insert(L, 1);
-  /* Stack: [cgencode=1, modules=2] */
-  lua_newtable(L); /* dedup: ptr -> closure */
-  lua_newtable(L); /* result */
-  /* Stack: [cgencode=1, modules=2, dedup=3, result=4] */
+  /* Stack: [cgencode=1, modules=2, luaobject=3, bool=4] */
+  lua_getfield(L, 3, "makemt");
+  lua_pushboolean(L, tostring_enabled ? 1 : 0);
+  lua_call(L, 1, 0);
+  lua_getfield(L, 3, "register_mt");
+  /* Stack: [cgencode=1, modules=2, luaobject=3, bool=4, register_mt=5] */
+  lua_newtable(L); /* dedup=6 */
+  lua_newtable(L); /* result=7 */
   for (const wowless_luaobject_type_entry *t = spec; t->type_name; t++) {
+    load_entries_dedup(L, t->methods, 6); /* pushes methods=8 */
+    lua_pushvalue(L, 5);                 /* register_mt */
+    lua_pushinteger(L, t->type_id);
+    lua_pushvalue(L, 8); /* methods */
+    if (tostring_enabled) {
+      lua_pushstring(L, t->type_name);
+    } else {
+      lua_pushnil(L);
+    }
+    lua_call(L, 3, 0);
+    lua_pop(L, 1); /* pop methods=8 */
     lua_newtable(L);
     lua_pushinteger(L, t->type_id);
     lua_setfield(L, -2, "typeid");
-    load_entries_dedup(L, t->methods, 3);
-    /* Stack: [..., type_info, sandbox_methods] */
-    lua_setfield(L, -2, "methods");
-    lua_setfield(L, 4, t->type_name);
+    lua_setfield(L, 7, t->type_name);
   }
-  lua_remove(L, 3); /* remove dedup table */
+  lua_remove(L, 6); /* remove dedup */
   return 1;
 }
 


### PR DESCRIPTION
## Summary

- Per-type metatables built in C via \`wowless_luaobject_make_mt\` (declared in \`luaobject.h\`), called directly from \`wowless_load_luaobject_stubs\` — no Lua closure involved
- \`__index\` and \`__newindex\` close over only the per-type methods table; \`__tostring\` closes over only the typename string; \`__eq\` has no upvalues
- \`wowless_luaobject_new\` closure closes over a \`metatables\` table (type_id → metatable) stored in the \`wowless.luaobject\` module
- Methods tables are transient stack values: built in stubs.cpp, passed to \`make_mt\`, then discarded — never returned to Lua
- \`luaobjects.lua\` reduced to tracking typeids and impl types; all Lua metatable code removed
- \`__tostring\` uses \`snprintf\` with \`0x%llx\` format for cross-platform pointer output (avoids Windows \`%p\` uppercase/no-prefix behavior)

## Test plan

- [x] \`cmake --build --preset default --target test\` passes (verified via pre-commit hook on every commit)
- [x] \`__eq\` fires correctly between same-type proxies (per-type metatables share identity within a type)
- [x] \`__newindex\` blocks writes to method keys and all five metamethod keys
- [x] \`__tostring\` honours the per-product \`tostring_metamethod\` config flag and produces consistent \`0x...\` format on all platforms

🤖 Generated with [Claude Code](https://claude.com/claude-code)