### PR TITLE
loader: assert xml attribute methods exist

### DIFF
--- a/wowless/modules/loader.lua
+++ b/wowless/modules/loader.lua
@@ -493,10 +493,8 @@ return function(
         elseif attr.impl.scope then
           return { [attr.impl.scope] = v }
         elseif attr.impl.method then
-          local fn = obj[attr.impl.method]
-          if not fn then
-            error(('missing method %q on object type %q'):format(attr.impl.method, obj.type))
-          elseif type(v) == 'table' then -- stringlist
+          local fn = assert(obj[attr.impl.method], attr.impl.method)
+          if type(v) == 'table' then -- stringlist
             fn(obj, unpack(v))
           else
             fn(obj, v)


### PR DESCRIPTION
## Summary

Follow-up to #717: now that the xml_spec invariant guarantees every `method=`
attribute impl on an instantiable XML tag resolves on its uiobject type, the
descriptive missing-method error in `processAttr` is a dead branch. Replace it
with a plain `assert` — if it ever fires, it's a wowless bug (data invariant
violated), not an addon data error needing a friendly message. Intrinsic types
share their base type's method table, so the guarantee covers them too.

## Test plan

- [x] `cmake --build --preset default --target test` passes (pre-commit
      build-and-test hook ran on commit)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013tcK2kG5TnMcMWDBv3ywu9