### PR TITLE
xml: match stringenum attribute values case-insensitively

### DIFF
--- a/tools/generatexmltest.lua
+++ b/tools/generatexmltest.lua
@@ -92,6 +92,10 @@ local content = {
         for name in sorted(stringenums.JustifyHorizontal) do
           table.insert(layer, fontString(name, name))
         end
+        -- Stringenum attribute values are matched case-insensitively and
+        -- coerced to their canonical casing; unconfirmed against real
+        -- clients beyond the fillStyle case that prompted this.
+        table.insert(layer, fontString('center', 'CENTER'))
         return layer
       end)(),
     },

--- a/tools/generatexmltest.lua
+++ b/tools/generatexmltest.lua
@@ -91,11 +91,8 @@ local content = {
         local layer = { tag = 'Layer', fontString(nil, 'CENTER') }
         for name in sorted(stringenums.JustifyHorizontal) do
           table.insert(layer, fontString(name, name))
+          table.insert(layer, fontString(name:lower(), name))
         end
-        -- Stringenum attribute values are matched case-insensitively and
-        -- coerced to their canonical casing; unconfirmed against real
-        -- clients beyond the fillStyle case that prompted this.
-        table.insert(layer, fontString('center', 'CENTER'))
         return layer
       end)(),
     },

--- a/wowless/modules/xml.lua
+++ b/wowless/modules/xml.lua
@@ -62,7 +62,8 @@ return function(datalua)
     end,
     stringenum = function(name, s)
       local set = stringenums[name]
-      return set[s] and s or nil
+      local upper = s:upper()
+      return set[upper] and upper or nil
     end,
     stringlist = function(s)
       local result = {}


### PR DESCRIPTION
## Summary
Real-client testing showed the `fillStyle` attribute accepts its value case-insensitively rather than requiring an exact match. Generalizes this to all stringenum-typed XML attributes rather than special-casing just one, since nothing in the existing behavior or test suite depended on case-sensitive rejection, and XML attribute value parsing elsewhere already normalizes case (e.g. boolean attributes).

Built on top of #746's tag-based dispatch (merged), so the actual change is tiny and isolated: `wowless/modules/xml.lua`'s `stringenum` dispatch entry now uppercases the incoming XML value and looks it up directly in the stringenum's value set (which #743, also merged, established and enforces is always fully uppercase), returning the canonical form. No metatable/`__index` needed anywhere in the file.

Also generalizes the `justifyH` case-insensitivity coverage in the generated XML test to every `JustifyHorizontal` value's inverted (lowercased) form, not a single hardcoded example.

## Test plan
- [x] `cmake --build --preset default --target test` passes
- [x] `pre-commit run -a` passes
- [x] CI green on all 7 checks

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>