### PR TITLE
loader: assert xml attribute methods exist

### DIFF
--- a/wowless/modules/loader.lua
+++ b/wowless/modules/loader.lua
@@ -493,10 +493,8 @@ return function(
         elseif attr.impl.scope then
           return { [attr.impl.scope] = v }
         elseif attr.impl.method then
-          local fn = obj[attr.impl.method]
-          if not fn then
-            error(('missing method %q on object type %q'):format(attr.impl.method, obj.type))
-          elseif type(v) == 'table' then -- stringlist
+          local fn = assert(obj[attr.impl.method], attr.impl.method)
+          if type(v) == 'table' then -- stringlist
             fn(obj, unpack(v))
           else
             fn(obj, v)


### PR DESCRIPTION
The xml_spec invariant guarantees every method= attribute impl on an
instantiable tag resolves on its uiobject type, so a missing method at
apply time is a wowless bug, not a data error worth a descriptive
message. Intrinsic types share their base type's method table, so the
guarantee extends to them.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_013tcK2kG5TnMcMWDBv3ywu9
