### PR TITLE
worktree genxml actortest

### DIFF
--- a/addon/Wowless/test.xml
+++ b/addon/Wowless/test.xml
@@ -1068,29 +1068,6 @@
     </Scripts>
   </Frame>
 
-  <Frame>
-    <Layers>
-      <Layer>
-        <FontString parentKey='hNone' />
-        <FontString parentKey='hLeft' justifyH='LEFT' />
-        <FontString parentKey='hCenter' justifyH='CENTER' />
-        <FontString parentKey='hRight' justifyH='RIGHT' />
-      </Layer>
-    </Layers>
-    <Scripts>
-      <OnLoad>
-        Wowless.check1(1, self.hNone:GetNumPoints())
-        Wowless.check5('CENTER', self, 'CENTER', 0, 0, self.hNone:GetPoint(1))
-        Wowless.check1(1, self.hLeft:GetNumPoints())
-        Wowless.check5('LEFT', self, 'LEFT', 0, 0, self.hLeft:GetPoint(1))
-        Wowless.check1(1, self.hCenter:GetNumPoints())
-        Wowless.check5('CENTER', self, 'CENTER', 0, 0, self.hCenter:GetPoint(1))
-        Wowless.check1(1, self.hRight:GetNumPoints())
-        Wowless.check5('RIGHT', self, 'RIGHT', 0, 0, self.hRight:GetPoint(1))
-      </OnLoad>
-    </Scripts>
-  </Frame>
-
   <Include file='generatedxml.xml' />
 
   <Script>

--- a/tools/generatexmltest.lua
+++ b/tools/generatexmltest.lua
@@ -58,31 +58,34 @@ local content = {
   },
   {
     tag = 'Frame',
-    (function()
-      local function fontString(justify)
-        local point = justify or 'CENTER'
-        local node = {
-          tag = 'FontString',
-          {
-            tag = 'Scripts',
+    {
+      tag = 'Layers',
+      (function()
+        local function fontString(justify)
+          local point = justify or 'CENTER'
+          local node = {
+            tag = 'FontString',
             {
-              tag = 'OnLoad',
-              text = ([[
-                Wowless.check1(1, self:GetNumPoints())
-                Wowless.check5('%s', self:GetParent(), '%s', 0, 0, self:GetPoint(1))
-              ]]):format(point, point),
+              tag = 'Scripts',
+              {
+                tag = 'OnLoad',
+                text = ([[
+                  Wowless.check1(1, self:GetNumPoints())
+                  Wowless.check5('%s', self:GetParent(), '%s', 0, 0, self:GetPoint(1))
+                ]]):format(point, point),
+              },
             },
-          },
-        }
-        node.justifyH = justify
-        return node
-      end
-      local layer = { tag = 'Layer', fontString(nil) }
-      for name in sorted(justifyh) do
-        table.insert(layer, fontString(name))
-      end
-      return { tag = 'Layers', layer }
-    end)(),
+          }
+          node.justifyH = justify
+          return node
+        end
+        local layer = { tag = 'Layer', fontString(nil) }
+        for name in sorted(justifyh) do
+          table.insert(layer, fontString(name))
+        end
+        return layer
+      end)(),
+    },
   },
 }
 

--- a/tools/generatexmltest.lua
+++ b/tools/generatexmltest.lua
@@ -19,8 +19,42 @@ local sorted = require('pl.tablex').sort
 local scripttypes = readyaml('data/scripttypes.yaml')
 local justifyh = readyaml('data/stringenums.yaml').JustifyHorizontal
 
-local function titlecase(name)
-  return name:sub(1, 1) .. name:sub(2):lower()
+local function actorScripts()
+  local t = {}
+  for name in sorted(scripttypes) do
+    table.insert(t, {
+      tag = name,
+      text = ([[end, table.insert(WowlessLog, '%s')--]]):format(name),
+    })
+  end
+  return t
+end
+
+local function justifyFontString(justify)
+  local point = justify or 'CENTER'
+  local node = {
+    tag = 'FontString',
+    {
+      tag = 'Scripts',
+      {
+        tag = 'OnLoad',
+        text = ([[
+          Wowless.check1(1, self:GetNumPoints())
+          Wowless.check5('%s', self:GetParent(), '%s', 0, 0, self:GetPoint(1))
+        ]]):format(point, point),
+      },
+    },
+  }
+  node.justifyH = justify
+  return node
+end
+
+local function justifyFontStrings()
+  local t = {}
+  for name in sorted(justifyh) do
+    table.insert(t, justifyFontString(name))
+  end
+  return t
 end
 
 local content = {
@@ -33,16 +67,10 @@ local content = {
     tag = 'Actor',
     name = 'WowlessActorTemplate',
     virtual = true,
-    (function()
-      local scripts = { tag = 'Scripts' }
-      for name in sorted(scripttypes) do
-        table.insert(scripts, {
-          tag = name,
-          text = ([[end, table.insert(WowlessLog, '%s')--]]):format(name),
-        })
-      end
-      return scripts
-    end)(),
+    {
+      tag = 'Scripts',
+      unpack(actorScripts()),
+    },
   },
   {
     tag = 'Script',
@@ -62,36 +90,14 @@ local content = {
   },
   {
     tag = 'Frame',
-    (function()
-      local layer = { tag = 'Layer' }
-      table.insert(layer, { tag = 'FontString', parentKey = 'hNone' })
-      for name in sorted(justifyh) do
-        table.insert(layer, {
-          tag = 'FontString',
-          parentKey = 'h' .. titlecase(name),
-          justifyH = name,
-        })
-      end
-      return { tag = 'Layers', layer }
-    end)(),
-    (function()
-      local checks = {
-        'Wowless.check1(1, self.hNone:GetNumPoints())',
-        'Wowless.check5(\'CENTER\', self, \'CENTER\', 0, 0, self.hNone:GetPoint(1))',
-      }
-      for name in sorted(justifyh) do
-        local key = 'h' .. titlecase(name)
-        table.insert(checks, ('Wowless.check1(1, self.%s:GetNumPoints())'):format(key))
-        table.insert(
-          checks,
-          ('Wowless.check5(\'%s\', self, \'%s\', 0, 0, self.%s:GetPoint(1))'):format(name, name, key)
-        )
-      end
-      return {
-        tag = 'Scripts',
-        { tag = 'OnLoad', text = table.concat(checks, '\n') },
-      }
-    end)(),
+    {
+      tag = 'Layers',
+      {
+        tag = 'Layer',
+        justifyFontString(nil),
+        unpack(justifyFontStrings()),
+      },
+    },
   },
 }
 

--- a/tools/generatexmltest.lua
+++ b/tools/generatexmltest.lua
@@ -61,10 +61,10 @@ local content = {
     {
       tag = 'Layers',
       (function()
-        local function fontString(point)
+        local function fontString(justify, point)
           return {
             tag = 'FontString',
-            justifyH = point,
+            justifyH = justify,
             {
               tag = 'Scripts',
               {
@@ -72,14 +72,14 @@ local content = {
                 text = ([[
                   Wowless.check1(1, self:GetNumPoints())
                   Wowless.check5('%s', self:GetParent(), '%s', 0, 0, self:GetPoint(1))
-                ]]):format(point or 'CENTER', point or 'CENTER'),
+                ]]):format(point, point),
               },
             },
           }
         end
-        local layer = { tag = 'Layer', fontString(nil) }
+        local layer = { tag = 'Layer', fontString(nil, 'CENTER') }
         for name in sorted(stringenums.JustifyHorizontal) do
-          table.insert(layer, fontString(name))
+          table.insert(layer, fontString(name, name))
         end
         return layer
       end)(),

--- a/tools/generatexmltest.lua
+++ b/tools/generatexmltest.lua
@@ -19,44 +19,6 @@ local sorted = require('pl.tablex').sort
 local scripttypes = readyaml('data/scripttypes.yaml')
 local justifyh = readyaml('data/stringenums.yaml').JustifyHorizontal
 
-local function actorScripts()
-  local t = {}
-  for name in sorted(scripttypes) do
-    table.insert(t, {
-      tag = name,
-      text = ([[end, table.insert(WowlessLog, '%s')--]]):format(name),
-    })
-  end
-  return t
-end
-
-local function justifyFontString(justify)
-  local point = justify or 'CENTER'
-  local node = {
-    tag = 'FontString',
-    {
-      tag = 'Scripts',
-      {
-        tag = 'OnLoad',
-        text = ([[
-          Wowless.check1(1, self:GetNumPoints())
-          Wowless.check5('%s', self:GetParent(), '%s', 0, 0, self:GetPoint(1))
-        ]]):format(point, point),
-      },
-    },
-  }
-  node.justifyH = justify
-  return node
-end
-
-local function justifyFontStrings()
-  local t = {}
-  for name in sorted(justifyh) do
-    table.insert(t, justifyFontString(name))
-  end
-  return t
-end
-
 local content = {
   tag = 'Ui',
   {
@@ -67,10 +29,16 @@ local content = {
     tag = 'Actor',
     name = 'WowlessActorTemplate',
     virtual = true,
-    {
-      tag = 'Scripts',
-      unpack(actorScripts()),
-    },
+    (function()
+      local scripts = { tag = 'Scripts' }
+      for name in sorted(scripttypes) do
+        table.insert(scripts, {
+          tag = name,
+          text = ([[end, table.insert(WowlessLog, '%s')--]]):format(name),
+        })
+      end
+      return scripts
+    end)(),
   },
   {
     tag = 'Script',
@@ -90,14 +58,31 @@ local content = {
   },
   {
     tag = 'Frame',
-    {
-      tag = 'Layers',
-      {
-        tag = 'Layer',
-        justifyFontString(nil),
-        unpack(justifyFontStrings()),
-      },
-    },
+    (function()
+      local function fontString(justify)
+        local point = justify or 'CENTER'
+        local node = {
+          tag = 'FontString',
+          {
+            tag = 'Scripts',
+            {
+              tag = 'OnLoad',
+              text = ([[
+                Wowless.check1(1, self:GetNumPoints())
+                Wowless.check5('%s', self:GetParent(), '%s', 0, 0, self:GetPoint(1))
+              ]]):format(point, point),
+            },
+          },
+        }
+        node.justifyH = justify
+        return node
+      end
+      local layer = { tag = 'Layer', fontString(nil) }
+      for name in sorted(justifyh) do
+        table.insert(layer, fontString(name))
+      end
+      return { tag = 'Layers', layer }
+    end)(),
   },
 }
 

--- a/tools/generatexmltest.lua
+++ b/tools/generatexmltest.lua
@@ -17,7 +17,7 @@ end)()
 
 local sorted = require('pl.tablex').sort
 local scripttypes = readyaml('data/scripttypes.yaml')
-local justifyh = readyaml('data/stringenums.yaml').JustifyHorizontal
+local stringenums = readyaml('data/stringenums.yaml')
 
 local content = {
   tag = 'Ui',
@@ -61,10 +61,10 @@ local content = {
     {
       tag = 'Layers',
       (function()
-        local function fontString(justify)
-          local point = justify or 'CENTER'
-          local node = {
+        local function fontString(point)
+          return {
             tag = 'FontString',
+            justifyH = point,
             {
               tag = 'Scripts',
               {
@@ -72,15 +72,13 @@ local content = {
                 text = ([[
                   Wowless.check1(1, self:GetNumPoints())
                   Wowless.check5('%s', self:GetParent(), '%s', 0, 0, self:GetPoint(1))
-                ]]):format(point, point),
+                ]]):format(point or 'CENTER', point or 'CENTER'),
               },
             },
           }
-          node.justifyH = justify
-          return node
         end
         local layer = { tag = 'Layer', fontString(nil) }
-        for name in sorted(justifyh) do
+        for name in sorted(stringenums.JustifyHorizontal) do
           table.insert(layer, fontString(name))
         end
         return layer

--- a/tools/generatexmltest.lua
+++ b/tools/generatexmltest.lua
@@ -17,6 +17,11 @@ end)()
 
 local sorted = require('pl.tablex').sort
 local scripttypes = readyaml('data/scripttypes.yaml')
+local justifyh = readyaml('data/stringenums.yaml').JustifyHorizontal
+
+local function titlecase(name)
+  return name:sub(1, 1) .. name:sub(2):lower()
+end
 
 local content = {
   tag = 'Ui',
@@ -54,6 +59,39 @@ local content = {
       end
       assertEquals(table.concat(expected, ','), table.concat(WowlessLog, ','))
     ]],
+  },
+  {
+    tag = 'Frame',
+    (function()
+      local layer = { tag = 'Layer' }
+      table.insert(layer, { tag = 'FontString', parentKey = 'hNone' })
+      for name in sorted(justifyh) do
+        table.insert(layer, {
+          tag = 'FontString',
+          parentKey = 'h' .. titlecase(name),
+          justifyH = name,
+        })
+      end
+      return { tag = 'Layers', layer }
+    end)(),
+    (function()
+      local checks = {
+        'Wowless.check1(1, self.hNone:GetNumPoints())',
+        'Wowless.check5(\'CENTER\', self, \'CENTER\', 0, 0, self.hNone:GetPoint(1))',
+      }
+      for name in sorted(justifyh) do
+        local key = 'h' .. titlecase(name)
+        table.insert(checks, ('Wowless.check1(1, self.%s:GetNumPoints())'):format(key))
+        table.insert(
+          checks,
+          ('Wowless.check5(\'%s\', self, \'%s\', 0, 0, self.%s:GetPoint(1))'):format(name, name, key)
+        )
+      end
+      return {
+        tag = 'Scripts',
+        { tag = 'OnLoad', text = table.concat(checks, '\n') },
+      }
+    end)(),
   },
 }
 


### PR DESCRIPTION
- **testaddon: generate FontString justifyH test from stringenums.yaml**
- **generatexmltest: keep statically-known tags out of generator functions**
- **generatexmltest: revert actor change, inline FontString generation**
- **generatexmltest: pull Layers tag out of the FontString IIFE**
- **generatexmltest: fontString takes point directly, hoist stringenums**
- **generatexmltest: fontString takes justify and point as separate args**
