### PR TITLE
loader: generate the Bindings XML element handlers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -512,14 +512,20 @@ foreach(product ${products})
   add_custom_command(
     OUTPUT stamp/${product}.txt
     BYPRODUCTS runtime/${product}.lua generated/${product}_stubs.cpp
+               runtime/${product}_xmlcode.lua
     COMMAND
       prep ${product} --sqls ${CMAKE_CURRENT_BINARY_DIR}/runtime/sqls.yaml
       --output ${CMAKE_CURRENT_BINARY_DIR}/generated/${product}.lua --coutput
-      ${CMAKE_CURRENT_BINARY_DIR}/generated/${product}_stubs.cpp
+      ${CMAKE_CURRENT_BINARY_DIR}/generated/${product}_stubs.cpp --xmlcode
+      ${CMAKE_CURRENT_BINARY_DIR}/generated/${product}_xmlcode.lua
     COMMAND
       ${CMAKE_COMMAND} -E copy_if_different
       ${CMAKE_CURRENT_BINARY_DIR}/generated/${product}.lua
       ${CMAKE_CURRENT_BINARY_DIR}/runtime/${product}.lua
+    COMMAND
+      ${CMAKE_COMMAND} -E copy_if_different
+      ${CMAKE_CURRENT_BINARY_DIR}/generated/${product}_xmlcode.lua
+      ${CMAKE_CURRENT_BINARY_DIR}/runtime/${product}_xmlcode.lua
     COMMAND ${CMAKE_COMMAND} -E touch
             ${CMAKE_CURRENT_BINARY_DIR}/stamp/${product}.txt
     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
@@ -527,9 +533,10 @@ foreach(product ${products})
     DEPENDS prep runtime/sqls.yaml)
   add_custom_target(datalua_${product}_lua DEPENDS stamp/${product}.txt)
   add_dependencies(datalua_${product}_lua stamp_sqls)
-  lua2c(datalua_${product}
-        build.products.${product}.data=runtime/${product}.lua
-        build.products.${product}.stubs=c)
+  lua2c(
+    datalua_${product} build.products.${product}.data=runtime/${product}.lua
+    build.products.${product}.stubs=c
+    build.products.${product}.xmlcode=runtime/${product}_xmlcode.lua)
   target_sources(
     datalua_${product}
     PRIVATE ${CMAKE_CURRENT_BINARY_DIR}/generated/${product}_stubs.cpp)
@@ -895,6 +902,7 @@ lua2c(
   wowless.modules.uiobjecttypes=${CMAKE_CURRENT_SOURCE_DIR}/wowless/modules/uiobjecttypes.lua
   wowless.modules.units=${CMAKE_CURRENT_SOURCE_DIR}/wowless/modules/units.lua
   wowless.modules.visibility=${CMAKE_CURRENT_SOURCE_DIR}/wowless/modules/visibility.lua
+  wowless.modules.xmlcode=${CMAKE_CURRENT_SOURCE_DIR}/wowless/modules/xmlcode.lua
   wowless.profiler=${CMAKE_CURRENT_SOURCE_DIR}/wowless/profiler.lua
   wowless.runner=${CMAKE_CURRENT_SOURCE_DIR}/wowless/runner.lua
   wowless.luaobject=c

--- a/data/modules.yaml
+++ b/data/modules.yaml
@@ -85,7 +85,6 @@ loader:
   deps:
     addons:
     api:
-    bindings:
     datalua:
     env:
     events:
@@ -98,6 +97,7 @@ loader:
     templates:
     uiobjects:
     uiobjecttypes:
+    xmlcode:
 loadercfg:
   root:
     default: '{}'
@@ -187,3 +187,7 @@ units:
 visibility:
   deps:
     scripts:
+xmlcode:
+  deps:
+    bindings:
+    datalua:

--- a/data/products/wow/xml.yaml
+++ b/data/products/wow/xml.yaml
@@ -176,6 +176,8 @@ Binding:
     runonup:
       type: boolean
   contents: text
+  impl:
+    generated: binding
 Bindings:
   contents:
     tags:
@@ -795,6 +797,8 @@ ModifiedClick:
       type: string
     default:
       type: string
+  impl:
+    generated: modifiedclick
 MovieFrame:
   extends: Frame
 NormalFont:

--- a/data/products/wow_anniversary/xml.yaml
+++ b/data/products/wow_anniversary/xml.yaml
@@ -176,6 +176,8 @@ Binding:
     runonup:
       type: boolean
   contents: text
+  impl:
+    generated: binding
 Bindings:
   contents:
     tags:
@@ -795,6 +797,8 @@ ModifiedClick:
       type: string
     default:
       type: string
+  impl:
+    generated: modifiedclick
 MovieFrame:
   extends: Frame
 NormalFont:

--- a/data/products/wow_classic/xml.yaml
+++ b/data/products/wow_classic/xml.yaml
@@ -176,6 +176,8 @@ Binding:
     runonup:
       type: boolean
   contents: text
+  impl:
+    generated: binding
 Bindings:
   contents:
     tags:
@@ -795,6 +797,8 @@ ModifiedClick:
       type: string
     default:
       type: string
+  impl:
+    generated: modifiedclick
 MovieFrame:
   extends: Frame
 NormalFont:

--- a/data/products/wow_classic_era/xml.yaml
+++ b/data/products/wow_classic_era/xml.yaml
@@ -176,6 +176,8 @@ Binding:
     runonup:
       type: boolean
   contents: text
+  impl:
+    generated: binding
 Bindings:
   contents:
     tags:
@@ -795,6 +797,8 @@ ModifiedClick:
       type: string
     default:
       type: string
+  impl:
+    generated: modifiedclick
 MovieFrame:
   extends: Frame
 NormalFont:

--- a/data/products/wow_classic_era_ptr/xml.yaml
+++ b/data/products/wow_classic_era_ptr/xml.yaml
@@ -176,6 +176,8 @@ Binding:
     runonup:
       type: boolean
   contents: text
+  impl:
+    generated: binding
 Bindings:
   contents:
     tags:
@@ -795,6 +797,8 @@ ModifiedClick:
       type: string
     default:
       type: string
+  impl:
+    generated: modifiedclick
 MovieFrame:
   extends: Frame
 NormalFont:

--- a/data/products/wow_classic_ptr/xml.yaml
+++ b/data/products/wow_classic_ptr/xml.yaml
@@ -176,6 +176,8 @@ Binding:
     runonup:
       type: boolean
   contents: text
+  impl:
+    generated: binding
 Bindings:
   contents:
     tags:
@@ -795,6 +797,8 @@ ModifiedClick:
       type: string
     default:
       type: string
+  impl:
+    generated: modifiedclick
 MovieFrame:
   extends: Frame
 NormalFont:

--- a/data/products/wowt/xml.yaml
+++ b/data/products/wowt/xml.yaml
@@ -176,6 +176,8 @@ Binding:
     runonup:
       type: boolean
   contents: text
+  impl:
+    generated: binding
 Bindings:
   contents:
     tags:
@@ -814,6 +816,8 @@ ModifiedClick:
       type: string
     default:
       type: string
+  impl:
+    generated: modifiedclick
 MovieFrame:
   extends: Frame
 NormalFont:

--- a/data/products/wowxptr/xml.yaml
+++ b/data/products/wowxptr/xml.yaml
@@ -176,6 +176,8 @@ Binding:
     runonup:
       type: boolean
   contents: text
+  impl:
+    generated: binding
 Bindings:
   contents:
     tags:
@@ -795,6 +797,8 @@ ModifiedClick:
       type: string
     default:
       type: string
+  impl:
+    generated: modifiedclick
 MovieFrame:
   extends: Frame
 NormalFont:

--- a/data/schemas/xml.yaml
+++ b/data/schemas/xml.yaml
@@ -67,6 +67,7 @@ type:
                     type:
                       ref:
                         schema: uiobject
+              generated: string
               loadstring: tag
               script:
                 record:

--- a/tools/prep.lua
+++ b/tools/prep.lua
@@ -4,6 +4,7 @@ local args = (function()
   parser:option('--sqls', 'sqls file')
   parser:option('-o --output', 'output file')
   parser:option('--coutput', 'C stubs output file'):count('1')
+  parser:option('--xmlcode', 'generated xml code output file'):count('1')
   return parser:parse()
 end)()
 
@@ -438,6 +439,88 @@ local xmlflat = (function()
     }
   end
   return newtree
+end)()
+
+-- Generated XML element handlers, instantiated as the xmlcode module: named
+-- functions calling each other directly, with static kid dispatch (the
+-- schema's child sets are closed). Dependencies arrive as capability APIs
+-- (AddBinding, LoadChunk) via the module system; only root-reachable entry
+-- points are exported, for loadElement's string-keyed boundary. Currently
+-- covers the Bindings family only.
+local xmlcodeimpls = {
+  binding = {
+    [[if not e.attr.debug then]],
+    [[  local chunk = 'return function(keystate) ' .. e.text .. ' end']],
+    [[  bindings[e.attr.name] = LoadChunk(chunk, ctx.filename, e.line)()]],
+    [[end]],
+  },
+  modifiedclick = {},
+}
+local xmlcode = (function()
+  local tree = xmlraw
+  local family = {}
+  local function visit(k)
+    if not family[k] then
+      family[k] = true
+      local v = assert(tree[k], k)
+      if type(v.contents) == 'table' then
+        for kid in pairs(v.contents.tags) do
+          visit(kid)
+        end
+      end
+    end
+  end
+  local roots = { 'Bindings' }
+  for _, root in ipairs(roots) do
+    visit(root)
+  end
+  local names, decls, defs = {}, {}, {}
+  for k in sorted(family) do
+    names[k] = 'gen_' .. k:lower()
+    table.insert(decls, names[k])
+  end
+  for k in sorted(family) do
+    local v = tree[k]
+    local fname = names[k]
+    if type(v.impl) == 'table' and v.impl.generated then
+      local body = assert(xmlcodeimpls[v.impl.generated], v.impl.generated)
+      table.insert(defs, ('function %s(ctx, e)'):format(fname))
+      for _, line in ipairs(body) do
+        table.insert(defs, '  ' .. line)
+      end
+      table.insert(defs, 'end')
+    elseif v.impl == 'transparent' then
+      table.insert(defs, ('function %s(ctx, e)'):format(fname))
+      table.insert(defs, '  for _, kid in ipairs(e.kids) do')
+      local word = 'if'
+      for kid in sorted(v.contents.tags) do
+        table.insert(defs, ('    %s kid.type == %q then'):format(word, kid:lower()))
+        table.insert(defs, ('      %s(ctx, kid)'):format(names[kid]))
+        word = 'elseif'
+      end
+      table.insert(defs, '    else')
+      table.insert(defs, ('      error(\'wowless bug: unexpected kid \' .. kid.type .. \' in ' .. k:lower() .. '\')'))
+      table.insert(defs, '    end')
+      table.insert(defs, '  end')
+      table.insert(defs, 'end')
+    else
+      error('cannot generate xml handler for ' .. k)
+    end
+  end
+  local out = {
+    'return function(bindings, LoadChunk)',
+    '  local ' .. table.concat(decls, ', '),
+  }
+  for _, line in ipairs(defs) do
+    table.insert(out, '  ' .. line)
+  end
+  table.insert(out, '  return {')
+  for _, root in ipairs(roots) do
+    table.insert(out, ('    %s = %s,'):format(root:lower(), names[root]))
+  end
+  table.insert(out, '  }')
+  table.insert(out, 'end')
+  return table.concat(out, '\n') .. '\n'
 end)()
 
 local data = {
@@ -1535,6 +1618,8 @@ local cf = assert(io.open(args.coutput, 'w'))
 cf:write(table.concat(lines, '\n'))
 cf:write('\n')
 cf:close()
+
+assert(require('pl.file').write(args.xmlcode, xmlcode))
 
 local outfn = args.output or ('build/products/' .. args.product .. '/data.lua')
 local tu = require('tools.util')

--- a/wowless/modules/loader.lua
+++ b/wowless/modules/loader.lua
@@ -1,7 +1,6 @@
 return function(
   addons,
   api,
-  bindingsmodule,
   datalua,
   envmodule,
   events,
@@ -13,7 +12,8 @@ return function(
   security,
   templates,
   uiobjects,
-  uiobjecttypes
+  uiobjecttypes,
+  xmlcode
 )
   local genv = envmodule.genv
   local secureenv = envmodule.secureenv
@@ -31,7 +31,6 @@ return function(
   local mixin = util.mixin
   local intrinsics = {}
   local readFile = util.readfile
-  local bindings = bindingsmodule.bindings
   local securemixins = {}
 
   local xmlimpls = datalua.xmlimpls
@@ -362,9 +361,6 @@ return function(
         end
       end
     end,
-    modifiedclick = function()
-      -- TODO support modified clicks
-    end,
     origin = function(_, e, parent)
       if e.attr.point then
         local x, y = getXY(e)
@@ -645,6 +641,10 @@ return function(
             end
           end
         else
+          local gfn = xmlcode[e.type]
+          if gfn then
+            return gfn(ctx, e)
+          end
           local impl = xmlimpls[e.type] and xmlimpls[e.type].tag or nil
           local fn = xmllang[e.type]
           if type(impl) == 'table' and impl.script then
@@ -670,12 +670,6 @@ return function(
             if impl == 'loadstring' and e.text then
               loadLuaString(filename, e.text, e.line, ctx.useSecureEnv)
             end
-          elseif e.type == 'binding' then -- TODO do this another way
-            -- TODO interpret all binding attributes
-            if not e.attr.debug then -- TODO support debug bindings
-              local bfn = 'return function(keystate) ' .. e.text .. ' end'
-              bindings[e.attr.name] = loadstr(bfn, filename, e.line)()
-            end
           elseif e.type == 'fontfamily' then -- TODO do this another way
             local font = e.kids[1].kids[1]
             loadElement(ctx, {
@@ -700,6 +694,7 @@ return function(
         end
         local ctx = {
           addonEnv = addonEnv,
+          filename = filename,
           ignoreVirtual = false,
           intrinsic = false,
           useAddonEnv = false,

--- a/wowless/modules/xmlcode.lua
+++ b/wowless/modules/xmlcode.lua
@@ -1,0 +1,9 @@
+local path = require('path')
+
+return function(bindings, datalua)
+  local function LoadChunk(str, filename, line)
+    local pre = line and string.rep('\n', line - 1) or ''
+    return assert(loadstring_untainted(pre .. str, '@' .. path.normalize(filename):gsub('/', '\\')))
+  end
+  return require('build.products.' .. datalua.product .. '.xmlcode')(bindings.bindings, LoadChunk)
+end


### PR DESCRIPTION
## Summary

Pilot of the XML codegen end state on the smallest possible tag family.
`Bindings`/`Binding`/`ModifiedClick` is a closed set — no uiobject types, no
templates, no intrinsics, text content — so its handlers are fully generated
at prep time. Rebased onto main after #734 landed the bindings-module
extraction; the generated chunk consumes that module's bare registry table
directly.

**The generated chunk** (`build.products.<product>.xmlcode`, emitted by prep as
`generated/<product>_xmlcode.lua` and lua2c'd into `datalua_<product>`):

```lua
return function(bindings, LoadChunk)
  local gen_binding, gen_bindings, gen_modifiedclick
  function gen_binding(ctx, e)
    if not e.attr.debug then
      local chunk = 'return function(keystate) ' .. e.text .. ' end'
      bindings[e.attr.name] = LoadChunk(chunk, ctx.filename, e.line)()
    end
  end
  function gen_bindings(ctx, e)
    for _, kid in ipairs(e.kids) do
      if kid.type == "binding" then
        gen_binding(ctx, kid)
      elseif kid.type == "modifiedclick" then
        gen_modifiedclick(ctx, kid)
      else
        error('wowless bug: unexpected kid ' .. kid.type .. ' in bindings')
      end
    end
  end
  function gen_modifiedclick(ctx, e)
  end
  return {
    bindings = gen_bindings,
  }
end
```

Architecture points this pilots at miniature scale:

- **Named functions, direct calls** — mutual recursion via forward-declared
  locals, no dispatch table in the recursion itself.
- **Static kid dispatch** — the schema's child sets are closed, so containers
  branch on `kid.type` directly.
- **Registry only at the string boundary** — the chunk returns just the
  root-reachable entry (`bindings`) for `loadElement`'s tag-name dispatch.
- **Narrow instantiation** — the new `xmlcode` module (deps: `bindings`,
  `datalua`, cstubs pattern) passes exactly the registry table (#734 style:
  callers manipulate it directly) and a `LoadChunk` helper it defines itself.
- **Declarative semantics markers** — new element impl kind
  `generated: <name>` in `data/schemas/xml.yaml`, naming a canned emitter in
  prep (`binding`, `modifiedclick`).

**Loader**: consults generated handlers first in `loadElement`'s non-uiobject
branch, deleting the `-- TODO do this another way` binding special case and
the `modifiedclick` stub. `ctx` now carries `filename` (scripts will want this
too). With registration moved into generated code, loader drops the `bindings`
module dependency (from #734) in favor of `xmlcode`. `loadstr` is untouched;
`LoadChunk` matches its compile semantics except the Wowless stack-taint
branch, which is unreachable for bindings files (none exists under any
Wowless-named directory).

## Test plan

- [x] `cmake --build --preset default --target test` passes
- [x] `cmake --build --preset default --target outs`: logs **byte-identical**
      to main across all 8 products. The runner's bindings step executes every
      registered binding, so this exercises parse → generated handler →
      compile → register → execute end to end.
- [x] pre-commit hooks pass on all changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013tcK2kG5TnMcMWDBv3ywu9