### PR TITLE
testaddon: generate XML test content from Lua data at build time

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1021,6 +1021,10 @@ add_lua_executable(
   wowlessutil
   wowlessyaml)
 
+add_lua_executable(
+  generatexmltest ${CMAKE_CURRENT_SOURCE_DIR}/tools/generatexmltest.lua
+  argparse penlight toolsutil wowlessyaml)
+
 set(d ${CMAKE_CURRENT_BINARY_DIR}/addon/Wowless)
 file(MAKE_DIRECTORY ${d} ${CMAKE_CURRENT_BINARY_DIR}/staging/addon/Wowless)
 set(testaddon_outs)
@@ -1059,6 +1063,20 @@ add_custom_command(
   COMMAND ${CMAKE_COMMAND} -DSRC=${staging} -DDST_DIR=${d} -P
           ${CMAKE_CURRENT_SOURCE_DIR}/cmake/copy_executable.cmake
   DEPENDS addon/Wowless/test.xml cmake/preprocess_line.cmake)
+set(out ${d}/generatedxml.xml)
+set(staged ${CMAKE_CURRENT_BINARY_DIR}/staging/addon/Wowless/generatedxml.xml)
+list(APPEND testaddon_outs ${out})
+add_custom_command(
+  OUTPUT ${staged}
+  COMMAND generatexmltest ${staged}
+  WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+  DEPFILE ${staged}.d
+  DEPENDS generatexmltest)
+add_custom_command(
+  OUTPUT ${out}
+  COMMAND ${CMAKE_COMMAND} -DSRC=${staged} -DDST_DIR=${d} -P
+          ${CMAKE_CURRENT_SOURCE_DIR}/cmake/copy_executable.cmake
+  DEPENDS ${staged})
 add_custom_command(
   OUTPUT testaddon.txt
   COMMAND ${CMAKE_COMMAND} -E touch testaddon.txt

--- a/addon/Wowless/test.xml
+++ b/addon/Wowless/test.xml
@@ -453,100 +453,6 @@
     assertEquals(foo, bar)
   </Script>
 
-  <!-- Actors support scripts through XML even though they aren't ScriptObjects. -->
-  <Script>
-    WowlessLog = {}
-  </Script>
-  <Actor name='WowlessActorTemplate' virtual='true'>
-    <Scripts>
-      <OnAnimFinished>end, table.insert(WowlessLog, 'OnAnimFinished')--</OnAnimFinished>
-      <OnAnimStarted>end, table.insert(WowlessLog, 'OnAnimStarted')--</OnAnimStarted>
-      <OnArrowPressed>end, table.insert(WowlessLog, 'OnArrowPressed')--</OnArrowPressed>
-      <OnAttributeChanged>end, table.insert(WowlessLog, 'OnAttributeChanged')--</OnAttributeChanged>
-      <OnButtonUpdate>end, table.insert(WowlessLog, 'OnButtonUpdate')--</OnButtonUpdate>
-      <OnChar>end, table.insert(WowlessLog, 'OnChar')--</OnChar>
-      <OnCharComposition>end, table.insert(WowlessLog, 'OnCharComposition')--</OnCharComposition>
-      <OnClick>end, table.insert(WowlessLog, 'OnClick')--</OnClick>
-      <OnColorSelect>end, table.insert(WowlessLog, 'OnColorSelect')--</OnColorSelect>
-      <OnCooldownDone>end, table.insert(WowlessLog, 'OnCooldownDone')--</OnCooldownDone>
-      <OnCursorChanged>end, table.insert(WowlessLog, 'OnCursorChanged')--</OnCursorChanged>
-      <OnDisable>end, table.insert(WowlessLog, 'OnDisable')--</OnDisable>
-      <OnDoubleClick>end, table.insert(WowlessLog, 'OnDoubleClick')--</OnDoubleClick>
-      <OnDragStart>end, table.insert(WowlessLog, 'OnDragStart')--</OnDragStart>
-      <OnDragStop>end, table.insert(WowlessLog, 'OnDragStop')--</OnDragStop>
-      <OnDressModel>end, table.insert(WowlessLog, 'OnDressModel')--</OnDressModel>
-      <OnEditFocusGained>end, table.insert(WowlessLog, 'OnEditFocusGained')--</OnEditFocusGained>
-      <OnEditFocusLost>end, table.insert(WowlessLog, 'OnEditFocusLost')--</OnEditFocusLost>
-      <OnEnable>end, table.insert(WowlessLog, 'OnEnable')--</OnEnable>
-      <OnEnter>end, table.insert(WowlessLog, 'OnEnter')--</OnEnter>
-      <OnEnterPressed>end, table.insert(WowlessLog, 'OnEnterPressed')--</OnEnterPressed>
-      <OnError>end, table.insert(WowlessLog, 'OnError')--</OnError>
-      <OnEscapePressed>end, table.insert(WowlessLog, 'OnEscapePressed')--</OnEscapePressed>
-      <OnEvent>end, table.insert(WowlessLog, 'OnEvent')--</OnEvent>
-      <OnExternalLink>end, table.insert(WowlessLog, 'OnExternalLink')--</OnExternalLink>
-      <OnFinished>end, table.insert(WowlessLog, 'OnFinished')--</OnFinished>
-      <OnGamePadButtonDown>end, table.insert(WowlessLog, 'OnGamePadButtonDown')--</OnGamePadButtonDown>
-      <OnGamePadButtonUp>end, table.insert(WowlessLog, 'OnGamePadButtonUp')--</OnGamePadButtonUp>
-      <OnHide>end, table.insert(WowlessLog, 'OnHide')--</OnHide>
-      <OnHorizontalScroll>end, table.insert(WowlessLog, 'OnHorizontalScroll')--</OnHorizontalScroll>
-      <OnHyperlinkClick>end, table.insert(WowlessLog, 'OnHyperlinkClick')--</OnHyperlinkClick>
-      <OnHyperlinkEnter>end, table.insert(WowlessLog, 'OnHyperlinkEnter')--</OnHyperlinkEnter>
-      <OnHyperlinkLeave>end, table.insert(WowlessLog, 'OnHyperlinkLeave')--</OnHyperlinkLeave>
-      <OnInputLanguageChanged>end, table.insert(WowlessLog, 'OnInputLanguageChanged')--</OnInputLanguageChanged>
-      <OnKeyDown>end, table.insert(WowlessLog, 'OnKeyDown')--</OnKeyDown>
-      <OnKeyUp>end, table.insert(WowlessLog, 'OnKeyUp')--</OnKeyUp>
-      <OnLeave>end, table.insert(WowlessLog, 'OnLeave')--</OnLeave>
-      <OnLoad>end, table.insert(WowlessLog, 'OnLoad')--</OnLoad>
-      <OnLoop>end, table.insert(WowlessLog, 'OnLoop')--</OnLoop>
-      <OnMinMaxChanged>end, table.insert(WowlessLog, 'OnMinMaxChanged')--</OnMinMaxChanged>
-      <OnModelCleared>end, table.insert(WowlessLog, 'OnModelCleared')--</OnModelCleared>
-      <OnModelLoaded>end, table.insert(WowlessLog, 'OnModelLoaded')--</OnModelLoaded>
-      <OnModelLoading>end, table.insert(WowlessLog, 'OnModelLoading')--</OnModelLoading>
-      <OnMouseDown>end, table.insert(WowlessLog, 'OnMouseDown')--</OnMouseDown>
-      <OnMouseUp>end, table.insert(WowlessLog, 'OnMouseUp')--</OnMouseUp>
-      <OnMouseWheel>end, table.insert(WowlessLog, 'OnMouseWheel')--</OnMouseWheel>
-      <OnMovieFinished>end, table.insert(WowlessLog, 'OnMovieFinished')--</OnMovieFinished>
-      <OnPause>end, table.insert(WowlessLog, 'OnPause')--</OnPause>
-      <OnPlay>end, table.insert(WowlessLog, 'OnPlay')--</OnPlay>
-      <OnReceiveDrag>end, table.insert(WowlessLog, 'OnReceiveDrag')--</OnReceiveDrag>
-      <OnRequestNewSize>end, table.insert(WowlessLog, 'OnRequestNewSize')--</OnRequestNewSize>
-      <OnScrollRangeChanged>end, table.insert(WowlessLog, 'OnScrollRangeChanged')--</OnScrollRangeChanged>
-      <OnShow>end, table.insert(WowlessLog, 'OnShow')--</OnShow>
-      <OnSizeChanged>end, table.insert(WowlessLog, 'OnSizeChanged')--</OnSizeChanged>
-      <OnSpacePressed>end, table.insert(WowlessLog, 'OnSpacePressed')--</OnSpacePressed>
-      <OnStop>end, table.insert(WowlessLog, 'OnStop')--</OnStop>
-      <OnTabPressed>end, table.insert(WowlessLog, 'OnTabPressed')--</OnTabPressed>
-      <OnTextChanged>end, table.insert(WowlessLog, 'OnTextChanged')--</OnTextChanged>
-      <OnTextSet>end, table.insert(WowlessLog, 'OnTextSet')--</OnTextSet>
-      <OnTooltipAddMoney>end, table.insert(WowlessLog, 'OnTooltipAddMoney')--</OnTooltipAddMoney>
-      <OnTooltipCleared>end, table.insert(WowlessLog, 'OnTooltipCleared')--</OnTooltipCleared>
-      <OnTooltipSetDefaultAnchor>end, table.insert(WowlessLog, 'OnTooltipSetDefaultAnchor')--</OnTooltipSetDefaultAnchor>
-      <OnTooltipSetFrameStack>end, table.insert(WowlessLog, 'OnTooltipSetFrameStack')--</OnTooltipSetFrameStack>
-      <OnTooltipSetItem>end, table.insert(WowlessLog, 'OnTooltipSetItem')--</OnTooltipSetItem>
-      <OnTooltipSetSpell>end, table.insert(WowlessLog, 'OnTooltipSetSpell')--</OnTooltipSetSpell>
-      <OnTooltipSetUnit>end, table.insert(WowlessLog, 'OnTooltipSetUnit')--</OnTooltipSetUnit>
-      <OnUiMapChanged>end, table.insert(WowlessLog, 'OnUiMapChanged')--</OnUiMapChanged>
-      <OnUpdate>end, table.insert(WowlessLog, 'OnUpdate')--</OnUpdate>
-      <OnValueChanged>end, table.insert(WowlessLog, 'OnValueChanged')--</OnValueChanged>
-      <OnVerticalScroll>end, table.insert(WowlessLog, 'OnVerticalScroll')--</OnVerticalScroll>
-      <PostClick>end, table.insert(WowlessLog, 'PostClick')--</PostClick>
-      <PreClick>end, table.insert(WowlessLog, 'PreClick')--</PreClick>
-    </Scripts>
-  </Actor>
-  <Script>
-    CreateFrame('ModelScene'):CreateActor(nil, 'WowlessActorTemplate')
-    local expected = {}
-    for k, v in _G.Wowless.sorted(_G.WowlessData.UIObjectApis.Actor.scripts) do
-      if v then
-        table.insert(expected, k)
-      else
-        local fmt = 'Frame ModelSceneActor: Unknown script element %s'
-        table.insert(_G.Wowless.ExpectedLuaWarnings, fmt:format(k))
-      end
-    end
-    assertEquals(table.concat(expected, ','), table.concat(WowlessLog, ','))
-  </Script>
-
   <Frame>
     <Layers>
       <Layer>
@@ -1184,6 +1090,8 @@
       </OnLoad>
     </Scripts>
   </Frame>
+
+  <Include file='generatedxml.xml' />
 
   <Script>
     if WowlessOldErrorHandler then

--- a/tools/generatexmltest.lua
+++ b/tools/generatexmltest.lua
@@ -1,0 +1,58 @@
+local deps = {}
+
+local function readfile(f)
+  deps[f] = true
+  return assert((require('pl.file').read(f)))
+end
+
+local function readyaml(f)
+  return require('wowapi.yaml').parse(readfile(f))
+end
+
+local args = (function()
+  local parser = require('argparse')()
+  parser:argument('output')
+  return parser:parse()
+end)()
+
+local names = {}
+for name in pairs(readyaml('data/scripttypes.yaml')) do
+  table.insert(names, name)
+end
+table.sort(names)
+
+local scripts = {}
+for _, name in ipairs(names) do
+  table.insert(scripts, ('      <%s>end, table.insert(WowlessLog, \'%s\')--</%s>'):format(name, name, name))
+end
+
+local content = table.concat({
+  '<Ui>',
+  '  <!-- Actors support scripts through XML even though they aren\'t ScriptObjects. -->',
+  '  <Script>',
+  '    WowlessLog = {}',
+  '  </Script>',
+  '  <Actor name=\'WowlessActorTemplate\' virtual=\'true\'>',
+  '    <Scripts>',
+  table.concat(scripts, '\n'),
+  '    </Scripts>',
+  '  </Actor>',
+  '  <Script>',
+  '    CreateFrame(\'ModelScene\'):CreateActor(nil, \'WowlessActorTemplate\')',
+  '    local expected = {}',
+  '    for k, v in _G.Wowless.sorted(_G.WowlessData.UIObjectApis.Actor.scripts) do',
+  '      if v then',
+  '        table.insert(expected, k)',
+  '      else',
+  '        local fmt = \'Frame ModelSceneActor: Unknown script element %s\'',
+  '        table.insert(_G.Wowless.ExpectedLuaWarnings, fmt:format(k))',
+  '      end',
+  '    end',
+  '    assertEquals(table.concat(expected, \',\'), table.concat(WowlessLog, \',\'))',
+  '  </Script>',
+  '</Ui>',
+  '',
+}, '\n')
+
+require('pl.file').write(args.output, content)
+require('tools.util').writedeps(args.output, deps)


### PR DESCRIPTION
## Summary
- Introduces a generic build-time mechanism for generating XML addon content from Lua: `tools/generatexmltest.lua` is built as a native lua-executable (`add_lua_executable`) and invoked via `add_custom_command` during the build, writing `build/addon/Wowless/generatedxml.xml`. Nothing about the tool or its wiring is actor-specific — that's just the one piece of content it happens to generate today.
- As the pilot, its content is the Actor script-name enumeration (previously ~90 lines hand-duplicated in `addon/Wowless/test.xml`), now driven from `data/scripttypes.yaml` — the same source of truth `tools/gentest.lua` already reads for `UIObjectApis.*.scripts`. This removes a manual-sync hazard between the two (confirmed by rebasing onto a concurrent upstream commit that hand-added two new script types to that block — the generator already produced them correctly since `data/scripttypes.yaml` had already been updated).
- Wired into the existing `addon/Wowless` copy step in `CMakeLists.txt` using the same staging + `cmake/copy_executable.cmake` pattern already used for `test.xml` (which applies the rwxr-xr-x bits when copying into the build addon directory) and for `gentest`'s per-product output.
- `test.xml` now pulls this in via a single, generically-named `<Include file='generatedxml.xml' />` placed near the bottom of the file (before the error-handler restore script), leaving room for more generated fragments to land in the same file later without needing more include sites.

## Test plan
- [x] `cmake --preset default && cmake --build --preset default --target generatexmltest` — builds the new tool
- [x] Ran the built tool directly and diffed output against the previously hand-written block — byte-identical content
- [x] `cmake --build --preset default --target test` — full suite passes (exit 0)
- [x] `pre-commit run` on changed files — all hooks pass, including the `build and test` hook

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KMvbM2b2MG8EoRRh8GYT5U