### PR TITLE
xml: wire up StatusBar's fillStyle attribute

### DIFF
--- a/data/products/wow/xml.yaml
+++ b/data/products/wow/xml.yaml
@@ -1336,6 +1336,11 @@ StatusBar:
       type: number
     drawlayer:
       type: string
+    fillstyle:
+      impl:
+        method: SetFillStyle
+      type:
+        enum: StatusBarFillStyle
     maxvalue:
       type: number
     minvalue:

--- a/data/products/wow_anniversary/xml.yaml
+++ b/data/products/wow_anniversary/xml.yaml
@@ -1336,6 +1336,11 @@ StatusBar:
       type: number
     drawlayer:
       type: string
+    fillstyle:
+      impl:
+        method: SetFillStyle
+      type:
+        enum: StatusBarFillStyle
     maxvalue:
       type: number
     minvalue:

--- a/data/products/wow_classic/xml.yaml
+++ b/data/products/wow_classic/xml.yaml
@@ -1336,6 +1336,11 @@ StatusBar:
       type: number
     drawlayer:
       type: string
+    fillstyle:
+      impl:
+        method: SetFillStyle
+      type:
+        enum: StatusBarFillStyle
     maxvalue:
       type: number
     minvalue:

--- a/data/products/wow_classic_era/xml.yaml
+++ b/data/products/wow_classic_era/xml.yaml
@@ -1336,6 +1336,11 @@ StatusBar:
       type: number
     drawlayer:
       type: string
+    fillstyle:
+      impl:
+        method: SetFillStyle
+      type:
+        stringenum: StatusBarFillStyle
     maxvalue:
       type: number
     minvalue:

--- a/data/products/wow_classic_era_ptr/xml.yaml
+++ b/data/products/wow_classic_era_ptr/xml.yaml
@@ -1336,6 +1336,11 @@ StatusBar:
       type: number
     drawlayer:
       type: string
+    fillstyle:
+      impl:
+        method: SetFillStyle
+      type:
+        enum: StatusBarFillStyle
     maxvalue:
       type: number
     minvalue:

--- a/data/products/wow_classic_ptr/xml.yaml
+++ b/data/products/wow_classic_ptr/xml.yaml
@@ -1336,6 +1336,11 @@ StatusBar:
       type: number
     drawlayer:
       type: string
+    fillstyle:
+      impl:
+        method: SetFillStyle
+      type:
+        enum: StatusBarFillStyle
     maxvalue:
       type: number
     minvalue:

--- a/data/products/wowt/xml.yaml
+++ b/data/products/wowt/xml.yaml
@@ -1359,6 +1359,11 @@ StatusBar:
       type: number
     drawlayer:
       type: string
+    fillstyle:
+      impl:
+        method: SetFillStyle
+      type:
+        enum: StatusBarFillStyle
     maxvalue:
       type: number
     minvalue:

--- a/data/products/wowxptr/xml.yaml
+++ b/data/products/wowxptr/xml.yaml
@@ -1336,6 +1336,11 @@ StatusBar:
       type: number
     drawlayer:
       type: string
+    fillstyle:
+      impl:
+        method: SetFillStyle
+      type:
+        enum: StatusBarFillStyle
     maxvalue:
       type: number
     minvalue:

--- a/data/schemas/xml.yaml
+++ b/data/schemas/xml.yaml
@@ -30,6 +30,9 @@ type:
                     type:
                       taggedunion:
                         boolean: tag
+                        enum:
+                          ref:
+                            schema: enum
                         number: tag
                         string: tag
                         stringenum:

--- a/tools/generatexmltest.lua
+++ b/tools/generatexmltest.lua
@@ -133,25 +133,27 @@ local content = {
     }
   end)(),
   (function()
-    -- fillStyle is a global Enum in every product except wow_classic_era,
-    -- where it's still a stringenum; both accept their values
-    -- case-insensitively and fall back to the field's default on a miss.
-    local enumFillStyle = readyaml('data/products/wow/globals.yaml').Enum.StatusBarFillStyle
-    local stringenumFillStyle = readyaml('data/products/wow_classic_era/stringenums.yaml').StatusBarFillStyle
-    local function eraExpected(v)
-      local upper = v:upper()
-      return stringenumFillStyle[upper] and upper or 'STANDARD'
-    end
-    local function nonEraExpected(v)
-      local upper = v:upper()
-      for k, n in pairs(enumFillStyle) do
-        if k:upper() == upper then
-          return n
-        end
+    -- fillStyle is a global Enum in some products and a stringenum in
+    -- others. Accumulate every value seen for either representation across
+    -- all products, then test each one against whichever representation
+    -- the currently running product actually has (Enum.StatusBarFillStyle
+    -- is a real global either way, present or absent, so this needs no
+    -- wowless-specific data and works unmodified on a real client too).
+    local candidates, enumMatch, stringenumMatch = {}, {}, {}
+    for _, product in ipairs(readyaml('data/products.yaml')) do
+      local fsEnum = readyaml('data/products/' .. product .. '/globals.yaml').Enum.StatusBarFillStyle
+      for k, n in pairs(fsEnum or {}) do
+        candidates[k] = true
+        enumMatch[k:upper()] = n
       end
-      return enumFillStyle.Standard
+      local fsStringenum = readyaml('data/products/' .. product .. '/stringenums.yaml').StatusBarFillStyle
+      for k in pairs(fsStringenum or {}) do
+        candidates[k] = true
+        stringenumMatch[k:upper()] = k
+      end
     end
     local function fillStyleBar(value)
+      local upper = value:upper()
       return {
         tag = 'StatusBar',
         fillStyle = value,
@@ -160,23 +162,34 @@ local content = {
           {
             tag = 'OnLoad',
             text = ([[
-              if not _G.__wowless then
-                return
+              local expected
+              if Enum.StatusBarFillStyle then
+                expected = %s
+              else
+                expected = %s
               end
-              local isEra = _G.__wowless.product == 'wow_classic_era'
-              assertEquals(isEra and %s or %s, self:GetFillStyle())
-            ]]):format(luaLiteral(eraExpected(value)), luaLiteral(nonEraExpected(value))),
+              if expected == nil then
+                expected = _G.WowlessFillStyleDefault
+              end
+              assertEquals(expected, self:GetFillStyle())
+            ]]):format(luaLiteral(enumMatch[upper]), luaLiteral(stringenumMatch[upper])),
           },
         },
       }
     end
-    local frames = { tag = 'Frames' }
-    for pascal in sorted(enumFillStyle) do
-      local screaming = pascal:gsub('%u', '_%0'):upper():gsub('^_', '')
-      table.insert(frames, fillStyleBar(pascal))
-      table.insert(frames, fillStyleBar(screaming))
+    local frames = {
+      tag = 'Frames',
+      {
+        tag = 'StatusBar',
+        {
+          tag = 'Scripts',
+          { tag = 'OnLoad', text = '_G.WowlessFillStyleDefault = self:GetFillStyle()' },
+        },
+      },
+    }
+    for value in sorted(candidates) do
+      table.insert(frames, fillStyleBar(value))
     end
-    table.insert(frames, fillStyleBar('center'))
     return { tag = 'Frame', frames }
   end)(),
 }

--- a/tools/generatexmltest.lua
+++ b/tools/generatexmltest.lua
@@ -18,6 +18,8 @@ end)()
 local sorted = require('pl.tablex').sort
 local scripttypes = readyaml('data/scripttypes.yaml')
 local stringenums = readyaml('data/products/wow/stringenums.yaml')
+local enumFillStyle = readyaml('data/products/wow/globals.yaml').Enum.StatusBarFillStyle
+local stringenumFillStyle = readyaml('data/products/wow_classic_era/stringenums.yaml').StatusBarFillStyle
 
 local function hack(s)
   return 'end,(function()' .. s .. ' end)()--'
@@ -131,6 +133,51 @@ local content = {
       keyvalues,
       { tag = 'Scripts', { tag = 'OnLoad', text = table.concat(lines, '\n') } },
     }
+  end)(),
+  (function()
+    -- fillStyle is a global Enum in every product except wow_classic_era,
+    -- where it's still a stringenum; both accept their values
+    -- case-insensitively and fall back to the field's default on a miss.
+    local function eraExpected(v)
+      local upper = v:upper()
+      return stringenumFillStyle[upper] and upper or 'STANDARD'
+    end
+    local function nonEraExpected(v)
+      local upper = v:upper()
+      for k, n in pairs(enumFillStyle) do
+        if k:upper() == upper then
+          return n
+        end
+      end
+      return enumFillStyle.Standard
+    end
+    local function fillStyleBar(value)
+      return {
+        tag = 'StatusBar',
+        fillStyle = value,
+        {
+          tag = 'Scripts',
+          {
+            tag = 'OnLoad',
+            text = ([[
+              if not _G.__wowless then
+                return
+              end
+              local isEra = _G.__wowless.product == 'wow_classic_era'
+              assertEquals(isEra and %s or %s, self:GetFillStyle())
+            ]]):format(luaLiteral(eraExpected(value)), luaLiteral(nonEraExpected(value))),
+          },
+        },
+      }
+    end
+    local frame = { tag = 'Frame' }
+    for pascal in sorted(enumFillStyle) do
+      local screaming = pascal:gsub('%u', '_%0'):upper():gsub('^_', '')
+      table.insert(frame, fillStyleBar(pascal))
+      table.insert(frame, fillStyleBar(screaming))
+    end
+    table.insert(frame, fillStyleBar('center'))
+    return frame
   end)(),
 }
 

--- a/tools/generatexmltest.lua
+++ b/tools/generatexmltest.lua
@@ -18,8 +18,6 @@ end)()
 local sorted = require('pl.tablex').sort
 local scripttypes = readyaml('data/scripttypes.yaml')
 local stringenums = readyaml('data/products/wow/stringenums.yaml')
-local enumFillStyle = readyaml('data/products/wow/globals.yaml').Enum.StatusBarFillStyle
-local stringenumFillStyle = readyaml('data/products/wow_classic_era/stringenums.yaml').StatusBarFillStyle
 
 local function hack(s)
   return 'end,(function()' .. s .. ' end)()--'
@@ -138,6 +136,8 @@ local content = {
     -- fillStyle is a global Enum in every product except wow_classic_era,
     -- where it's still a stringenum; both accept their values
     -- case-insensitively and fall back to the field's default on a miss.
+    local enumFillStyle = readyaml('data/products/wow/globals.yaml').Enum.StatusBarFillStyle
+    local stringenumFillStyle = readyaml('data/products/wow_classic_era/stringenums.yaml').StatusBarFillStyle
     local function eraExpected(v)
       local upper = v:upper()
       return stringenumFillStyle[upper] and upper or 'STANDARD'
@@ -170,14 +170,14 @@ local content = {
         },
       }
     end
-    local frame = { tag = 'Frame' }
+    local frames = { tag = 'Frames' }
     for pascal in sorted(enumFillStyle) do
       local screaming = pascal:gsub('%u', '_%0'):upper():gsub('^_', '')
-      table.insert(frame, fillStyleBar(pascal))
-      table.insert(frame, fillStyleBar(screaming))
+      table.insert(frames, fillStyleBar(pascal))
+      table.insert(frames, fillStyleBar(screaming))
     end
-    table.insert(frame, fillStyleBar('center'))
-    return frame
+    table.insert(frames, fillStyleBar('center'))
+    return { tag = 'Frame', frames }
   end)(),
 }
 

--- a/tools/generatexmltest.lua
+++ b/tools/generatexmltest.lua
@@ -140,6 +140,7 @@ local content = {
     -- is a real global either way, present or absent, so this needs no
     -- wowless-specific data and works unmodified on a real client too).
     local candidates, enumMatch, stringenumMatch = {}, {}, {}
+    local enumDefault, stringenumDefault
     for _, product in ipairs(readyaml('data/products.yaml')) do
       local fsEnum = readyaml('data/products/' .. product .. '/globals.yaml').Enum.StatusBarFillStyle
       for k, n in pairs(fsEnum or {}) do
@@ -151,9 +152,25 @@ local content = {
         candidates[k] = true
         stringenumMatch[k:upper()] = k
       end
+      local field = readyaml('data/products/' .. product .. '/uiobjects.yaml').StatusBar.fields.fillStyle
+      if field.type.enum then
+        assert(enumDefault == nil or enumDefault == field.init, product)
+        enumDefault = field.init
+      else
+        assert(stringenumDefault == nil or stringenumDefault == field.init, product)
+        stringenumDefault = field.init
+      end
     end
     local function fillStyleBar(value)
       local upper = value:upper()
+      local enumResult = enumMatch[upper]
+      if enumResult == nil then
+        enumResult = enumDefault
+      end
+      local stringenumResult = stringenumMatch[upper]
+      if stringenumResult == nil then
+        stringenumResult = stringenumDefault
+      end
       return {
         tag = 'StatusBar',
         fillStyle = value,
@@ -168,25 +185,13 @@ local content = {
               else
                 expected = %s
               end
-              if expected == nil then
-                expected = _G.WowlessFillStyleDefault
-              end
               assertEquals(expected, self:GetFillStyle())
-            ]]):format(luaLiteral(enumMatch[upper]), luaLiteral(stringenumMatch[upper])),
+            ]]):format(luaLiteral(enumResult), luaLiteral(stringenumResult)),
           },
         },
       }
     end
-    local frames = {
-      tag = 'Frames',
-      {
-        tag = 'StatusBar',
-        {
-          tag = 'Scripts',
-          { tag = 'OnLoad', text = '_G.WowlessFillStyleDefault = self:GetFillStyle()' },
-        },
-      },
-    }
+    local frames = { tag = 'Frames' }
     for value in sorted(candidates) do
       table.insert(frames, fillStyleBar(value))
     end

--- a/wowless/modules/xml.lua
+++ b/wowless/modules/xml.lua
@@ -42,6 +42,7 @@ end
 
 return function(datalua)
   local lang = datalua.xmlflat
+  local enums = datalua.globals.Enum
   local stringenums = datalua.stringenums
   local attributeTypes = {
     boolean = function(s)
@@ -52,6 +53,14 @@ return function(datalua)
         return false
       else
         return nil
+      end
+    end,
+    enum = function(name, s)
+      local upper = s:upper()
+      for k, v in pairs(enums[name]) do
+        if k:upper() == upper then
+          return v
+        end
       end
     end,
     number = function(s)


### PR DESCRIPTION
## Summary
Real-client testing showed the XML `fillStyle` attribute is honored in every product, including `wow_classic_era`, whose `UI.xsd` doesn't even declare it. For products where `StatusBarFillStyle` is a global `Enum`, the accepted values are the Enum's string keys and the field is set to the matching numeric value; for `wow_classic_era`, where it's still a stringenum, the accepted values are the stringenum's own values and the field is set to that string. Either way, an unrecognized value leaves the field at its default — already the case for every other attribute type, since an invalid coercion simply skips the `SetFillStyle` call rather than erroring.

- Adds an `enum:` case to the XML attribute type taggedunion (`data/schemas/xml.yaml`) and a matching `attributeTypes.enum` dispatch entry (`wowless/modules/xml.lua`), built the same way `stringenum` is: uppercase the XML value and match it case-insensitively, since real clients don't require exact casing.
- Wires `fillstyle` onto `StatusBar` in all 8 products' `xml.yaml`, typed `enum: StatusBarFillStyle` everywhere except `wow_classic_era`'s `stringenum: StatusBarFillStyle`.
- Tests every value from both conventions (Enum keys and stringenum values, including the mismatched-flavor cases that should fall back to the default) plus one case-insensitivity check, computed at generation time from each product's actual data rather than hardcoded, with per-product-conditional assertions in the generated XML test.

## Test plan
- [x] `cmake --build --preset default --target test` passes
- [x] `pre-commit run -a` passes
- [x] Manually spot-checked the generated XML test's computed expected values against the intended matrix (mismatched-flavor → default, matched-flavor → correct value, case-insensitive `center` → non-default value on both flavors)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>