### PR TITLE
spec: assert every stringenum is actually referenced somewhere

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1126,6 +1126,7 @@ set(specs
     spec/data/schema_coverage_spec.lua
     spec/data/scripttypes_spec.lua
     spec/data/sql_spec.lua
+    spec/data/stringenums_spec.lua
     spec/data/structures_spec.lua
     spec/data/test_spec.lua
     spec/data/uiobjectimpl_spec.lua

--- a/data/products/wow/stringenums.yaml
+++ b/data/products/wow/stringenums.yaml
@@ -66,11 +66,6 @@ SmoothingType:
   NONE:
   OUT:
   OUT_IN:
-StatusBarFillStyle:
-  CENTER:
-  REVERSE:
-  STANDARD:
-  STANDARD_NO_RANGE_FILL:
 WrapMode:
   CLAMP:
   CLAMPTOBLACK:

--- a/data/products/wow_anniversary/stringenums.yaml
+++ b/data/products/wow_anniversary/stringenums.yaml
@@ -66,11 +66,6 @@ SmoothingType:
   NONE:
   OUT:
   OUT_IN:
-StatusBarFillStyle:
-  CENTER:
-  REVERSE:
-  STANDARD:
-  STANDARD_NO_RANGE_FILL:
 WrapMode:
   CLAMP:
   CLAMPTOBLACK:

--- a/data/products/wow_classic/stringenums.yaml
+++ b/data/products/wow_classic/stringenums.yaml
@@ -66,11 +66,6 @@ SmoothingType:
   NONE:
   OUT:
   OUT_IN:
-StatusBarFillStyle:
-  CENTER:
-  REVERSE:
-  STANDARD:
-  STANDARD_NO_RANGE_FILL:
 WrapMode:
   CLAMP:
   CLAMPTOBLACK:

--- a/data/products/wow_classic_era_ptr/stringenums.yaml
+++ b/data/products/wow_classic_era_ptr/stringenums.yaml
@@ -66,11 +66,6 @@ SmoothingType:
   NONE:
   OUT:
   OUT_IN:
-StatusBarFillStyle:
-  CENTER:
-  REVERSE:
-  STANDARD:
-  STANDARD_NO_RANGE_FILL:
 WrapMode:
   CLAMP:
   CLAMPTOBLACK:

--- a/data/products/wow_classic_ptr/stringenums.yaml
+++ b/data/products/wow_classic_ptr/stringenums.yaml
@@ -66,11 +66,6 @@ SmoothingType:
   NONE:
   OUT:
   OUT_IN:
-StatusBarFillStyle:
-  CENTER:
-  REVERSE:
-  STANDARD:
-  STANDARD_NO_RANGE_FILL:
 WrapMode:
   CLAMP:
   CLAMPTOBLACK:

--- a/data/products/wowt/stringenums.yaml
+++ b/data/products/wowt/stringenums.yaml
@@ -66,11 +66,6 @@ SmoothingType:
   NONE:
   OUT:
   OUT_IN:
-StatusBarFillStyle:
-  CENTER:
-  REVERSE:
-  STANDARD:
-  STANDARD_NO_RANGE_FILL:
 WrapMode:
   CLAMP:
   CLAMPTOBLACK:

--- a/data/products/wowxptr/stringenums.yaml
+++ b/data/products/wowxptr/stringenums.yaml
@@ -66,11 +66,6 @@ SmoothingType:
   NONE:
   OUT:
   OUT_IN:
-StatusBarFillStyle:
-  CENTER:
-  REVERSE:
-  STANDARD:
-  STANDARD_NO_RANGE_FILL:
 WrapMode:
   CLAMP:
   CLAMPTOBLACK:

--- a/spec/data/stringenums_spec.lua
+++ b/spec/data/stringenums_spec.lua
@@ -1,0 +1,48 @@
+describe('stringenums', function()
+  for _, p in ipairs(require('build.data.products')) do
+    describe(p, function()
+      local used = {}
+      local function refty(ty)
+        if ty.arrayof then
+          refty(ty.arrayof)
+        elseif ty.stringenum then
+          used[ty.stringenum] = true
+        end
+      end
+      local function reflist(xs)
+        for _, x in ipairs(xs or {}) do
+          refty(x.type)
+        end
+      end
+      for _, v in pairs(require('build.data.products.' .. p .. '.apis')) do
+        reflist(v.inputs)
+        reflist(v.outputs)
+      end
+      for _, v in pairs(require('build.data.products.' .. p .. '.events')) do
+        for _, pv in ipairs(v.payload) do
+          refty(pv.type)
+        end
+      end
+      for _, v in pairs(require('build.data.products.' .. p .. '.structures')) do
+        for _, f in pairs(v.fields) do
+          refty(f.type)
+        end
+      end
+      for _, v in pairs(require('build.data.products.' .. p .. '.uiobjects')) do
+        for _, f in pairs(v.fields) do
+          refty(f.type)
+        end
+        for _, m in pairs(v.methods) do
+          reflist(m.inputs)
+          reflist(m.outputs)
+        end
+      end
+      local actual = require('build.data.products.' .. p .. '.stringenums')
+      for k in pairs(actual) do
+        it(k, function()
+          assert.True(used[k])
+        end)
+      end
+    end)
+  end
+end)


### PR DESCRIPTION
## Summary
- Adds `spec/data/stringenums_spec.lua`, adapted from the existing unused-structure check in `spec/data/structures_spec.lua`: for each product, collects every type reference from api inputs/outputs, event payloads, structure fields, and uiobject fields/method inputs/outputs, then asserts every `data/products/<product>/stringenums.yaml` entry appears in that set.
- This immediately caught a real bug: `StatusBarFillStyle` was dead weight in every product's `stringenums.yaml` except `wow_classic_era`, the only product whose API docs haven't promoted it to a proper `Enum` yet (so it's still consumed via `stringenum: StatusBarFillStyle` there instead of `enum: StatusBarFillStyle`). Removed the orphaned entries, kept the one genuinely still used.

## Test plan
- [x] `cmake --build --preset default --target test` (full build + `runtests`) passes
- [x] `pre-commit run -a` passes

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>