### PR TITLE
xml: support enum-typed XML attributes, wire up FontString.scaleAnimationMode

### DIFF
--- a/data/products/wow/xml.yaml
+++ b/data/products/wow/xml.yaml
@@ -446,6 +446,11 @@ FontString:
       type: number
     nonspacewrap:
       type: boolean
+    scaleanimationmode:
+      impl:
+        field: scaleAnimationMode
+      type:
+        enum: FontStringScaleAnimationMode
     spacing:
       type: number
     text:

--- a/data/products/wow_anniversary/xml.yaml
+++ b/data/products/wow_anniversary/xml.yaml
@@ -446,6 +446,11 @@ FontString:
       type: number
     nonspacewrap:
       type: boolean
+    scaleanimationmode:
+      impl:
+        field: scaleAnimationMode
+      type:
+        enum: FontStringScaleAnimationMode
     spacing:
       type: number
     text:

--- a/data/products/wow_classic/xml.yaml
+++ b/data/products/wow_classic/xml.yaml
@@ -446,6 +446,11 @@ FontString:
       type: number
     nonspacewrap:
       type: boolean
+    scaleanimationmode:
+      impl:
+        field: scaleAnimationMode
+      type:
+        enum: FontStringScaleAnimationMode
     spacing:
       type: number
     text:

--- a/data/products/wow_classic_era_ptr/xml.yaml
+++ b/data/products/wow_classic_era_ptr/xml.yaml
@@ -446,6 +446,11 @@ FontString:
       type: number
     nonspacewrap:
       type: boolean
+    scaleanimationmode:
+      impl:
+        field: scaleAnimationMode
+      type:
+        enum: FontStringScaleAnimationMode
     spacing:
       type: number
     text:

--- a/data/products/wow_classic_ptr/xml.yaml
+++ b/data/products/wow_classic_ptr/xml.yaml
@@ -446,6 +446,11 @@ FontString:
       type: number
     nonspacewrap:
       type: boolean
+    scaleanimationmode:
+      impl:
+        field: scaleAnimationMode
+      type:
+        enum: FontStringScaleAnimationMode
     spacing:
       type: number
     text:

--- a/data/products/wowt/xml.yaml
+++ b/data/products/wowt/xml.yaml
@@ -446,6 +446,11 @@ FontString:
       type: number
     nonspacewrap:
       type: boolean
+    scaleanimationmode:
+      impl:
+        field: scaleAnimationMode
+      type:
+        enum: FontStringScaleAnimationMode
     spacing:
       type: number
     text:

--- a/data/products/wowxptr/xml.yaml
+++ b/data/products/wowxptr/xml.yaml
@@ -446,6 +446,11 @@ FontString:
       type: number
     nonspacewrap:
       type: boolean
+    scaleanimationmode:
+      impl:
+        field: scaleAnimationMode
+      type:
+        enum: FontStringScaleAnimationMode
     spacing:
       type: number
     text:

--- a/data/schemas/xml.yaml
+++ b/data/schemas/xml.yaml
@@ -30,6 +30,9 @@ type:
                     type:
                       taggedunion:
                         boolean: tag
+                        enum:
+                          ref:
+                            schema: enum
                         number: tag
                         string: tag
                         stringenum:

--- a/tools/gentest.lua
+++ b/tools/gentest.lua
@@ -254,7 +254,12 @@ local function discoverCases(p)
 end
 
 local function attrMembers(p, case)
-  local ty = perproduct(p, 'xml')[case.xmlTag].attributes[case.xmlAttrKey].type
+  local tdef = perproduct(p, 'xml')[case.xmlTag]
+  local attrDef = tdef and tdef.attributes[case.xmlAttrKey]
+  if not attrDef then
+    return {}
+  end
+  local ty = attrDef.type
   if ty.stringenum then
     local members = {}
     for name in pairs(perproduct(p, 'stringenums')[ty.stringenum]) do

--- a/wowless/modules/xml.lua
+++ b/wowless/modules/xml.lua
@@ -43,6 +43,7 @@ end
 return function(datalua)
   local lang = datalua.xmlflat
   local stringenums = datalua.stringenums
+  local enums = datalua.globals.Enum
   local attributeTypes = {
     boolean = function(s)
       local x = string.lower(s)
@@ -53,6 +54,10 @@ return function(datalua)
       else
         return nil
       end
+    end,
+    enum = function(name, s)
+      local set = enums[name]
+      return set[s]
     end,
     number = function(s)
       return tonumber(s)


### PR DESCRIPTION
## Summary
- `wowless/modules/xml.lua`'s attribute-value dispatch table only handled `stringenum`, not `enum` — any XML attribute typed `enum:` hard-crashed the whole file's loading instead of warning on invalid values like every other attribute type. Adds a generic `enum` handler (case-sensitive match against `Enum.<name>`, since real Enum member names aren't uppercase like stringenum members).
- Allows `enum:` in `data/schemas/xml.yaml`'s attribute type taggedunion (mirrors `data/schemas/type.yaml`'s existing generic `enum` case).
- Wires up the first real user: `FontString.scaleAnimationMode` (`Enum.FontStringScaleAnimationMode`, backed by the field #770 added getter/setter support for), across every product that has that field (`wow_classic_era` doesn't).
- Fixes a latent bug in `tools/gentest.lua`'s cross-product negative-candidate pass (part of the per-product template test framework from #767): `attrMembers` assumed every product defines any attribute discovered on one product, and crashed indexing a nil attribute definition on a product that doesn't have it at all. Now treats a missing attribute on a foreign product as contributing zero candidate members.
- The per-product template test framework automatically picked up `FontString.scaleAnimationMode` as a new test case once the attribute was added — no test-side code changes needed.

## Test plan
- [x] `cmake --build --preset default --target test` passes (all products)
- [x] `pre-commit run -a` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)