### PR TITLE
uiobjects: honor drawLayer/templateName in Frame:CreateFontString

### DIFF
--- a/addon/Wowless/test.xml
+++ b/addon/Wowless/test.xml
@@ -472,6 +472,17 @@
     </Scripts>
   </Frame>
 
+  <FontString name='WowlessCreateFontStringTemplate' virtual='true' justifyH='RIGHT' />
+  <Frame>
+    <Scripts>
+      <OnLoad>
+        local fs = self:CreateFontString(nil, 'OVERLAY', 'WowlessCreateFontStringTemplate')
+        assertEquals('RIGHT', fs:GetJustifyH())
+        assertEquals('OVERLAY', fs:GetDrawLayer())
+      </OnLoad>
+    </Scripts>
+  </Frame>
+
   <Script>
     WowlessLog = {}
     WowlessHide = function()

--- a/data/uiobjectimpl.yaml
+++ b/data/uiobjectimpl.yaml
@@ -65,6 +65,7 @@ Frame/CreateFontString:
   luafile:
     modules:
       api:
+      templates:
 Frame/CreateLine:
   luafile:
     modules:

--- a/data/uiobjects/Frame/CreateFontString.lua
+++ b/data/uiobjects/Frame/CreateFontString.lua
@@ -1,4 +1,12 @@
-local api = ...
-return function(self, name)
-  return api.CreateUIObject('fontstring', type(name) == 'string' and name or nil, self)
+local api, templates = ...
+return function(self, name, layer, inherits)
+  local tmpls = {}
+  for templateName in string.gmatch(inherits or '', '[^, ]+') do
+    table.insert(tmpls, templates.GetTemplateOrThrow(templateName))
+  end
+  local fs = api.CreateUIObject('fontstring', type(name) == 'string' and name or nil, self, nil, tmpls)
+  if layer then
+    fs:SetDrawLayer(layer)
+  end
+  return fs
 end


### PR DESCRIPTION
## Summary
- `Frame:CreateFontString`'s real implementation silently dropped its declared `drawLayer` and `templateName` parameters, even though every product's `uiobjects.yaml` declares `CreateFontString(name, drawLayer, templateName)` identically. `Frame:CreateTexture` already handles the equivalent arguments correctly (via `templates.GetTemplateOrThrow`) — mirror that pattern.
- Added `templates:` to `Frame/CreateFontString`'s module wiring in `data/uiobjectimpl.yaml` (it only had `api:`).
- Added coverage in `addon/Wowless/test.xml` proving template inheritance and draw-layer wiring now actually apply — there was previously no runtime test anywhere exercising template inheritance through `CreateFontString` or `CreateTexture`.

This is a prerequisite for a follow-up per-product XML template test framework (tracked in #751), which needs `CreateFontString(..., templateName)` to work directly. `CreateLine`/`CreateMaskTexture` have the identical bug pattern, tracked separately in #750.

## Test plan
- [x] `cmake --build --preset default --target test` — exits 0, no output
- [x] `pre-commit run -a` — all hooks pass