### PR TITLE
data: xml attribute impls must resolve on their uiobject type

### DIFF
--- a/data/products/wow/xml.yaml
+++ b/data/products/wow/xml.yaml
@@ -101,18 +101,35 @@ Animation:
       Scripts:
 AnimationGroup:
   attributes:
+    inherits:
+      type: stringlist
     looping:
       impl:
         method: SetLooping
+      type: string
+    mixin:
+      impl: internal
+      phase: early
+      type: stringlist
+    name:
+      type: string
+    parentarray:
+      impl: internal
+      type: string
+    parentkey:
+      impl: internal
       type: string
     settofinalalpha:
       impl:
         method: SetToFinalAlpha
       type: boolean
+    virtual:
+      type: boolean
   contents:
     tags:
       Animation:
-  extends: LayoutFrame
+      KeyValues:
+      Scripts:
 Animations:
   contents:
     tags:
@@ -457,7 +474,7 @@ FontString:
     tags:
       FontHeight:
       Shadow:
-  extends: ScalableRegion
+  extends: LayoutFrame
 FontStringHeader1:
   extends: FontString
 FontStringHeader2:
@@ -549,7 +566,7 @@ Frame:
       HitRectInsets:
       Layers:
       ResizeBounds:
-  extends: ScalableRegion
+  extends: LayoutFrame
 Frames:
   contents:
     tags:
@@ -645,8 +662,20 @@ Layers:
   phase: late
 LayoutFrame:
   attributes:
+    alpha:
+      impl:
+        method: SetAlpha
+      type: number
     hidden:
       impl: internal
+      type: boolean
+    ignoreparentalpha:
+      impl:
+        method: SetIgnoreParentAlpha
+      type: boolean
+    ignoreparentscale:
+      impl:
+        method: SetIgnoreParentScale
       type: boolean
     inherits:
       type: stringlist
@@ -662,6 +691,10 @@ LayoutFrame:
     parentkey:
       impl: internal
       type: string
+    scale:
+      impl:
+        method: SetScale
+      type: number
     setallpoints:
       impl: internal
       type: boolean
@@ -683,7 +716,7 @@ Line:
       type: string
     thickness:
       type: number
-  extends: ScalableRegion
+  extends: LayoutFrame
 LineScale:
   attributes:
     fromscalex:
@@ -1161,26 +1194,6 @@ Rotation:
     degrees:
       type: number
   extends: Animation
-ScalableRegion:
-  attributes:
-    alpha:
-      impl:
-        method: SetAlpha
-      type: number
-    ignoreparentalpha:
-      impl:
-        method: SetIgnoreParentAlpha
-      type: boolean
-    ignoreparentscale:
-      impl:
-        method: SetIgnoreParentScale
-      type: boolean
-    scale:
-      impl:
-        method: SetScale
-      type: number
-  extends: LayoutFrame
-  virtual: true
 Scale:
   attributes:
     fromscalex:
@@ -1214,6 +1227,7 @@ ScopedModifier:
   contents:
     tags:
       Actor:
+      AnimationGroup:
       LayoutFrame:
       Script:
   impl: transparent
@@ -1402,7 +1416,7 @@ Texture:
       Animations:
       Gradient:
       TexCoords:
-  extends: ScalableRegion
+  extends: LayoutFrame
 TextureCoordTranslation:
   extends: Animation
 ThumbTexture:
@@ -1423,6 +1437,7 @@ Ui:
   contents:
     tags:
       Actor:
+      AnimationGroup:
       Font:
       FontFamily:
       Include:

--- a/data/products/wow/xml.yaml
+++ b/data/products/wow/xml.yaml
@@ -457,7 +457,7 @@ FontString:
     tags:
       FontHeight:
       Shadow:
-  extends: LayoutFrame
+  extends: ScalableRegion
 FontStringHeader1:
   extends: FontString
 FontStringHeader2:
@@ -549,7 +549,7 @@ Frame:
       HitRectInsets:
       Layers:
       ResizeBounds:
-  extends: LayoutFrame
+  extends: ScalableRegion
 Frames:
   contents:
     tags:
@@ -645,20 +645,8 @@ Layers:
   phase: late
 LayoutFrame:
   attributes:
-    alpha:
-      impl:
-        method: SetAlpha
-      type: number
     hidden:
       impl: internal
-      type: boolean
-    ignoreparentalpha:
-      impl:
-        method: SetIgnoreParentAlpha
-      type: boolean
-    ignoreparentscale:
-      impl:
-        method: SetIgnoreParentScale
       type: boolean
     inherits:
       type: stringlist
@@ -674,10 +662,6 @@ LayoutFrame:
     parentkey:
       impl: internal
       type: string
-    scale:
-      impl:
-        method: SetScale
-      type: number
     setallpoints:
       impl: internal
       type: boolean
@@ -699,7 +683,7 @@ Line:
       type: string
     thickness:
       type: number
-  extends: LayoutFrame
+  extends: ScalableRegion
 LineScale:
   attributes:
     fromscalex:
@@ -1177,6 +1161,26 @@ Rotation:
     degrees:
       type: number
   extends: Animation
+ScalableRegion:
+  attributes:
+    alpha:
+      impl:
+        method: SetAlpha
+      type: number
+    ignoreparentalpha:
+      impl:
+        method: SetIgnoreParentAlpha
+      type: boolean
+    ignoreparentscale:
+      impl:
+        method: SetIgnoreParentScale
+      type: boolean
+    scale:
+      impl:
+        method: SetScale
+      type: number
+  extends: LayoutFrame
+  virtual: true
 Scale:
   attributes:
     fromscalex:
@@ -1398,7 +1402,7 @@ Texture:
       Animations:
       Gradient:
       TexCoords:
-  extends: LayoutFrame
+  extends: ScalableRegion
 TextureCoordTranslation:
   extends: Animation
 ThumbTexture:

--- a/data/products/wow_anniversary/xml.yaml
+++ b/data/products/wow_anniversary/xml.yaml
@@ -457,7 +457,7 @@ FontString:
     tags:
       FontHeight:
       Shadow:
-  extends: LayoutFrame
+  extends: ScalableRegion
 FontStringHeader1:
   extends: FontString
 FontStringHeader2:
@@ -549,7 +549,7 @@ Frame:
       HitRectInsets:
       Layers:
       ResizeBounds:
-  extends: LayoutFrame
+  extends: ScalableRegion
 Frames:
   contents:
     tags:
@@ -645,20 +645,8 @@ Layers:
   phase: late
 LayoutFrame:
   attributes:
-    alpha:
-      impl:
-        method: SetAlpha
-      type: number
     hidden:
       impl: internal
-      type: boolean
-    ignoreparentalpha:
-      impl:
-        method: SetIgnoreParentAlpha
-      type: boolean
-    ignoreparentscale:
-      impl:
-        method: SetIgnoreParentScale
       type: boolean
     inherits:
       type: stringlist
@@ -674,10 +662,6 @@ LayoutFrame:
     parentkey:
       impl: internal
       type: string
-    scale:
-      impl:
-        method: SetScale
-      type: number
     setallpoints:
       impl: internal
       type: boolean
@@ -699,7 +683,7 @@ Line:
       type: string
     thickness:
       type: number
-  extends: LayoutFrame
+  extends: ScalableRegion
 LineScale:
   attributes:
     fromscalex:
@@ -1177,6 +1161,26 @@ Rotation:
     degrees:
       type: number
   extends: Animation
+ScalableRegion:
+  attributes:
+    alpha:
+      impl:
+        method: SetAlpha
+      type: number
+    ignoreparentalpha:
+      impl:
+        method: SetIgnoreParentAlpha
+      type: boolean
+    ignoreparentscale:
+      impl:
+        method: SetIgnoreParentScale
+      type: boolean
+    scale:
+      impl:
+        method: SetScale
+      type: number
+  extends: LayoutFrame
+  virtual: true
 Scale:
   attributes:
     fromscalex:
@@ -1376,8 +1380,6 @@ Texture:
         method: SetHorizTile
       type: boolean
     nonblocking:
-      impl:
-        method: SetNonBlocking
       type: boolean
     snaptopixelgrid:
       impl:
@@ -1398,7 +1400,7 @@ Texture:
       Animations:
       Gradient:
       TexCoords:
-  extends: LayoutFrame
+  extends: ScalableRegion
 TextureCoordTranslation:
   extends: Animation
 ThumbTexture:

--- a/data/products/wow_anniversary/xml.yaml
+++ b/data/products/wow_anniversary/xml.yaml
@@ -101,18 +101,35 @@ Animation:
       Scripts:
 AnimationGroup:
   attributes:
+    inherits:
+      type: stringlist
     looping:
       impl:
         method: SetLooping
+      type: string
+    mixin:
+      impl: internal
+      phase: early
+      type: stringlist
+    name:
+      type: string
+    parentarray:
+      impl: internal
+      type: string
+    parentkey:
+      impl: internal
       type: string
     settofinalalpha:
       impl:
         method: SetToFinalAlpha
       type: boolean
+    virtual:
+      type: boolean
   contents:
     tags:
       Animation:
-  extends: LayoutFrame
+      KeyValues:
+      Scripts:
 Animations:
   contents:
     tags:
@@ -457,7 +474,7 @@ FontString:
     tags:
       FontHeight:
       Shadow:
-  extends: ScalableRegion
+  extends: LayoutFrame
 FontStringHeader1:
   extends: FontString
 FontStringHeader2:
@@ -549,7 +566,7 @@ Frame:
       HitRectInsets:
       Layers:
       ResizeBounds:
-  extends: ScalableRegion
+  extends: LayoutFrame
 Frames:
   contents:
     tags:
@@ -645,8 +662,20 @@ Layers:
   phase: late
 LayoutFrame:
   attributes:
+    alpha:
+      impl:
+        method: SetAlpha
+      type: number
     hidden:
       impl: internal
+      type: boolean
+    ignoreparentalpha:
+      impl:
+        method: SetIgnoreParentAlpha
+      type: boolean
+    ignoreparentscale:
+      impl:
+        method: SetIgnoreParentScale
       type: boolean
     inherits:
       type: stringlist
@@ -662,6 +691,10 @@ LayoutFrame:
     parentkey:
       impl: internal
       type: string
+    scale:
+      impl:
+        method: SetScale
+      type: number
     setallpoints:
       impl: internal
       type: boolean
@@ -683,7 +716,7 @@ Line:
       type: string
     thickness:
       type: number
-  extends: ScalableRegion
+  extends: LayoutFrame
 LineScale:
   attributes:
     fromscalex:
@@ -1161,26 +1194,6 @@ Rotation:
     degrees:
       type: number
   extends: Animation
-ScalableRegion:
-  attributes:
-    alpha:
-      impl:
-        method: SetAlpha
-      type: number
-    ignoreparentalpha:
-      impl:
-        method: SetIgnoreParentAlpha
-      type: boolean
-    ignoreparentscale:
-      impl:
-        method: SetIgnoreParentScale
-      type: boolean
-    scale:
-      impl:
-        method: SetScale
-      type: number
-  extends: LayoutFrame
-  virtual: true
 Scale:
   attributes:
     fromscalex:
@@ -1214,6 +1227,7 @@ ScopedModifier:
   contents:
     tags:
       Actor:
+      AnimationGroup:
       LayoutFrame:
       Script:
   impl: transparent
@@ -1400,7 +1414,7 @@ Texture:
       Animations:
       Gradient:
       TexCoords:
-  extends: ScalableRegion
+  extends: LayoutFrame
 TextureCoordTranslation:
   extends: Animation
 ThumbTexture:
@@ -1421,6 +1435,7 @@ Ui:
   contents:
     tags:
       Actor:
+      AnimationGroup:
       Font:
       FontFamily:
       Include:

--- a/data/products/wow_classic/xml.yaml
+++ b/data/products/wow_classic/xml.yaml
@@ -457,7 +457,7 @@ FontString:
     tags:
       FontHeight:
       Shadow:
-  extends: LayoutFrame
+  extends: ScalableRegion
 FontStringHeader1:
   extends: FontString
 FontStringHeader2:
@@ -549,7 +549,7 @@ Frame:
       HitRectInsets:
       Layers:
       ResizeBounds:
-  extends: LayoutFrame
+  extends: ScalableRegion
 Frames:
   contents:
     tags:
@@ -645,20 +645,8 @@ Layers:
   phase: late
 LayoutFrame:
   attributes:
-    alpha:
-      impl:
-        method: SetAlpha
-      type: number
     hidden:
       impl: internal
-      type: boolean
-    ignoreparentalpha:
-      impl:
-        method: SetIgnoreParentAlpha
-      type: boolean
-    ignoreparentscale:
-      impl:
-        method: SetIgnoreParentScale
       type: boolean
     inherits:
       type: stringlist
@@ -674,10 +662,6 @@ LayoutFrame:
     parentkey:
       impl: internal
       type: string
-    scale:
-      impl:
-        method: SetScale
-      type: number
     setallpoints:
       impl: internal
       type: boolean
@@ -699,7 +683,7 @@ Line:
       type: string
     thickness:
       type: number
-  extends: LayoutFrame
+  extends: ScalableRegion
 LineScale:
   attributes:
     fromscalex:
@@ -1177,6 +1161,26 @@ Rotation:
     degrees:
       type: number
   extends: Animation
+ScalableRegion:
+  attributes:
+    alpha:
+      impl:
+        method: SetAlpha
+      type: number
+    ignoreparentalpha:
+      impl:
+        method: SetIgnoreParentAlpha
+      type: boolean
+    ignoreparentscale:
+      impl:
+        method: SetIgnoreParentScale
+      type: boolean
+    scale:
+      impl:
+        method: SetScale
+      type: number
+  extends: LayoutFrame
+  virtual: true
 Scale:
   attributes:
     fromscalex:
@@ -1376,8 +1380,6 @@ Texture:
         method: SetHorizTile
       type: boolean
     nonblocking:
-      impl:
-        method: SetNonBlocking
       type: boolean
     snaptopixelgrid:
       impl:
@@ -1398,7 +1400,7 @@ Texture:
       Animations:
       Gradient:
       TexCoords:
-  extends: LayoutFrame
+  extends: ScalableRegion
 TextureCoordTranslation:
   extends: Animation
 ThumbTexture:

--- a/data/products/wow_classic/xml.yaml
+++ b/data/products/wow_classic/xml.yaml
@@ -101,18 +101,35 @@ Animation:
       Scripts:
 AnimationGroup:
   attributes:
+    inherits:
+      type: stringlist
     looping:
       impl:
         method: SetLooping
+      type: string
+    mixin:
+      impl: internal
+      phase: early
+      type: stringlist
+    name:
+      type: string
+    parentarray:
+      impl: internal
+      type: string
+    parentkey:
+      impl: internal
       type: string
     settofinalalpha:
       impl:
         method: SetToFinalAlpha
       type: boolean
+    virtual:
+      type: boolean
   contents:
     tags:
       Animation:
-  extends: LayoutFrame
+      KeyValues:
+      Scripts:
 Animations:
   contents:
     tags:
@@ -457,7 +474,7 @@ FontString:
     tags:
       FontHeight:
       Shadow:
-  extends: ScalableRegion
+  extends: LayoutFrame
 FontStringHeader1:
   extends: FontString
 FontStringHeader2:
@@ -549,7 +566,7 @@ Frame:
       HitRectInsets:
       Layers:
       ResizeBounds:
-  extends: ScalableRegion
+  extends: LayoutFrame
 Frames:
   contents:
     tags:
@@ -645,8 +662,20 @@ Layers:
   phase: late
 LayoutFrame:
   attributes:
+    alpha:
+      impl:
+        method: SetAlpha
+      type: number
     hidden:
       impl: internal
+      type: boolean
+    ignoreparentalpha:
+      impl:
+        method: SetIgnoreParentAlpha
+      type: boolean
+    ignoreparentscale:
+      impl:
+        method: SetIgnoreParentScale
       type: boolean
     inherits:
       type: stringlist
@@ -662,6 +691,10 @@ LayoutFrame:
     parentkey:
       impl: internal
       type: string
+    scale:
+      impl:
+        method: SetScale
+      type: number
     setallpoints:
       impl: internal
       type: boolean
@@ -683,7 +716,7 @@ Line:
       type: string
     thickness:
       type: number
-  extends: ScalableRegion
+  extends: LayoutFrame
 LineScale:
   attributes:
     fromscalex:
@@ -1161,26 +1194,6 @@ Rotation:
     degrees:
       type: number
   extends: Animation
-ScalableRegion:
-  attributes:
-    alpha:
-      impl:
-        method: SetAlpha
-      type: number
-    ignoreparentalpha:
-      impl:
-        method: SetIgnoreParentAlpha
-      type: boolean
-    ignoreparentscale:
-      impl:
-        method: SetIgnoreParentScale
-      type: boolean
-    scale:
-      impl:
-        method: SetScale
-      type: number
-  extends: LayoutFrame
-  virtual: true
 Scale:
   attributes:
     fromscalex:
@@ -1214,6 +1227,7 @@ ScopedModifier:
   contents:
     tags:
       Actor:
+      AnimationGroup:
       LayoutFrame:
       Script:
   impl: transparent
@@ -1400,7 +1414,7 @@ Texture:
       Animations:
       Gradient:
       TexCoords:
-  extends: ScalableRegion
+  extends: LayoutFrame
 TextureCoordTranslation:
   extends: Animation
 ThumbTexture:
@@ -1421,6 +1435,7 @@ Ui:
   contents:
     tags:
       Actor:
+      AnimationGroup:
       Font:
       FontFamily:
       Include:

--- a/data/products/wow_classic_era/xml.yaml
+++ b/data/products/wow_classic_era/xml.yaml
@@ -457,7 +457,7 @@ FontString:
     tags:
       FontHeight:
       Shadow:
-  extends: LayoutFrame
+  extends: ScalableRegion
 FontStringHeader1:
   extends: FontString
 FontStringHeader2:
@@ -549,7 +549,7 @@ Frame:
       HitRectInsets:
       Layers:
       ResizeBounds:
-  extends: LayoutFrame
+  extends: ScalableRegion
 Frames:
   contents:
     tags:
@@ -645,20 +645,8 @@ Layers:
   phase: late
 LayoutFrame:
   attributes:
-    alpha:
-      impl:
-        method: SetAlpha
-      type: number
     hidden:
       impl: internal
-      type: boolean
-    ignoreparentalpha:
-      impl:
-        method: SetIgnoreParentAlpha
-      type: boolean
-    ignoreparentscale:
-      impl:
-        method: SetIgnoreParentScale
       type: boolean
     inherits:
       type: stringlist
@@ -674,10 +662,6 @@ LayoutFrame:
     parentkey:
       impl: internal
       type: string
-    scale:
-      impl:
-        method: SetScale
-      type: number
     setallpoints:
       impl: internal
       type: boolean
@@ -699,7 +683,7 @@ Line:
       type: string
     thickness:
       type: number
-  extends: LayoutFrame
+  extends: ScalableRegion
 LineScale:
   attributes:
     fromscalex:
@@ -1177,6 +1161,26 @@ Rotation:
     degrees:
       type: number
   extends: Animation
+ScalableRegion:
+  attributes:
+    alpha:
+      impl:
+        method: SetAlpha
+      type: number
+    ignoreparentalpha:
+      impl:
+        method: SetIgnoreParentAlpha
+      type: boolean
+    ignoreparentscale:
+      impl:
+        method: SetIgnoreParentScale
+      type: boolean
+    scale:
+      impl:
+        method: SetScale
+      type: number
+  extends: LayoutFrame
+  virtual: true
 Scale:
   attributes:
     fromscalex:
@@ -1376,8 +1380,6 @@ Texture:
         method: SetHorizTile
       type: boolean
     nonblocking:
-      impl:
-        method: SetNonBlocking
       type: boolean
     snaptopixelgrid:
       impl:
@@ -1398,7 +1400,7 @@ Texture:
       Animations:
       Gradient:
       TexCoords:
-  extends: LayoutFrame
+  extends: ScalableRegion
 TextureCoordTranslation:
   extends: Animation
 ThumbTexture:

--- a/data/products/wow_classic_era/xml.yaml
+++ b/data/products/wow_classic_era/xml.yaml
@@ -101,18 +101,35 @@ Animation:
       Scripts:
 AnimationGroup:
   attributes:
+    inherits:
+      type: stringlist
     looping:
       impl:
         method: SetLooping
+      type: string
+    mixin:
+      impl: internal
+      phase: early
+      type: stringlist
+    name:
+      type: string
+    parentarray:
+      impl: internal
+      type: string
+    parentkey:
+      impl: internal
       type: string
     settofinalalpha:
       impl:
         method: SetToFinalAlpha
       type: boolean
+    virtual:
+      type: boolean
   contents:
     tags:
       Animation:
-  extends: LayoutFrame
+      KeyValues:
+      Scripts:
 Animations:
   contents:
     tags:
@@ -457,7 +474,7 @@ FontString:
     tags:
       FontHeight:
       Shadow:
-  extends: ScalableRegion
+  extends: LayoutFrame
 FontStringHeader1:
   extends: FontString
 FontStringHeader2:
@@ -549,7 +566,7 @@ Frame:
       HitRectInsets:
       Layers:
       ResizeBounds:
-  extends: ScalableRegion
+  extends: LayoutFrame
 Frames:
   contents:
     tags:
@@ -645,8 +662,20 @@ Layers:
   phase: late
 LayoutFrame:
   attributes:
+    alpha:
+      impl:
+        method: SetAlpha
+      type: number
     hidden:
       impl: internal
+      type: boolean
+    ignoreparentalpha:
+      impl:
+        method: SetIgnoreParentAlpha
+      type: boolean
+    ignoreparentscale:
+      impl:
+        method: SetIgnoreParentScale
       type: boolean
     inherits:
       type: stringlist
@@ -662,6 +691,10 @@ LayoutFrame:
     parentkey:
       impl: internal
       type: string
+    scale:
+      impl:
+        method: SetScale
+      type: number
     setallpoints:
       impl: internal
       type: boolean
@@ -683,7 +716,7 @@ Line:
       type: string
     thickness:
       type: number
-  extends: ScalableRegion
+  extends: LayoutFrame
 LineScale:
   attributes:
     fromscalex:
@@ -1161,26 +1194,6 @@ Rotation:
     degrees:
       type: number
   extends: Animation
-ScalableRegion:
-  attributes:
-    alpha:
-      impl:
-        method: SetAlpha
-      type: number
-    ignoreparentalpha:
-      impl:
-        method: SetIgnoreParentAlpha
-      type: boolean
-    ignoreparentscale:
-      impl:
-        method: SetIgnoreParentScale
-      type: boolean
-    scale:
-      impl:
-        method: SetScale
-      type: number
-  extends: LayoutFrame
-  virtual: true
 Scale:
   attributes:
     fromscalex:
@@ -1214,6 +1227,7 @@ ScopedModifier:
   contents:
     tags:
       Actor:
+      AnimationGroup:
       LayoutFrame:
       Script:
   impl: transparent
@@ -1400,7 +1414,7 @@ Texture:
       Animations:
       Gradient:
       TexCoords:
-  extends: ScalableRegion
+  extends: LayoutFrame
 TextureCoordTranslation:
   extends: Animation
 ThumbTexture:
@@ -1421,6 +1435,7 @@ Ui:
   contents:
     tags:
       Actor:
+      AnimationGroup:
       Font:
       FontFamily:
       Include:

--- a/data/products/wow_classic_era_ptr/xml.yaml
+++ b/data/products/wow_classic_era_ptr/xml.yaml
@@ -457,7 +457,7 @@ FontString:
     tags:
       FontHeight:
       Shadow:
-  extends: LayoutFrame
+  extends: ScalableRegion
 FontStringHeader1:
   extends: FontString
 FontStringHeader2:
@@ -549,7 +549,7 @@ Frame:
       HitRectInsets:
       Layers:
       ResizeBounds:
-  extends: LayoutFrame
+  extends: ScalableRegion
 Frames:
   contents:
     tags:
@@ -645,20 +645,8 @@ Layers:
   phase: late
 LayoutFrame:
   attributes:
-    alpha:
-      impl:
-        method: SetAlpha
-      type: number
     hidden:
       impl: internal
-      type: boolean
-    ignoreparentalpha:
-      impl:
-        method: SetIgnoreParentAlpha
-      type: boolean
-    ignoreparentscale:
-      impl:
-        method: SetIgnoreParentScale
       type: boolean
     inherits:
       type: stringlist
@@ -674,10 +662,6 @@ LayoutFrame:
     parentkey:
       impl: internal
       type: string
-    scale:
-      impl:
-        method: SetScale
-      type: number
     setallpoints:
       impl: internal
       type: boolean
@@ -699,7 +683,7 @@ Line:
       type: string
     thickness:
       type: number
-  extends: LayoutFrame
+  extends: ScalableRegion
 LineScale:
   attributes:
     fromscalex:
@@ -1177,6 +1161,26 @@ Rotation:
     degrees:
       type: number
   extends: Animation
+ScalableRegion:
+  attributes:
+    alpha:
+      impl:
+        method: SetAlpha
+      type: number
+    ignoreparentalpha:
+      impl:
+        method: SetIgnoreParentAlpha
+      type: boolean
+    ignoreparentscale:
+      impl:
+        method: SetIgnoreParentScale
+      type: boolean
+    scale:
+      impl:
+        method: SetScale
+      type: number
+  extends: LayoutFrame
+  virtual: true
 Scale:
   attributes:
     fromscalex:
@@ -1376,8 +1380,6 @@ Texture:
         method: SetHorizTile
       type: boolean
     nonblocking:
-      impl:
-        method: SetNonBlocking
       type: boolean
     snaptopixelgrid:
       impl:
@@ -1398,7 +1400,7 @@ Texture:
       Animations:
       Gradient:
       TexCoords:
-  extends: LayoutFrame
+  extends: ScalableRegion
 TextureCoordTranslation:
   extends: Animation
 ThumbTexture:

--- a/data/products/wow_classic_era_ptr/xml.yaml
+++ b/data/products/wow_classic_era_ptr/xml.yaml
@@ -101,18 +101,35 @@ Animation:
       Scripts:
 AnimationGroup:
   attributes:
+    inherits:
+      type: stringlist
     looping:
       impl:
         method: SetLooping
+      type: string
+    mixin:
+      impl: internal
+      phase: early
+      type: stringlist
+    name:
+      type: string
+    parentarray:
+      impl: internal
+      type: string
+    parentkey:
+      impl: internal
       type: string
     settofinalalpha:
       impl:
         method: SetToFinalAlpha
       type: boolean
+    virtual:
+      type: boolean
   contents:
     tags:
       Animation:
-  extends: LayoutFrame
+      KeyValues:
+      Scripts:
 Animations:
   contents:
     tags:
@@ -457,7 +474,7 @@ FontString:
     tags:
       FontHeight:
       Shadow:
-  extends: ScalableRegion
+  extends: LayoutFrame
 FontStringHeader1:
   extends: FontString
 FontStringHeader2:
@@ -549,7 +566,7 @@ Frame:
       HitRectInsets:
       Layers:
       ResizeBounds:
-  extends: ScalableRegion
+  extends: LayoutFrame
 Frames:
   contents:
     tags:
@@ -645,8 +662,20 @@ Layers:
   phase: late
 LayoutFrame:
   attributes:
+    alpha:
+      impl:
+        method: SetAlpha
+      type: number
     hidden:
       impl: internal
+      type: boolean
+    ignoreparentalpha:
+      impl:
+        method: SetIgnoreParentAlpha
+      type: boolean
+    ignoreparentscale:
+      impl:
+        method: SetIgnoreParentScale
       type: boolean
     inherits:
       type: stringlist
@@ -662,6 +691,10 @@ LayoutFrame:
     parentkey:
       impl: internal
       type: string
+    scale:
+      impl:
+        method: SetScale
+      type: number
     setallpoints:
       impl: internal
       type: boolean
@@ -683,7 +716,7 @@ Line:
       type: string
     thickness:
       type: number
-  extends: ScalableRegion
+  extends: LayoutFrame
 LineScale:
   attributes:
     fromscalex:
@@ -1161,26 +1194,6 @@ Rotation:
     degrees:
       type: number
   extends: Animation
-ScalableRegion:
-  attributes:
-    alpha:
-      impl:
-        method: SetAlpha
-      type: number
-    ignoreparentalpha:
-      impl:
-        method: SetIgnoreParentAlpha
-      type: boolean
-    ignoreparentscale:
-      impl:
-        method: SetIgnoreParentScale
-      type: boolean
-    scale:
-      impl:
-        method: SetScale
-      type: number
-  extends: LayoutFrame
-  virtual: true
 Scale:
   attributes:
     fromscalex:
@@ -1214,6 +1227,7 @@ ScopedModifier:
   contents:
     tags:
       Actor:
+      AnimationGroup:
       LayoutFrame:
       Script:
   impl: transparent
@@ -1400,7 +1414,7 @@ Texture:
       Animations:
       Gradient:
       TexCoords:
-  extends: ScalableRegion
+  extends: LayoutFrame
 TextureCoordTranslation:
   extends: Animation
 ThumbTexture:
@@ -1421,6 +1435,7 @@ Ui:
   contents:
     tags:
       Actor:
+      AnimationGroup:
       Font:
       FontFamily:
       Include:

--- a/data/products/wow_classic_ptr/xml.yaml
+++ b/data/products/wow_classic_ptr/xml.yaml
@@ -457,7 +457,7 @@ FontString:
     tags:
       FontHeight:
       Shadow:
-  extends: LayoutFrame
+  extends: ScalableRegion
 FontStringHeader1:
   extends: FontString
 FontStringHeader2:
@@ -549,7 +549,7 @@ Frame:
       HitRectInsets:
       Layers:
       ResizeBounds:
-  extends: LayoutFrame
+  extends: ScalableRegion
 Frames:
   contents:
     tags:
@@ -645,20 +645,8 @@ Layers:
   phase: late
 LayoutFrame:
   attributes:
-    alpha:
-      impl:
-        method: SetAlpha
-      type: number
     hidden:
       impl: internal
-      type: boolean
-    ignoreparentalpha:
-      impl:
-        method: SetIgnoreParentAlpha
-      type: boolean
-    ignoreparentscale:
-      impl:
-        method: SetIgnoreParentScale
       type: boolean
     inherits:
       type: stringlist
@@ -674,10 +662,6 @@ LayoutFrame:
     parentkey:
       impl: internal
       type: string
-    scale:
-      impl:
-        method: SetScale
-      type: number
     setallpoints:
       impl: internal
       type: boolean
@@ -699,7 +683,7 @@ Line:
       type: string
     thickness:
       type: number
-  extends: LayoutFrame
+  extends: ScalableRegion
 LineScale:
   attributes:
     fromscalex:
@@ -1177,6 +1161,26 @@ Rotation:
     degrees:
       type: number
   extends: Animation
+ScalableRegion:
+  attributes:
+    alpha:
+      impl:
+        method: SetAlpha
+      type: number
+    ignoreparentalpha:
+      impl:
+        method: SetIgnoreParentAlpha
+      type: boolean
+    ignoreparentscale:
+      impl:
+        method: SetIgnoreParentScale
+      type: boolean
+    scale:
+      impl:
+        method: SetScale
+      type: number
+  extends: LayoutFrame
+  virtual: true
 Scale:
   attributes:
     fromscalex:
@@ -1376,8 +1380,6 @@ Texture:
         method: SetHorizTile
       type: boolean
     nonblocking:
-      impl:
-        method: SetNonBlocking
       type: boolean
     snaptopixelgrid:
       impl:
@@ -1398,7 +1400,7 @@ Texture:
       Animations:
       Gradient:
       TexCoords:
-  extends: LayoutFrame
+  extends: ScalableRegion
 TextureCoordTranslation:
   extends: Animation
 ThumbTexture:

--- a/data/products/wow_classic_ptr/xml.yaml
+++ b/data/products/wow_classic_ptr/xml.yaml
@@ -101,18 +101,35 @@ Animation:
       Scripts:
 AnimationGroup:
   attributes:
+    inherits:
+      type: stringlist
     looping:
       impl:
         method: SetLooping
+      type: string
+    mixin:
+      impl: internal
+      phase: early
+      type: stringlist
+    name:
+      type: string
+    parentarray:
+      impl: internal
+      type: string
+    parentkey:
+      impl: internal
       type: string
     settofinalalpha:
       impl:
         method: SetToFinalAlpha
       type: boolean
+    virtual:
+      type: boolean
   contents:
     tags:
       Animation:
-  extends: LayoutFrame
+      KeyValues:
+      Scripts:
 Animations:
   contents:
     tags:
@@ -457,7 +474,7 @@ FontString:
     tags:
       FontHeight:
       Shadow:
-  extends: ScalableRegion
+  extends: LayoutFrame
 FontStringHeader1:
   extends: FontString
 FontStringHeader2:
@@ -549,7 +566,7 @@ Frame:
       HitRectInsets:
       Layers:
       ResizeBounds:
-  extends: ScalableRegion
+  extends: LayoutFrame
 Frames:
   contents:
     tags:
@@ -645,8 +662,20 @@ Layers:
   phase: late
 LayoutFrame:
   attributes:
+    alpha:
+      impl:
+        method: SetAlpha
+      type: number
     hidden:
       impl: internal
+      type: boolean
+    ignoreparentalpha:
+      impl:
+        method: SetIgnoreParentAlpha
+      type: boolean
+    ignoreparentscale:
+      impl:
+        method: SetIgnoreParentScale
       type: boolean
     inherits:
       type: stringlist
@@ -662,6 +691,10 @@ LayoutFrame:
     parentkey:
       impl: internal
       type: string
+    scale:
+      impl:
+        method: SetScale
+      type: number
     setallpoints:
       impl: internal
       type: boolean
@@ -683,7 +716,7 @@ Line:
       type: string
     thickness:
       type: number
-  extends: ScalableRegion
+  extends: LayoutFrame
 LineScale:
   attributes:
     fromscalex:
@@ -1161,26 +1194,6 @@ Rotation:
     degrees:
       type: number
   extends: Animation
-ScalableRegion:
-  attributes:
-    alpha:
-      impl:
-        method: SetAlpha
-      type: number
-    ignoreparentalpha:
-      impl:
-        method: SetIgnoreParentAlpha
-      type: boolean
-    ignoreparentscale:
-      impl:
-        method: SetIgnoreParentScale
-      type: boolean
-    scale:
-      impl:
-        method: SetScale
-      type: number
-  extends: LayoutFrame
-  virtual: true
 Scale:
   attributes:
     fromscalex:
@@ -1214,6 +1227,7 @@ ScopedModifier:
   contents:
     tags:
       Actor:
+      AnimationGroup:
       LayoutFrame:
       Script:
   impl: transparent
@@ -1400,7 +1414,7 @@ Texture:
       Animations:
       Gradient:
       TexCoords:
-  extends: ScalableRegion
+  extends: LayoutFrame
 TextureCoordTranslation:
   extends: Animation
 ThumbTexture:
@@ -1421,6 +1435,7 @@ Ui:
   contents:
     tags:
       Actor:
+      AnimationGroup:
       Font:
       FontFamily:
       Include:

--- a/data/products/wowt/xml.yaml
+++ b/data/products/wowt/xml.yaml
@@ -101,18 +101,35 @@ Animation:
       Scripts:
 AnimationGroup:
   attributes:
+    inherits:
+      type: stringlist
     looping:
       impl:
         method: SetLooping
+      type: string
+    mixin:
+      impl: internal
+      phase: early
+      type: stringlist
+    name:
+      type: string
+    parentarray:
+      impl: internal
+      type: string
+    parentkey:
+      impl: internal
       type: string
     settofinalalpha:
       impl:
         method: SetToFinalAlpha
       type: boolean
+    virtual:
+      type: boolean
   contents:
     tags:
       Animation:
-  extends: LayoutFrame
+      KeyValues:
+      Scripts:
 Animations:
   contents:
     tags:
@@ -457,7 +474,7 @@ FontString:
     tags:
       FontHeight:
       Shadow:
-  extends: ScalableRegion
+  extends: LayoutFrame
 FontStringHeader1:
   extends: FontString
 FontStringHeader2:
@@ -549,7 +566,7 @@ Frame:
       HitRectInsets:
       Layers:
       ResizeBounds:
-  extends: ScalableRegion
+  extends: LayoutFrame
 Frames:
   contents:
     tags:
@@ -645,8 +662,20 @@ Layers:
   phase: late
 LayoutFrame:
   attributes:
+    alpha:
+      impl:
+        method: SetAlpha
+      type: number
     hidden:
       impl: internal
+      type: boolean
+    ignoreparentalpha:
+      impl:
+        method: SetIgnoreParentAlpha
+      type: boolean
+    ignoreparentscale:
+      impl:
+        method: SetIgnoreParentScale
       type: boolean
     inherits:
       type: stringlist
@@ -662,6 +691,10 @@ LayoutFrame:
     parentkey:
       impl: internal
       type: string
+    scale:
+      impl:
+        method: SetScale
+      type: number
     setallpoints:
       impl: internal
       type: boolean
@@ -684,7 +717,7 @@ Line:
       type: string
     thickness:
       type: number
-  extends: ScalableRegion
+  extends: LayoutFrame
 LineScale:
   attributes:
     fromscalex:
@@ -1180,26 +1213,6 @@ Rotation:
     degrees:
       type: number
   extends: Animation
-ScalableRegion:
-  attributes:
-    alpha:
-      impl:
-        method: SetAlpha
-      type: number
-    ignoreparentalpha:
-      impl:
-        method: SetIgnoreParentAlpha
-      type: boolean
-    ignoreparentscale:
-      impl:
-        method: SetIgnoreParentScale
-      type: boolean
-    scale:
-      impl:
-        method: SetScale
-      type: number
-  extends: LayoutFrame
-  virtual: true
 Scale:
   attributes:
     fromscalex:
@@ -1237,6 +1250,7 @@ ScopedModifier:
   contents:
     tags:
       Actor:
+      AnimationGroup:
       LayoutFrame:
       Script:
   impl: transparent
@@ -1425,7 +1439,7 @@ Texture:
       Animations:
       Gradient:
       TexCoords:
-  extends: ScalableRegion
+  extends: LayoutFrame
 TextureCoordTranslation:
   extends: Animation
 ThumbTexture:
@@ -1446,6 +1460,7 @@ Ui:
   contents:
     tags:
       Actor:
+      AnimationGroup:
       Font:
       FontFamily:
       Include:

--- a/data/products/wowt/xml.yaml
+++ b/data/products/wowt/xml.yaml
@@ -457,7 +457,7 @@ FontString:
     tags:
       FontHeight:
       Shadow:
-  extends: LayoutFrame
+  extends: ScalableRegion
 FontStringHeader1:
   extends: FontString
 FontStringHeader2:
@@ -549,7 +549,7 @@ Frame:
       HitRectInsets:
       Layers:
       ResizeBounds:
-  extends: LayoutFrame
+  extends: ScalableRegion
 Frames:
   contents:
     tags:
@@ -645,20 +645,8 @@ Layers:
   phase: late
 LayoutFrame:
   attributes:
-    alpha:
-      impl:
-        method: SetAlpha
-      type: number
     hidden:
       impl: internal
-      type: boolean
-    ignoreparentalpha:
-      impl:
-        method: SetIgnoreParentAlpha
-      type: boolean
-    ignoreparentscale:
-      impl:
-        method: SetIgnoreParentScale
       type: boolean
     inherits:
       type: stringlist
@@ -674,10 +662,6 @@ LayoutFrame:
     parentkey:
       impl: internal
       type: string
-    scale:
-      impl:
-        method: SetScale
-      type: number
     setallpoints:
       impl: internal
       type: boolean
@@ -700,7 +684,7 @@ Line:
       type: string
     thickness:
       type: number
-  extends: LayoutFrame
+  extends: ScalableRegion
 LineScale:
   attributes:
     fromscalex:
@@ -1196,6 +1180,26 @@ Rotation:
     degrees:
       type: number
   extends: Animation
+ScalableRegion:
+  attributes:
+    alpha:
+      impl:
+        method: SetAlpha
+      type: number
+    ignoreparentalpha:
+      impl:
+        method: SetIgnoreParentAlpha
+      type: boolean
+    ignoreparentscale:
+      impl:
+        method: SetIgnoreParentScale
+      type: boolean
+    scale:
+      impl:
+        method: SetScale
+      type: number
+  extends: LayoutFrame
+  virtual: true
 Scale:
   attributes:
     fromscalex:
@@ -1421,7 +1425,7 @@ Texture:
       Animations:
       Gradient:
       TexCoords:
-  extends: LayoutFrame
+  extends: ScalableRegion
 TextureCoordTranslation:
   extends: Animation
 ThumbTexture:

--- a/data/products/wowxptr/xml.yaml
+++ b/data/products/wowxptr/xml.yaml
@@ -101,18 +101,35 @@ Animation:
       Scripts:
 AnimationGroup:
   attributes:
+    inherits:
+      type: stringlist
     looping:
       impl:
         method: SetLooping
+      type: string
+    mixin:
+      impl: internal
+      phase: early
+      type: stringlist
+    name:
+      type: string
+    parentarray:
+      impl: internal
+      type: string
+    parentkey:
+      impl: internal
       type: string
     settofinalalpha:
       impl:
         method: SetToFinalAlpha
       type: boolean
+    virtual:
+      type: boolean
   contents:
     tags:
       Animation:
-  extends: LayoutFrame
+      KeyValues:
+      Scripts:
 Animations:
   contents:
     tags:
@@ -457,7 +474,7 @@ FontString:
     tags:
       FontHeight:
       Shadow:
-  extends: ScalableRegion
+  extends: LayoutFrame
 FontStringHeader1:
   extends: FontString
 FontStringHeader2:
@@ -549,7 +566,7 @@ Frame:
       HitRectInsets:
       Layers:
       ResizeBounds:
-  extends: ScalableRegion
+  extends: LayoutFrame
 Frames:
   contents:
     tags:
@@ -645,8 +662,20 @@ Layers:
   phase: late
 LayoutFrame:
   attributes:
+    alpha:
+      impl:
+        method: SetAlpha
+      type: number
     hidden:
       impl: internal
+      type: boolean
+    ignoreparentalpha:
+      impl:
+        method: SetIgnoreParentAlpha
+      type: boolean
+    ignoreparentscale:
+      impl:
+        method: SetIgnoreParentScale
       type: boolean
     inherits:
       type: stringlist
@@ -662,6 +691,10 @@ LayoutFrame:
     parentkey:
       impl: internal
       type: string
+    scale:
+      impl:
+        method: SetScale
+      type: number
     setallpoints:
       impl: internal
       type: boolean
@@ -683,7 +716,7 @@ Line:
       type: string
     thickness:
       type: number
-  extends: ScalableRegion
+  extends: LayoutFrame
 LineScale:
   attributes:
     fromscalex:
@@ -1161,26 +1194,6 @@ Rotation:
     degrees:
       type: number
   extends: Animation
-ScalableRegion:
-  attributes:
-    alpha:
-      impl:
-        method: SetAlpha
-      type: number
-    ignoreparentalpha:
-      impl:
-        method: SetIgnoreParentAlpha
-      type: boolean
-    ignoreparentscale:
-      impl:
-        method: SetIgnoreParentScale
-      type: boolean
-    scale:
-      impl:
-        method: SetScale
-      type: number
-  extends: LayoutFrame
-  virtual: true
 Scale:
   attributes:
     fromscalex:
@@ -1214,6 +1227,7 @@ ScopedModifier:
   contents:
     tags:
       Actor:
+      AnimationGroup:
       LayoutFrame:
       Script:
   impl: transparent
@@ -1402,7 +1416,7 @@ Texture:
       Animations:
       Gradient:
       TexCoords:
-  extends: ScalableRegion
+  extends: LayoutFrame
 TextureCoordTranslation:
   extends: Animation
 ThumbTexture:
@@ -1423,6 +1437,7 @@ Ui:
   contents:
     tags:
       Actor:
+      AnimationGroup:
       Font:
       FontFamily:
       Include:

--- a/data/products/wowxptr/xml.yaml
+++ b/data/products/wowxptr/xml.yaml
@@ -457,7 +457,7 @@ FontString:
     tags:
       FontHeight:
       Shadow:
-  extends: LayoutFrame
+  extends: ScalableRegion
 FontStringHeader1:
   extends: FontString
 FontStringHeader2:
@@ -549,7 +549,7 @@ Frame:
       HitRectInsets:
       Layers:
       ResizeBounds:
-  extends: LayoutFrame
+  extends: ScalableRegion
 Frames:
   contents:
     tags:
@@ -645,20 +645,8 @@ Layers:
   phase: late
 LayoutFrame:
   attributes:
-    alpha:
-      impl:
-        method: SetAlpha
-      type: number
     hidden:
       impl: internal
-      type: boolean
-    ignoreparentalpha:
-      impl:
-        method: SetIgnoreParentAlpha
-      type: boolean
-    ignoreparentscale:
-      impl:
-        method: SetIgnoreParentScale
       type: boolean
     inherits:
       type: stringlist
@@ -674,10 +662,6 @@ LayoutFrame:
     parentkey:
       impl: internal
       type: string
-    scale:
-      impl:
-        method: SetScale
-      type: number
     setallpoints:
       impl: internal
       type: boolean
@@ -699,7 +683,7 @@ Line:
       type: string
     thickness:
       type: number
-  extends: LayoutFrame
+  extends: ScalableRegion
 LineScale:
   attributes:
     fromscalex:
@@ -1177,6 +1161,26 @@ Rotation:
     degrees:
       type: number
   extends: Animation
+ScalableRegion:
+  attributes:
+    alpha:
+      impl:
+        method: SetAlpha
+      type: number
+    ignoreparentalpha:
+      impl:
+        method: SetIgnoreParentAlpha
+      type: boolean
+    ignoreparentscale:
+      impl:
+        method: SetIgnoreParentScale
+      type: boolean
+    scale:
+      impl:
+        method: SetScale
+      type: number
+  extends: LayoutFrame
+  virtual: true
 Scale:
   attributes:
     fromscalex:
@@ -1398,7 +1402,7 @@ Texture:
       Animations:
       Gradient:
       TexCoords:
-  extends: LayoutFrame
+  extends: ScalableRegion
 TextureCoordTranslation:
   extends: Animation
 ThumbTexture:

--- a/spec/data/xml_spec.lua
+++ b/spec/data/xml_spec.lua
@@ -2,10 +2,62 @@ describe('xml', function()
   local scripttypes = require('build.data.scripttypes')
   for _, p in ipairs(require('build.data.products')) do
     describe(p, function()
-      for name, elem in pairs(require('build.data.products.' .. p .. '.xml')) do
+      local xml = require('build.data.products.' .. p .. '.xml')
+      local uiobjects = require('build.data.products.' .. p .. '.uiobjects')
+      local methods = {}
+      local fields = {}
+      local function flatten(k)
+        if not methods[k] then
+          local m, f = {}, {}
+          for inh in pairs(uiobjects[k].inherits) do
+            flatten(inh)
+            for mk in pairs(methods[inh]) do
+              m[mk] = true
+            end
+            for fk in pairs(fields[inh]) do
+              f[fk] = true
+            end
+          end
+          for mk in pairs(uiobjects[k].methods) do
+            m[mk] = true
+          end
+          for fk in pairs(uiobjects[k].fields) do
+            f[fk] = true
+          end
+          methods[k] = m
+          fields[k] = f
+        end
+      end
+      for k in pairs(uiobjects) do
+        flatten(k)
+      end
+      for name, elem in pairs(xml) do
         if elem.extends == 'ScriptType' then
           it(name .. ' is in scripttypes', function()
             assert.Not.Nil(scripttypes[name])
+          end)
+        end
+        -- Non-virtual xml tags that instantiate a uiobject type must only carry
+        -- method/field attribute impls resolvable on that type, so attribute
+        -- application never needs a does-this-method-exist check at runtime.
+        if uiobjects[name] and not elem.virtual then
+          it(name .. ' attribute impls resolve', function()
+            local attrs = {}
+            local e = elem
+            while e do
+              for an, a in pairs(e.attributes or {}) do
+                attrs[an] = attrs[an] or a
+              end
+              e = e.extends and xml[e.extends] or nil
+            end
+            for an, a in pairs(attrs) do
+              local impl = type(a.impl) == 'table' and a.impl or nil
+              if impl and impl.method then
+                assert(methods[name][impl.method], ('%s.%s: no method %s'):format(name, an, impl.method))
+              elseif impl and impl.field then
+                assert(fields[name][impl.field], ('%s.%s: no field %s'):format(name, an, impl.field))
+              end
+            end
           end)
         end
       end


### PR DESCRIPTION
## Summary

Preliminary PR for the XML codegen migration (#716): establish and enforce the
invariant that every `method=`/`field=` attribute impl on a non-virtual,
uiobject-instantiating XML tag resolves against that uiobject type's flattened
methods/fields. Once this holds, generated attribute-application code can call
`obj:Method(v)` directly with no per-call "does this method exist" guard.

**Data fixes**, cross-referenced against the client-shipped
`Blizzard_SharedXML/UI.xsd`:

- **AnimationGroup modeled per the XSD** (all products): `AnimationGroupType`
  in the XSD is a standalone type, not an extension of `LayoutFrameType` —
  exactly the attributes `name, mixin, inherits, virtual, parentKey,
  parentArray, looping, setToFinalAlpha` with `Animation`/`Scripts`/`KeyValues`
  children. Its top-level placement comes from explicit `UiField` substitution
  group membership. xml.yaml now matches: AnimationGroup no longer extends
  `LayoutFrame` (so it stops inheriting impls for `SetAlpha`/`SetScale`/
  `SetIgnoreParentAlpha`/`SetIgnoreParentScale`, which its uiobject type does
  not have), and `Ui`/`ScopedModifier` list `AnimationGroup` explicitly.
  A survey of every `<AnimationGroup>` tag across all product extracts found
  only the eight XSD attributes in use, and a `-l3` run produced zero new
  parse warnings — no FrameXML relied on the LayoutFrame-inherited attrs or
  kids that AnimationGroup loses.
- **Classic-family products only**: drop the `SetNonBlocking` impl from
  `Texture`'s `nonblocking` attribute; the method does not exist on those
  products' texture types. The attribute stays declared (it is in the XSD's
  `TextureAttributes`) so FrameXML carrying it still parses and is silently
  ignored, matching the real classic client. Previously, loading such a file
  would have hard-errored.

**Invariant test** (`spec/data/xml_spec.lua`): for each product, for each
non-virtual XML tag that is also a uiobject type, flatten the attribute set
through the `extends` chain and assert every `method=`/`field=` impl exists in
the uiobject type's flattened methods/fields. Virtual tags (e.g. `POIFrame`,
which extends `Frame` in xml.yaml but implements none of its methods) are
skipped — the parser rejects instantiating them, and concrete subtypes
re-check the full flattened set against their own complete method lists.

Note on history: the first commit fixed the AnimationGroup mismatch with a
`ScalableRegion` intermediate tag; the second commit replaces that with the
XSD-faithful model after cross-referencing `UI.xsd`.

## Test plan

- [x] `cmake --build --preset default --target test` passes
- [x] Verified the new test bites: reverting one product's xml.yaml fix fails
      with `Texture.nonblocking: no method SetNonBlocking`
- [x] `cmake --build --preset default --target outs`: all 8 products produce
      logs identical to main except timestamps (`wow_anniversary`'s 2 known
      errors unchanged, all other products clean)
- [x] `wowless_wow run -l3`: zero animationgroup-related parse warnings
- [x] Grepped extracts: `<AnimationGroup>` tags use only the eight XSD
      attributes; `nonBlocking=` appears only in files not loaded by `outs`
- [x] pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013tcK2kG5TnMcMWDBv3ywu9