### PR TITLE
loader: extract keybinding registry into a bindings module

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -856,6 +856,7 @@ lua2c(
   wowless.modules.addons=${CMAKE_CURRENT_SOURCE_DIR}/wowless/modules/addons.lua
   wowless.modules.api=${CMAKE_CURRENT_SOURCE_DIR}/wowless/modules/api.lua
   wowless.modules.atlas=${CMAKE_CURRENT_SOURCE_DIR}/wowless/modules/atlas.lua
+  wowless.modules.bindings=${CMAKE_CURRENT_SOURCE_DIR}/wowless/modules/bindings.lua
   wowless.modules.calendar=${CMAKE_CURRENT_SOURCE_DIR}/wowless/modules/calendar.lua
   wowless.modules.cgencode=${CMAKE_CURRENT_SOURCE_DIR}/wowless/modules/cgencode.lua
   wowless.modules.clog=${CMAKE_CURRENT_SOURCE_DIR}/wowless/modules/clog.lua

--- a/data/modules.yaml
+++ b/data/modules.yaml
@@ -18,6 +18,8 @@ api:
 atlas:
   deps:
     env:
+bindings:
+  deps:
 calendar:
   deps:
 cgencode:
@@ -83,6 +85,7 @@ loader:
   deps:
     addons:
     api:
+    bindings:
     datalua:
     env:
     events:

--- a/wowless/modules/bindings.lua
+++ b/wowless/modules/bindings.lua
@@ -1,0 +1,5 @@
+return function()
+  return {
+    bindings = {},
+  }
+end

--- a/wowless/modules/loader.lua
+++ b/wowless/modules/loader.lua
@@ -1,6 +1,7 @@
 return function(
   addons,
   api,
+  bindingsmodule,
   datalua,
   envmodule,
   events,
@@ -30,7 +31,7 @@ return function(
   local mixin = util.mixin
   local intrinsics = {}
   local readFile = util.readfile
-  local bindings = {}
+  local bindings = bindingsmodule.bindings
   local securemixins = {}
 
   local xmlimpls = datalua.xmlimpls
@@ -1104,7 +1105,6 @@ return function(
   end
 
   return {
-    bindings = bindings,
     loadAddon = loadAddon,
     loadAddons = loadAddons,
     saveAllVariables = saveAllVariables,

--- a/wowless/runner.lua
+++ b/wowless/runner.lua
@@ -148,15 +148,15 @@ local function run(cfg)
     local scripts = {
       bindings = function()
         local skip = runnercfg.skip_bindings or {}
-        local allBindings = modules.bindings.bindings
+        local bindings = modules.bindings.bindings
         if cfg.dir then
           for name in pairs(skip) do
             CallSafely(function()
-              assert(allBindings[name], 'missing skip_bindings ' .. name)
+              assert(bindings[name], 'missing skip_bindings ' .. name)
             end)
           end
         end
-        for name, fn in sorted(allBindings) do
+        for name, fn in sorted(bindings) do
           if skip[name] then
             log(2, 'skipping binding %s per config', name)
             skip[name] = nil

--- a/wowless/runner.lua
+++ b/wowless/runner.lua
@@ -148,14 +148,15 @@ local function run(cfg)
     local scripts = {
       bindings = function()
         local skip = runnercfg.skip_bindings or {}
+        local allBindings = modules.bindings.bindings
         if cfg.dir then
           for name in pairs(skip) do
             CallSafely(function()
-              assert(loader.bindings[name], 'missing skip_bindings ' .. name)
+              assert(allBindings[name], 'missing skip_bindings ' .. name)
             end)
           end
         end
-        for name, fn in sorted(loader.bindings) do
+        for name, fn in sorted(allBindings) do
           if skip[name] then
             log(2, 'skipping binding %s per config', name)
             skip[name] = nil


### PR DESCRIPTION
## Summary

First piece of breaking up #731 into independently reviewable steps: pulls
the keybinding registry out of `loader.lua` and into its own module, with no
API surface beyond a bare table.

- New `bindings` module (`wowless/modules/bindings.lua`) owns the registry as
  a plain field: `{ bindings = {} }`. No `AddBinding`/`GetBindings`
  accessors — callers manipulate the table directly.
- `loader.lua` takes `bindings` as a dependency and writes into
  `bindingsmodule.bindings` (aliased locally as `bindings`, same table by
  reference, same call sites as before). It no longer exports its own
  `bindings` field.
- `runner.lua`'s bindings step reads `modules.bindings.bindings` directly
  instead of going through `loader`.

This is a pure internal-wiring change — no behavior change — intended to land
before the XML-codegen pilot in #731, which already introduces this module
shape and can rebase on top of it.

## Test plan

- [x] `cmake --build --preset default --target test` passes
- [x] pre-commit hooks pass on all changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q2zVCtSzRDfbZY8bXSL5Es