### PR TITLE
gentest: add per-product template test framework for XML attribute coercion

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -670,6 +670,8 @@ foreach(product ${products})
   gentest(luaobjects.lua luaobjects)
   gentest(namespaceapis.lua namespaceapis)
   gentest(product.lua product)
+  gentest(templates.lua templates)
+  gentest(templates.xml templatexml)
   gentest(uiobjectapis.lua uiobjectapis)
   add_custom_command(
     OUTPUT ${product}_addon.txt

--- a/addon/Wowless/generated.lua
+++ b/addon/Wowless/generated.lua
@@ -613,6 +613,20 @@ G.testsuite.generated = function()
     return tests
   end
 
+  local function templates()
+    local tests = {}
+    for name, cfg in pairs(_G.WowlessData.Templates) do
+      tests[name] = function()
+        local obj = _G.WowlessGeneratedXmlTests
+        for _, key in ipairs(cfg.objectPath) do
+          obj = obj[key]
+        end
+        assertEquals(cfg.expected, obj[cfg.getter](obj))
+      end
+    end
+    return tests
+  end
+
   return {
     apiNamespaces = apiNamespaces,
     cvars = cvars,
@@ -620,6 +634,7 @@ G.testsuite.generated = function()
     globalApis = globalApis,
     globals = globals,
     impltests = impltests,
+    templates = templates,
     uiobjects = uiobjects,
     ['~cfuncs'] = cfuncs.test,
   }

--- a/tools/generatexmltest.lua
+++ b/tools/generatexmltest.lua
@@ -17,6 +17,7 @@ end)()
 
 local sorted = require('pl.tablex').sort
 local scripttypes = readyaml('data/scripttypes.yaml')
+local stringenums = readyaml('data/products/wow/stringenums.yaml')
 
 local function hack(s)
   return 'end,(function()' .. s .. ' end)()--'
@@ -65,6 +66,36 @@ local content = {
       end
       assertEquals(table.concat(expected, ','), table.concat(WowlessLog, ','))
     ]],
+  },
+  {
+    tag = 'Frame',
+    {
+      tag = 'Layers',
+      (function()
+        local function fontString(justify, point)
+          return {
+            tag = 'FontString',
+            justifyH = justify,
+            {
+              tag = 'Scripts',
+              {
+                tag = 'OnLoad',
+                text = ([[
+                  Wowless.check1(1, self:GetNumPoints())
+                  Wowless.check5('%s', self:GetParent(), '%s', 0, 0, self:GetPoint(1))
+                ]]):format(point, point),
+              },
+            },
+          }
+        end
+        local layer = { tag = 'Layer', fontString(nil, 'CENTER') }
+        for name in sorted(stringenums.JustifyHorizontal) do
+          table.insert(layer, fontString(name, name))
+          table.insert(layer, fontString(name:lower(), name))
+        end
+        return layer
+      end)(),
+    },
   },
   (function()
     -- KeyValue/attribute type coercion cases, one row per key: the raw XML

--- a/tools/generatexmltest.lua
+++ b/tools/generatexmltest.lua
@@ -17,7 +17,6 @@ end)()
 
 local sorted = require('pl.tablex').sort
 local scripttypes = readyaml('data/scripttypes.yaml')
-local stringenums = readyaml('data/products/wow/stringenums.yaml')
 
 local function hack(s)
   return 'end,(function()' .. s .. ' end)()--'
@@ -66,36 +65,6 @@ local content = {
       end
       assertEquals(table.concat(expected, ','), table.concat(WowlessLog, ','))
     ]],
-  },
-  {
-    tag = 'Frame',
-    {
-      tag = 'Layers',
-      (function()
-        local function fontString(justify, point)
-          return {
-            tag = 'FontString',
-            justifyH = justify,
-            {
-              tag = 'Scripts',
-              {
-                tag = 'OnLoad',
-                text = ([[
-                  Wowless.check1(1, self:GetNumPoints())
-                  Wowless.check5('%s', self:GetParent(), '%s', 0, 0, self:GetPoint(1))
-                ]]):format(point, point),
-              },
-            },
-          }
-        end
-        local layer = { tag = 'Layer', fontString(nil, 'CENTER') }
-        for name in sorted(stringenums.JustifyHorizontal) do
-          table.insert(layer, fontString(name, name))
-          table.insert(layer, fontString(name:lower(), name))
-        end
-        return layer
-      end)(),
-    },
   },
   (function()
     -- KeyValue/attribute type coercion cases, one row per key: the raw XML

--- a/tools/gentest.lua
+++ b/tools/gentest.lua
@@ -26,7 +26,165 @@ local function tpath(t, ...)
   return t
 end
 
-local ptablemap = {
+local function renderXml(x)
+  local attrs = {}
+  for k in pairs(x) do
+    if type(k) == 'string' and k ~= 'tag' then
+      table.insert(attrs, k)
+    end
+  end
+  table.sort(attrs)
+  local astr = {}
+  for _, k in ipairs(attrs) do
+    table.insert(astr, (' %s=\'%s\''):format(k, tostring(x[k])))
+  end
+  local kids = {}
+  for _, v in ipairs(x) do
+    table.insert(kids, renderXml(v))
+  end
+  if #kids == 0 then
+    return ('<%s%s />'):format(x.tag, table.concat(astr))
+  end
+  return ('<%s%s>%s</%s>'):format(x.tag, table.concat(astr), table.concat(kids), x.tag)
+end
+
+-- Which XML tags are reachable, recursively, as descendants of <Frame>?
+-- Mirrors the supertypes/children containment logic wowless/modules/xml.lua
+-- itself uses at runtime (built in tools/prep.lua's xmlflat).
+local function framesReachable(p)
+  local xml = perproduct(p, 'xml')
+  local function supertypesOf(tag)
+    local st = { [tag:lower()] = true }
+    local t = xml[tag]
+    while t.extends do
+      st[t.extends:lower()] = true
+      t = xml[t.extends]
+    end
+    return st
+  end
+  local function childrenOf(tag)
+    local kids = {}
+    local t = xml[tag]
+    while true do
+      if t.contents and t.contents ~= 'text' then
+        for kid in pairs(t.contents.tags) do
+          kids[kid:lower()] = true
+        end
+      end
+      if not t.extends then
+        break
+      end
+      t = xml[t.extends]
+    end
+    return kids
+  end
+  local supertypes, children = {}, {}
+  for tag in pairs(xml) do
+    supertypes[tag] = supertypesOf(tag)
+    children[tag] = childrenOf(tag)
+  end
+  local reachable = { Frame = true }
+  local frontier = { 'Frame' }
+  while #frontier > 0 do
+    local from = table.remove(frontier)
+    local allowed = children[from]
+    for tag in pairs(xml) do
+      if not reachable[tag] then
+        for st in pairs(supertypes[tag]) do
+          if allowed[st] then
+            reachable[tag] = true
+            table.insert(frontier, tag)
+            break
+          end
+        end
+      end
+    end
+  end
+  return reachable
+end
+
+local ptablemap
+
+-- Every (tag, attribute) pair typed stringenum:/enum:, for tags reachable
+-- from Frame (see framesReachable) -- these are eligible for per-product
+-- XML-attribute-value template tests. An eligible attribute's impl is
+-- required to be field-based (data/schemas/xml.yaml's attribute impl
+-- taggedunion also allows method/internal/loadfile/scope, but every
+-- stringenum-/enum-typed attribute reachable from Frame today uses
+-- `impl.field` directly) -- resolve the field's default and real getter
+-- method via the existing uiobjectapis entry's already-computed,
+-- inherits-flattened field/getter data, rather than re-deriving either
+-- from string transforms.
+local function discoverCases(p)
+  local reachable = framesReachable(p)
+  local _, uiobjectApis = ptablemap.uiobjectapis(p)
+  local cases = {}
+  for tag, tdef in pairs(perproduct(p, 'xml')) do
+    if reachable[tag] then
+      for attrKey, attrDef in pairs(tdef.attributes or {}) do
+        local ty = attrDef.type
+        if ty.stringenum or ty.enum then
+          local fieldName = assert(attrDef.impl.field, 'unsupported attribute impl for ' .. tag .. '.' .. attrKey)
+          local fv = uiobjectApis[tag].fields[fieldName]
+          table.insert(cases, {
+            getter = fv.getters[1].method,
+            id = tag:lower() .. '_' .. attrKey,
+            init = fv.init,
+            xmlAttrKey = attrKey,
+            xmlTag = tag,
+          })
+        end
+      end
+    end
+  end
+  return cases
+end
+
+local function attrMembers(p, case)
+  local ty = perproduct(p, 'xml')[case.xmlTag].attributes[case.xmlAttrKey].type
+  if ty.stringenum then
+    local members = {}
+    for name in pairs(perproduct(p, 'stringenums')[ty.stringenum]) do
+      members[name] = name
+    end
+    return members
+  elseif ty.enum then
+    return perproduct(p, 'globals').Enum[ty.enum] or {}
+  end
+  error('unsupported template-case attribute type for ' .. case.id)
+end
+
+-- Native candidates from this product's own data (plus a lowercase variant
+-- per stringenum member, to check case-insensitive attribute parsing),
+-- then a negative pass unioning in other products' foreign values: values
+-- valid elsewhere but not native to this product, expecting this
+-- product's own field default (mirrors the events ptablemap entry below).
+local function computeCandidates(p, case)
+  local candidates = {}
+  local native = {}
+  for name, expected in pairs(attrMembers(p, case)) do
+    native[name:upper()] = true
+    table.insert(candidates, { expected = expected, suffix = name:lower(), value = name })
+    if type(expected) == 'string' then
+      table.insert(candidates, { expected = expected, suffix = name:lower() .. '_lower', value = name:lower() })
+    end
+  end
+  local seenForeign = {}
+  for _, product in ipairs(readyaml('data/products.yaml')) do
+    if product ~= p then
+      for name in pairs(attrMembers(product, case)) do
+        local upper = name:upper()
+        if not native[upper] and not seenForeign[upper] then
+          seenForeign[upper] = true
+          table.insert(candidates, { expected = case.init, suffix = name:lower(), value = name })
+        end
+      end
+    end
+  end
+  return candidates
+end
+
+ptablemap = {
   build = function(p)
     return 'Build', perproduct(p, 'build')
   end,
@@ -206,6 +364,16 @@ local ptablemap = {
     end
     return 'NamespaceApis', t
   end,
+  templates = function(p)
+    local t = {}
+    for _, case in ipairs(discoverCases(p)) do
+      for _, c in ipairs(computeCandidates(p, case)) do
+        local key = case.id .. '_' .. c.suffix
+        t[key] = { expected = c.expected, getter = case.getter, objectPath = { key } }
+      end
+    end
+    return 'Templates', t
+  end,
   uiobjectapis = function(p)
     local uiobjects = perproduct(p, 'uiobjects')
     local allscripts = readyaml('data/scripttypes.yaml')
@@ -325,11 +493,27 @@ local function doit(k, p)
     return '_G.WowlessData.' .. nn .. ' = ' .. require('tools.prettywrite')(tt) .. '\n'
   elseif k == 'product' then
     return ('_G.WowlessData = { product = %q }'):format(p)
+  elseif k == 'templatexml' then
+    local layer = { tag = 'Layer' }
+    for _, case in ipairs(discoverCases(p)) do
+      for _, c in ipairs(computeCandidates(p, case)) do
+        table.insert(layer, {
+          [case.xmlAttrKey] = c.value,
+          parentKey = case.id .. '_' .. c.suffix,
+          tag = case.xmlTag,
+        })
+      end
+    end
+    return renderXml({
+      { name = 'WowlessGeneratedXmlTests', tag = 'Frame', { tag = 'Layers', layer } },
+      tag = 'Ui',
+    })
   elseif k == 'toc' then
     local tt = {}
     for kk in pairs(ptablemap) do
       table.insert(tt, kk .. '.lua')
     end
+    table.insert(tt, 'templates.xml')
     table.sort(tt)
     table.insert(tt, 1, 'product.lua')
     table.insert(tt, 1, '## Interface: ' .. perproduct(p, 'build').tocversion)

--- a/tools/gentest.lua
+++ b/tools/gentest.lua
@@ -27,25 +27,33 @@ local function tpath(t, ...)
 end
 
 local function renderXml(x)
-  local attrs = {}
-  for k in pairs(x) do
-    if type(k) == 'string' and k ~= 'tag' then
-      table.insert(attrs, k)
+  local function doRenderXml(y, n, t)
+    local attrs = {}
+    for k in pairs(y) do
+      if type(k) == 'string' and k ~= 'tag' then
+        table.insert(attrs, k)
+      end
+    end
+    table.sort(attrs)
+    local tt = { (' '):rep(n), '<', y.tag }
+    for _, k in ipairs(attrs) do
+      table.insert(tt, (' %s=\'%s\''):format(k, tostring(y[k])))
+    end
+    if #y == 0 then
+      table.insert(tt, ' />')
+      table.insert(t, table.concat(tt))
+    else
+      table.insert(tt, '>')
+      table.insert(t, table.concat(tt))
+      for _, v in ipairs(y) do
+        doRenderXml(v, n + 2, t)
+      end
+      table.insert(t, table.concat({ (' '):rep(n), '</', y.tag, '>' }))
     end
   end
-  table.sort(attrs)
-  local astr = {}
-  for _, k in ipairs(attrs) do
-    table.insert(astr, (' %s=\'%s\''):format(k, tostring(x[k])))
-  end
-  local kids = {}
-  for _, v in ipairs(x) do
-    table.insert(kids, renderXml(v))
-  end
-  if #kids == 0 then
-    return ('<%s%s />'):format(x.tag, table.concat(astr))
-  end
-  return ('<%s%s>%s</%s>'):format(x.tag, table.concat(astr), table.concat(kids), x.tag)
+  local t = {}
+  doRenderXml(x, 0, t)
+  return table.concat(t, '\n')
 end
 
 -- Which XML tags are reachable, recursively, as descendants of <Frame>?

--- a/tools/gentest.lua
+++ b/tools/gentest.lua
@@ -103,7 +103,113 @@ local function framesReachable(p)
   return reachable
 end
 
-local ptablemap
+-- Per-type field/method data (fields, their init defaults, and which
+-- methods getter/set them), flattened across the inherits chain. Shared by
+-- the uiobjectapis ptablemap entry and discoverCases below.
+local function computeUiobjectApis(p)
+  local uiobjects = perproduct(p, 'uiobjects')
+  local allscripts = readyaml('data/scripttypes.yaml')
+  for _, cfg in pairs(uiobjects) do
+    cfg.fieldinitoverrides = cfg.fieldinitoverrides or {}
+  end
+  for k, cfg in pairs(uiobjects) do
+    cfg.isa = {}
+    for k2, cfg2 in pairs(uiobjects) do
+      cfg.isa[k2] = false
+      if cfg2.objectType then
+        cfg.isa[cfg2.objectType] = false
+      end
+    end
+    if not cfg.virtual or cfg.objectType then
+      cfg.isa[cfg.objectType or k] = true
+    end
+  end
+  local function fixup(cfg)
+    for inhname in pairs(cfg.inherits) do
+      local inh = uiobjects[inhname]
+      fixup(inh)
+      for n, f in pairs(inh.fieldinitoverrides) do
+        cfg.fieldinitoverrides[n] = f
+      end
+      for n, f in pairs(inh.fields) do
+        cfg.fields[n] = f
+      end
+      for n, m in pairs(inh.methods) do
+        cfg.methods[n] = cfg.methods[n] or m -- overrides
+      end
+      if inh.scripts then
+        cfg.scripts = cfg.scripts or {}
+        for n in pairs(inh.scripts) do
+          cfg.scripts[n] = {}
+        end
+      end
+      for ik, iv in pairs(inh.isa) do
+        if iv then
+          cfg.isa[ik] = true
+        end
+      end
+    end
+  end
+  for _, cfg in pairs(uiobjects) do
+    fixup(cfg)
+  end
+  local t = {}
+  for k, v in pairs(uiobjects) do
+    local ft = {}
+    for fk, fv in pairs(v.fields) do
+      local init = fv.init
+      local override = v.fieldinitoverrides[fk]
+      if override ~= nil then
+        init = override
+      end
+      ft[fk] = {
+        dynamicinit = fv.dynamicinit,
+        getters = {},
+        init = init,
+      }
+    end
+    local mt = {}
+    for mk, mv in pairs(v.methods) do
+      mt[mk] = true
+      for gk, gv in ipairs(mv.impl and mv.impl.getter or {}) do
+        table.insert(ft[gv.name].getters, { index = gk, method = mk })
+      end
+    end
+    for fk, fv in pairs(ft) do
+      if fv.dynamicinit then
+        ft[fk] = nil
+      end
+    end
+    -- TODO remove these super duper field hacks
+    ft.parent = nil
+    if v.singleton then
+      ft = {}
+    elseif k == 'EditBox' then
+      ft.shown.init = false
+    end
+    local st = {}
+    for scripttype in pairs(allscripts) do
+      st[scripttype] = not not (v.scripts and v.scripts[scripttype])
+    end
+    t[k] = {
+      fields = ft,
+      isa = v.isa,
+      methods = mt,
+      objtype = v.objectType or k,
+      scripts = st,
+      singleton = v.singleton,
+      virtual = v.virtual,
+    }
+  end
+  for _, product in ipairs(readyaml('data/products.yaml')) do
+    for k in pairs(perproduct(product, 'uiobjects')) do
+      if not t[k] then
+        t[k] = { unsupported = true }
+      end
+    end
+  end
+  return t
+end
 
 -- Every (tag, attribute) pair typed stringenum:/enum:, for tags reachable
 -- from Frame (see framesReachable) -- these are eligible for per-product
@@ -112,12 +218,11 @@ local ptablemap
 -- taggedunion also allows method/internal/loadfile/scope, but every
 -- stringenum-/enum-typed attribute reachable from Frame today uses
 -- `impl.field` directly) -- resolve the field's default and real getter
--- method via the existing uiobjectapis entry's already-computed,
--- inherits-flattened field/getter data, rather than re-deriving either
--- from string transforms.
+-- method via computeUiobjectApis's already-computed, inherits-flattened
+-- field/getter data, rather than re-deriving either from string transforms.
 local function discoverCases(p)
   local reachable = framesReachable(p)
-  local _, uiobjectApis = ptablemap.uiobjectapis(p)
+  local uiobjectApis = computeUiobjectApis(p)
   local cases = {}
   for tag, tdef in pairs(perproduct(p, 'xml')) do
     if reachable[tag] then
@@ -184,7 +289,7 @@ local function computeCandidates(p, case)
   return candidates
 end
 
-ptablemap = {
+local ptablemap = {
   build = function(p)
     return 'Build', perproduct(p, 'build')
   end,
@@ -375,108 +480,7 @@ ptablemap = {
     return 'Templates', t
   end,
   uiobjectapis = function(p)
-    local uiobjects = perproduct(p, 'uiobjects')
-    local allscripts = readyaml('data/scripttypes.yaml')
-    for _, cfg in pairs(uiobjects) do
-      cfg.fieldinitoverrides = cfg.fieldinitoverrides or {}
-    end
-    for k, cfg in pairs(uiobjects) do
-      cfg.isa = {}
-      for k2, cfg2 in pairs(uiobjects) do
-        cfg.isa[k2] = false
-        if cfg2.objectType then
-          cfg.isa[cfg2.objectType] = false
-        end
-      end
-      if not cfg.virtual or cfg.objectType then
-        cfg.isa[cfg.objectType or k] = true
-      end
-    end
-    local function fixup(cfg)
-      for inhname in pairs(cfg.inherits) do
-        local inh = uiobjects[inhname]
-        fixup(inh)
-        for n, f in pairs(inh.fieldinitoverrides) do
-          cfg.fieldinitoverrides[n] = f
-        end
-        for n, f in pairs(inh.fields) do
-          cfg.fields[n] = f
-        end
-        for n, m in pairs(inh.methods) do
-          cfg.methods[n] = cfg.methods[n] or m -- overrides
-        end
-        if inh.scripts then
-          cfg.scripts = cfg.scripts or {}
-          for n in pairs(inh.scripts) do
-            cfg.scripts[n] = {}
-          end
-        end
-        for ik, iv in pairs(inh.isa) do
-          if iv then
-            cfg.isa[ik] = true
-          end
-        end
-      end
-    end
-    for _, cfg in pairs(uiobjects) do
-      fixup(cfg)
-    end
-    local t = {}
-    for k, v in pairs(uiobjects) do
-      local ft = {}
-      for fk, fv in pairs(v.fields) do
-        local init = fv.init
-        local override = v.fieldinitoverrides[fk]
-        if override ~= nil then
-          init = override
-        end
-        ft[fk] = {
-          dynamicinit = fv.dynamicinit,
-          getters = {},
-          init = init,
-        }
-      end
-      local mt = {}
-      for mk, mv in pairs(v.methods) do
-        mt[mk] = true
-        for gk, gv in ipairs(mv.impl and mv.impl.getter or {}) do
-          table.insert(ft[gv.name].getters, { index = gk, method = mk })
-        end
-      end
-      for fk, fv in pairs(ft) do
-        if fv.dynamicinit then
-          ft[fk] = nil
-        end
-      end
-      -- TODO remove these super duper field hacks
-      ft.parent = nil
-      if v.singleton then
-        ft = {}
-      elseif k == 'EditBox' then
-        ft.shown.init = false
-      end
-      local st = {}
-      for scripttype in pairs(allscripts) do
-        st[scripttype] = not not (v.scripts and v.scripts[scripttype])
-      end
-      t[k] = {
-        fields = ft,
-        isa = v.isa,
-        methods = mt,
-        objtype = v.objectType or k,
-        scripts = st,
-        singleton = v.singleton,
-        virtual = v.virtual,
-      }
-    end
-    for _, product in ipairs(readyaml('data/products.yaml')) do
-      for k in pairs(perproduct(product, 'uiobjects')) do
-        if not t[k] then
-          t[k] = { unsupported = true }
-        end
-      end
-    end
-    return 'UIObjectApis', t
+    return 'UIObjectApis', computeUiobjectApis(p)
   end,
 }
 

--- a/tools/gentest.lua
+++ b/tools/gentest.lua
@@ -272,6 +272,8 @@ end
 -- then a negative pass unioning in other products' foreign values: values
 -- valid elsewhere but not native to this product, expecting this
 -- product's own field default (mirrors the events ptablemap entry below).
+-- Also always includes a guaranteed-nonsense negative case, so this
+-- coverage doesn't depend on products having diverged.
 local function computeCandidates(p, case)
   local candidates = {}
   local native = {}
@@ -294,6 +296,8 @@ local function computeCandidates(p, case)
       end
     end
   end
+  assert(not native.NONSENSE, 'nonsense is apparently not nonsense for ' .. case.id)
+  table.insert(candidates, { expected = case.init, suffix = 'nonsense', value = 'nonsense' })
   return candidates
 end
 


### PR DESCRIPTION
## Summary
- `gentest.lua` now discovers every stringenum-/enum-typed XML attribute on tags reachable from `Frame` (via the same `supertypes`/`children` containment logic `wowless/modules/xml.lua` uses at runtime), and generates, per product, one real (non-virtual) element per candidate value under a single root `Frame` named `WowlessGeneratedXmlTests` — addressed via `parentKey`, not a per-case global name, to avoid namespace-collision risk against real Blizzard UI content.
- Candidates include a cross-product negative pass: values valid in *other* products but foreign to the product under test, expecting that product's own field default (mirrors the existing `events` `ptablemap` entry). On today's data every product has identical stringenum members, so this pass is correctly dormant — it exists and is ready for when products diverge.
- New addon-side `templateTests()` (in `addon/Wowless/generated.lua`) walks `WowlessData.Templates` and asserts `getter()==expected` for each generated case. A missing/mis-nested element surfaces as a loud "attempt to index a nil value" Lua error rather than a silently dropped XML element (the failure mode that let a whole prior attempt at this, PR #749, pass green with zero effective assertions for a full PR cycle).
- Scoped to attribute types that structurally nest under `Frame` (`Font` is out of scope — it's a standalone declaration type, not reachable via the normal `<Frames>`/`<Layers>` containment tree; tracked separately).
- `generatexmltest.lua`'s existing `JustifyHorizontal` test is **left as-is** — it's still hardcoded to `wow`'s stringenums (a known, accepted limitation for now), coexisting with the new automatic `FontString.justifyh`/`justifyv` coverage this framework also produces. Migrating/removing it is out of scope for this PR.

Design discussion and the full rationale (including two abandoned intermediate designs — virtual-template instantiation, and a generalized checker-registry — both walked back in favor of this simpler, more targeted shape) are in #751.

## Test plan
- [x] `cmake --build --preset default --target test` — exits 0, no output, across all 8 products
- [x] `pre-commit run -a` — all hooks pass
- [x] Manually inspected generated `templates.lua`/`templates.xml` for `wow` and spot-checked all 8 products generate without error