### PR TITLE
uiobjects: give CreateUIObject layer/sublevel params, unify layered-region creators

### DIFF
--- a/data/products/wow/xml.yaml
+++ b/data/products/wow/xml.yaml
@@ -625,6 +625,8 @@ Layer:
       required: true
       type: string
     texturesublevel:
+      impl:
+        scope: sublevel
       type: number
   contents:
     tags:

--- a/data/products/wow_anniversary/xml.yaml
+++ b/data/products/wow_anniversary/xml.yaml
@@ -625,6 +625,8 @@ Layer:
       required: true
       type: string
     texturesublevel:
+      impl:
+        scope: sublevel
       type: number
   contents:
     tags:

--- a/data/products/wow_classic/xml.yaml
+++ b/data/products/wow_classic/xml.yaml
@@ -625,6 +625,8 @@ Layer:
       required: true
       type: string
     texturesublevel:
+      impl:
+        scope: sublevel
       type: number
   contents:
     tags:

--- a/data/products/wow_classic_era/xml.yaml
+++ b/data/products/wow_classic_era/xml.yaml
@@ -625,6 +625,8 @@ Layer:
       required: true
       type: string
     texturesublevel:
+      impl:
+        scope: sublevel
       type: number
   contents:
     tags:

--- a/data/products/wow_classic_era_ptr/xml.yaml
+++ b/data/products/wow_classic_era_ptr/xml.yaml
@@ -625,6 +625,8 @@ Layer:
       required: true
       type: string
     texturesublevel:
+      impl:
+        scope: sublevel
       type: number
   contents:
     tags:

--- a/data/products/wow_classic_ptr/xml.yaml
+++ b/data/products/wow_classic_ptr/xml.yaml
@@ -625,6 +625,8 @@ Layer:
       required: true
       type: string
     texturesublevel:
+      impl:
+        scope: sublevel
       type: number
   contents:
     tags:

--- a/data/products/wowt/xml.yaml
+++ b/data/products/wowt/xml.yaml
@@ -625,6 +625,8 @@ Layer:
       required: true
       type: string
     texturesublevel:
+      impl:
+        scope: sublevel
       type: number
   contents:
     tags:

--- a/data/products/wowxptr/xml.yaml
+++ b/data/products/wowxptr/xml.yaml
@@ -625,6 +625,8 @@ Layer:
       required: true
       type: string
     texturesublevel:
+      impl:
+        scope: sublevel
       type: number
   contents:
     tags:

--- a/data/uiobjectimpl.yaml
+++ b/data/uiobjectimpl.yaml
@@ -65,7 +65,6 @@ Frame/CreateFontString:
   luafile:
     modules:
       api:
-      templates:
 Frame/CreateLine:
   luafile:
     modules:
@@ -78,7 +77,6 @@ Frame/CreateTexture:
   luafile:
     modules:
       api:
-      templates:
 Frame/GetAttribute:
   luafile:
 Frame/GetChildren:

--- a/data/uiobjects/Frame/CreateFontString.lua
+++ b/data/uiobjects/Frame/CreateFontString.lua
@@ -1,12 +1,4 @@
-local api, templates = ...
+local api = ...
 return function(self, name, layer, inherits)
-  local tmpls = {}
-  for templateName in string.gmatch(inherits or '', '[^, ]+') do
-    table.insert(tmpls, templates.GetTemplateOrThrow(templateName))
-  end
-  local fs = api.CreateUIObject('fontstring', type(name) == 'string' and name or nil, self, nil, tmpls)
-  if layer then
-    fs:SetDrawLayer(layer)
-  end
-  return fs
+  return api.CreateChildUIObject('fontstring', self, type(name) == 'string' and name or nil, inherits, layer)
 end

--- a/data/uiobjects/Frame/CreateLine.lua
+++ b/data/uiobjects/Frame/CreateLine.lua
@@ -1,4 +1,4 @@
 local api = ...
-return function(self)
-  return api.CreateUIObject('line', nil, self)
+return function(self, name, layer, inherits, sublevel)
+  return api.CreateChildUIObject('line', self, name, inherits, layer, sublevel)
 end

--- a/data/uiobjects/Frame/CreateMaskTexture.lua
+++ b/data/uiobjects/Frame/CreateMaskTexture.lua
@@ -1,4 +1,4 @@
 local api = ...
-return function(self)
-  return api.CreateUIObject('masktexture', nil, self)
+return function(self, name, layer, inherits, sublevel)
+  return api.CreateChildUIObject('masktexture', self, name, inherits, layer, sublevel)
 end

--- a/data/uiobjects/Frame/CreateTexture.lua
+++ b/data/uiobjects/Frame/CreateTexture.lua
@@ -1,13 +1,4 @@
-local api, templates = ...
-return function(self, name, layer, inherits, sublayer)
-  -- TODO unify with api
-  local tmpls = {}
-  for templateName in string.gmatch(inherits or '', '[^, ]+') do
-    table.insert(tmpls, templates.GetTemplateOrThrow(templateName))
-  end
-  local tex = api.CreateUIObject('texture', name, self, nil, tmpls)
-  if layer then
-    tex:SetDrawLayer(layer, sublayer)
-  end
-  return tex
+local api = ...
+return function(self, name, layer, inherits, sublevel)
+  return api.CreateChildUIObject('texture', self, name, inherits, layer, sublevel)
 end

--- a/wowless/modules/api.lua
+++ b/wowless/modules/api.lua
@@ -160,7 +160,7 @@ return function(
     for _, template in ipairs(tmpls) do
       template.initEarlyAttrs(ud)
     end
-    if layer or sublevel then
+    if (layer or sublevel) and ud.SetDrawLayer then
       ud:SetDrawLayer(layer or ud.layer, sublevel or ud.sublevel)
     end
     if objname then

--- a/wowless/modules/api.lua
+++ b/wowless/modules/api.lua
@@ -124,7 +124,7 @@ return function(
     end
   end
 
-  local function CreateUIObject(typename, objnamearg, parent, addonEnv, tmplsarg, id)
+  local function CreateUIObject(typename, objnamearg, parent, addonEnv, tmplsarg, id, layer, sublevel)
     local objname
     if type(objnamearg) == 'string' then
       objname = ParentSub(objnamearg, parent)
@@ -159,6 +159,9 @@ return function(
     end
     for _, template in ipairs(tmpls) do
       template.initEarlyAttrs(ud)
+    end
+    if layer or sublevel then
+      ud:SetDrawLayer(layer or ud.layer, sublevel or ud.sublevel)
     end
     if objname then
       if type(objnamearg) == 'string' then
@@ -213,7 +216,16 @@ return function(
     return CreateUIObject(ltype, name, parent, nil, tmpls, id)
   end
 
+  local function CreateChildUIObject(typename, self, name, inherits, layer, sublevel)
+    local tmpls = {}
+    for templateName in string.gmatch(inherits or '', '[^, ]+') do
+      table.insert(tmpls, templates.GetTemplateOrThrow(templateName))
+    end
+    return CreateUIObject(typename, name, self, nil, tmpls, nil, layer, sublevel)
+  end
+
   return {
+    CreateChildUIObject = CreateChildUIObject,
     CreateForbiddenFrame = CreateFrame, -- TODO implement properly
     CreateFrame = CreateFrame,
     CreateUIObject = CreateUIObject,

--- a/wowless/modules/loader.lua
+++ b/wowless/modules/loader.lua
@@ -547,9 +547,6 @@ return function(
 
       local phases = {
         EarlyAttrs = function(ctx, e, obj)
-          if ctx.layer and obj.SetDrawLayer then
-            obj:SetDrawLayer(ctx.layer)
-          end
           processAttrs(ctx, e, obj, 'early')
         end,
         Attrs = function(ctx, e, obj)
@@ -642,7 +639,7 @@ return function(
               end
               local ety = e.type == 'worldframe' and 'frame' or e.type
               local env = ctx.useAddonEnv and addonEnv or ctx.useSecureEnv and secureenv or genv
-              return api.CreateUIObject(ety, name, parent, env, { template })
+              return api.CreateUIObject(ety, name, parent, env, { template }, nil, ctx.layer, ctx.sublevel)
             end
           end
         else


### PR DESCRIPTION
## Summary
- `CreateUIObject` now takes optional `layer`/`sublevel` params and applies them before `OnLoad` fires, instead of each caller bolting on a post-hoc `SetDrawLayer` call after the object (and its `OnLoad`) already exist.
- New `CreateChildUIObject` helper in `wowless/modules/api.lua` centralizes the template-name-parsing loop that `CreateTexture`/`CreateFontString`/`CreateLine`/`CreateMaskTexture` each duplicated (addressing the `-- TODO unify with api` in `CreateTexture.lua`).
- `CreateLine` and `CreateMaskTexture` previously ignored every argument, including `name` — they now honor their full declared API surface (`name`, `drawLayer`, `templateName`, `subLevel`), matching `CreateTexture`/`CreateFontString`.
- The XML loader passes `ctx.layer`/`ctx.sublevel` straight into `CreateUIObject` instead of a separate `EarlyAttrs` special case for `SetDrawLayer`. `CreateUIObject` guards the call on `ud.SetDrawLayer` existing, since `ctx.layer` isn't scoped to just `<Layer>`'s immediate children — it's ambient for the rest of that subtree, so it can still reach a non-layered descendant (e.g. an `AnimationGroup` nested inside a Layer's `<Texture><Animations>`) even though only `Texture`/`MaskTexture`/`FontString`/`Line` are valid direct Layer content per `UI.xsd`. This matches the pre-existing behavior of the `EarlyAttrs` special case being replaced.
- `<Layer texturesublevel="...">` now has a `scope: sublevel` impl (mirroring `level`'s `scope: layer`) across all 8 product `xml.yaml` files — previously it was parsed but had no effect at all.

## Test plan
- [x] `cmake --build --preset default --target test` (all 8 products, addon + elune scriptcases)
- [x] `cmake --build --preset default --target outs` (all 8 products, log.txt empty)
- [x] `pre-commit run -a`