### PR TITLE
getfenv: disable bubblewrap taint isolation, closes remaining elune gaps

### DIFF
--- a/data/impl.yaml
+++ b/data/impl.yaml
@@ -352,6 +352,7 @@ geterrorhandler:
 getfenv:
   moduledelegate:
     name: env
+    nobubblewrap: true
 GetFileIDFromPath:
   impl:
     sqls:

--- a/spec/wowless/addon_spec.lua
+++ b/spec/wowless/addon_spec.lua
@@ -1,10 +1,3 @@
--- These represent real gaps between wowless's taint semantics and elune's;
--- follow-up work should shrink this set, not grow it.
-local expectedScriptcaseFailures = {
-  ['OP_GETGLOBAL: Read from insecure function environment'] = true,
-  ['getfenv: Read tainted environment'] = true,
-}
-
 describe('addon', function()
   for _, product in ipairs(require('build.data.products')) do
     describe(product, function()
@@ -41,11 +34,7 @@ describe('addon', function()
         end)
         _G.assert = tmpassert
         assert.True(success, modules)
-        local actualFailures = {}
-        for name in pairs(modules.env.genv.EluneScriptcaseFailures) do
-          actualFailures[name] = true
-        end
-        assert.same(expectedScriptcaseFailures, actualFailures)
+        assert.same({}, modules.env.genv.EluneScriptcaseFailures)
       end)
     end)
   end


### PR DESCRIPTION
## Summary
- `getfenv`'s native elune implementation (`lbaselib.c:118-135`) intentionally taints the *calling context* when reading a function's environment that was itself tainted (via `setfenv` while insecure taints the closure object, `lbaselib.c:151`) — this is a documented elune VM side effect, not just a return-value taint.
- wowless exposes `getfenv` via `moduledelegate`, which by default routes through the generic API stub `wowless_impl_stub` (`wowless/stubs.cpp:9-16`). That stub wraps every call with `wowless_bubblewrap_cstub_enter`/`_exit` (`wowless/bubblewrap.c`), which unconditionally restores the caller's pre-call taint state on exit — correct for ordinary APIs (a call's internals shouldn't taint the caller, only its return value should), but it silently discards `getfenv`'s intentional ambient-taint side effect.
- Verified via `debug.getinfo` frame dumps that the actual call chain is `test code -> [C stub "getfenv"] -> env.lua wrapper -> native getfenv`, and that the stub's exit path is exactly what erases the taint set deep inside the native call.
- Setting `nobubblewrap: true` on the `getfenv` entry in `data/impl.yaml` routes it through `wowless_impl_stub_nobubblewrap` instead (`wowless/stubs.cpp:18-23`), a plain `lua_call` with no taint save/restore, letting the native side effect propagate correctly. Both stub variants are still registered as genuine C closures (`stubs.cpp:52/56`), so this doesn't change `getfenv`'s C-function appearance (e.g. `coroutine.create(getfenv)` still fails as it should).
- Closes the last two of the three elune scriptcase gaps tracked since #721 (`OP_GETGLOBAL: Read from insecure function environment`, `getfenv: Read tainted environment`); the third (`seterrorhandler`) was already fixed by #722. `expectedScriptcaseFailures` in `spec/wowless/addon_spec.lua` is now empty, so the test is simplified to assert `EluneScriptcaseFailures` is `{}` directly (matching the existing `WowlessTestFailures` pattern), dropping the now-unneeded indirection.

## Test plan
- [x] `cmake --build --preset default --target test` passes cleanly from a fresh build directory
- [x] `pre-commit run -a` passes (including the build-and-test hook)
- [x] Verified via temporary `debug.getinfo` instrumentation that the taint-discarding boundary is exactly wowless's bubblewrap stub exit path, before removing the instrumentation

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016B493A4vLKVFBeUJP6rnKL