### PR TITLE
impl: implement table.count for all products

### DIFF
--- a/data/impl.yaml
+++ b/data/impl.yaml
@@ -652,6 +652,8 @@ SwapToGlobalEnvironment:
     name: env
 table.concat:
   stdlib: table.concat
+table.count:
+  impl:
 table.foreach:
   stdlib: table.foreach
 table.foreachi:

--- a/data/impl/table.count.lua
+++ b/data/impl/table.count.lua
@@ -1,0 +1,17 @@
+local usage = '(Usage: local numTableNodes, numArrayNodes, maxArrayIndex = table.count(table))'
+local err = 'bad argument #1 to \'?\' ' .. usage
+return function(t)
+  if t == nil then
+    error(err, 0)
+  elseif type(t) == 'table' then
+    local nt, na, ma = 0, 0, 0
+    for k in pairs(t) do
+      nt = nt + 1
+      if type(k) == 'number' and k > 0 and math.floor(k) == k then
+        na = na + 1
+        ma = k > ma and k or ma
+      end
+    end
+    return nt, na, ma
+  end
+end

--- a/data/products/wow/apis.yaml
+++ b/data/products/wow/apis.yaml
@@ -39033,9 +39033,10 @@ SwitchAchievementSearchTab:
 table.concat:
   impl: table.concat
 table.count:
+  impl: table.count
   inputs:
   - name: table
-    type: unknown
+    type: any
   mayreturnnothing: true
   outputs:
   - name: numTableNodes

--- a/data/products/wow/docs.yaml
+++ b/data/products/wow/docs.yaml
@@ -104,6 +104,12 @@ lies:
           _change:
             from: unknown
             to: any
+    table.count:
+      inputs:
+      - type:
+          _change:
+            from: unknown
+            to: any
     UnitFactionGroup:
       _add:
         mayreturnnothing: true

--- a/data/products/wow_anniversary/apis.yaml
+++ b/data/products/wow_anniversary/apis.yaml
@@ -24157,9 +24157,10 @@ SwitchAchievementSearchTab:
 table.concat:
   impl: table.concat
 table.count:
+  impl: table.count
   inputs:
   - name: table
-    type: unknown
+    type: any
   mayreturnnothing: true
   outputs:
   - name: numTableNodes

--- a/data/products/wow_anniversary/docs.yaml
+++ b/data/products/wow_anniversary/docs.yaml
@@ -27,6 +27,12 @@ lies:
       outputs:
       - _add:
           nilable: true
+    table.count:
+      inputs:
+      - type:
+          _change:
+            from: unknown
+            to: any
     UnitFactionGroup:
       _add:
         mayreturnnothing: true

--- a/data/products/wow_classic/apis.yaml
+++ b/data/products/wow_classic/apis.yaml
@@ -29198,9 +29198,10 @@ SwitchAchievementSearchTab:
 table.concat:
   impl: table.concat
 table.count:
+  impl: table.count
   inputs:
   - name: table
-    type: unknown
+    type: any
   mayreturnnothing: true
   outputs:
   - name: numTableNodes

--- a/data/products/wow_classic/docs.yaml
+++ b/data/products/wow_classic/docs.yaml
@@ -98,6 +98,12 @@ lies:
           _change:
             from: unknown
             to: any
+    table.count:
+      inputs:
+      - type:
+          _change:
+            from: unknown
+            to: any
     UnitFactionGroup:
       _add:
         mayreturnnothing: true

--- a/data/products/wow_classic_era/apis.yaml
+++ b/data/products/wow_classic_era/apis.yaml
@@ -22376,9 +22376,10 @@ SwitchAchievementSearchTab:
 table.concat:
   impl: table.concat
 table.count:
+  impl: table.count
   inputs:
   - name: table
-    type: unknown
+    type: any
   mayreturnnothing: true
   outputs:
   - name: numTableNodes

--- a/data/products/wow_classic_era/docs.yaml
+++ b/data/products/wow_classic_era/docs.yaml
@@ -16,6 +16,12 @@ lies:
       outputs:
       - _add:
           nilable: true
+    table.count:
+      inputs:
+      - type:
+          _change:
+            from: unknown
+            to: any
     UnitFactionGroup:
       _add:
         mayreturnnothing: true

--- a/data/products/wow_classic_era_ptr/apis.yaml
+++ b/data/products/wow_classic_era_ptr/apis.yaml
@@ -24157,9 +24157,10 @@ SwitchAchievementSearchTab:
 table.concat:
   impl: table.concat
 table.count:
+  impl: table.count
   inputs:
   - name: table
-    type: unknown
+    type: any
   mayreturnnothing: true
   outputs:
   - name: numTableNodes

--- a/data/products/wow_classic_era_ptr/docs.yaml
+++ b/data/products/wow_classic_era_ptr/docs.yaml
@@ -27,6 +27,12 @@ lies:
       outputs:
       - _add:
           nilable: true
+    table.count:
+      inputs:
+      - type:
+          _change:
+            from: unknown
+            to: any
     UnitFactionGroup:
       _add:
         mayreturnnothing: true

--- a/data/products/wow_classic_ptr/apis.yaml
+++ b/data/products/wow_classic_ptr/apis.yaml
@@ -29198,9 +29198,10 @@ SwitchAchievementSearchTab:
 table.concat:
   impl: table.concat
 table.count:
+  impl: table.count
   inputs:
   - name: table
-    type: unknown
+    type: any
   mayreturnnothing: true
   outputs:
   - name: numTableNodes

--- a/data/products/wow_classic_ptr/docs.yaml
+++ b/data/products/wow_classic_ptr/docs.yaml
@@ -98,6 +98,12 @@ lies:
           _change:
             from: unknown
             to: any
+    table.count:
+      inputs:
+      - type:
+          _change:
+            from: unknown
+            to: any
     UnitFactionGroup:
       _add:
         mayreturnnothing: true

--- a/data/products/wowt/apis.yaml
+++ b/data/products/wowt/apis.yaml
@@ -38825,9 +38825,10 @@ SwitchAchievementSearchTab:
 table.concat:
   impl: table.concat
 table.count:
+  impl: table.count
   inputs:
   - name: table
-    type: unknown
+    type: any
   mayreturnnothing: true
   outputs:
   - name: numTableNodes

--- a/data/products/wowt/docs.yaml
+++ b/data/products/wowt/docs.yaml
@@ -104,6 +104,12 @@ lies:
           _change:
             from: unknown
             to: any
+    table.count:
+      inputs:
+      - type:
+          _change:
+            from: unknown
+            to: any
     UnitFactionGroup:
       _add:
         mayreturnnothing: true

--- a/data/products/wowxptr/apis.yaml
+++ b/data/products/wowxptr/apis.yaml
@@ -39033,9 +39033,10 @@ SwitchAchievementSearchTab:
 table.concat:
   impl: table.concat
 table.count:
+  impl: table.count
   inputs:
   - name: table
-    type: unknown
+    type: any
   mayreturnnothing: true
   outputs:
   - name: numTableNodes

--- a/data/products/wowxptr/docs.yaml
+++ b/data/products/wowxptr/docs.yaml
@@ -104,6 +104,12 @@ lies:
           _change:
             from: unknown
             to: any
+    table.count:
+      inputs:
+      - type:
+          _change:
+            from: unknown
+            to: any
     UnitFactionGroup:
       _add:
         mayreturnnothing: true

--- a/data/test.yaml
+++ b/data/test.yaml
@@ -125,6 +125,8 @@ string.trim:
   string.trim:
 SwapToGlobalEnvironment:
   SwapToGlobalEnvironment:
+table.count:
+  table.count:
 table.wipe:
   table.wipe:
 UnitName:

--- a/data/test/table.count.lua
+++ b/data/test/table.count.lua
@@ -1,0 +1,28 @@
+local T, count = ...
+local usage = '(Usage: local numTableNodes, numArrayNodes, maxArrayIndex = table.count(table))'
+return {
+  array = function()
+    return T.match(3, 5, 5, 5, count({ 1, 2, 3, 4, 5 }))
+  end,
+  big = function()
+    return T.match(3, 1, 1, 1000000, count({ [1000000] = true }))
+  end,
+  empty = function()
+    return T.match(3, 0, 0, 0, count({}))
+  end,
+  hole = function()
+    return T.match(3, 4, 4, 5, count({ 1, 2, nil, 4, 5 }))
+  end,
+  keyvalue = function()
+    return T.match(3, 3, 0, 0, count({ a = true, b = true, c = true }))
+  end,
+  nilarg = function()
+    return T.match(2, false, 'bad argument #1 to \'?\' ' .. usage, pcall(count, nil))
+  end,
+  none = function()
+    return T.match(2, false, 'bad argument #1 to \'?\' ' .. usage, pcall(count))
+  end,
+  number = function()
+    return T.match(0, count(42))
+  end,
+}


### PR DESCRIPTION
## Summary

- Implements `table.count` for all 8 WoW products (wow, wowt, wow_classic, wow_classic_era, wow_classic_era_ptr, wow_classic_ptr, wow_anniversary, wowxptr)
- Returns `numTableNodes, numArrayNodes, maxArrayIndex` for a table; errors on nil; returns nothing for non-table types
- Fixes input type from `unknown` to `any` in all product APIs
- Adds tests covering arrays, holes, key-value tables, empty tables, nil/non-table args

Extracted from PR #705 (wowt bump) and applied to all products.

## Test plan
- [x] `cmake --build --preset default --target test` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)