### PR TITLE
spec: check that every stringenum is nonempty and fully uppercase

### DIFF
--- a/spec/data/stringenums_spec.lua
+++ b/spec/data/stringenums_spec.lua
@@ -43,6 +43,20 @@ describe('stringenums', function()
           assert.True(used[k])
         end)
       end
+      for k, v in pairs(actual) do
+        describe(k, function()
+          it('nonempty', function()
+            assert.True(next(v) ~= nil)
+          end)
+          describe('uppercase', function()
+            for value in pairs(v) do
+              it(value, function()
+                assert.same(value:upper(), value)
+              end)
+            end
+          end)
+        end)
+      end
     end)
   end
 end)


### PR DESCRIPTION
## Summary
- Extends `spec/data/stringenums_spec.lua` with two new checks per stringenum, grouped as `describe(name) > it('nonempty') / describe('uppercase') > it(value)`:
  - Every stringenum's value set is nonempty.
  - Every value in every stringenum is already fully uppercase.
- The uppercase invariant this establishes is what a separate XML attribute-parsing PR (case-insensitive stringenum matching) relies on to simplify its coercion to a direct lookup instead of a scan. Split out here since this is purely a data-integrity spec change, unrelated to that PR's runtime behavior change.

## Test plan
- [x] `cmake --build --preset default --target test` (fresh build from scratch) passes
- [x] `pre-commit run -a` passes

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>