### PR TITLE
luaobjects: attach host metatable to host rep table

### DIFF
--- a/wowless/modules/luaobjects.lua
+++ b/wowless/modules/luaobjects.lua
@@ -4,6 +4,7 @@ return function(cstubs, datalua)
   local config = datalua.config.modules and datalua.config.modules.luaobjects or {}
   local typeids = {}
   local impltypes = {}
+  local host_mts = {}
 
   local function LoadTypes(modules)
     local type_stubs = cstubs.loadluaobjects(modules, luaobject, config.tostring_metamethod)
@@ -12,7 +13,11 @@ return function(cstubs, datalua)
     end
     for k, v in pairs(datalua.luaobjects) do
       if v.impl and not v.virtual then
-        impltypes[k] = modules[v.impl]
+        local impl = modules[v.impl]
+        impltypes[k] = impl
+        if impl.methods then
+          host_mts[k] = { __index = impl.methods }
+        end
       end
     end
   end
@@ -20,6 +25,7 @@ return function(cstubs, datalua)
   local function Create(k, ...)
     local impl = impltypes[k]
     local obj = { assert(typeids[k], k), table = {} }
+    setmetatable(obj, host_mts[k])
     if impl and impl.construct then
       impl.construct(obj, ...)
     end
@@ -30,6 +36,7 @@ return function(cstubs, datalua)
     local impl = impltypes[k]
     if impl and impl.coerce then
       local obj = { assert(typeids[k], k), table = {} }
+      setmetatable(obj, host_mts[k])
       if impl.coerce(obj, value) then
         return obj
       end


### PR DESCRIPTION
## Summary

- Updates `vendor/dbdefs` to include the `12.1.0.68629` build for `FactionGroup` (needed since the wowt bump; picked up from upstream `wowdev/wowdbdefs` master)
- For impl-backed luaobject types (currently only `LuaFunctionContainer`), builds a per-type `host_mt = { __index = impl.methods }` during `LoadTypes` and applies it to the host rep table (`obj`) in both `Create` and `Coerce`

The host rep table is the plain Lua table stored as the fenv of the sandbox userdata proxy. After this change, host-side code can call `obj:Cancel()`, `obj:IsCancelled()`, etc. using colon syntax instead of `impl.methods.Cancel(obj)`.

No changes to C code, prep.lua, YAML schemas, impl modules, or generated stubs.

Generated with Claude Code https://claude.ai/code/session_019p5JtuhF4VmL3TpcxUuCFR