### PR TITLE
xml: support enum-typed XML attributes, wire up FontString.scaleAnimationMode

### DIFF
--- a/data/products/wow/xml.yaml
+++ b/data/products/wow/xml.yaml
@@ -446,6 +446,11 @@ FontString:
       type: number
     nonspacewrap:
       type: boolean
+    scaleanimationmode:
+      impl:
+        field: scaleAnimationMode
+      type:
+        enum: FontStringScaleAnimationMode
     spacing:
       type: number
     text:

--- a/data/products/wow_anniversary/xml.yaml
+++ b/data/products/wow_anniversary/xml.yaml
@@ -446,6 +446,11 @@ FontString:
       type: number
     nonspacewrap:
       type: boolean
+    scaleanimationmode:
+      impl:
+        field: scaleAnimationMode
+      type:
+        enum: FontStringScaleAnimationMode
     spacing:
       type: number
     text:

--- a/data/products/wow_classic/xml.yaml
+++ b/data/products/wow_classic/xml.yaml
@@ -446,6 +446,11 @@ FontString:
       type: number
     nonspacewrap:
       type: boolean
+    scaleanimationmode:
+      impl:
+        field: scaleAnimationMode
+      type:
+        enum: FontStringScaleAnimationMode
     spacing:
       type: number
     text:

--- a/data/products/wow_classic_era_ptr/xml.yaml
+++ b/data/products/wow_classic_era_ptr/xml.yaml
@@ -446,6 +446,11 @@ FontString:
       type: number
     nonspacewrap:
       type: boolean
+    scaleanimationmode:
+      impl:
+        field: scaleAnimationMode
+      type:
+        enum: FontStringScaleAnimationMode
     spacing:
       type: number
     text:

--- a/data/products/wow_classic_ptr/xml.yaml
+++ b/data/products/wow_classic_ptr/xml.yaml
@@ -446,6 +446,11 @@ FontString:
       type: number
     nonspacewrap:
       type: boolean
+    scaleanimationmode:
+      impl:
+        field: scaleAnimationMode
+      type:
+        enum: FontStringScaleAnimationMode
     spacing:
       type: number
     text:

--- a/data/products/wowt/xml.yaml
+++ b/data/products/wowt/xml.yaml
@@ -446,6 +446,11 @@ FontString:
       type: number
     nonspacewrap:
       type: boolean
+    scaleanimationmode:
+      impl:
+        field: scaleAnimationMode
+      type:
+        enum: FontStringScaleAnimationMode
     spacing:
       type: number
     text:

--- a/data/products/wowxptr/xml.yaml
+++ b/data/products/wowxptr/xml.yaml
@@ -446,6 +446,11 @@ FontString:
       type: number
     nonspacewrap:
       type: boolean
+    scaleanimationmode:
+      impl:
+        field: scaleAnimationMode
+      type:
+        enum: FontStringScaleAnimationMode
     spacing:
       type: number
     text:

--- a/data/schemas/xml.yaml
+++ b/data/schemas/xml.yaml
@@ -30,6 +30,9 @@ type:
                     type:
                       taggedunion:
                         boolean: tag
+                        enum:
+                          ref:
+                            schema: enum
                         number: tag
                         string: tag
                         stringenum:

--- a/tools/gentest.lua
+++ b/tools/gentest.lua
@@ -254,7 +254,12 @@ local function discoverCases(p)
 end
 
 local function attrMembers(p, case)
-  local ty = perproduct(p, 'xml')[case.xmlTag].attributes[case.xmlAttrKey].type
+  local tdef = perproduct(p, 'xml')[case.xmlTag]
+  local attrDef = tdef and tdef.attributes[case.xmlAttrKey]
+  if not attrDef then
+    return {}
+  end
+  local ty = attrDef.type
   if ty.stringenum then
     local members = {}
     for name in pairs(perproduct(p, 'stringenums')[ty.stringenum]) do

--- a/wowless/modules/xml.lua
+++ b/wowless/modules/xml.lua
@@ -43,6 +43,7 @@ end
 return function(datalua)
   local lang = datalua.xmlflat
   local stringenums = datalua.stringenums
+  local enums = datalua.globals.Enum
   local attributeTypes = {
     boolean = function(s)
       local x = string.lower(s)
@@ -53,6 +54,10 @@ return function(datalua)
       else
         return nil
       end
+    end,
+    enum = function(name, s)
+      local set = enums[name]
+      return set[s]
     end,
     number = function(s)
       return tonumber(s)


### PR DESCRIPTION
wowless/modules/xml.lua's attribute-type dispatch table only handled
stringenum, not enum, so any XML attribute typed `enum:` would
hard-crash the whole file's loading instead of warning on invalid
values like every other attribute type. Add a generic enum handler
(case-sensitive match against Enum.<name>, since real Enum member
names aren't uppercase like stringenum members), and allow `enum:` in
data/schemas/xml.yaml's attribute type taggedunion.

Wire up the first real user of this: FontString's scaleAnimationMode
attribute (Enum.FontStringScaleAnimationMode, backed by the
scaleAnimationMode field PR #770 added getter/setter support for),
across every product that has that field. Not every product has it
(wow_classic_era doesn't), which exposed a latent bug in gentest.lua's
cross-product negative-candidate pass: attrMembers assumed every
product defines any attribute discovered on one product, and crashed
indexing a nil attribute definition on a product that simply doesn't
have it. Fixed to treat a missing attribute in a foreign product as
contributing zero candidate members.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
