### PR TITLE
getfenv: disable bubblewrap taint isolation, closes remaining elune gaps

### DIFF
--- a/data/impl.yaml
+++ b/data/impl.yaml
@@ -352,6 +352,7 @@ geterrorhandler:
 getfenv:
   moduledelegate:
     name: env
+    nobubblewrap: true
 GetFileIDFromPath:
   impl:
     sqls:

--- a/spec/wowless/addon_spec.lua
+++ b/spec/wowless/addon_spec.lua
@@ -1,10 +1,3 @@
--- These represent real gaps between wowless's taint semantics and elune's;
--- follow-up work should shrink this set, not grow it.
-local expectedScriptcaseFailures = {
-  ['OP_GETGLOBAL: Read from insecure function environment'] = true,
-  ['getfenv: Read tainted environment'] = true,
-}
-
 describe('addon', function()
   for _, product in ipairs(require('build.data.products')) do
     describe(product, function()
@@ -41,11 +34,7 @@ describe('addon', function()
         end)
         _G.assert = tmpassert
         assert.True(success, modules)
-        local actualFailures = {}
-        for name in pairs(modules.env.genv.EluneScriptcaseFailures) do
-          actualFailures[name] = true
-        end
-        assert.same(expectedScriptcaseFailures, actualFailures)
+        assert.same({}, modules.env.genv.EluneScriptcaseFailures)
       end)
     end)
   end


### PR DESCRIPTION
getfenv's native elune implementation intentionally taints the calling
context when reading a function's environment that was itself tainted
(via setfenv while insecure). wowless routed getfenv through the generic
API stub, whose bubblewrap enter/exit boundary unconditionally restores
the caller's pre-call taint state, silently discarding that side effect.
Marking getfenv nobubblewrap lets the native taint propagate, closing
the last two gaps tracked since #721 (the third, seterrorhandler, was
already fixed by #722).

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_016B493A4vLKVFBeUJP6rnKL
