### PR TITLE
errorhandler: replicate elune's "*:" object-name substitution

### DIFF
--- a/data/modules.yaml
+++ b/data/modules.yaml
@@ -52,7 +52,9 @@ env:
   deps:
 errorhandler:
   deps:
+    api:
     eventqueue:
+    uiobjects:
 errors:
   deps:
     log:

--- a/data/modules.yaml
+++ b/data/modules.yaml
@@ -52,7 +52,6 @@ env:
   deps:
 errorhandler:
   deps:
-    api:
     eventqueue:
     uiobjects:
 errors:

--- a/data/modules.yaml
+++ b/data/modules.yaml
@@ -54,6 +54,7 @@ errorhandler:
   deps:
     eventqueue:
     uiobjects:
+    uiobjecttypes:
 errors:
   deps:
     log:

--- a/data/test.yaml
+++ b/data/test.yaml
@@ -40,8 +40,11 @@ environmentmetafield:
 error:
   error:
 errorhandler:
+  CreateFrame:
   error:
   geterrorhandler:
+  loadstring:
+  securecall:
   securecallfunction:
   seterrorhandler:
 GetAddOnInterfaceVersion:

--- a/data/test/errorhandler.lua
+++ b/data/test/errorhandler.lua
@@ -1,4 +1,4 @@
-local T, error, geterrorhandler, securecallfunction, seterrorhandler = ...
+local T, CreateFrame, error, geterrorhandler, loadstring, securecall, securecallfunction, seterrorhandler = ...
 
 local tests = {
   ['get returns set function'] = function()
@@ -42,6 +42,33 @@ local tests = {
     local t = { key = 'value' }
     securecallfunction(error, t)
     T.assertEquals('UNKNOWN ERROR', received)
+  end,
+  ['star source replaced with named object name'] = function()
+    local frame = CreateFrame('Frame', 'WowlessEHTestFrame')
+    local received
+    seterrorhandler(function(e)
+      received = e
+    end)
+    local chunk = 'local _ = ...; WowlessEHTestGlobal1 = WowlessEHTestGlobal1 + 1'
+    securecall(loadstring(chunk, '*:OnBanana'), frame)
+    T.assertEquals(
+      [[[string "WowlessEHTestFrame:OnBanana"]:1: attempt to perform arithmetic on global ]]
+        .. [['WowlessEHTestGlobal1' (a nil value)]],
+      received
+    )
+  end,
+  ['star source not replaced for unnamed object'] = function()
+    local frame = CreateFrame('Frame')
+    local received
+    seterrorhandler(function(e)
+      received = e
+    end)
+    local chunk = 'local _ = ...; WowlessEHTestGlobal2 = WowlessEHTestGlobal2 + 1'
+    securecall(loadstring(chunk, '*:OnBanana'), frame)
+    T.assertEquals(
+      [[[string "*:OnBanana"]:1: attempt to perform arithmetic on global 'WowlessEHTestGlobal2' (a nil value)]],
+      received
+    )
   end,
 }
 

--- a/data/test/errorhandler.lua
+++ b/data/test/errorhandler.lua
@@ -57,7 +57,7 @@ local tests = {
       received
     )
   end,
-  ['star source not replaced for unnamed object'] = function()
+  ['star source replaced with type name for unnamed object'] = function()
     local frame = CreateFrame('Frame')
     local received
     seterrorhandler(function(e)
@@ -66,7 +66,7 @@ local tests = {
     local chunk = 'local _ = ...; WowlessEHTestGlobal2 = WowlessEHTestGlobal2 + 1'
     securecall(loadstring(chunk, '*:OnBanana'), frame)
     T.assertEquals(
-      [[[string "*:OnBanana"]:1: attempt to perform arithmetic on global 'WowlessEHTestGlobal2' (a nil value)]],
+      [[[string "Frame:OnBanana"]:1: attempt to perform arithmetic on global 'WowlessEHTestGlobal2' (a nil value)]],
       received
     )
   end,

--- a/spec/wowless/addon_spec.lua
+++ b/spec/wowless/addon_spec.lua
@@ -3,7 +3,6 @@
 local expectedScriptcaseFailures = {
   ['OP_GETGLOBAL: Read from insecure function environment'] = true,
   ['getfenv: Read tainted environment'] = true,
-  ['seterrorhandler: replaces \'*\' source with object names'] = true,
 }
 
 describe('addon', function()

--- a/wowless/modules/errorhandler.lua
+++ b/wowless/modules/errorhandler.lua
@@ -1,6 +1,7 @@
-return function(eventqueue, uiobjects)
+return function(eventqueue, uiobjects, uiobjecttypes)
   local QueueEvent = eventqueue.QueueEvent
   local UserData = uiobjects.UserData
+  local GetObjectType = uiobjecttypes.GetObjectType
   local currentFn
 
   -- elune's reference error handler (f_errorhandler/f_errorobjname in
@@ -9,12 +10,12 @@ return function(eventqueue, uiobjects)
   -- frame's userdata has a __name metamethod. Wowless's uiobject userdata is
   -- exposed directly to the sandbox and must stay bare (no metatable), so we
   -- replicate the substitution here instead, using wowless's own uiobject
-  -- registry to resolve the name field (as GetClickFrame does; no
-  -- substitution if the object has no name). Level 4 (relative to this
-  -- function) is empirically the function that errored: 1 is this function,
-  -- 2 is the dispatcher below, 3 is an elune-internal C frame that invokes
-  -- the dispatcher on behalf of f_errorhandler, and 4 is the erroring
-  -- function.
+  -- registry to resolve the name field (as GetClickFrame does), falling back
+  -- to the object's type name (as GetObjectType does) when it has no name;
+  -- confirmed against the real client. Level 4 (relative to this function)
+  -- is empirically the function that errored: 1 is this function, 2 is the
+  -- dispatcher below, 3 is an elune-internal C frame that invokes the
+  -- dispatcher on behalf of f_errorhandler, and 4 is the erroring function.
   local function SubstituteObjectName(msg)
     local s, e = string.find(msg, '*:', 1, true)
     if not s then
@@ -29,10 +30,10 @@ return function(eventqueue, uiobjects)
       return msg
     end
     local ud = UserData(frame)
-    local name = ud and ud.name
-    if not name then
+    if not ud then
       return msg
     end
+    local name = ud.name or GetObjectType(ud)
     return string.sub(msg, 1, s - 1) .. name .. string.sub(msg, e)
   end
 

--- a/wowless/modules/errorhandler.lua
+++ b/wowless/modules/errorhandler.lua
@@ -1,8 +1,43 @@
-return function(eventqueue)
+return function(api, eventqueue, uiobjects)
   local QueueEvent = eventqueue.QueueEvent
+  local UserData = uiobjects.UserData
   local currentFn
 
+  -- elune's reference error handler (f_errorhandler/f_errorobjname in
+  -- lbaselib.c) substitutes a "*:" script source token with the name of the
+  -- frame found in the erroring function's first local, but only if that
+  -- frame's userdata has a __name metamethod. Wowless's uiobject userdata is
+  -- exposed directly to the sandbox and must stay bare (no metatable), so we
+  -- replicate the substitution here instead, using wowless's own uiobject
+  -- registry to resolve the name. Level 4 (relative to this function) is
+  -- empirically the function that errored: 1 is this function, 2 is the
+  -- dispatcher below, 3 is an elune-internal C frame that invokes the
+  -- dispatcher on behalf of f_errorhandler, and 4 is the erroring function.
+  local function SubstituteObjectName(msg)
+    local s, e = string.find(msg, '*:', 1, true)
+    if not s then
+      return msg
+    end
+    local info = debug.getinfo(4, 'S')
+    if not info or string.sub(info.source, 1, 1) ~= '*' then
+      return msg
+    end
+    local _, frame = debug.getlocal(4, 1)
+    if type(frame) ~= 'table' then
+      return msg
+    end
+    local ud = UserData(frame)
+    local name = ud and api.GetDebugName(ud)
+    if not name then
+      return msg
+    end
+    return string.sub(msg, 1, s - 1) .. name .. string.sub(msg, e)
+  end
+
   seterrorhandler(function(msg)
+    if type(msg) == 'string' then
+      msg = SubstituteObjectName(msg)
+    end
     if not pcall(currentFn, msg) then
       QueueEvent('LUA_WARNING', msg)
     end

--- a/wowless/modules/errorhandler.lua
+++ b/wowless/modules/errorhandler.lua
@@ -1,4 +1,4 @@
-return function(api, eventqueue, uiobjects)
+return function(eventqueue, uiobjects)
   local QueueEvent = eventqueue.QueueEvent
   local UserData = uiobjects.UserData
   local currentFn
@@ -9,10 +9,12 @@ return function(api, eventqueue, uiobjects)
   -- frame's userdata has a __name metamethod. Wowless's uiobject userdata is
   -- exposed directly to the sandbox and must stay bare (no metatable), so we
   -- replicate the substitution here instead, using wowless's own uiobject
-  -- registry to resolve the name. Level 4 (relative to this function) is
-  -- empirically the function that errored: 1 is this function, 2 is the
-  -- dispatcher below, 3 is an elune-internal C frame that invokes the
-  -- dispatcher on behalf of f_errorhandler, and 4 is the erroring function.
+  -- registry to resolve the name field (as GetClickFrame does; no
+  -- substitution if the object has no name). Level 4 (relative to this
+  -- function) is empirically the function that errored: 1 is this function,
+  -- 2 is the dispatcher below, 3 is an elune-internal C frame that invokes
+  -- the dispatcher on behalf of f_errorhandler, and 4 is the erroring
+  -- function.
   local function SubstituteObjectName(msg)
     local s, e = string.find(msg, '*:', 1, true)
     if not s then
@@ -27,7 +29,7 @@ return function(api, eventqueue, uiobjects)
       return msg
     end
     local ud = UserData(frame)
-    local name = ud and api.GetDebugName(ud)
+    local name = ud and ud.name
     if not name then
       return msg
     end


### PR DESCRIPTION
## Summary
- elune's reference error handler (`f_errorhandler`/`f_errorobjname` in `lbaselib.c`) rewrites a `"*:"` script source token in error messages with the name of the frame found in the erroring function's first local — but only if that frame's userdata exposes a `__name` metamethod.
- Wowless's uiobject userdata is exposed directly to the sandbox and must stay bare (no metatable), so this check never passed and the substitution silently never happened. This was tracked as a known gap in `spec/wowless/addon_spec.lua` since #721.
- Instead of giving the userdata a metatable, `wowless/modules/errorhandler.lua`'s dispatcher (which sits downstream of elune's `f_errorhandler`, since `seterrorhandler` wraps whatever handler is installed) now replicates the substitution itself, resolving the frame's name via wowless's own uiobject registry (`uiobjects.UserData`) — using its `name` field directly (the same way `GetClickFrame` resolves names), and falling back to the object's type name (`uiobjecttypes.GetObjectType`) when it has no name. The type-name fallback was added after validating the named-object-only version against a real client, which showed unnamed frames still get substituted with their type name (e.g. `"Frame"`) rather than being left unsubstituted.
- `errorhandler` now depends on `uiobjects` and `uiobjecttypes` in `data/modules.yaml` (no cycle).
- Removed the now-fixed `seterrorhandler: replaces '*' source with object names` entry from the expected elune scriptcase failures.
- Added test cases to `data/test/errorhandler.lua` (run inside the `addon/Wowless` test addon) covering both the named-frame substitution and the type-name-fallback substitution for an anonymous frame, so this behavior can also be validated against a real client by loading the Wowless test addon in-game.

## Test plan
- [x] `cmake --build --preset default --target test` passes cleanly
- [x] `pre-commit run -a` passes (including the build-and-test hook)
- [x] Verified via temporary stack-level instrumentation that the erroring frame is reachable at `debug.getinfo(4, ...)`/`debug.getlocal(4, 1)` relative to the substitution helper, before removing the instrumentation
- [x] Verified against real-client output that unnamed objects get the type-name fallback rather than no substitution

🤖 Generated with [Claude Code](https://claude.com/claude-code)