### PR TITLE
xml: dispatch attribute types by tag instead of a fused name table

### DIFF
--- a/tools/prep.lua
+++ b/tools/prep.lua
@@ -397,7 +397,7 @@ local xmlflat = (function()
   for k, v in pairs(tree) do
     local attrs = {}
     for ak, av in pairs(v.attributes or {}) do
-      attrs[ak] = av.type.stringenum or av.type
+      attrs[ak] = av.type
     end
     local kids = {}
     local text = false
@@ -417,7 +417,7 @@ local xmlflat = (function()
       t = tree[t.extends]
       for ak, av in pairs(t.attributes or {}) do
         assert(not attrs[ak], ak .. ' is already an attribute of ' .. k)
-        attrs[ak] = av.type.stringenum or av.type
+        attrs[ak] = av.type
       end
       if t.contents == 'text' then
         text = true

--- a/wowless/modules/xml.lua
+++ b/wowless/modules/xml.lua
@@ -1,5 +1,15 @@
 local mixin = require('wowless.util').mixin
 
+local function dispatch(t, u, ...)
+  if type(u) == 'string' then
+    return assert(t[u], u)(...)
+  else
+    local uk, uv = next(u)
+    assert(next(u, uk) == nil, uk)
+    return assert(t[uk], uk)(uv, ...)
+  end
+end
+
 local baseAttributeTypes = {
   boolean = function(s)
     local x = string.lower(s)
@@ -58,11 +68,11 @@ end
 
 return function(datalua)
   local lang = datalua.xmlflat
+  local stringenums = datalua.stringenums
   local attributeTypes = mixin({}, baseAttributeTypes)
-  for sk, sv in pairs(datalua.stringenums) do
-    attributeTypes[sk] = function(s)
-      return sv[s] and s or nil
-    end
+  attributeTypes.stringenum = function(name, s)
+    local set = stringenums[name]
+    return set[s] and s or nil
   end
 
   local function parseRoot(root, intrinsics, snapshot)
@@ -96,7 +106,7 @@ return function(datalua)
           table.insert(warnings, 'attribute ' .. k .. ' is not supported by ' .. tname)
         else
           local v = e._attr[k]
-          local vv = attributeTypes[attr](v)
+          local vv = dispatch(attributeTypes, attr, v)
           if vv == nil then
             table.insert(warnings, 'attribute ' .. k .. ' has invalid value ' .. v)
           else

--- a/wowless/modules/xml.lua
+++ b/wowless/modules/xml.lua
@@ -10,32 +10,6 @@ local function dispatch(t, u, ...)
   end
 end
 
-local baseAttributeTypes = {
-  boolean = function(s)
-    local x = string.lower(s)
-    if x == 'true' then
-      return true
-    elseif x == 'false' then
-      return false
-    else
-      return nil
-    end
-  end,
-  number = function(s)
-    return tonumber(s)
-  end,
-  string = function(s)
-    return s
-  end,
-  stringlist = function(s)
-    local result = {}
-    for part in string.gmatch(s, '[^, ]+') do
-      table.insert(result, part)
-    end
-    return result
-  end,
-}
-
 -- Simulates xml2lua dom output via luaexpat.
 local function xml2dom(xmlstr)
   local stack = { { _children = {} } }
@@ -69,11 +43,35 @@ end
 return function(datalua)
   local lang = datalua.xmlflat
   local stringenums = datalua.stringenums
-  local attributeTypes = mixin({}, baseAttributeTypes)
-  attributeTypes.stringenum = function(name, s)
-    local set = stringenums[name]
-    return set[s] and s or nil
-  end
+  local attributeTypes = {
+    boolean = function(s)
+      local x = string.lower(s)
+      if x == 'true' then
+        return true
+      elseif x == 'false' then
+        return false
+      else
+        return nil
+      end
+    end,
+    number = function(s)
+      return tonumber(s)
+    end,
+    string = function(s)
+      return s
+    end,
+    stringenum = function(name, s)
+      local set = stringenums[name]
+      return set[s] and s or nil
+    end,
+    stringlist = function(s)
+      local result = {}
+      for part in string.gmatch(s, '[^, ]+') do
+        table.insert(result, part)
+      end
+      return result
+    end,
+  }
 
   local function parseRoot(root, intrinsics, snapshot)
     local warnings = {}


### PR DESCRIPTION
## Summary
Pre-work for an isolated case-insensitive-stringenum-matching follow-up. Pure structural refactor, no behavior change.

- `tools/prep.lua`'s `xmlflat` builder used to flatten an attribute's type down to just a bare name (`av.type.stringenum or av.type`), discarding whether that name came from a builtin tag or a stringenum. That meant a stringenum literally named e.g. `boolean` would silently collide with and shadow the builtin handler in `attributeTypes`, with no error or warning. Stop flattening — keep the full tagged value (`xml.yaml`'s own shape: a bare string tag, or `{stringenum = name}`).
- `wowless/modules/xml.lua` now dispatches on that tag via a copy of the same `dispatch(t, u, ...)` helper `tools/prep.lua` itself uses for tagged-union types (copied directly rather than shared, per discussion — not expected to live long in this duplicated form). `stringenum` gets one fixed table entry, `function(name, s)`, instead of one entry per stringenum name.
- Side effect: replaces the previous per-`datalua` eager loop over every stringenum with a single static function.

## Test plan
- [x] `cmake --build --preset default --target test` (fresh build from scratch) passes
- [x] `pre-commit run -a` passes

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>