### PR TITLE
xml: forbid method attribute impls that are trivial setters

### DIFF
--- a/data/products/wow/xml.yaml
+++ b/data/products/wow/xml.yaml
@@ -35,11 +35,11 @@ Alpha:
   attributes:
     fromalpha:
       impl:
-        method: SetFromAlpha
+        field: fromAlpha
       type: number
     toalpha:
       impl:
-        method: SetToAlpha
+        field: toAlpha
       type: number
   extends: Animation
 Anchor:
@@ -85,7 +85,7 @@ Animation:
       type: string
     smoothing:
       impl:
-        method: SetSmoothing
+        field: smoothing
       type: string
     startdelay:
       impl:
@@ -105,7 +105,7 @@ AnimationGroup:
       type: stringlist
     looping:
       impl:
-        method: SetLooping
+        field: looping
       type: string
     mixin:
       impl: internal
@@ -193,7 +193,7 @@ Button:
   attributes:
     motionscriptswhiledisabled:
       impl:
-        method: SetMotionScriptsWhileDisabled
+        field: motionScriptsWhileDisabled
       type: boolean
     registerforclicks:
       impl:
@@ -412,12 +412,12 @@ Font:
       type: stringlist
     justifyh:
       impl:
-        method: SetJustifyH
+        field: justifyh
       type:
         stringenum: JustifyHorizontal
     justifyv:
       impl:
-        method: SetJustifyV
+        field: justifyv
       type:
         stringenum: JustifyVertical
     monochrome:
@@ -452,12 +452,12 @@ FontString:
       type: string
     justifyh:
       impl:
-        method: SetJustifyH
+        field: justifyh
       type:
         stringenum: JustifyHorizontal
     justifyv:
       impl:
-        method: SetJustifyV
+        field: justifyv
       type:
         stringenum: JustifyVertical
     maxlines:
@@ -485,7 +485,7 @@ Frame:
   attributes:
     clampedtoscreen:
       impl:
-        method: SetClampedToScreen
+        field: isClampedToScreen
       type: boolean
     clipchildren:
       impl:
@@ -509,7 +509,7 @@ Frame:
       type: boolean
     enablemousewheel:
       impl:
-        method: EnableMouseWheel
+        field: mouseWheelEnabled
       type: boolean
     flattenrenderlayers:
       type: boolean
@@ -519,21 +519,21 @@ Frame:
       type: number
     framestrata:
       impl:
-        method: SetFrameStrata
+        field: frameStrata
       type: string
     hyperlinksenabled:
       impl:
-        method: SetHyperlinksEnabled
+        field: hyperlinksEnabled
       type: boolean
     id:
       impl:
-        method: SetID
+        field: id
       type: number
     intrinsic:
       type: boolean
     movable:
       impl:
-        method: SetMovable
+        field: movable
       type: boolean
     parent:
       impl: internal
@@ -547,14 +547,14 @@ Frame:
       type: boolean
     resizable:
       impl:
-        method: SetResizable
+        field: resizable
       type: boolean
     securemixin:
       impl: internal
       type: stringlist
     toplevel:
       impl:
-        method: SetToplevel
+        field: toplevel
       type: boolean
     useparentlevel:
       type: boolean
@@ -671,11 +671,11 @@ LayoutFrame:
       type: boolean
     ignoreparentalpha:
       impl:
-        method: SetIgnoreParentAlpha
+        field: isIgnoringParentAlpha
       type: boolean
     ignoreparentscale:
       impl:
-        method: SetIgnoreParentScale
+        field: isIgnoringParentScale
       type: boolean
     inherits:
       type: stringlist
@@ -1314,15 +1314,15 @@ Slider:
       type: boolean
     orientation:
       impl:
-        method: SetOrientation
+        field: orientation
       type: string
     stepsperpage:
       impl:
-        method: SetStepsPerPage
+        field: stepsPerPage
       type: number
     valuestep:
       impl:
-        method: SetValueStep
+        field: valueStep
       type: number
   contents:
     tags:
@@ -1342,7 +1342,7 @@ StatusBar:
       type: number
     reversefill:
       impl:
-        method: SetReverseFill
+        field: reverseFill
       type: boolean
   contents:
     tags:
@@ -1372,7 +1372,7 @@ Texture:
   attributes:
     alphamode:
       impl:
-        method: SetBlendMode
+        field: blendMode
       type:
         stringenum: BlendMode
     atlas:
@@ -1389,7 +1389,7 @@ Texture:
       type: string
     horiztile:
       impl:
-        method: SetHorizTile
+        field: horizTile
       type: boolean
     nonblocking:
       impl:
@@ -1401,13 +1401,13 @@ Texture:
       type: boolean
     texelsnappingbias:
       impl:
-        method: SetTexelSnappingBias
+        field: texelSnappingBias
       type: number
     useatlassize:
       type: boolean
     verttile:
       impl:
-        method: SetVertTile
+        field: vertTile
       type: boolean
   contents:
     tags:

--- a/data/products/wow_anniversary/xml.yaml
+++ b/data/products/wow_anniversary/xml.yaml
@@ -35,11 +35,11 @@ Alpha:
   attributes:
     fromalpha:
       impl:
-        method: SetFromAlpha
+        field: fromAlpha
       type: number
     toalpha:
       impl:
-        method: SetToAlpha
+        field: toAlpha
       type: number
   extends: Animation
 Anchor:
@@ -85,7 +85,7 @@ Animation:
       type: string
     smoothing:
       impl:
-        method: SetSmoothing
+        field: smoothing
       type: string
     startdelay:
       impl:
@@ -105,7 +105,7 @@ AnimationGroup:
       type: stringlist
     looping:
       impl:
-        method: SetLooping
+        field: looping
       type: string
     mixin:
       impl: internal
@@ -193,7 +193,7 @@ Button:
   attributes:
     motionscriptswhiledisabled:
       impl:
-        method: SetMotionScriptsWhileDisabled
+        field: motionScriptsWhileDisabled
       type: boolean
     registerforclicks:
       impl:
@@ -412,12 +412,12 @@ Font:
       type: stringlist
     justifyh:
       impl:
-        method: SetJustifyH
+        field: justifyh
       type:
         stringenum: JustifyHorizontal
     justifyv:
       impl:
-        method: SetJustifyV
+        field: justifyv
       type:
         stringenum: JustifyVertical
     monochrome:
@@ -452,12 +452,12 @@ FontString:
       type: string
     justifyh:
       impl:
-        method: SetJustifyH
+        field: justifyh
       type:
         stringenum: JustifyHorizontal
     justifyv:
       impl:
-        method: SetJustifyV
+        field: justifyv
       type:
         stringenum: JustifyVertical
     maxlines:
@@ -485,7 +485,7 @@ Frame:
   attributes:
     clampedtoscreen:
       impl:
-        method: SetClampedToScreen
+        field: isClampedToScreen
       type: boolean
     clipchildren:
       impl:
@@ -509,7 +509,7 @@ Frame:
       type: boolean
     enablemousewheel:
       impl:
-        method: EnableMouseWheel
+        field: mouseWheelEnabled
       type: boolean
     flattenrenderlayers:
       type: boolean
@@ -519,21 +519,21 @@ Frame:
       type: number
     framestrata:
       impl:
-        method: SetFrameStrata
+        field: frameStrata
       type: string
     hyperlinksenabled:
       impl:
-        method: SetHyperlinksEnabled
+        field: hyperlinksEnabled
       type: boolean
     id:
       impl:
-        method: SetID
+        field: id
       type: number
     intrinsic:
       type: boolean
     movable:
       impl:
-        method: SetMovable
+        field: movable
       type: boolean
     parent:
       impl: internal
@@ -547,14 +547,14 @@ Frame:
       type: boolean
     resizable:
       impl:
-        method: SetResizable
+        field: resizable
       type: boolean
     securemixin:
       impl: internal
       type: stringlist
     toplevel:
       impl:
-        method: SetToplevel
+        field: toplevel
       type: boolean
     useparentlevel:
       type: boolean
@@ -671,11 +671,11 @@ LayoutFrame:
       type: boolean
     ignoreparentalpha:
       impl:
-        method: SetIgnoreParentAlpha
+        field: isIgnoringParentAlpha
       type: boolean
     ignoreparentscale:
       impl:
-        method: SetIgnoreParentScale
+        field: isIgnoringParentScale
       type: boolean
     inherits:
       type: stringlist
@@ -1314,15 +1314,15 @@ Slider:
       type: boolean
     orientation:
       impl:
-        method: SetOrientation
+        field: orientation
       type: string
     stepsperpage:
       impl:
-        method: SetStepsPerPage
+        field: stepsPerPage
       type: number
     valuestep:
       impl:
-        method: SetValueStep
+        field: valueStep
       type: number
   contents:
     tags:
@@ -1342,7 +1342,7 @@ StatusBar:
       type: number
     reversefill:
       impl:
-        method: SetReverseFill
+        field: reverseFill
       type: boolean
   contents:
     tags:
@@ -1372,7 +1372,7 @@ Texture:
   attributes:
     alphamode:
       impl:
-        method: SetBlendMode
+        field: blendMode
       type:
         stringenum: BlendMode
     atlas:
@@ -1389,7 +1389,7 @@ Texture:
       type: string
     horiztile:
       impl:
-        method: SetHorizTile
+        field: horizTile
       type: boolean
     nonblocking:
       type: boolean
@@ -1399,13 +1399,13 @@ Texture:
       type: boolean
     texelsnappingbias:
       impl:
-        method: SetTexelSnappingBias
+        field: texelSnappingBias
       type: number
     useatlassize:
       type: boolean
     verttile:
       impl:
-        method: SetVertTile
+        field: vertTile
       type: boolean
   contents:
     tags:

--- a/data/products/wow_classic/xml.yaml
+++ b/data/products/wow_classic/xml.yaml
@@ -35,11 +35,11 @@ Alpha:
   attributes:
     fromalpha:
       impl:
-        method: SetFromAlpha
+        field: fromAlpha
       type: number
     toalpha:
       impl:
-        method: SetToAlpha
+        field: toAlpha
       type: number
   extends: Animation
 Anchor:
@@ -85,7 +85,7 @@ Animation:
       type: string
     smoothing:
       impl:
-        method: SetSmoothing
+        field: smoothing
       type: string
     startdelay:
       impl:
@@ -105,7 +105,7 @@ AnimationGroup:
       type: stringlist
     looping:
       impl:
-        method: SetLooping
+        field: looping
       type: string
     mixin:
       impl: internal
@@ -193,7 +193,7 @@ Button:
   attributes:
     motionscriptswhiledisabled:
       impl:
-        method: SetMotionScriptsWhileDisabled
+        field: motionScriptsWhileDisabled
       type: boolean
     registerforclicks:
       impl:
@@ -412,12 +412,12 @@ Font:
       type: stringlist
     justifyh:
       impl:
-        method: SetJustifyH
+        field: justifyh
       type:
         stringenum: JustifyHorizontal
     justifyv:
       impl:
-        method: SetJustifyV
+        field: justifyv
       type:
         stringenum: JustifyVertical
     monochrome:
@@ -452,12 +452,12 @@ FontString:
       type: string
     justifyh:
       impl:
-        method: SetJustifyH
+        field: justifyh
       type:
         stringenum: JustifyHorizontal
     justifyv:
       impl:
-        method: SetJustifyV
+        field: justifyv
       type:
         stringenum: JustifyVertical
     maxlines:
@@ -485,7 +485,7 @@ Frame:
   attributes:
     clampedtoscreen:
       impl:
-        method: SetClampedToScreen
+        field: isClampedToScreen
       type: boolean
     clipchildren:
       impl:
@@ -509,7 +509,7 @@ Frame:
       type: boolean
     enablemousewheel:
       impl:
-        method: EnableMouseWheel
+        field: mouseWheelEnabled
       type: boolean
     flattenrenderlayers:
       type: boolean
@@ -519,21 +519,21 @@ Frame:
       type: number
     framestrata:
       impl:
-        method: SetFrameStrata
+        field: frameStrata
       type: string
     hyperlinksenabled:
       impl:
-        method: SetHyperlinksEnabled
+        field: hyperlinksEnabled
       type: boolean
     id:
       impl:
-        method: SetID
+        field: id
       type: number
     intrinsic:
       type: boolean
     movable:
       impl:
-        method: SetMovable
+        field: movable
       type: boolean
     parent:
       impl: internal
@@ -547,14 +547,14 @@ Frame:
       type: boolean
     resizable:
       impl:
-        method: SetResizable
+        field: resizable
       type: boolean
     securemixin:
       impl: internal
       type: stringlist
     toplevel:
       impl:
-        method: SetToplevel
+        field: toplevel
       type: boolean
     useparentlevel:
       type: boolean
@@ -671,11 +671,11 @@ LayoutFrame:
       type: boolean
     ignoreparentalpha:
       impl:
-        method: SetIgnoreParentAlpha
+        field: isIgnoringParentAlpha
       type: boolean
     ignoreparentscale:
       impl:
-        method: SetIgnoreParentScale
+        field: isIgnoringParentScale
       type: boolean
     inherits:
       type: stringlist
@@ -1314,15 +1314,15 @@ Slider:
       type: boolean
     orientation:
       impl:
-        method: SetOrientation
+        field: orientation
       type: string
     stepsperpage:
       impl:
-        method: SetStepsPerPage
+        field: stepsPerPage
       type: number
     valuestep:
       impl:
-        method: SetValueStep
+        field: valueStep
       type: number
   contents:
     tags:
@@ -1342,7 +1342,7 @@ StatusBar:
       type: number
     reversefill:
       impl:
-        method: SetReverseFill
+        field: reverseFill
       type: boolean
   contents:
     tags:
@@ -1372,7 +1372,7 @@ Texture:
   attributes:
     alphamode:
       impl:
-        method: SetBlendMode
+        field: blendMode
       type:
         stringenum: BlendMode
     atlas:
@@ -1389,7 +1389,7 @@ Texture:
       type: string
     horiztile:
       impl:
-        method: SetHorizTile
+        field: horizTile
       type: boolean
     nonblocking:
       type: boolean
@@ -1399,13 +1399,13 @@ Texture:
       type: boolean
     texelsnappingbias:
       impl:
-        method: SetTexelSnappingBias
+        field: texelSnappingBias
       type: number
     useatlassize:
       type: boolean
     verttile:
       impl:
-        method: SetVertTile
+        field: vertTile
       type: boolean
   contents:
     tags:

--- a/data/products/wow_classic_era/xml.yaml
+++ b/data/products/wow_classic_era/xml.yaml
@@ -35,11 +35,11 @@ Alpha:
   attributes:
     fromalpha:
       impl:
-        method: SetFromAlpha
+        field: fromAlpha
       type: number
     toalpha:
       impl:
-        method: SetToAlpha
+        field: toAlpha
       type: number
   extends: Animation
 Anchor:
@@ -85,7 +85,7 @@ Animation:
       type: string
     smoothing:
       impl:
-        method: SetSmoothing
+        field: smoothing
       type: string
     startdelay:
       impl:
@@ -105,7 +105,7 @@ AnimationGroup:
       type: stringlist
     looping:
       impl:
-        method: SetLooping
+        field: looping
       type: string
     mixin:
       impl: internal
@@ -193,7 +193,7 @@ Button:
   attributes:
     motionscriptswhiledisabled:
       impl:
-        method: SetMotionScriptsWhileDisabled
+        field: motionScriptsWhileDisabled
       type: boolean
     registerforclicks:
       impl:
@@ -412,12 +412,12 @@ Font:
       type: stringlist
     justifyh:
       impl:
-        method: SetJustifyH
+        field: justifyh
       type:
         stringenum: JustifyHorizontal
     justifyv:
       impl:
-        method: SetJustifyV
+        field: justifyv
       type:
         stringenum: JustifyVertical
     monochrome:
@@ -452,12 +452,12 @@ FontString:
       type: string
     justifyh:
       impl:
-        method: SetJustifyH
+        field: justifyh
       type:
         stringenum: JustifyHorizontal
     justifyv:
       impl:
-        method: SetJustifyV
+        field: justifyv
       type:
         stringenum: JustifyVertical
     maxlines:
@@ -485,7 +485,7 @@ Frame:
   attributes:
     clampedtoscreen:
       impl:
-        method: SetClampedToScreen
+        field: isClampedToScreen
       type: boolean
     clipchildren:
       impl:
@@ -509,7 +509,7 @@ Frame:
       type: boolean
     enablemousewheel:
       impl:
-        method: EnableMouseWheel
+        field: mouseWheelEnabled
       type: boolean
     flattenrenderlayers:
       type: boolean
@@ -519,21 +519,21 @@ Frame:
       type: number
     framestrata:
       impl:
-        method: SetFrameStrata
+        field: frameStrata
       type: string
     hyperlinksenabled:
       impl:
-        method: SetHyperlinksEnabled
+        field: hyperlinksEnabled
       type: boolean
     id:
       impl:
-        method: SetID
+        field: id
       type: number
     intrinsic:
       type: boolean
     movable:
       impl:
-        method: SetMovable
+        field: movable
       type: boolean
     parent:
       impl: internal
@@ -547,14 +547,14 @@ Frame:
       type: boolean
     resizable:
       impl:
-        method: SetResizable
+        field: resizable
       type: boolean
     securemixin:
       impl: internal
       type: stringlist
     toplevel:
       impl:
-        method: SetToplevel
+        field: toplevel
       type: boolean
     useparentlevel:
       type: boolean
@@ -671,11 +671,11 @@ LayoutFrame:
       type: boolean
     ignoreparentalpha:
       impl:
-        method: SetIgnoreParentAlpha
+        field: isIgnoringParentAlpha
       type: boolean
     ignoreparentscale:
       impl:
-        method: SetIgnoreParentScale
+        field: isIgnoringParentScale
       type: boolean
     inherits:
       type: stringlist
@@ -1314,15 +1314,15 @@ Slider:
       type: boolean
     orientation:
       impl:
-        method: SetOrientation
+        field: orientation
       type: string
     stepsperpage:
       impl:
-        method: SetStepsPerPage
+        field: stepsPerPage
       type: number
     valuestep:
       impl:
-        method: SetValueStep
+        field: valueStep
       type: number
   contents:
     tags:
@@ -1342,7 +1342,7 @@ StatusBar:
       type: number
     reversefill:
       impl:
-        method: SetReverseFill
+        field: reverseFill
       type: boolean
   contents:
     tags:
@@ -1372,7 +1372,7 @@ Texture:
   attributes:
     alphamode:
       impl:
-        method: SetBlendMode
+        field: blendMode
       type:
         stringenum: BlendMode
     atlas:
@@ -1389,7 +1389,7 @@ Texture:
       type: string
     horiztile:
       impl:
-        method: SetHorizTile
+        field: horizTile
       type: boolean
     nonblocking:
       type: boolean
@@ -1399,13 +1399,13 @@ Texture:
       type: boolean
     texelsnappingbias:
       impl:
-        method: SetTexelSnappingBias
+        field: texelSnappingBias
       type: number
     useatlassize:
       type: boolean
     verttile:
       impl:
-        method: SetVertTile
+        field: vertTile
       type: boolean
   contents:
     tags:

--- a/data/products/wow_classic_era_ptr/xml.yaml
+++ b/data/products/wow_classic_era_ptr/xml.yaml
@@ -35,11 +35,11 @@ Alpha:
   attributes:
     fromalpha:
       impl:
-        method: SetFromAlpha
+        field: fromAlpha
       type: number
     toalpha:
       impl:
-        method: SetToAlpha
+        field: toAlpha
       type: number
   extends: Animation
 Anchor:
@@ -85,7 +85,7 @@ Animation:
       type: string
     smoothing:
       impl:
-        method: SetSmoothing
+        field: smoothing
       type: string
     startdelay:
       impl:
@@ -105,7 +105,7 @@ AnimationGroup:
       type: stringlist
     looping:
       impl:
-        method: SetLooping
+        field: looping
       type: string
     mixin:
       impl: internal
@@ -193,7 +193,7 @@ Button:
   attributes:
     motionscriptswhiledisabled:
       impl:
-        method: SetMotionScriptsWhileDisabled
+        field: motionScriptsWhileDisabled
       type: boolean
     registerforclicks:
       impl:
@@ -412,12 +412,12 @@ Font:
       type: stringlist
     justifyh:
       impl:
-        method: SetJustifyH
+        field: justifyh
       type:
         stringenum: JustifyHorizontal
     justifyv:
       impl:
-        method: SetJustifyV
+        field: justifyv
       type:
         stringenum: JustifyVertical
     monochrome:
@@ -452,12 +452,12 @@ FontString:
       type: string
     justifyh:
       impl:
-        method: SetJustifyH
+        field: justifyh
       type:
         stringenum: JustifyHorizontal
     justifyv:
       impl:
-        method: SetJustifyV
+        field: justifyv
       type:
         stringenum: JustifyVertical
     maxlines:
@@ -485,7 +485,7 @@ Frame:
   attributes:
     clampedtoscreen:
       impl:
-        method: SetClampedToScreen
+        field: isClampedToScreen
       type: boolean
     clipchildren:
       impl:
@@ -509,7 +509,7 @@ Frame:
       type: boolean
     enablemousewheel:
       impl:
-        method: EnableMouseWheel
+        field: mouseWheelEnabled
       type: boolean
     flattenrenderlayers:
       type: boolean
@@ -519,21 +519,21 @@ Frame:
       type: number
     framestrata:
       impl:
-        method: SetFrameStrata
+        field: frameStrata
       type: string
     hyperlinksenabled:
       impl:
-        method: SetHyperlinksEnabled
+        field: hyperlinksEnabled
       type: boolean
     id:
       impl:
-        method: SetID
+        field: id
       type: number
     intrinsic:
       type: boolean
     movable:
       impl:
-        method: SetMovable
+        field: movable
       type: boolean
     parent:
       impl: internal
@@ -547,14 +547,14 @@ Frame:
       type: boolean
     resizable:
       impl:
-        method: SetResizable
+        field: resizable
       type: boolean
     securemixin:
       impl: internal
       type: stringlist
     toplevel:
       impl:
-        method: SetToplevel
+        field: toplevel
       type: boolean
     useparentlevel:
       type: boolean
@@ -671,11 +671,11 @@ LayoutFrame:
       type: boolean
     ignoreparentalpha:
       impl:
-        method: SetIgnoreParentAlpha
+        field: isIgnoringParentAlpha
       type: boolean
     ignoreparentscale:
       impl:
-        method: SetIgnoreParentScale
+        field: isIgnoringParentScale
       type: boolean
     inherits:
       type: stringlist
@@ -1314,15 +1314,15 @@ Slider:
       type: boolean
     orientation:
       impl:
-        method: SetOrientation
+        field: orientation
       type: string
     stepsperpage:
       impl:
-        method: SetStepsPerPage
+        field: stepsPerPage
       type: number
     valuestep:
       impl:
-        method: SetValueStep
+        field: valueStep
       type: number
   contents:
     tags:
@@ -1342,7 +1342,7 @@ StatusBar:
       type: number
     reversefill:
       impl:
-        method: SetReverseFill
+        field: reverseFill
       type: boolean
   contents:
     tags:
@@ -1372,7 +1372,7 @@ Texture:
   attributes:
     alphamode:
       impl:
-        method: SetBlendMode
+        field: blendMode
       type:
         stringenum: BlendMode
     atlas:
@@ -1389,7 +1389,7 @@ Texture:
       type: string
     horiztile:
       impl:
-        method: SetHorizTile
+        field: horizTile
       type: boolean
     nonblocking:
       type: boolean
@@ -1399,13 +1399,13 @@ Texture:
       type: boolean
     texelsnappingbias:
       impl:
-        method: SetTexelSnappingBias
+        field: texelSnappingBias
       type: number
     useatlassize:
       type: boolean
     verttile:
       impl:
-        method: SetVertTile
+        field: vertTile
       type: boolean
   contents:
     tags:

--- a/data/products/wow_classic_ptr/xml.yaml
+++ b/data/products/wow_classic_ptr/xml.yaml
@@ -35,11 +35,11 @@ Alpha:
   attributes:
     fromalpha:
       impl:
-        method: SetFromAlpha
+        field: fromAlpha
       type: number
     toalpha:
       impl:
-        method: SetToAlpha
+        field: toAlpha
       type: number
   extends: Animation
 Anchor:
@@ -85,7 +85,7 @@ Animation:
       type: string
     smoothing:
       impl:
-        method: SetSmoothing
+        field: smoothing
       type: string
     startdelay:
       impl:
@@ -105,7 +105,7 @@ AnimationGroup:
       type: stringlist
     looping:
       impl:
-        method: SetLooping
+        field: looping
       type: string
     mixin:
       impl: internal
@@ -193,7 +193,7 @@ Button:
   attributes:
     motionscriptswhiledisabled:
       impl:
-        method: SetMotionScriptsWhileDisabled
+        field: motionScriptsWhileDisabled
       type: boolean
     registerforclicks:
       impl:
@@ -412,12 +412,12 @@ Font:
       type: stringlist
     justifyh:
       impl:
-        method: SetJustifyH
+        field: justifyh
       type:
         stringenum: JustifyHorizontal
     justifyv:
       impl:
-        method: SetJustifyV
+        field: justifyv
       type:
         stringenum: JustifyVertical
     monochrome:
@@ -452,12 +452,12 @@ FontString:
       type: string
     justifyh:
       impl:
-        method: SetJustifyH
+        field: justifyh
       type:
         stringenum: JustifyHorizontal
     justifyv:
       impl:
-        method: SetJustifyV
+        field: justifyv
       type:
         stringenum: JustifyVertical
     maxlines:
@@ -485,7 +485,7 @@ Frame:
   attributes:
     clampedtoscreen:
       impl:
-        method: SetClampedToScreen
+        field: isClampedToScreen
       type: boolean
     clipchildren:
       impl:
@@ -509,7 +509,7 @@ Frame:
       type: boolean
     enablemousewheel:
       impl:
-        method: EnableMouseWheel
+        field: mouseWheelEnabled
       type: boolean
     flattenrenderlayers:
       type: boolean
@@ -519,21 +519,21 @@ Frame:
       type: number
     framestrata:
       impl:
-        method: SetFrameStrata
+        field: frameStrata
       type: string
     hyperlinksenabled:
       impl:
-        method: SetHyperlinksEnabled
+        field: hyperlinksEnabled
       type: boolean
     id:
       impl:
-        method: SetID
+        field: id
       type: number
     intrinsic:
       type: boolean
     movable:
       impl:
-        method: SetMovable
+        field: movable
       type: boolean
     parent:
       impl: internal
@@ -547,14 +547,14 @@ Frame:
       type: boolean
     resizable:
       impl:
-        method: SetResizable
+        field: resizable
       type: boolean
     securemixin:
       impl: internal
       type: stringlist
     toplevel:
       impl:
-        method: SetToplevel
+        field: toplevel
       type: boolean
     useparentlevel:
       type: boolean
@@ -671,11 +671,11 @@ LayoutFrame:
       type: boolean
     ignoreparentalpha:
       impl:
-        method: SetIgnoreParentAlpha
+        field: isIgnoringParentAlpha
       type: boolean
     ignoreparentscale:
       impl:
-        method: SetIgnoreParentScale
+        field: isIgnoringParentScale
       type: boolean
     inherits:
       type: stringlist
@@ -1314,15 +1314,15 @@ Slider:
       type: boolean
     orientation:
       impl:
-        method: SetOrientation
+        field: orientation
       type: string
     stepsperpage:
       impl:
-        method: SetStepsPerPage
+        field: stepsPerPage
       type: number
     valuestep:
       impl:
-        method: SetValueStep
+        field: valueStep
       type: number
   contents:
     tags:
@@ -1342,7 +1342,7 @@ StatusBar:
       type: number
     reversefill:
       impl:
-        method: SetReverseFill
+        field: reverseFill
       type: boolean
   contents:
     tags:
@@ -1372,7 +1372,7 @@ Texture:
   attributes:
     alphamode:
       impl:
-        method: SetBlendMode
+        field: blendMode
       type:
         stringenum: BlendMode
     atlas:
@@ -1389,7 +1389,7 @@ Texture:
       type: string
     horiztile:
       impl:
-        method: SetHorizTile
+        field: horizTile
       type: boolean
     nonblocking:
       type: boolean
@@ -1399,13 +1399,13 @@ Texture:
       type: boolean
     texelsnappingbias:
       impl:
-        method: SetTexelSnappingBias
+        field: texelSnappingBias
       type: number
     useatlassize:
       type: boolean
     verttile:
       impl:
-        method: SetVertTile
+        field: vertTile
       type: boolean
   contents:
     tags:

--- a/data/products/wowt/xml.yaml
+++ b/data/products/wowt/xml.yaml
@@ -35,11 +35,11 @@ Alpha:
   attributes:
     fromalpha:
       impl:
-        method: SetFromAlpha
+        field: fromAlpha
       type: number
     toalpha:
       impl:
-        method: SetToAlpha
+        field: toAlpha
       type: number
   extends: Animation
 Anchor:
@@ -85,7 +85,7 @@ Animation:
       type: string
     smoothing:
       impl:
-        method: SetSmoothing
+        field: smoothing
       type: string
     startdelay:
       impl:
@@ -105,7 +105,7 @@ AnimationGroup:
       type: stringlist
     looping:
       impl:
-        method: SetLooping
+        field: looping
       type: string
     mixin:
       impl: internal
@@ -193,7 +193,7 @@ Button:
   attributes:
     motionscriptswhiledisabled:
       impl:
-        method: SetMotionScriptsWhileDisabled
+        field: motionScriptsWhileDisabled
       type: boolean
     registerforclicks:
       impl:
@@ -412,12 +412,12 @@ Font:
       type: stringlist
     justifyh:
       impl:
-        method: SetJustifyH
+        field: justifyh
       type:
         stringenum: JustifyHorizontal
     justifyv:
       impl:
-        method: SetJustifyV
+        field: justifyv
       type:
         stringenum: JustifyVertical
     monochrome:
@@ -452,12 +452,12 @@ FontString:
       type: string
     justifyh:
       impl:
-        method: SetJustifyH
+        field: justifyh
       type:
         stringenum: JustifyHorizontal
     justifyv:
       impl:
-        method: SetJustifyV
+        field: justifyv
       type:
         stringenum: JustifyVertical
     maxlines:
@@ -485,7 +485,7 @@ Frame:
   attributes:
     clampedtoscreen:
       impl:
-        method: SetClampedToScreen
+        field: isClampedToScreen
       type: boolean
     clipchildren:
       impl:
@@ -509,7 +509,7 @@ Frame:
       type: boolean
     enablemousewheel:
       impl:
-        method: EnableMouseWheel
+        field: mouseWheelEnabled
       type: boolean
     flattenrenderlayers:
       type: boolean
@@ -519,21 +519,21 @@ Frame:
       type: number
     framestrata:
       impl:
-        method: SetFrameStrata
+        field: frameStrata
       type: string
     hyperlinksenabled:
       impl:
-        method: SetHyperlinksEnabled
+        field: hyperlinksEnabled
       type: boolean
     id:
       impl:
-        method: SetID
+        field: id
       type: number
     intrinsic:
       type: boolean
     movable:
       impl:
-        method: SetMovable
+        field: movable
       type: boolean
     parent:
       impl: internal
@@ -547,14 +547,14 @@ Frame:
       type: boolean
     resizable:
       impl:
-        method: SetResizable
+        field: resizable
       type: boolean
     securemixin:
       impl: internal
       type: stringlist
     toplevel:
       impl:
-        method: SetToplevel
+        field: toplevel
       type: boolean
     useparentlevel:
       type: boolean
@@ -671,11 +671,11 @@ LayoutFrame:
       type: boolean
     ignoreparentalpha:
       impl:
-        method: SetIgnoreParentAlpha
+        field: isIgnoringParentAlpha
       type: boolean
     ignoreparentscale:
       impl:
-        method: SetIgnoreParentScale
+        field: isIgnoringParentScale
       type: boolean
     inherits:
       type: stringlist
@@ -1337,15 +1337,15 @@ Slider:
       type: boolean
     orientation:
       impl:
-        method: SetOrientation
+        field: orientation
       type: string
     stepsperpage:
       impl:
-        method: SetStepsPerPage
+        field: stepsPerPage
       type: number
     valuestep:
       impl:
-        method: SetValueStep
+        field: valueStep
       type: number
   contents:
     tags:
@@ -1365,7 +1365,7 @@ StatusBar:
       type: number
     reversefill:
       impl:
-        method: SetReverseFill
+        field: reverseFill
       type: boolean
   contents:
     tags:
@@ -1395,7 +1395,7 @@ Texture:
   attributes:
     alphamode:
       impl:
-        method: SetBlendMode
+        field: blendMode
       type:
         stringenum: BlendMode
     atlas:
@@ -1412,7 +1412,7 @@ Texture:
       type: string
     horiztile:
       impl:
-        method: SetHorizTile
+        field: horizTile
       type: boolean
     nonblocking:
       impl:
@@ -1424,13 +1424,13 @@ Texture:
       type: boolean
     texelsnappingbias:
       impl:
-        method: SetTexelSnappingBias
+        field: texelSnappingBias
       type: number
     useatlassize:
       type: boolean
     verttile:
       impl:
-        method: SetVertTile
+        field: vertTile
       type: boolean
   contents:
     tags:

--- a/data/products/wowxptr/xml.yaml
+++ b/data/products/wowxptr/xml.yaml
@@ -35,11 +35,11 @@ Alpha:
   attributes:
     fromalpha:
       impl:
-        method: SetFromAlpha
+        field: fromAlpha
       type: number
     toalpha:
       impl:
-        method: SetToAlpha
+        field: toAlpha
       type: number
   extends: Animation
 Anchor:
@@ -85,7 +85,7 @@ Animation:
       type: string
     smoothing:
       impl:
-        method: SetSmoothing
+        field: smoothing
       type: string
     startdelay:
       impl:
@@ -105,7 +105,7 @@ AnimationGroup:
       type: stringlist
     looping:
       impl:
-        method: SetLooping
+        field: looping
       type: string
     mixin:
       impl: internal
@@ -193,7 +193,7 @@ Button:
   attributes:
     motionscriptswhiledisabled:
       impl:
-        method: SetMotionScriptsWhileDisabled
+        field: motionScriptsWhileDisabled
       type: boolean
     registerforclicks:
       impl:
@@ -412,12 +412,12 @@ Font:
       type: stringlist
     justifyh:
       impl:
-        method: SetJustifyH
+        field: justifyh
       type:
         stringenum: JustifyHorizontal
     justifyv:
       impl:
-        method: SetJustifyV
+        field: justifyv
       type:
         stringenum: JustifyVertical
     monochrome:
@@ -452,12 +452,12 @@ FontString:
       type: string
     justifyh:
       impl:
-        method: SetJustifyH
+        field: justifyh
       type:
         stringenum: JustifyHorizontal
     justifyv:
       impl:
-        method: SetJustifyV
+        field: justifyv
       type:
         stringenum: JustifyVertical
     maxlines:
@@ -485,7 +485,7 @@ Frame:
   attributes:
     clampedtoscreen:
       impl:
-        method: SetClampedToScreen
+        field: isClampedToScreen
       type: boolean
     clipchildren:
       impl:
@@ -509,7 +509,7 @@ Frame:
       type: boolean
     enablemousewheel:
       impl:
-        method: EnableMouseWheel
+        field: mouseWheelEnabled
       type: boolean
     flattenrenderlayers:
       type: boolean
@@ -519,21 +519,21 @@ Frame:
       type: number
     framestrata:
       impl:
-        method: SetFrameStrata
+        field: frameStrata
       type: string
     hyperlinksenabled:
       impl:
-        method: SetHyperlinksEnabled
+        field: hyperlinksEnabled
       type: boolean
     id:
       impl:
-        method: SetID
+        field: id
       type: number
     intrinsic:
       type: boolean
     movable:
       impl:
-        method: SetMovable
+        field: movable
       type: boolean
     parent:
       impl: internal
@@ -547,14 +547,14 @@ Frame:
       type: boolean
     resizable:
       impl:
-        method: SetResizable
+        field: resizable
       type: boolean
     securemixin:
       impl: internal
       type: stringlist
     toplevel:
       impl:
-        method: SetToplevel
+        field: toplevel
       type: boolean
     useparentlevel:
       type: boolean
@@ -671,11 +671,11 @@ LayoutFrame:
       type: boolean
     ignoreparentalpha:
       impl:
-        method: SetIgnoreParentAlpha
+        field: isIgnoringParentAlpha
       type: boolean
     ignoreparentscale:
       impl:
-        method: SetIgnoreParentScale
+        field: isIgnoringParentScale
       type: boolean
     inherits:
       type: stringlist
@@ -1314,15 +1314,15 @@ Slider:
       type: boolean
     orientation:
       impl:
-        method: SetOrientation
+        field: orientation
       type: string
     stepsperpage:
       impl:
-        method: SetStepsPerPage
+        field: stepsPerPage
       type: number
     valuestep:
       impl:
-        method: SetValueStep
+        field: valueStep
       type: number
   contents:
     tags:
@@ -1342,7 +1342,7 @@ StatusBar:
       type: number
     reversefill:
       impl:
-        method: SetReverseFill
+        field: reverseFill
       type: boolean
   contents:
     tags:
@@ -1372,7 +1372,7 @@ Texture:
   attributes:
     alphamode:
       impl:
-        method: SetBlendMode
+        field: blendMode
       type:
         stringenum: BlendMode
     atlas:
@@ -1389,7 +1389,7 @@ Texture:
       type: string
     horiztile:
       impl:
-        method: SetHorizTile
+        field: horizTile
       type: boolean
     nonblocking:
       impl:
@@ -1401,13 +1401,13 @@ Texture:
       type: boolean
     texelsnappingbias:
       impl:
-        method: SetTexelSnappingBias
+        field: texelSnappingBias
       type: number
     useatlassize:
       type: boolean
     verttile:
       impl:
-        method: SetVertTile
+        field: vertTile
       type: boolean
   contents:
     tags:

--- a/spec/data/xml_spec.lua
+++ b/spec/data/xml_spec.lua
@@ -32,50 +32,56 @@ describe('xml', function()
         flatten(k)
       end
       for name, elem in pairs(xml) do
-        if elem.extends == 'ScriptType' then
-          it(name .. ' is in scripttypes', function()
-            assert.Not.Nil(scripttypes[name])
-          end)
-        end
-        -- Non-virtual xml tags that instantiate a uiobject type must only carry
-        -- method/field attribute impls resolvable on that type, so attribute
-        -- application never needs a does-this-method-exist check at runtime.
-        if uiobjects[name] and not elem.virtual then
-          local attrs = {}
-          local e = elem
-          while e do
-            for an, a in pairs(e.attributes or {}) do
-              attrs[an] = attrs[an] or a
-            end
-            e = e.extends and xml[e.extends] or nil
+        describe(name, function()
+          if elem.extends == 'ScriptType' then
+            it('is in scripttypes', function()
+              assert.Not.Nil(scripttypes[name])
+            end)
           end
-          it(name .. ' attribute impls resolve', function()
-            for an, a in pairs(attrs) do
-              local impl = type(a.impl) == 'table' and a.impl or nil
-              if impl and impl.method then
-                assert(methods[name][impl.method], ('%s.%s: no method %s'):format(name, an, impl.method))
-              elseif impl and impl.field then
-                assert(fields[name][impl.field], ('%s.%s: no field %s'):format(name, an, impl.field))
+          -- Non-virtual xml tags that instantiate a uiobject type must only carry
+          -- method/field attribute impls resolvable on that type, so attribute
+          -- application never needs a does-this-method-exist check at runtime.
+          if uiobjects[name] and not elem.virtual then
+            local attrs = {}
+            local e = elem
+            while e do
+              for an, a in pairs(e.attributes or {}) do
+                attrs[an] = attrs[an] or a
               end
+              e = e.extends and xml[e.extends] or nil
             end
-          end)
-          -- A method whose entire implementation is a generated trivial setter
-          -- (self.field = value, no side effects) should be declared with a
-          -- field impl instead, so attribute application skips the method
-          -- call/lookup entirely.
-          it(name .. ' method attribute impls are not trivial setters', function()
-            for an, a in pairs(attrs) do
-              local impl = type(a.impl) == 'table' and a.impl or nil
-              if impl and impl.method then
-                local mimpl = methods[name][impl.method]
-                assert(
-                  not (type(mimpl) == 'table' and mimpl.setter),
-                  ('%s.%s: method %s is a trivial setter, use a field impl instead'):format(name, an, impl.method)
-                )
+            describe('attribute impls resolve', function()
+              for an, a in pairs(attrs) do
+                it(an, function()
+                  local impl = type(a.impl) == 'table' and a.impl or nil
+                  if impl and impl.method then
+                    assert(methods[name][impl.method], ('%s.%s: no method %s'):format(name, an, impl.method))
+                  elseif impl and impl.field then
+                    assert(fields[name][impl.field], ('%s.%s: no field %s'):format(name, an, impl.field))
+                  end
+                end)
               end
-            end
-          end)
-        end
+            end)
+            -- A method whose entire implementation is a generated trivial setter
+            -- (self.field = value, no side effects) should be declared with a
+            -- field impl instead, so attribute application skips the method
+            -- call/lookup entirely.
+            describe('method attribute impls are not trivial setters', function()
+              for an, a in pairs(attrs) do
+                it(an, function()
+                  local impl = type(a.impl) == 'table' and a.impl or nil
+                  if impl and impl.method then
+                    local mimpl = methods[name][impl.method]
+                    assert(
+                      not (type(mimpl) == 'table' and mimpl.setter),
+                      ('%s.%s: method %s is a trivial setter, use a field impl instead'):format(name, an, impl.method)
+                    )
+                  end
+                end)
+              end
+            end)
+          end
+        end)
       end
     end)
   end

--- a/spec/data/xml_spec.lua
+++ b/spec/data/xml_spec.lua
@@ -11,15 +11,15 @@ describe('xml', function()
           local m, f = {}, {}
           for inh in pairs(uiobjects[k].inherits) do
             flatten(inh)
-            for mk in pairs(methods[inh]) do
-              m[mk] = true
+            for mk, mv in pairs(methods[inh]) do
+              m[mk] = mv
             end
             for fk in pairs(fields[inh]) do
               f[fk] = true
             end
           end
-          for mk in pairs(uiobjects[k].methods) do
-            m[mk] = true
+          for mk, mv in pairs(uiobjects[k].methods) do
+            m[mk] = mv.impl or true
           end
           for fk in pairs(uiobjects[k].fields) do
             f[fk] = true
@@ -41,21 +41,37 @@ describe('xml', function()
         -- method/field attribute impls resolvable on that type, so attribute
         -- application never needs a does-this-method-exist check at runtime.
         if uiobjects[name] and not elem.virtual then
-          it(name .. ' attribute impls resolve', function()
-            local attrs = {}
-            local e = elem
-            while e do
-              for an, a in pairs(e.attributes or {}) do
-                attrs[an] = attrs[an] or a
-              end
-              e = e.extends and xml[e.extends] or nil
+          local attrs = {}
+          local e = elem
+          while e do
+            for an, a in pairs(e.attributes or {}) do
+              attrs[an] = attrs[an] or a
             end
+            e = e.extends and xml[e.extends] or nil
+          end
+          it(name .. ' attribute impls resolve', function()
             for an, a in pairs(attrs) do
               local impl = type(a.impl) == 'table' and a.impl or nil
               if impl and impl.method then
                 assert(methods[name][impl.method], ('%s.%s: no method %s'):format(name, an, impl.method))
               elseif impl and impl.field then
                 assert(fields[name][impl.field], ('%s.%s: no field %s'):format(name, an, impl.field))
+              end
+            end
+          end)
+          -- A method whose entire implementation is a generated trivial setter
+          -- (self.field = value, no side effects) should be declared with a
+          -- field impl instead, so attribute application skips the method
+          -- call/lookup entirely.
+          it(name .. ' method attribute impls are not trivial setters', function()
+            for an, a in pairs(attrs) do
+              local impl = type(a.impl) == 'table' and a.impl or nil
+              if impl and impl.method then
+                local mimpl = methods[name][impl.method]
+                assert(
+                  not (type(mimpl) == 'table' and mimpl.setter),
+                  ('%s.%s: method %s is a trivial setter, use a field impl instead'):format(name, an, impl.method)
+                )
               end
             end
           end)


### PR DESCRIPTION
## Summary

- Step 1 of the ask (\"xml_spec validates that fields/methods exist on the objects they would apply to\") is already satisfied on `main` by `3f28acb8b` (`data: xml attribute impls must resolve on their uiobject type`) — no new PR needed for it.
- This PR is step 2: it adds a new `spec/data/xml_spec.lua` check requiring `method:` attribute impls to resolve to something other than a bare generated setter (`self.field = value`, no side effects), since those are strictly worse than declaring `field:` directly (extra method call/lookup at attribute-application time for identical behavior).
- Migrates the 24 attribute/method pairs across all 8 products that violated the new rule (`movable`→`SetMovable`, `justifyh`/`justifyv`→`SetJustifyH`/`SetJustifyV`, `framestrata`→`SetFrameStrata`, `smoothing`→`SetSmoothing`, etc.) to use `field:` impls instead.
- Verified via a standalone analysis that none of these methods have a differing (non-setter) override on any uiobject type reachable through an xml attribute that uses them, so the migration is behavior-preserving everywhere it applies.

## Test plan

- [x] `cmake --build --preset default --target test` passes cleanly (no output)
- [x] `pre-commit run -a` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VnGci4uREFUSEDzJniV6TW