### PR TITLE
docs: source stringenum values from Blizzard_SharedXML/UI.xsd

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -792,6 +792,7 @@ add_lua_executable(
   docs
   ${CMAKE_CURRENT_SOURCE_DIR}/tools/docs.lua
   argparse
+  luaexpat
   penlight
   toolstedit
   toolsutil

--- a/data/products/wow/docs.yaml
+++ b/data/products/wow/docs.yaml
@@ -540,6 +540,19 @@ script_objects:
     uiobject: TextureBase
   UnitHealPredictionCalculatorAPI:
     luaobject: UnitHealPredictionCalculator
+stringenums:
+  ALPHAMODE: BlendMode
+  ANIMCURVETYPE: CurveType
+  ANIMLOOPTYPE: LoopType
+  ANIMSMOOTHTYPE: SmoothingType
+  DRAWLAYER: DrawLayer
+  FRAMEPOINT: FramePoint
+  FRAMESTRATA: FrameStrata
+  INSERTMODE: InsertMode
+  JUSTIFYHTYPE: JustifyHorizontal
+  JUSTIFYVTYPE: JustifyVertical
+  ORIENTATION: Orientation
+  WRAPMODE: WrapMode
 typedefs:
   AbbreviateConfig:
     type:

--- a/data/products/wow_anniversary/docs.yaml
+++ b/data/products/wow_anniversary/docs.yaml
@@ -675,6 +675,19 @@ script_objects:
     uiobject: TextureBase
   UnitHealPredictionCalculatorAPI:
     luaobject: UnitHealPredictionCalculator
+stringenums:
+  ALPHAMODE: BlendMode
+  ANIMCURVETYPE: CurveType
+  ANIMLOOPTYPE: LoopType
+  ANIMSMOOTHTYPE: SmoothingType
+  DRAWLAYER: DrawLayer
+  FRAMEPOINT: FramePoint
+  FRAMESTRATA: FrameStrata
+  INSERTMODE: InsertMode
+  JUSTIFYHTYPE: JustifyHorizontal
+  JUSTIFYVTYPE: JustifyVertical
+  ORIENTATION: Orientation
+  WRAPMODE: WrapMode
 typedefs:
   AbbreviateConfig:
     type:

--- a/data/products/wow_classic/docs.yaml
+++ b/data/products/wow_classic/docs.yaml
@@ -557,6 +557,19 @@ script_objects:
     uiobject: TextureBase
   UnitHealPredictionCalculatorAPI:
     luaobject: UnitHealPredictionCalculator
+stringenums:
+  ALPHAMODE: BlendMode
+  ANIMCURVETYPE: CurveType
+  ANIMLOOPTYPE: LoopType
+  ANIMSMOOTHTYPE: SmoothingType
+  DRAWLAYER: DrawLayer
+  FRAMEPOINT: FramePoint
+  FRAMESTRATA: FrameStrata
+  INSERTMODE: InsertMode
+  JUSTIFYHTYPE: JustifyHorizontal
+  JUSTIFYVTYPE: JustifyVertical
+  ORIENTATION: Orientation
+  WRAPMODE: WrapMode
 typedefs:
   AbbreviateConfig:
     type:

--- a/data/products/wow_classic_era/docs.yaml
+++ b/data/products/wow_classic_era/docs.yaml
@@ -598,6 +598,19 @@ script_objects:
     uiobject: Texture
   SimpleTextureBaseAPI:
     uiobject: TextureBase
+stringenums:
+  ALPHAMODE: BlendMode
+  ANIMCURVETYPE: CurveType
+  ANIMLOOPTYPE: LoopType
+  ANIMSMOOTHTYPE: SmoothingType
+  DRAWLAYER: DrawLayer
+  FRAMEPOINT: FramePoint
+  FRAMESTRATA: FrameStrata
+  INSERTMODE: InsertMode
+  JUSTIFYHTYPE: JustifyHorizontal
+  JUSTIFYVTYPE: JustifyVertical
+  ORIENTATION: Orientation
+  WRAPMODE: WrapMode
 typedefs:
   AnimationDataEnum:
     type: number

--- a/data/products/wow_classic_era_ptr/docs.yaml
+++ b/data/products/wow_classic_era_ptr/docs.yaml
@@ -675,6 +675,19 @@ script_objects:
     uiobject: TextureBase
   UnitHealPredictionCalculatorAPI:
     luaobject: UnitHealPredictionCalculator
+stringenums:
+  ALPHAMODE: BlendMode
+  ANIMCURVETYPE: CurveType
+  ANIMLOOPTYPE: LoopType
+  ANIMSMOOTHTYPE: SmoothingType
+  DRAWLAYER: DrawLayer
+  FRAMEPOINT: FramePoint
+  FRAMESTRATA: FrameStrata
+  INSERTMODE: InsertMode
+  JUSTIFYHTYPE: JustifyHorizontal
+  JUSTIFYVTYPE: JustifyVertical
+  ORIENTATION: Orientation
+  WRAPMODE: WrapMode
 typedefs:
   AbbreviateConfig:
     type:

--- a/data/products/wow_classic_ptr/docs.yaml
+++ b/data/products/wow_classic_ptr/docs.yaml
@@ -557,6 +557,19 @@ script_objects:
     uiobject: TextureBase
   UnitHealPredictionCalculatorAPI:
     luaobject: UnitHealPredictionCalculator
+stringenums:
+  ALPHAMODE: BlendMode
+  ANIMCURVETYPE: CurveType
+  ANIMLOOPTYPE: LoopType
+  ANIMSMOOTHTYPE: SmoothingType
+  DRAWLAYER: DrawLayer
+  FRAMEPOINT: FramePoint
+  FRAMESTRATA: FrameStrata
+  INSERTMODE: InsertMode
+  JUSTIFYHTYPE: JustifyHorizontal
+  JUSTIFYVTYPE: JustifyVertical
+  ORIENTATION: Orientation
+  WRAPMODE: WrapMode
 typedefs:
   AbbreviateConfig:
     type:

--- a/data/products/wowt/docs.yaml
+++ b/data/products/wowt/docs.yaml
@@ -534,6 +534,19 @@ script_objects:
     uiobject: VectorGraphics
   UnitHealPredictionCalculatorAPI:
     luaobject: UnitHealPredictionCalculator
+stringenums:
+  ALPHAMODE: BlendMode
+  ANIMCURVETYPE: CurveType
+  ANIMLOOPTYPE: LoopType
+  ANIMSMOOTHTYPE: SmoothingType
+  DRAWLAYER: DrawLayer
+  FRAMEPOINT: FramePoint
+  FRAMESTRATA: FrameStrata
+  INSERTMODE: InsertMode
+  JUSTIFYHTYPE: JustifyHorizontal
+  JUSTIFYVTYPE: JustifyVertical
+  ORIENTATION: Orientation
+  WRAPMODE: WrapMode
 typedefs:
   AbbreviateConfig:
     type:

--- a/data/products/wowxptr/docs.yaml
+++ b/data/products/wowxptr/docs.yaml
@@ -540,6 +540,19 @@ script_objects:
     uiobject: TextureBase
   UnitHealPredictionCalculatorAPI:
     luaobject: UnitHealPredictionCalculator
+stringenums:
+  ALPHAMODE: BlendMode
+  ANIMCURVETYPE: CurveType
+  ANIMLOOPTYPE: LoopType
+  ANIMSMOOTHTYPE: SmoothingType
+  DRAWLAYER: DrawLayer
+  FRAMEPOINT: FramePoint
+  FRAMESTRATA: FrameStrata
+  INSERTMODE: InsertMode
+  JUSTIFYHTYPE: JustifyHorizontal
+  JUSTIFYVTYPE: JustifyVertical
+  ORIENTATION: Orientation
+  WRAPMODE: WrapMode
 typedefs:
   AbbreviateConfig:
     type:

--- a/data/schemas/docs.yaml
+++ b/data/schemas/docs.yaml
@@ -67,6 +67,13 @@ type:
               uiobject:
                 ref:
                   schema: uiobject
+    stringenums:
+      type:
+        mapof:
+          key: string
+          value:
+            ref:
+              schema: stringenum
     typedefs:
       type:
         mapof:

--- a/tools/docs.lua
+++ b/tools/docs.lua
@@ -108,6 +108,34 @@ do
   processDocDir(prefix .. 'Blizzard_APIDocumentationGenerated')
 end
 
+local xsdenums = {}
+do
+  local content = require('pl.file').read('build/extracts/' .. product .. '/Interface/AddOns/Blizzard_SharedXML/UI.xsd')
+  if content then
+    local name, values
+    local parser = require('lxp').new({
+      StartElement = function(_, tag, attrs)
+        if tag:match('simpleType$') and attrs.name then
+          name = attrs.name
+          values = {}
+        elseif tag:match('enumeration$') and values and attrs.value then
+          table.insert(values, attrs.value)
+        end
+      end,
+      EndElement = function(_, tag)
+        if tag:match('simpleType$') and name then
+          if #values > 0 then
+            xsdenums[name] = values
+          end
+          name = nil
+        end
+      end,
+    })
+    parser:parse(content)
+    parser:close()
+  end
+end
+
 local config = parseYaml('data/products/' .. product .. '/docs.yaml')
 local enum = parseYaml('data/products/' .. product .. '/globals.yaml').Enum
 
@@ -537,11 +565,23 @@ local function rewriteLuaObjects(luaobjects)
   end
 end
 
+local function rewriteStringenums(stringenums)
+  for xsdname, name in pairs(config.stringenums or {}) do
+    local values = assert(xsdenums[xsdname], 'unknown xsd simpleType ' .. xsdname)
+    local t = {}
+    for _, v in ipairs(values) do
+      t[v] = {}
+    end
+    stringenums[name] = t
+  end
+end
+
 local rewriteFuncs = {
   apis = rewriteApis,
   events = rewriteEvents,
   globals = rewriteGlobals,
   luaobjects = rewriteLuaObjects,
+  stringenums = rewriteStringenums,
   structures = rewriteStructures,
   uiobjects = rewriteUIObjects,
 }


### PR DESCRIPTION
## Summary
- `tools/docs.lua` now parses each product's own `Blizzard_SharedXML/UI.xsd` (already fetched by `tools/fetch.lua`) for `xs:simpleType`/`xs:enumeration` definitions.
- A new `docs.yaml` `stringenums:` map (xsd name → canonical `stringenums.yaml` name) drives a new `rewriteStringenums` pass that overwrites just the mapped entries in that product's `stringenums.yaml` with the xsd's complete value set. Unmapped stringenums (`FilterMode`, `SimpleButtonStateToken` — no xsd source found) are left untouched, matching how the other docs.lua rewriters only ever touch names they actually see in their source.
- Mapped 12 names across all 8 products: `FramePoint`, `FrameStrata`, `DrawLayer`, `BlendMode`, `JustifyVertical`, `JustifyHorizontal`, `InsertMode`, `Orientation`, `WrapMode`, `LoopType`, `SmoothingType`, `CurveType`.

## Test plan
- [x] `cmake --build --preset default --target test` passes
- [x] `cmake --build --preset default --target docs-all` regenerates cleanly for all 8 products with **zero diff** to any `stringenums.yaml` — confirms the mapped names already matched their xsd source exactly (including `wow_classic_era`, which diverges from the rest in a different stringenum, `StatusBarFillStyle`, untouched by this change)
- [x] `pre-commit run -a` passes

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>