### PR TITLE
loader: give Shadow its own XML handler instead of a ctx-scope flag

### DIFF
--- a/data/products/wow/xml.yaml
+++ b/data/products/wow/xml.yaml
@@ -1281,8 +1281,6 @@ Shadow:
     tags:
       Color:
       Offset:
-  impl:
-    scope: shadow
 SimpleHTML:
   contents:
     tags:

--- a/data/products/wow_anniversary/xml.yaml
+++ b/data/products/wow_anniversary/xml.yaml
@@ -1281,8 +1281,6 @@ Shadow:
     tags:
       Color:
       Offset:
-  impl:
-    scope: shadow
 SimpleHTML:
   contents:
     tags:

--- a/data/products/wow_classic/xml.yaml
+++ b/data/products/wow_classic/xml.yaml
@@ -1281,8 +1281,6 @@ Shadow:
     tags:
       Color:
       Offset:
-  impl:
-    scope: shadow
 SimpleHTML:
   contents:
     tags:

--- a/data/products/wow_classic_era/xml.yaml
+++ b/data/products/wow_classic_era/xml.yaml
@@ -1281,8 +1281,6 @@ Shadow:
     tags:
       Color:
       Offset:
-  impl:
-    scope: shadow
 SimpleHTML:
   contents:
     tags:

--- a/data/products/wow_classic_era_ptr/xml.yaml
+++ b/data/products/wow_classic_era_ptr/xml.yaml
@@ -1281,8 +1281,6 @@ Shadow:
     tags:
       Color:
       Offset:
-  impl:
-    scope: shadow
 SimpleHTML:
   contents:
     tags:

--- a/data/products/wow_classic_ptr/xml.yaml
+++ b/data/products/wow_classic_ptr/xml.yaml
@@ -1281,8 +1281,6 @@ Shadow:
     tags:
       Color:
       Offset:
-  impl:
-    scope: shadow
 SimpleHTML:
   contents:
     tags:

--- a/data/products/wowt/xml.yaml
+++ b/data/products/wowt/xml.yaml
@@ -1304,8 +1304,6 @@ Shadow:
     tags:
       Color:
       Offset:
-  impl:
-    scope: shadow
 SimpleHTML:
   contents:
     tags:

--- a/data/products/wowxptr/xml.yaml
+++ b/data/products/wowxptr/xml.yaml
@@ -1281,8 +1281,6 @@ Shadow:
     tags:
       Color:
       Offset:
-  impl:
-    scope: shadow
 SimpleHTML:
   contents:
     tags:

--- a/data/schemas/xml.yaml
+++ b/data/schemas/xml.yaml
@@ -68,7 +68,6 @@ type:
                       ref:
                         schema: uiobject
               loadstring: tag
-              scope: string
               script:
                 record:
                   args:

--- a/wowless/modules/loader.lua
+++ b/wowless/modules/loader.lua
@@ -277,16 +277,12 @@ return function(
     blingtexture = function(_, e, parent)
       parent:SetBlingTexture(e.attr.file or '', getColor(e))
     end,
-    color = function(ctx, e, parent)
+    color = function(_, e, parent)
       local r, g, b, a = getColor(e)
       if uiobjecttypes.InheritsFrom(parent.type, 'texturebase') then
         parent:SetColorTexture(r, g, b, a)
       elseif uiobjecttypes.InheritsFrom(parent.type, 'fontinstance') then
-        if ctx.shadow then
-          parent:SetShadowColor(r, g, b, a)
-        else
-          parent:SetTextColor(r, g, b, a)
-        end
+        parent:SetTextColor(r, g, b, a)
       elseif uiobjecttypes.InheritsFrom(parent.type, 'statusbar') then
         parent:SetStatusBarColor(r, g, b, a)
       else
@@ -368,10 +364,6 @@ return function(
     modifiedclick = function()
       -- TODO support modified clicks
     end,
-    offset = function(ctx, e, parent)
-      assert(ctx.shadow, 'this should only run on shadow for now')
-      parent:SetShadowOffset(getXY(e))
-    end,
     origin = function(_, e, parent)
       if e.attr.point then
         local x, y = getXY(e)
@@ -380,6 +372,22 @@ return function(
     end,
     pushedtextoffset = function(_, e, parent)
       parent:SetPushedTextOffset(getXY(e))
+    end,
+    shadow = function(_, e, parent)
+      local color, offset
+      for _, kid in ipairs(e.kids) do
+        if kid.type == 'color' then
+          color = kid
+        elseif kid.type == 'offset' then
+          offset = kid
+        end
+      end
+      if color then
+        parent:SetShadowColor(getColor(color))
+      end
+      if offset then
+        parent:SetShadowOffset(getXY(offset))
+      end
     end,
     size = function(_, e, parent)
       local x, y = getXY(e)
@@ -641,8 +649,6 @@ return function(
           if type(impl) == 'table' and impl.script then
             local env = ctx.useAddonEnv and addonEnv or ctx.useSecureEnv and secureenv or genv
             precacheScriptText(e, parent, env, filename)
-          elseif type(impl) == 'table' and impl.scope then
-            loadElements(mixin({}, ctx, { [impl.scope] = true }), e.kids, parent)
           elseif type(impl) == 'table' and impl.call then
             local elt = impl.call.argument == 'lastkid' and e.kids[#e.kids]
               or mixin({}, e, { type = impl.call.argument })


### PR DESCRIPTION
## Summary
- First step in moving XML field application away from context-flag threading and toward object-driven, self-contained handlers.
- `Shadow` was the only user of the `impl.scope` element mechanism (`ctx.shadow` set during recursive descent, consumed several frames later by the generic `color`/`offset` handlers). It now has its own handler that reads its `Color`/`Offset` kids directly and calls `SetShadowColor`/`SetShadowOffset` on `parent`, matching how `size`, `anchor`, and `texcoords` already work.
- Since Shadow was the last user of element-level `impl.scope`, that dead schema branch and its dispatcher in `loader.lua` are removed too (`data/schemas/xml.yaml` coverage test caught this).

## Test plan
- [x] `cmake --build --preset default --target test` passes
- [x] `pre-commit run -a` passes
- [x] Manually loaded a test addon with `<FontString><Shadow><Color .../><Offset .../></Shadow></FontString>` through `build/wowless_wow run` — parses cleanly, `SetShadowColor`/`SetShadowOffset` invoked with correctly-typed args (a type mismatch would trip the C stub typecheck), no errors or warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XQvWzQY4qUMYhkmd8ppdff