### PR TITLE
uiobjects: add AnimatableObject virtual type to all non-wowt products

### DIFF
--- a/data/products/wow/docs.yaml
+++ b/data/products/wow/docs.yaml
@@ -465,7 +465,7 @@ script_objects:
   SimpleAnimAPI:
     uiobject: Animation
   SimpleAnimatableObjectAPI:
-    uiobject: Region
+    uiobject: AnimatableObject
   SimpleAnimFlipBookAPI:
     uiobject: FlipBook
   SimpleAnimGroupAPI:

--- a/data/products/wow/uiobjects.yaml
+++ b/data/products/wow/uiobjects.yaml
@@ -659,6 +659,40 @@ Alpha:
       - name: normalizedAlpha
         type: number
       outputs:
+AnimatableObject:
+  fields:
+    animationGroups:
+      init:
+      type: table
+  inherits:
+  methods:
+    CreateAnimationGroup:
+      impl:
+        uiobjectimpl: Region/CreateAnimationGroup
+      inputs:
+      - name: name
+        nilable: true
+        type: string
+      - name: templateName
+        nilable: true
+        type: string
+      outputs:
+      - name: group
+        type:
+          uiobject: AnimationGroup
+    GetAnimationGroups:
+      impl:
+        uiobjectimpl: Region/GetAnimationGroups
+      inputs:
+      outputs:
+      - name: groups
+        type:
+          uiobject: AnimationGroup
+      outstride: 1
+    StopAnimating:
+      inputs:
+      outputs:
+  virtual: true
 Animation:
   fields:
     endDelay:
@@ -3381,6 +3415,7 @@ FontString:
       init: 1
       type: number
   inherits:
+    AnimatableObject:
     FontInstance:
     LayeredRegion:
     ScriptObject:
@@ -3698,6 +3733,7 @@ Frame:
       init: false
       type: boolean
   inherits:
+    AnimatableObject:
     Region:
     ScriptObject:
   methods:
@@ -6670,9 +6706,6 @@ Region:
     anchoredBy:
       init:
       type: table
-    animationGroups:
-      init:
-      type: table
     bottom:
       nilable: true
       type: number
@@ -6774,20 +6807,6 @@ Region:
       outputs:
       - name: collapsesLayout
         type: boolean
-    CreateAnimationGroup:
-      impl:
-        uiobjectimpl: Region/CreateAnimationGroup
-      inputs:
-      - name: name
-        nilable: true
-        type: string
-      - name: templateName
-        nilable: true
-        type: string
-      outputs:
-      - name: group
-        type:
-          uiobject: AnimationGroup
     EnableMouse:
       impl:
         uiobjectimpl: MouseMixin/EnableMouse
@@ -6811,15 +6830,6 @@ Region:
         name: enable
         type: boolean
       outputs:
-    GetAnimationGroups:
-      impl:
-        uiobjectimpl: Region/GetAnimationGroups
-      inputs:
-      outputs:
-      - name: groups
-        type:
-          uiobject: AnimationGroup
-      outstride: 1
     GetBottom:
       impl:
         uiobjectimpl: Region/GetBottom
@@ -7229,9 +7239,6 @@ Region:
       outputs:
       - name: shouldPassThrough
         type: boolean
-    StopAnimating:
-      inputs:
-      outputs:
   objectType: Region
   scripts:
     OnEnter:
@@ -8465,6 +8472,7 @@ TextureBase:
       init: false
       type: boolean
   inherits:
+    AnimatableObject:
     LayeredRegion:
     ScriptObject:
   methods:

--- a/data/products/wow_anniversary/docs.yaml
+++ b/data/products/wow_anniversary/docs.yaml
@@ -600,7 +600,7 @@ script_objects:
   SimpleAnimAPI:
     uiobject: Animation
   SimpleAnimatableObjectAPI:
-    uiobject: Region
+    uiobject: AnimatableObject
   SimpleAnimFlipBookAPI:
     uiobject: FlipBook
   SimpleAnimGroupAPI:

--- a/data/products/wow_anniversary/uiobjects.yaml
+++ b/data/products/wow_anniversary/uiobjects.yaml
@@ -604,6 +604,40 @@ Alpha:
       - name: normalizedAlpha
         type: number
       outputs:
+AnimatableObject:
+  fields:
+    animationGroups:
+      init:
+      type: table
+  inherits:
+  methods:
+    CreateAnimationGroup:
+      impl:
+        uiobjectimpl: Region/CreateAnimationGroup
+      inputs:
+      - name: name
+        nilable: true
+        type: string
+      - name: templateName
+        nilable: true
+        type: string
+      outputs:
+      - name: group
+        type:
+          uiobject: AnimationGroup
+    GetAnimationGroups:
+      impl:
+        uiobjectimpl: Region/GetAnimationGroups
+      inputs:
+      outputs:
+      - name: groups
+        type:
+          uiobject: AnimationGroup
+      outstride: 1
+    StopAnimating:
+      inputs:
+      outputs:
+  virtual: true
 Animation:
   fields:
     endDelay:
@@ -3318,6 +3352,7 @@ FontString:
       init: 1
       type: number
   inherits:
+    AnimatableObject:
     FontInstance:
     LayeredRegion:
     ScriptObject:
@@ -3638,6 +3673,7 @@ Frame:
       init: false
       type: boolean
   inherits:
+    AnimatableObject:
     Region:
     ScriptObject:
   methods:
@@ -6470,9 +6506,6 @@ Region:
     anchoredBy:
       init:
       type: table
-    animationGroups:
-      init:
-      type: table
     bottom:
       nilable: true
       type: number
@@ -6574,20 +6607,6 @@ Region:
       outputs:
       - name: collapsesLayout
         type: boolean
-    CreateAnimationGroup:
-      impl:
-        uiobjectimpl: Region/CreateAnimationGroup
-      inputs:
-      - name: name
-        nilable: true
-        type: string
-      - name: templateName
-        nilable: true
-        type: string
-      outputs:
-      - name: group
-        type:
-          uiobject: AnimationGroup
     EnableMouse:
       impl:
         uiobjectimpl: MouseMixin/EnableMouse
@@ -6611,15 +6630,6 @@ Region:
         name: enable
         type: boolean
       outputs:
-    GetAnimationGroups:
-      impl:
-        uiobjectimpl: Region/GetAnimationGroups
-      inputs:
-      outputs:
-      - name: groups
-        type:
-          uiobject: AnimationGroup
-      outstride: 1
     GetBottom:
       impl:
         uiobjectimpl: Region/GetBottom
@@ -7029,9 +7039,6 @@ Region:
       outputs:
       - name: shouldPassThrough
         type: boolean
-    StopAnimating:
-      inputs:
-      outputs:
   objectType: Region
   scripts:
     OnEnter:
@@ -8244,6 +8251,7 @@ TextureBase:
       init: false
       type: boolean
   inherits:
+    AnimatableObject:
     LayeredRegion:
     ScriptObject:
   methods:

--- a/data/products/wow_classic/docs.yaml
+++ b/data/products/wow_classic/docs.yaml
@@ -482,7 +482,7 @@ script_objects:
   SimpleAnimAPI:
     uiobject: Animation
   SimpleAnimatableObjectAPI:
-    uiobject: Region
+    uiobject: AnimatableObject
   SimpleAnimFlipBookAPI:
     uiobject: FlipBook
   SimpleAnimGroupAPI:

--- a/data/products/wow_classic/uiobjects.yaml
+++ b/data/products/wow_classic/uiobjects.yaml
@@ -604,6 +604,40 @@ Alpha:
       - name: normalizedAlpha
         type: number
       outputs:
+AnimatableObject:
+  fields:
+    animationGroups:
+      init:
+      type: table
+  inherits:
+  methods:
+    CreateAnimationGroup:
+      impl:
+        uiobjectimpl: Region/CreateAnimationGroup
+      inputs:
+      - name: name
+        nilable: true
+        type: string
+      - name: templateName
+        nilable: true
+        type: string
+      outputs:
+      - name: group
+        type:
+          uiobject: AnimationGroup
+    GetAnimationGroups:
+      impl:
+        uiobjectimpl: Region/GetAnimationGroups
+      inputs:
+      outputs:
+      - name: groups
+        type:
+          uiobject: AnimationGroup
+      outstride: 1
+    StopAnimating:
+      inputs:
+      outputs:
+  virtual: true
 Animation:
   fields:
     endDelay:
@@ -3324,6 +3358,7 @@ FontString:
       init: 1
       type: number
   inherits:
+    AnimatableObject:
     FontInstance:
     LayeredRegion:
     ScriptObject:
@@ -3644,6 +3679,7 @@ Frame:
       init: false
       type: boolean
   inherits:
+    AnimatableObject:
     Region:
     ScriptObject:
   methods:
@@ -6596,9 +6632,6 @@ Region:
     anchoredBy:
       init:
       type: table
-    animationGroups:
-      init:
-      type: table
     bottom:
       nilable: true
       type: number
@@ -6700,20 +6733,6 @@ Region:
       outputs:
       - name: collapsesLayout
         type: boolean
-    CreateAnimationGroup:
-      impl:
-        uiobjectimpl: Region/CreateAnimationGroup
-      inputs:
-      - name: name
-        nilable: true
-        type: string
-      - name: templateName
-        nilable: true
-        type: string
-      outputs:
-      - name: group
-        type:
-          uiobject: AnimationGroup
     EnableMouse:
       impl:
         uiobjectimpl: MouseMixin/EnableMouse
@@ -6737,15 +6756,6 @@ Region:
         name: enable
         type: boolean
       outputs:
-    GetAnimationGroups:
-      impl:
-        uiobjectimpl: Region/GetAnimationGroups
-      inputs:
-      outputs:
-      - name: groups
-        type:
-          uiobject: AnimationGroup
-      outstride: 1
     GetBottom:
       impl:
         uiobjectimpl: Region/GetBottom
@@ -7155,9 +7165,6 @@ Region:
       outputs:
       - name: shouldPassThrough
         type: boolean
-    StopAnimating:
-      inputs:
-      outputs:
   objectType: Region
   scripts:
     OnEnter:
@@ -8391,6 +8398,7 @@ TextureBase:
       init: false
       type: boolean
   inherits:
+    AnimatableObject:
     LayeredRegion:
     ScriptObject:
   methods:

--- a/data/products/wow_classic_era/docs.yaml
+++ b/data/products/wow_classic_era/docs.yaml
@@ -525,7 +525,7 @@ script_objects:
   SimpleAnimAPI:
     uiobject: Animation
   SimpleAnimatableObjectAPI:
-    uiobject: Region
+    uiobject: AnimatableObject
   SimpleAnimFlipBookAPI:
     uiobject: FlipBook
   SimpleAnimGroupAPI:

--- a/data/products/wow_classic_era/uiobjects.yaml
+++ b/data/products/wow_classic_era/uiobjects.yaml
@@ -388,6 +388,40 @@ Alpha:
       - name: normalizedAlpha
         type: number
       outputs:
+AnimatableObject:
+  fields:
+    animationGroups:
+      init:
+      type: table
+  inherits:
+  methods:
+    CreateAnimationGroup:
+      impl:
+        uiobjectimpl: Region/CreateAnimationGroup
+      inputs:
+      - name: name
+        nilable: true
+        type: string
+      - name: templateName
+        nilable: true
+        type: string
+      outputs:
+      - name: group
+        type:
+          uiobject: AnimationGroup
+    GetAnimationGroups:
+      impl:
+        uiobjectimpl: Region/GetAnimationGroups
+      inputs:
+      outputs:
+      - name: groups
+        type:
+          uiobject: AnimationGroup
+      outstride: 1
+    StopAnimating:
+      inputs:
+      outputs:
+  virtual: true
 Animation:
   fields:
     endDelay:
@@ -3027,6 +3061,7 @@ FontString:
       init: 1
       type: number
   inherits:
+    AnimatableObject:
     FontInstance:
     LayeredRegion:
     ScriptObject:
@@ -3315,6 +3350,7 @@ Frame:
       init: false
       type: boolean
   inherits:
+    AnimatableObject:
     Region:
     ScriptObject:
   methods:
@@ -6033,9 +6069,6 @@ Region:
     anchoredBy:
       init:
       type: table
-    animationGroups:
-      init:
-      type: table
     bottom:
       nilable: true
       type: number
@@ -6137,20 +6170,6 @@ Region:
       outputs:
       - name: collapsesLayout
         type: boolean
-    CreateAnimationGroup:
-      impl:
-        uiobjectimpl: Region/CreateAnimationGroup
-      inputs:
-      - name: name
-        nilable: true
-        type: string
-      - name: templateName
-        nilable: true
-        type: string
-      outputs:
-      - name: group
-        type:
-          uiobject: AnimationGroup
     EnableMouse:
       impl:
         uiobjectimpl: MouseMixin/EnableMouse
@@ -6174,15 +6193,6 @@ Region:
         name: enable
         type: boolean
       outputs:
-    GetAnimationGroups:
-      impl:
-        uiobjectimpl: Region/GetAnimationGroups
-      inputs:
-      outputs:
-      - name: groups
-        type:
-          uiobject: AnimationGroup
-      outstride: 1
     GetBottom:
       impl:
         uiobjectimpl: Region/GetBottom
@@ -6576,9 +6586,6 @@ Region:
       outputs:
       - name: shouldPassThrough
         type: boolean
-    StopAnimating:
-      inputs:
-      outputs:
   objectType: Region
   scripts:
     OnEnter:
@@ -7750,6 +7757,7 @@ TextureBase:
       init: false
       type: boolean
   inherits:
+    AnimatableObject:
     LayeredRegion:
     ScriptObject:
   methods:

--- a/data/products/wow_classic_era_ptr/docs.yaml
+++ b/data/products/wow_classic_era_ptr/docs.yaml
@@ -600,7 +600,7 @@ script_objects:
   SimpleAnimAPI:
     uiobject: Animation
   SimpleAnimatableObjectAPI:
-    uiobject: Region
+    uiobject: AnimatableObject
   SimpleAnimFlipBookAPI:
     uiobject: FlipBook
   SimpleAnimGroupAPI:

--- a/data/products/wow_classic_era_ptr/uiobjects.yaml
+++ b/data/products/wow_classic_era_ptr/uiobjects.yaml
@@ -604,6 +604,40 @@ Alpha:
       - name: normalizedAlpha
         type: number
       outputs:
+AnimatableObject:
+  fields:
+    animationGroups:
+      init:
+      type: table
+  inherits:
+  methods:
+    CreateAnimationGroup:
+      impl:
+        uiobjectimpl: Region/CreateAnimationGroup
+      inputs:
+      - name: name
+        nilable: true
+        type: string
+      - name: templateName
+        nilable: true
+        type: string
+      outputs:
+      - name: group
+        type:
+          uiobject: AnimationGroup
+    GetAnimationGroups:
+      impl:
+        uiobjectimpl: Region/GetAnimationGroups
+      inputs:
+      outputs:
+      - name: groups
+        type:
+          uiobject: AnimationGroup
+      outstride: 1
+    StopAnimating:
+      inputs:
+      outputs:
+  virtual: true
 Animation:
   fields:
     endDelay:
@@ -3318,6 +3352,7 @@ FontString:
       init: 1
       type: number
   inherits:
+    AnimatableObject:
     FontInstance:
     LayeredRegion:
     ScriptObject:
@@ -3638,6 +3673,7 @@ Frame:
       init: false
       type: boolean
   inherits:
+    AnimatableObject:
     Region:
     ScriptObject:
   methods:
@@ -6470,9 +6506,6 @@ Region:
     anchoredBy:
       init:
       type: table
-    animationGroups:
-      init:
-      type: table
     bottom:
       nilable: true
       type: number
@@ -6574,20 +6607,6 @@ Region:
       outputs:
       - name: collapsesLayout
         type: boolean
-    CreateAnimationGroup:
-      impl:
-        uiobjectimpl: Region/CreateAnimationGroup
-      inputs:
-      - name: name
-        nilable: true
-        type: string
-      - name: templateName
-        nilable: true
-        type: string
-      outputs:
-      - name: group
-        type:
-          uiobject: AnimationGroup
     EnableMouse:
       impl:
         uiobjectimpl: MouseMixin/EnableMouse
@@ -6611,15 +6630,6 @@ Region:
         name: enable
         type: boolean
       outputs:
-    GetAnimationGroups:
-      impl:
-        uiobjectimpl: Region/GetAnimationGroups
-      inputs:
-      outputs:
-      - name: groups
-        type:
-          uiobject: AnimationGroup
-      outstride: 1
     GetBottom:
       impl:
         uiobjectimpl: Region/GetBottom
@@ -7029,9 +7039,6 @@ Region:
       outputs:
       - name: shouldPassThrough
         type: boolean
-    StopAnimating:
-      inputs:
-      outputs:
   objectType: Region
   scripts:
     OnEnter:
@@ -8244,6 +8251,7 @@ TextureBase:
       init: false
       type: boolean
   inherits:
+    AnimatableObject:
     LayeredRegion:
     ScriptObject:
   methods:

--- a/data/products/wow_classic_ptr/docs.yaml
+++ b/data/products/wow_classic_ptr/docs.yaml
@@ -482,7 +482,7 @@ script_objects:
   SimpleAnimAPI:
     uiobject: Animation
   SimpleAnimatableObjectAPI:
-    uiobject: Region
+    uiobject: AnimatableObject
   SimpleAnimFlipBookAPI:
     uiobject: FlipBook
   SimpleAnimGroupAPI:

--- a/data/products/wow_classic_ptr/uiobjects.yaml
+++ b/data/products/wow_classic_ptr/uiobjects.yaml
@@ -604,6 +604,40 @@ Alpha:
       - name: normalizedAlpha
         type: number
       outputs:
+AnimatableObject:
+  fields:
+    animationGroups:
+      init:
+      type: table
+  inherits:
+  methods:
+    CreateAnimationGroup:
+      impl:
+        uiobjectimpl: Region/CreateAnimationGroup
+      inputs:
+      - name: name
+        nilable: true
+        type: string
+      - name: templateName
+        nilable: true
+        type: string
+      outputs:
+      - name: group
+        type:
+          uiobject: AnimationGroup
+    GetAnimationGroups:
+      impl:
+        uiobjectimpl: Region/GetAnimationGroups
+      inputs:
+      outputs:
+      - name: groups
+        type:
+          uiobject: AnimationGroup
+      outstride: 1
+    StopAnimating:
+      inputs:
+      outputs:
+  virtual: true
 Animation:
   fields:
     endDelay:
@@ -3324,6 +3358,7 @@ FontString:
       init: 1
       type: number
   inherits:
+    AnimatableObject:
     FontInstance:
     LayeredRegion:
     ScriptObject:
@@ -3644,6 +3679,7 @@ Frame:
       init: false
       type: boolean
   inherits:
+    AnimatableObject:
     Region:
     ScriptObject:
   methods:
@@ -6596,9 +6632,6 @@ Region:
     anchoredBy:
       init:
       type: table
-    animationGroups:
-      init:
-      type: table
     bottom:
       nilable: true
       type: number
@@ -6700,20 +6733,6 @@ Region:
       outputs:
       - name: collapsesLayout
         type: boolean
-    CreateAnimationGroup:
-      impl:
-        uiobjectimpl: Region/CreateAnimationGroup
-      inputs:
-      - name: name
-        nilable: true
-        type: string
-      - name: templateName
-        nilable: true
-        type: string
-      outputs:
-      - name: group
-        type:
-          uiobject: AnimationGroup
     EnableMouse:
       impl:
         uiobjectimpl: MouseMixin/EnableMouse
@@ -6737,15 +6756,6 @@ Region:
         name: enable
         type: boolean
       outputs:
-    GetAnimationGroups:
-      impl:
-        uiobjectimpl: Region/GetAnimationGroups
-      inputs:
-      outputs:
-      - name: groups
-        type:
-          uiobject: AnimationGroup
-      outstride: 1
     GetBottom:
       impl:
         uiobjectimpl: Region/GetBottom
@@ -7155,9 +7165,6 @@ Region:
       outputs:
       - name: shouldPassThrough
         type: boolean
-    StopAnimating:
-      inputs:
-      outputs:
   objectType: Region
   scripts:
     OnEnter:
@@ -8391,6 +8398,7 @@ TextureBase:
       init: false
       type: boolean
   inherits:
+    AnimatableObject:
     LayeredRegion:
     ScriptObject:
   methods:

--- a/data/products/wowxptr/docs.yaml
+++ b/data/products/wowxptr/docs.yaml
@@ -465,7 +465,7 @@ script_objects:
   SimpleAnimAPI:
     uiobject: Animation
   SimpleAnimatableObjectAPI:
-    uiobject: Region
+    uiobject: AnimatableObject
   SimpleAnimFlipBookAPI:
     uiobject: FlipBook
   SimpleAnimGroupAPI:

--- a/data/products/wowxptr/uiobjects.yaml
+++ b/data/products/wowxptr/uiobjects.yaml
@@ -659,6 +659,40 @@ Alpha:
       - name: normalizedAlpha
         type: number
       outputs:
+AnimatableObject:
+  fields:
+    animationGroups:
+      init:
+      type: table
+  inherits:
+  methods:
+    CreateAnimationGroup:
+      impl:
+        uiobjectimpl: Region/CreateAnimationGroup
+      inputs:
+      - name: name
+        nilable: true
+        type: string
+      - name: templateName
+        nilable: true
+        type: string
+      outputs:
+      - name: group
+        type:
+          uiobject: AnimationGroup
+    GetAnimationGroups:
+      impl:
+        uiobjectimpl: Region/GetAnimationGroups
+      inputs:
+      outputs:
+      - name: groups
+        type:
+          uiobject: AnimationGroup
+      outstride: 1
+    StopAnimating:
+      inputs:
+      outputs:
+  virtual: true
 Animation:
   fields:
     endDelay:
@@ -3381,6 +3415,7 @@ FontString:
       init: 1
       type: number
   inherits:
+    AnimatableObject:
     FontInstance:
     LayeredRegion:
     ScriptObject:
@@ -3698,6 +3733,7 @@ Frame:
       init: false
       type: boolean
   inherits:
+    AnimatableObject:
     Region:
     ScriptObject:
   methods:
@@ -6670,9 +6706,6 @@ Region:
     anchoredBy:
       init:
       type: table
-    animationGroups:
-      init:
-      type: table
     bottom:
       nilable: true
       type: number
@@ -6774,20 +6807,6 @@ Region:
       outputs:
       - name: collapsesLayout
         type: boolean
-    CreateAnimationGroup:
-      impl:
-        uiobjectimpl: Region/CreateAnimationGroup
-      inputs:
-      - name: name
-        nilable: true
-        type: string
-      - name: templateName
-        nilable: true
-        type: string
-      outputs:
-      - name: group
-        type:
-          uiobject: AnimationGroup
     EnableMouse:
       impl:
         uiobjectimpl: MouseMixin/EnableMouse
@@ -6811,15 +6830,6 @@ Region:
         name: enable
         type: boolean
       outputs:
-    GetAnimationGroups:
-      impl:
-        uiobjectimpl: Region/GetAnimationGroups
-      inputs:
-      outputs:
-      - name: groups
-        type:
-          uiobject: AnimationGroup
-      outstride: 1
     GetBottom:
       impl:
         uiobjectimpl: Region/GetBottom
@@ -7229,9 +7239,6 @@ Region:
       outputs:
       - name: shouldPassThrough
         type: boolean
-    StopAnimating:
-      inputs:
-      outputs:
   objectType: Region
   scripts:
     OnEnter:
@@ -8465,6 +8472,7 @@ TextureBase:
       init: false
       type: boolean
   inherits:
+    AnimatableObject:
     LayeredRegion:
     ScriptObject:
   methods:


### PR DESCRIPTION
## Summary

- Mirrors the AnimatableObject hierarchy refactoring from PR #705 (wowt bump) to all other products: wow, wow_anniversary, wow_classic, wow_classic_era, wow_classic_era_ptr, wow_classic_ptr, wowxptr
- Moves `CreateAnimationGroup`, `GetAnimationGroups`, `StopAnimating`, and the `animationGroups` field out of `Region` into a new `virtual: true` type `AnimatableObject`
- Adds `AnimatableObject` to the inherits of `FontString`, `Frame`, and `TextureBase` in each product

## Test plan

- [x] All tests pass (`cmake --build --preset default --target test`)
- [x] Pre-commit hooks pass (yamlfmt, build and test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XWL542LTwbi4KWcrExnVpB