### PR TITLE
testaddon: generate KeyValue type-coercion test from data

### DIFF
--- a/addon/Wowless/test.xml
+++ b/addon/Wowless/test.xml
@@ -817,47 +817,6 @@
   </Script>
 
   <Frame>
-    <KeyValues>
-      <KeyValue key='knilstr' value='str' />
-      <KeyValue key='knilnum' value='42' />
-      <KeyValue key='knilbool' value='true' />
-      <KeyValue key='kstrstr' value='str' type='string' />
-      <KeyValue key='kstrnum' value='42' type='string' />
-      <KeyValue key='kstrbool' value='true' type='string' />
-      <KeyValue key='knumstr' value='str' type='number' />
-      <KeyValue key='knumnum' value='42' type='number' />
-      <KeyValue key='knumbool' value='true' type='number' />
-      <KeyValue key='kjunkstr' value='str' type='wat' />
-      <KeyValue key='kjunknum' value='42' type='wat' />
-      <KeyValue key='kjunkbool' value='true' type='wat' />
-      <KeyValue key='kboolstr' value='str' type='boolean' />
-      <KeyValue key='kboolnum' value='42' type='boolean' />
-      <KeyValue key='kboolbool' value='true' type='boolean' />
-      <KeyValue key='kboolzero' value='0' type='boolean' />
-    </KeyValues>
-    <Scripts>
-      <OnLoad>
-        assertEquals('str', self.knilstr)
-        assertEquals('42', self.knilnum)
-        assertEquals('true', self.knilbool)
-        assertEquals('str', self.kstrstr)
-        assertEquals('42', self.kstrnum)
-        assertEquals('true', self.kstrbool)
-        assertEquals(0, self.knumstr)
-        assertEquals(42, self.knumnum)
-        assertEquals(0, self.knumbool)
-        assertEquals('str', self.kjunkstr)
-        assertEquals('42', self.kjunknum)
-        assertEquals('true', self.kjunkbool)
-        assertEquals(false, self.kboolstr)
-        assertEquals(true, self.kboolnum)
-        assertEquals(true, self.kboolbool)
-        assertEquals(false, self.kboolzero)
-      </OnLoad>
-    </Scripts>
-  </Frame>
-
-  <Frame>
     <Animations>
       <AnimationGroup>
         <Scale>

--- a/tools/generatexmltest.lua
+++ b/tools/generatexmltest.lua
@@ -23,6 +23,13 @@ local function hack(s)
   return 'end,(function()' .. s .. ' end)()--'
 end
 
+local function luaLiteral(v)
+  if type(v) == 'string' then
+    return ('%q'):format(v)
+  end
+  return tostring(v)
+end
+
 local content = {
   tag = 'Ui',
   {
@@ -89,6 +96,41 @@ local content = {
       end)(),
     },
   },
+  (function()
+    -- KeyValue/attribute type coercion cases, one row per key: the raw XML
+    -- value/type attrs and the value they should coerce to (see
+    -- parseTypedValue in wowless/modules/loader.lua). The 'global' type is
+    -- covered elsewhere.
+    local kvCases = {
+      { key = 'knilstr', value = 'str', expected = 'str' },
+      { key = 'knilnum', value = '42', expected = '42' },
+      { key = 'knilbool', value = 'true', expected = 'true' },
+      { key = 'kstrstr', value = 'str', type = 'string', expected = 'str' },
+      { key = 'kstrnum', value = '42', type = 'string', expected = '42' },
+      { key = 'kstrbool', value = 'true', type = 'string', expected = 'true' },
+      { key = 'knumstr', value = 'str', type = 'number', expected = 0 },
+      { key = 'knumnum', value = '42', type = 'number', expected = 42 },
+      { key = 'knumbool', value = 'true', type = 'number', expected = 0 },
+      { key = 'kjunkstr', value = 'str', type = 'wat', expected = 'str' },
+      { key = 'kjunknum', value = '42', type = 'wat', expected = '42' },
+      { key = 'kjunkbool', value = 'true', type = 'wat', expected = 'true' },
+      { key = 'kboolstr', value = 'str', type = 'boolean', expected = false },
+      { key = 'kboolnum', value = '42', type = 'boolean', expected = true },
+      { key = 'kboolbool', value = 'true', type = 'boolean', expected = true },
+      { key = 'kboolzero', value = '0', type = 'boolean', expected = false },
+    }
+    local keyvalues = { tag = 'KeyValues' }
+    local lines = {}
+    for _, c in ipairs(kvCases) do
+      table.insert(keyvalues, { tag = 'KeyValue', key = c.key, value = c.value, type = c.type })
+      table.insert(lines, ('assertEquals(%s, self.%s)'):format(luaLiteral(c.expected), c.key))
+    end
+    return {
+      tag = 'Frame',
+      keyvalues,
+      { tag = 'Scripts', { tag = 'OnLoad', text = table.concat(lines, '\n') } },
+    }
+  end)(),
 }
 
 local renderXml


### PR DESCRIPTION
Replaces the hand-written KeyValues/OnLoad frame in test.xml with a
generated one, driven by a single table of {key, value, type, expected}
cases covering parseTypedValue's string/number/boolean/junk-type coercion.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_016qipYaTedFRpwCHCwzh6WK
