### PR TITLE
luaobjects: pre-flatten method inheritance in prep instead of createMethods

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -528,6 +528,9 @@ foreach(product ${products})
   target_sources(
     datalua_${product}
     PRIVATE ${CMAKE_CURRENT_BINARY_DIR}/generated/${product}_stubs.cpp)
+  if(MSVC)
+    target_compile_options(datalua_${product} PRIVATE /Gy-)
+  endif()
   add_dependencies(datalua_${product} datalua_${product}_lua)
   list(APPEND dataluas datalua_${product})
 endforeach()

--- a/tools/prep.lua
+++ b/tools/prep.lua
@@ -1408,20 +1408,19 @@ for loname in sorted(luaobjectdata) do
 end
 emit('')
 
--- Per-type luaobject method entry arrays; only direct (non-inherited) methods are
--- listed per type. Inherited methods are picked up via luaobjects.lua inheritance.
--- Virtual types are also included so their stubs can be shared across subtypes.
+-- Per-type luaobject method entry arrays; all (including inherited) methods are
+-- pre-flattened at prep time via luaobject_flat, referencing the source type's stub.
+-- wowless_load_luaobject_stubs deduplicates closures by C function pointer so that
+-- inherited methods remain the same Lua function object across sibling types.
 for loname in sorted(luaobjectdata) do
-  local lodata = luaobjectdata[loname]
   emit('static const wowless_stub_entry lo_methods_%s[] = {', safename(loname))
-  if not lodata.virtual and lodata.impl then
-    for mname in sorted(lodata.methods or {}) do
-      local sn = string.format('lomethod_%s_%s', safename(loname), safename(mname))
+  for mname in sorted(luaobject_flat[loname] or {}) do
+    local source = luaobject_source[loname][mname]
+    local source_data = luaobjectdata[source]
+    local sn = string.format('lomethod_%s_%s', safename(source), safename(mname))
+    if not source_data.virtual and source_data.impl then
       emit('  {%s, implstub_%s, 0, &impldata_%s},', cstring(mname), sn, sn)
-    end
-  else
-    for mname in sorted(lodata.methods or {}) do
-      local sn = string.format('lomethod_%s_%s', safename(loname), safename(mname))
+    else
       emit('  {%s, stub_%s, 0, nullptr},', cstring(mname), sn)
     end
   end
@@ -1430,7 +1429,7 @@ for loname in sorted(luaobjectdata) do
   emit('')
 end
 
--- Luaobject type registry (all types including virtual, for method stub sharing)
+-- Luaobject type registry (all types including virtual).
 emit('static const wowless_luaobject_type_entry lo_types[] = {')
 for loname in sorted(luaobjectdata) do
   emit('  {%s, %d, lo_methods_%s},', cstring(loname), luaobject_typeids[loname], safename(loname))

--- a/wowless/modules/luaobjects.lua
+++ b/wowless/modules/luaobjects.lua
@@ -9,35 +9,11 @@ return function(cstubs, datalua)
   local function LoadTypes(modules)
     local type_stubs = cstubs.loadluaobjects(modules)
 
-    -- Build methods tables with inheritance so that inherited methods share the
-    -- same Lua function object across types (type_stubs has all types including virtual).
-    local allmethods = {}
-    local function createMethods(k)
-      if allmethods[k] then
-        return allmethods[k]
-      end
-      local v = datalua.luaobjects[k]
-      local methods = {}
-      if v.inherits then
-        for mk, mfn in pairs(createMethods(v.inherits)) do
-          methods[mk] = mfn
-        end
-      end
-      local ts = type_stubs[k]
-      if ts then
-        for mk, mfn in pairs(ts.methods) do
-          methods[mk] = mfn
-        end
-      end
-      allmethods[k] = methods
-      return methods
-    end
-
     for k, ts in pairs(type_stubs) do
       typeids[k] = ts.typeid
       local v = datalua.luaobjects[k]
       if not v.virtual then
-        local methods = createMethods(k)
+        local methods = ts.methods
         local mt
         mt = {
           __eq = function(u1, u2)

--- a/wowless/stubs.cpp
+++ b/wowless/stubs.cpp
@@ -103,24 +103,46 @@ void wowless_stub_log_extra_args(lua_State *L, const char *fname) {
   lua_call(L, 2, 0);
 }
 
+/*
+ * Variant of load_entries that deduplicates closures via a func-ptr-keyed table
+ * so that inherited methods share the same Lua function object across types.
+ */
+static void load_entries_dedup(lua_State *L, const struct wowless_stub_entry *e,
+                               int dedup_idx) {
+  lua_newtable(L); /* sandbox */
+  for (; e->name; e++) {
+    lua_pushlightuserdata(L, reinterpret_cast<void *>(e->func));
+    lua_rawget(L, dedup_idx);
+    if (lua_isnil(L, -1)) {
+      lua_pop(L, 1);
+      load_entry(L, e);
+      lua_pushlightuserdata(L, reinterpret_cast<void *>(e->func));
+      lua_pushvalue(L, -2); /* dup closure */
+      lua_rawset(L, dedup_idx);
+    }
+    lua_setfield(L, -2, e->name); /* into sandbox */
+  }
+}
+
 int wowless_load_luaobject_stubs(lua_State *L) {
   const auto *spec = static_cast<const wowless_luaobject_type_entry *>(
       lua_touserdata(L, lua_upvalueindex(1)));
   lua_getfield(L, 1, "cgencode");
   lua_insert(L, 1);
-  /* Stack: [cgencode, modules] */
-  lua_newtable(L);
-  /* Stack: [cgencode, modules, result] */
+  /* Stack: [cgencode=1, modules=2] */
+  lua_newtable(L); /* dedup: ptr -> closure */
+  lua_newtable(L); /* result */
+  /* Stack: [cgencode=1, modules=2, dedup=3, result=4] */
   for (const wowless_luaobject_type_entry *t = spec; t->type_name; t++) {
     lua_newtable(L);
     lua_pushinteger(L, t->type_id);
     lua_setfield(L, -2, "typeid");
-    load_entries(L, t->methods);
-    /* Stack: [cgencode, modules, result, type_info, sandbox_methods, host_methods] */
-    lua_pop(L, 1); /* discard host_methods */
+    load_entries_dedup(L, t->methods, 3);
+    /* Stack: [..., type_info, sandbox_methods] */
     lua_setfield(L, -2, "methods");
-    lua_setfield(L, -2, t->type_name);
+    lua_setfield(L, 4, t->type_name);
   }
+  lua_remove(L, 3); /* remove dedup table */
   return 1;
 }
 


### PR DESCRIPTION
## Summary

- `prep.lua` already computed `luaobject_flat` (full flattened method set per type via inheritance) but only used it internally. Now `lo_methods_TypeName[]` C arrays include all inherited methods by referencing the source type's stub directly (via `luaobject_source[loname][mname]`).
- `wowless_load_luaobject_stubs` now returns fully flat method tables, so `createMethods` in `luaobjects.lua` is no longer needed and is removed.
- `load_entries_dedup` in `stubs.cpp` deduplicates closures by C function pointer so inherited methods share the same Lua function object across sibling types. Host table and `secureonly` handling are omitted — luaobject methods are sandbox-only and never secureonly.
- `/Gy-` is set on `datalua_${product}` targets under MSVC to disable function-level linking, preventing ICF from merging stub functions with identical bodies and collapsing distinct methods to the same closure.

## Test plan

- [x] All existing tests pass (`cmake --build --preset default --target test`)
- [x] Pre-commit hooks pass (build and test, luacheck, stylua)

🤖 Generated with [Claude Code](https://claude.com/claude-code)