### PR TITLE
uiobjects: honor drawLayer/templateName in Frame:CreateFontString

### DIFF
--- a/addon/Wowless/test.xml
+++ b/addon/Wowless/test.xml
@@ -472,6 +472,17 @@
     </Scripts>
   </Frame>
 
+  <FontString name='WowlessCreateFontStringTemplate' virtual='true' justifyH='RIGHT' />
+  <Frame>
+    <Scripts>
+      <OnLoad>
+        local fs = self:CreateFontString(nil, 'OVERLAY', 'WowlessCreateFontStringTemplate')
+        assertEquals('RIGHT', fs:GetJustifyH())
+        assertEquals('OVERLAY', fs:GetDrawLayer())
+      </OnLoad>
+    </Scripts>
+  </Frame>
+
   <Script>
     WowlessLog = {}
     WowlessHide = function()

--- a/data/uiobjectimpl.yaml
+++ b/data/uiobjectimpl.yaml
@@ -65,6 +65,7 @@ Frame/CreateFontString:
   luafile:
     modules:
       api:
+      templates:
 Frame/CreateLine:
   luafile:
     modules:

--- a/data/uiobjects/Frame/CreateFontString.lua
+++ b/data/uiobjects/Frame/CreateFontString.lua
@@ -1,4 +1,12 @@
-local api = ...
-return function(self, name)
-  return api.CreateUIObject('fontstring', type(name) == 'string' and name or nil, self)
+local api, templates = ...
+return function(self, name, layer, inherits)
+  local tmpls = {}
+  for templateName in string.gmatch(inherits or '', '[^, ]+') do
+    table.insert(tmpls, templates.GetTemplateOrThrow(templateName))
+  end
+  local fs = api.CreateUIObject('fontstring', type(name) == 'string' and name or nil, self, nil, tmpls)
+  if layer then
+    fs:SetDrawLayer(layer)
+  end
+  return fs
 end


### PR DESCRIPTION
CreateFontString's real implementation silently dropped its declared
drawLayer and templateName parameters, unlike CreateTexture which already
handles the equivalent arguments correctly. Mirror CreateTexture.lua's
pattern and add coverage proving template inheritance actually applies.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_0188h6MtSB9mVTJZVg78qTg7
