### PR TITLE
addon: incorporate elune's scripttest into wowless testing

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -11,6 +11,7 @@ read_globals = {
   'debug.setstacktaint',
   'debug.settaintmode',
   'forceinsecure',
+  'geterrorhandler',
   'hooksecurefunc',
   'issecure',
   'issecurevariable',

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1064,6 +1064,35 @@ add_custom_command(
   COMMAND ${CMAKE_COMMAND} -E touch testaddon.txt
   DEPENDS ${testaddon_outs})
 
+# Built outside of addon/ so it isn't swept up by other tests' otherAddonDirs
+# parent-directory addon discovery (see wowless/modules/loader.lua).
+set(d ${CMAKE_CURRENT_BINARY_DIR}/eluneaddon/EluneTest)
+file(MAKE_DIRECTORY ${d})
+set(eluneaddon_outs)
+foreach(f case.lua EluneTest.toc)
+  set(out ${d}/${f})
+  list(APPEND eluneaddon_outs ${out})
+  add_custom_command(
+    OUTPUT ${out}
+    COMMAND
+      ${CMAKE_COMMAND} -DSRC=${CMAKE_CURRENT_SOURCE_DIR}/addon/EluneTest/${f}
+      -DDST_DIR=${d} -P ${CMAKE_CURRENT_SOURCE_DIR}/cmake/copy_executable.cmake
+    DEPENDS addon/EluneTest/${f})
+endforeach()
+set(out ${d}/luatest_scriptcases.lua)
+list(APPEND eluneaddon_outs ${out})
+add_custom_command(
+  OUTPUT ${out}
+  COMMAND
+    ${CMAKE_COMMAND}
+    -DSRC=${CMAKE_CURRENT_SOURCE_DIR}/vendor/elune/tests/luatest_scriptcases.lua
+    -DDST_DIR=${d} -P ${CMAKE_CURRENT_SOURCE_DIR}/cmake/copy_executable.cmake
+  DEPENDS vendor/elune/tests/luatest_scriptcases.lua)
+add_custom_command(
+  OUTPUT eluneaddon.txt
+  COMMAND ${CMAKE_COMMAND} -E touch eluneaddon.txt
+  DEPENDS ${eluneaddon_outs})
+
 set(specs
     spec/addon/arraydiff_spec.lua
     spec/addon/framework_spec.lua
@@ -1103,8 +1132,13 @@ add_custom_command(
   COMMENT "Running tests"
   OUTPUT test.out
   COMMAND runtests -o ${CMAKE_CURRENT_BINARY_DIR}/test.out ${specs}
-  DEPENDS runtests addons.txt ${schemadbs} ${specs} spec/wowless/temp.blp
+  DEPENDS runtests
+          addons.txt
+          ${schemadbs}
+          ${specs}
+          spec/wowless/temp.blp
           testaddon.txt
+          eluneaddon.txt
   WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
 add_custom_target(test DEPENDS test.out)
 

--- a/addon/EluneTest/EluneTest.toc
+++ b/addon/EluneTest/EluneTest.toc
@@ -1,0 +1,3 @@
+## Interface: 120000
+case.lua
+luatest_scriptcases.lua

--- a/addon/EluneTest/case.lua
+++ b/addon/EluneTest/case.lua
@@ -1,0 +1,16 @@
+_G.EluneScriptcaseFailures = {}
+
+_G.case = function(name, func)
+  local olderrorhandler = geterrorhandler()
+  local errors = {}
+  seterrorhandler(function(err)
+    table.insert(errors, err)
+  end)
+  securecall(func)
+  if olderrorhandler then
+    seterrorhandler(olderrorhandler)
+  end
+  if #errors > 0 then
+    _G.EluneScriptcaseFailures[name] = errors
+  end
+end

--- a/spec/wowless/addon_spec.lua
+++ b/spec/wowless/addon_spec.lua
@@ -1,3 +1,11 @@
+-- These represent real gaps between wowless's taint semantics and elune's;
+-- follow-up work should shrink this set, not grow it.
+local expectedScriptcaseFailures = {
+  ['OP_GETGLOBAL: Read from insecure function environment'] = true,
+  ['getfenv: Read tainted environment'] = true,
+  ['seterrorhandler: replaces \'*\' source with object names'] = true,
+}
+
 describe('addon', function()
   for _, product in ipairs(require('build.data.products')) do
     describe(product, function()
@@ -20,6 +28,25 @@ describe('addon', function()
         assert.True(modules.env.genv.WowlessTestsDone)
         assert.same({}, modules.env.genv.WowlessTestFailures)
         assert.same(0, modules.errors.GetErrorCount())
+      end)
+      it('runs elune scriptcases', function()
+        local tmpassert = _G.assert
+        _G.assert = _G.oldassert
+        local success, modules = pcall(function()
+          return require('wowless.runner').run({
+            signedAddonDirs = {
+              'build/eluneaddon/EluneTest/',
+            },
+            product = product,
+          })
+        end)
+        _G.assert = tmpassert
+        assert.True(success, modules)
+        local actualFailures = {}
+        for name in pairs(modules.env.genv.EluneScriptcaseFailures) do
+          actualFailures[name] = true
+        end
+        assert.same(expectedScriptcaseFailures, actualFailures)
       end)
     end)
   end

--- a/wowless/modules/loader.lua
+++ b/wowless/modules/loader.lua
@@ -22,6 +22,7 @@ return function(
   local product = datalua.product
   assert(product, 'loader requires a product')
   local otherAddonDirs = loadercfg.otherAddonDirs or {}
+  local signedAddonDirs = loadercfg.signedAddonDirs or {}
 
   local path = require('path')
   local parseXml = require('wowless.xml').newParser(product)
@@ -847,6 +848,9 @@ return function(
           maybeAdd(path.join(rootDir, path.dirname(filepath)), true)
         end
       end
+    end
+    for _, d in ipairs(signedAddonDirs) do
+      maybeAdd(d, true)
     end
     for _, d in ipairs(otherAddonDirs) do
       local dir = path.dirname(d)

--- a/wowless/runner.lua
+++ b/wowless/runner.lua
@@ -44,16 +44,22 @@ local function run(cfg)
     end
   end
   local path = require('path')
-  local otherAddonDirs = {}
-  for _, d in ipairs(cfg.otherAddonDirs or {}) do
-    local dd = path.basename(d) == '' and path.dirname(d) or d
-    table.insert(otherAddonDirs, dd)
+  local function normalizeAddonDirs(dirs)
+    local result = {}
+    for _, d in ipairs(dirs or {}) do
+      local dd = path.basename(d) == '' and path.dirname(d) or d
+      table.insert(result, dd)
+    end
+    return result
   end
+  local otherAddonDirs = normalizeAddonDirs(cfg.otherAddonDirs)
+  local signedAddonDirs = normalizeAddonDirs(cfg.signedAddonDirs)
   local modules = require('wowless.modules')({
     datalua = require('build.products.' .. cfg.product .. '.data'),
     loadercfg = {
       otherAddonDirs = otherAddonDirs,
       rootDir = cfg.dir,
+      signedAddonDirs = signedAddonDirs,
     },
     log = log,
     loglevel = cfg.loglevel or 0,


### PR DESCRIPTION
## Summary
- Adds a new `EluneTest` addon that loads elune's vendored `luatest_scriptcases.lua` (the taint/security conformance suite) verbatim, copied from `vendor/elune/tests/` at build time so it stays in sync with the submodule.
- Loads it as a *signed* addon (new `signedAddonDirs` option threaded through `wowless.runner.run()` -> `loader.lua`) so each top-level scriptcase file-load starts from wowless's clean/untainted baseline, while still exercising the full product API surface (`genv`), not a raw host Lua state.
- A small `case()` shim (`addon/EluneTest/case.lua`) adapts elune's `case(name, func)` registration convention to collect per-case failures into `_G.EluneScriptcaseFailures`.
- Built outside of `addon/` (`build/eluneaddon/EluneTest/`) so it isn't accidentally swept up by other tests' `otherAddonDirs` parent-directory addon auto-discovery.
- A new `it('runs elune scriptcases', ...)` block in `spec/wowless/addon_spec.lua`, run once per product, asserts the failing-case set matches an explicit expected list — 3 known gaps between wowless's taint semantics and elune's (`OP_GETGLOBAL`, `getfenv`, `seterrorhandler` cases), to be closed in follow-ups rather than silently regressed.

## Test plan
- [x] `cmake --build --preset default --target test` passes cleanly from a fresh build directory
- [x] `pre-commit run -a` (cmake-format, stylua, luacheck, build-and-test) passes
- [x] Verified the addon is isolated from the existing `Wowless` test addon run (no shared-globals collision)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017TzrfyiiCYeGJghZqMkuR6