### PR TITLE
xml: assert every used scripttype is a ScriptType in xml.yaml

### DIFF
--- a/spec/data/xml_spec.lua
+++ b/spec/data/xml_spec.lua
@@ -31,6 +31,17 @@ describe('xml', function()
       for k in pairs(uiobjects) do
         flatten(k)
       end
+      local usedscripts = {}
+      for _, obj in pairs(uiobjects) do
+        for name in pairs(obj.scripts or {}) do
+          usedscripts[name] = true
+        end
+      end
+      for name in pairs(usedscripts) do
+        it(name .. ' is a ScriptType in xml', function()
+          assert.equals('ScriptType', xml[name] and xml[name].extends)
+        end)
+      end
       for name, elem in pairs(xml) do
         describe(name, function()
           if elem.extends == 'ScriptType' then


### PR DESCRIPTION
For each product, checks that every script name referenced by
uiobjects.yaml's scripts fields is present in xml.yaml as a tag
extending ScriptType. Currently holds for all products with no
fixes needed.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_015HztdE63jaKzjk2yBCcxCW
