### PR TITLE
worktree xml stringenum fields

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -496,6 +496,8 @@ foreach(product ${products})
 endforeach()
 
 lua2c(toolsenum tools.enum=${CMAKE_CURRENT_SOURCE_DIR}/tools/enum.lua)
+lua2c(toolsxmlcontainment
+      tools.xmlcontainment=${CMAKE_CURRENT_SOURCE_DIR}/tools/xmlcontainment.lua)
 
 add_lua_executable(
   prep
@@ -636,6 +638,7 @@ add_lua_executable(
   penlight
   toolsenum
   toolsutil
+  toolsxmlcontainment
   wowlessyaml)
 
 foreach(product ${products})
@@ -1012,6 +1015,7 @@ add_lua_executable(
   runtimeproducts
   toolsenum
   toolstedit
+  toolsxmlcontainment
   tsort
   wowapischema
   wowlessblp
@@ -1139,6 +1143,7 @@ set(specs
     spec/tools/enum_spec.lua
     spec/tools/prettywrite_spec.lua
     spec/tools/tedit_spec.lua
+    spec/tools/xmlcontainment_spec.lua
     spec/wowapi/schema_spec.lua
     spec/wowapi/yaml_spec.lua
     spec/wowless/addon_spec.lua

--- a/data/products/wow/xml.yaml
+++ b/data/products/wow/xml.yaml
@@ -80,8 +80,7 @@ Animation:
     smoothing:
       impl:
         field: smoothing
-      type:
-        stringenum: SmoothingType
+      type: string
     startdelay:
       type: number
     target:
@@ -520,8 +519,7 @@ Frame:
     framestrata:
       impl:
         field: frameStrata
-      type:
-        stringenum: FrameStrata
+      type: string
     hyperlinksenabled:
       impl:
         field: hyperlinksEnabled

--- a/data/products/wow/xml.yaml
+++ b/data/products/wow/xml.yaml
@@ -80,7 +80,8 @@ Animation:
     smoothing:
       impl:
         field: smoothing
-      type: string
+      type:
+        stringenum: SmoothingType
     startdelay:
       type: number
     target:
@@ -96,7 +97,8 @@ AnimationGroup:
     looping:
       impl:
         field: looping
-      type: string
+      type:
+        stringenum: LoopType
     mixin:
       impl: internal
       phase: early
@@ -518,7 +520,8 @@ Frame:
     framestrata:
       impl:
         field: frameStrata
-      type: string
+      type:
+        stringenum: FrameStrata
     hyperlinksenabled:
       impl:
         field: hyperlinksEnabled
@@ -1315,7 +1318,8 @@ Slider:
     orientation:
       impl:
         field: orientation
-      type: string
+      type:
+        stringenum: Orientation
     stepsperpage:
       impl:
         field: stepsPerPage

--- a/data/products/wow_anniversary/xml.yaml
+++ b/data/products/wow_anniversary/xml.yaml
@@ -80,8 +80,7 @@ Animation:
     smoothing:
       impl:
         field: smoothing
-      type:
-        stringenum: SmoothingType
+      type: string
     startdelay:
       type: number
     target:
@@ -520,8 +519,7 @@ Frame:
     framestrata:
       impl:
         field: frameStrata
-      type:
-        stringenum: FrameStrata
+      type: string
     hyperlinksenabled:
       impl:
         field: hyperlinksEnabled

--- a/data/products/wow_anniversary/xml.yaml
+++ b/data/products/wow_anniversary/xml.yaml
@@ -80,7 +80,8 @@ Animation:
     smoothing:
       impl:
         field: smoothing
-      type: string
+      type:
+        stringenum: SmoothingType
     startdelay:
       type: number
     target:
@@ -96,7 +97,8 @@ AnimationGroup:
     looping:
       impl:
         field: looping
-      type: string
+      type:
+        stringenum: LoopType
     mixin:
       impl: internal
       phase: early
@@ -518,7 +520,8 @@ Frame:
     framestrata:
       impl:
         field: frameStrata
-      type: string
+      type:
+        stringenum: FrameStrata
     hyperlinksenabled:
       impl:
         field: hyperlinksEnabled
@@ -1315,7 +1318,8 @@ Slider:
     orientation:
       impl:
         field: orientation
-      type: string
+      type:
+        stringenum: Orientation
     stepsperpage:
       impl:
         field: stepsPerPage

--- a/data/products/wow_classic/xml.yaml
+++ b/data/products/wow_classic/xml.yaml
@@ -80,8 +80,7 @@ Animation:
     smoothing:
       impl:
         field: smoothing
-      type:
-        stringenum: SmoothingType
+      type: string
     startdelay:
       type: number
     target:
@@ -520,8 +519,7 @@ Frame:
     framestrata:
       impl:
         field: frameStrata
-      type:
-        stringenum: FrameStrata
+      type: string
     hyperlinksenabled:
       impl:
         field: hyperlinksEnabled

--- a/data/products/wow_classic/xml.yaml
+++ b/data/products/wow_classic/xml.yaml
@@ -80,7 +80,8 @@ Animation:
     smoothing:
       impl:
         field: smoothing
-      type: string
+      type:
+        stringenum: SmoothingType
     startdelay:
       type: number
     target:
@@ -96,7 +97,8 @@ AnimationGroup:
     looping:
       impl:
         field: looping
-      type: string
+      type:
+        stringenum: LoopType
     mixin:
       impl: internal
       phase: early
@@ -518,7 +520,8 @@ Frame:
     framestrata:
       impl:
         field: frameStrata
-      type: string
+      type:
+        stringenum: FrameStrata
     hyperlinksenabled:
       impl:
         field: hyperlinksEnabled
@@ -1315,7 +1318,8 @@ Slider:
     orientation:
       impl:
         field: orientation
-      type: string
+      type:
+        stringenum: Orientation
     stepsperpage:
       impl:
         field: stepsPerPage

--- a/data/products/wow_classic_era/xml.yaml
+++ b/data/products/wow_classic_era/xml.yaml
@@ -80,8 +80,7 @@ Animation:
     smoothing:
       impl:
         field: smoothing
-      type:
-        stringenum: SmoothingType
+      type: string
     startdelay:
       type: number
     target:
@@ -515,8 +514,7 @@ Frame:
     framestrata:
       impl:
         field: frameStrata
-      type:
-        stringenum: FrameStrata
+      type: string
     hyperlinksenabled:
       impl:
         field: hyperlinksEnabled

--- a/data/products/wow_classic_era/xml.yaml
+++ b/data/products/wow_classic_era/xml.yaml
@@ -80,7 +80,8 @@ Animation:
     smoothing:
       impl:
         field: smoothing
-      type: string
+      type:
+        stringenum: SmoothingType
     startdelay:
       type: number
     target:
@@ -96,7 +97,8 @@ AnimationGroup:
     looping:
       impl:
         field: looping
-      type: string
+      type:
+        stringenum: LoopType
     mixin:
       impl: internal
       phase: early
@@ -513,7 +515,8 @@ Frame:
     framestrata:
       impl:
         field: frameStrata
-      type: string
+      type:
+        stringenum: FrameStrata
     hyperlinksenabled:
       impl:
         field: hyperlinksEnabled
@@ -1310,7 +1313,8 @@ Slider:
     orientation:
       impl:
         field: orientation
-      type: string
+      type:
+        stringenum: Orientation
     stepsperpage:
       impl:
         field: stepsPerPage

--- a/data/products/wow_classic_era_ptr/xml.yaml
+++ b/data/products/wow_classic_era_ptr/xml.yaml
@@ -80,8 +80,7 @@ Animation:
     smoothing:
       impl:
         field: smoothing
-      type:
-        stringenum: SmoothingType
+      type: string
     startdelay:
       type: number
     target:
@@ -520,8 +519,7 @@ Frame:
     framestrata:
       impl:
         field: frameStrata
-      type:
-        stringenum: FrameStrata
+      type: string
     hyperlinksenabled:
       impl:
         field: hyperlinksEnabled

--- a/data/products/wow_classic_era_ptr/xml.yaml
+++ b/data/products/wow_classic_era_ptr/xml.yaml
@@ -80,7 +80,8 @@ Animation:
     smoothing:
       impl:
         field: smoothing
-      type: string
+      type:
+        stringenum: SmoothingType
     startdelay:
       type: number
     target:
@@ -96,7 +97,8 @@ AnimationGroup:
     looping:
       impl:
         field: looping
-      type: string
+      type:
+        stringenum: LoopType
     mixin:
       impl: internal
       phase: early
@@ -518,7 +520,8 @@ Frame:
     framestrata:
       impl:
         field: frameStrata
-      type: string
+      type:
+        stringenum: FrameStrata
     hyperlinksenabled:
       impl:
         field: hyperlinksEnabled
@@ -1315,7 +1318,8 @@ Slider:
     orientation:
       impl:
         field: orientation
-      type: string
+      type:
+        stringenum: Orientation
     stepsperpage:
       impl:
         field: stepsPerPage

--- a/data/products/wow_classic_ptr/xml.yaml
+++ b/data/products/wow_classic_ptr/xml.yaml
@@ -80,8 +80,7 @@ Animation:
     smoothing:
       impl:
         field: smoothing
-      type:
-        stringenum: SmoothingType
+      type: string
     startdelay:
       type: number
     target:
@@ -520,8 +519,7 @@ Frame:
     framestrata:
       impl:
         field: frameStrata
-      type:
-        stringenum: FrameStrata
+      type: string
     hyperlinksenabled:
       impl:
         field: hyperlinksEnabled

--- a/data/products/wow_classic_ptr/xml.yaml
+++ b/data/products/wow_classic_ptr/xml.yaml
@@ -80,7 +80,8 @@ Animation:
     smoothing:
       impl:
         field: smoothing
-      type: string
+      type:
+        stringenum: SmoothingType
     startdelay:
       type: number
     target:
@@ -96,7 +97,8 @@ AnimationGroup:
     looping:
       impl:
         field: looping
-      type: string
+      type:
+        stringenum: LoopType
     mixin:
       impl: internal
       phase: early
@@ -518,7 +520,8 @@ Frame:
     framestrata:
       impl:
         field: frameStrata
-      type: string
+      type:
+        stringenum: FrameStrata
     hyperlinksenabled:
       impl:
         field: hyperlinksEnabled
@@ -1315,7 +1318,8 @@ Slider:
     orientation:
       impl:
         field: orientation
-      type: string
+      type:
+        stringenum: Orientation
     stepsperpage:
       impl:
         field: stepsPerPage

--- a/data/products/wowt/xml.yaml
+++ b/data/products/wowt/xml.yaml
@@ -80,8 +80,7 @@ Animation:
     smoothing:
       impl:
         field: smoothing
-      type:
-        stringenum: SmoothingType
+      type: string
     startdelay:
       type: number
     target:
@@ -520,8 +519,7 @@ Frame:
     framestrata:
       impl:
         field: frameStrata
-      type:
-        stringenum: FrameStrata
+      type: string
     hyperlinksenabled:
       impl:
         field: hyperlinksEnabled

--- a/data/products/wowt/xml.yaml
+++ b/data/products/wowt/xml.yaml
@@ -80,7 +80,8 @@ Animation:
     smoothing:
       impl:
         field: smoothing
-      type: string
+      type:
+        stringenum: SmoothingType
     startdelay:
       type: number
     target:
@@ -96,7 +97,8 @@ AnimationGroup:
     looping:
       impl:
         field: looping
-      type: string
+      type:
+        stringenum: LoopType
     mixin:
       impl: internal
       phase: early
@@ -518,7 +520,8 @@ Frame:
     framestrata:
       impl:
         field: frameStrata
-      type: string
+      type:
+        stringenum: FrameStrata
     hyperlinksenabled:
       impl:
         field: hyperlinksEnabled
@@ -1338,7 +1341,8 @@ Slider:
     orientation:
       impl:
         field: orientation
-      type: string
+      type:
+        stringenum: Orientation
     stepsperpage:
       impl:
         field: stepsPerPage

--- a/data/products/wowxptr/xml.yaml
+++ b/data/products/wowxptr/xml.yaml
@@ -80,8 +80,7 @@ Animation:
     smoothing:
       impl:
         field: smoothing
-      type:
-        stringenum: SmoothingType
+      type: string
     startdelay:
       type: number
     target:
@@ -520,8 +519,7 @@ Frame:
     framestrata:
       impl:
         field: frameStrata
-      type:
-        stringenum: FrameStrata
+      type: string
     hyperlinksenabled:
       impl:
         field: hyperlinksEnabled

--- a/data/products/wowxptr/xml.yaml
+++ b/data/products/wowxptr/xml.yaml
@@ -80,7 +80,8 @@ Animation:
     smoothing:
       impl:
         field: smoothing
-      type: string
+      type:
+        stringenum: SmoothingType
     startdelay:
       type: number
     target:
@@ -96,7 +97,8 @@ AnimationGroup:
     looping:
       impl:
         field: looping
-      type: string
+      type:
+        stringenum: LoopType
     mixin:
       impl: internal
       phase: early
@@ -518,7 +520,8 @@ Frame:
     framestrata:
       impl:
         field: frameStrata
-      type: string
+      type:
+        stringenum: FrameStrata
     hyperlinksenabled:
       impl:
         field: hyperlinksEnabled
@@ -1315,7 +1318,8 @@ Slider:
     orientation:
       impl:
         field: orientation
-      type: string
+      type:
+        stringenum: Orientation
     stepsperpage:
       impl:
         field: stepsPerPage

--- a/spec/tools/xmlcontainment_spec.lua
+++ b/spec/tools/xmlcontainment_spec.lua
@@ -1,206 +1,120 @@
 describe('xmlcontainment', function()
   local xmlcontainment = require('tools.xmlcontainment')
 
-  describe('frameChains', function()
-    it('finds a direct child', function()
-      local xml = {
-        Frame = { contents = { tags = { Leaf = true } } },
-        Leaf = {},
-      }
-      local chains, ambiguous = xmlcontainment.frameChains(xml, 'Frame')
-      assert.same({ 'Frame', 'Leaf' }, chains.Leaf)
-      assert.same({}, ambiguous)
-    end)
-
-    it('walks through wrapper tags to find the shortest chain', function()
-      local xml = {
-        Frame = { contents = { tags = { Wrap = true } } },
-        Wrap = { contents = { tags = { Leaf = true } } },
-        Leaf = {},
-      }
-      local chains = xmlcontainment.frameChains(xml, 'Frame')
-      assert.same({ 'Frame', 'Wrap', 'Leaf' }, chains.Leaf)
-    end)
-
-    it('matches a tag reachable only via its extends chain', function()
-      local xml = {
-        Base = {},
-        Frame = { contents = { tags = { Base = true } } },
-        Sub = { extends = 'Base' },
-      }
-      local chains = xmlcontainment.frameChains(xml, 'Frame')
-      assert.same({ 'Frame', 'Base' }, chains.Base)
-      assert.same({ 'Frame', 'Sub' }, chains.Sub)
-    end)
-
-    it('does not mark a tag reachable if nothing accepts it', function()
-      local xml = {
-        Frame = { contents = { tags = {} } },
-        Orphan = {},
-      }
-      local chains = xmlcontainment.frameChains(xml, 'Frame')
-      assert.is_nil(chains.Orphan)
-    end)
-
-    it('sealed stops extends-chain climbing for containment purposes', function()
-      local xml = {
-        Base = {},
-        Frame = { contents = { tags = { Base = true } } },
-        Sub = { extends = 'Base', sealed = true },
-      }
-      local chains = xmlcontainment.frameChains(xml, 'Frame')
-      assert.same({ 'Frame', 'Base' }, chains.Base)
-      assert.is_nil(chains.Sub)
-    end)
-
-    it('sealed does not affect a tag reachable via its own declared contents', function()
-      local xml = {
-        Base = {},
-        Frame = { contents = { tags = { Sub = true } } },
-        Sub = { extends = 'Base', sealed = true },
-      }
-      local chains = xmlcontainment.frameChains(xml, 'Frame')
-      assert.same({ 'Frame', 'Sub' }, chains.Sub)
-    end)
-
-    it('marks a tag ambiguous when two equally-shallow parents both accept it', function()
-      local xml = {
-        A = { contents = { tags = { Leaf = true } } },
-        B = { contents = { tags = { Leaf = true } } },
-        Frame = { contents = { tags = { A = true, B = true } } },
-        Leaf = {},
-      }
-      local chains, ambiguous = xmlcontainment.frameChains(xml, 'Frame')
-      assert.is_true(ambiguous.Leaf)
-      assert.is_not_nil(chains.Leaf)
-    end)
-
-    it('does not mark a tag ambiguous when a second route is strictly deeper', function()
-      local xml = {
-        A = { contents = { tags = { Leaf = true } } },
-        B = { contents = { tags = { Leaf = true } } },
-        C = { contents = { tags = { B = true } } },
-        Frame = { contents = { tags = { A = true, C = true } } },
-        Leaf = {},
-      }
-      local chains, ambiguous = xmlcontainment.frameChains(xml, 'Frame')
-      assert.same({ 'Frame', 'A', 'Leaf' }, chains.Leaf)
-      assert.is_nil(ambiguous.Leaf)
-    end)
-
-    it('preferParent resolves a tie without marking it ambiguous', function()
-      local xml = {
-        A = { contents = { tags = { Leaf = true } } },
-        B = { contents = { tags = { Leaf = true } } },
-        Frame = { contents = { tags = { A = true, B = true } } },
-        Leaf = {},
-      }
-      local chains, ambiguous = xmlcontainment.frameChains(xml, 'Frame', 'B')
-      assert.same({ 'Frame', 'B', 'Leaf' }, chains.Leaf)
-      assert.is_nil(ambiguous.Leaf)
-    end)
-
-    it('preferParent does not affect tags with only one candidate', function()
-      local xml = {
-        A = { contents = { tags = { Leaf = true } } },
-        Frame = { contents = { tags = { A = true } } },
-        Leaf = {},
-      }
-      local chains = xmlcontainment.frameChains(xml, 'Frame', 'NeverAppears')
-      assert.same({ 'Frame', 'A', 'Leaf' }, chains.Leaf)
-    end)
-
-    it('rediscovers the root tag as an ordinary two-hop descendant of itself', function()
-      local xml = {
-        Frame = { contents = { tags = { Wrap = true } } },
-        Wrap = { contents = { tags = { Frame = true } } },
-      }
-      local chains = xmlcontainment.frameChains(xml, 'Frame')
-      assert.same({ 'Frame', 'Wrap', 'Frame' }, chains.Frame)
-    end)
+  it('finds a direct child', function()
+    local xml = {
+      Frame = { contents = { tags = { Leaf = true } } },
+      Leaf = {},
+    }
+    local chains, ambiguous = xmlcontainment.chains(xml, 'Frame')
+    assert.same({ 'Frame', 'Leaf' }, chains.Leaf)
+    assert.same({}, ambiguous)
   end)
 
-  describe('identityHops', function()
-    it('finds no hops when nothing in the chain has identity', function()
-      local hasIdentity = {}
-      assert.same({}, xmlcontainment.identityHops(hasIdentity, { 'Frame', 'Wrap', 'Leaf' }))
-    end)
-
-    it('finds every identity-bearing position after the root', function()
-      local hasIdentity = { B = true, D = true }
-      local chain = { 'Frame', 'Wrap', 'B', 'Wrap2', 'D' }
-      assert.same({ 3, 5 }, xmlcontainment.identityHops(hasIdentity, chain))
-    end)
-
-    it('ignores the root even if it has identity', function()
-      local hasIdentity = { Frame = true, Leaf = true }
-      assert.same({ 3 }, xmlcontainment.identityHops(hasIdentity, { 'Frame', 'Wrap', 'Leaf' }))
-    end)
+  it('walks through wrapper tags to find the shortest chain', function()
+    local xml = {
+      Frame = { contents = { tags = { Wrap = true } } },
+      Wrap = { contents = { tags = { Leaf = true } } },
+      Leaf = {},
+    }
+    local chains = xmlcontainment.chains(xml, 'Frame')
+    assert.same({ 'Frame', 'Wrap', 'Leaf' }, chains.Leaf)
   end)
 
-  describe('hopKey', function()
-    it('uses the plain key for the last hop', function()
-      assert.equal('foo', xmlcontainment.hopKey('foo', 2, 2))
-      assert.equal('foo', xmlcontainment.hopKey('foo', 1, 1))
-    end)
-
-    it('suffixes earlier hops', function()
-      assert.equal('foo_1', xmlcontainment.hopKey('foo', 1, 2))
-      assert.equal('foo_2', xmlcontainment.hopKey('foo', 2, 3))
-    end)
+  it('matches a tag reachable only via its extends chain', function()
+    local xml = {
+      Base = {},
+      Frame = { contents = { tags = { Base = true } } },
+      Sub = { extends = 'Base' },
+    }
+    local chains = xmlcontainment.chains(xml, 'Frame')
+    assert.same({ 'Frame', 'Base' }, chains.Base)
+    assert.same({ 'Frame', 'Sub' }, chains.Sub)
   end)
 
-  describe('objectPath', function()
-    it('is empty when the chain has no identity hops', function()
-      local hasIdentity = {}
-      assert.same({}, xmlcontainment.objectPath(hasIdentity, { 'Frame', 'Wrap', 'Leaf' }, 'key'))
-    end)
-
-    it('is a single hop when only the leaf has identity', function()
-      local hasIdentity = { Slider = true }
-      assert.same({ 'key' }, xmlcontainment.objectPath(hasIdentity, { 'Frame', 'Frames', 'Slider' }, 'key'))
-    end)
-
-    it('suffixes scaffolding hops and keeps the plain key for the leaf', function()
-      local hasIdentity = { AnimationGroup = true, Animation = true }
-      local chain = { 'Frame', 'Animations', 'AnimationGroup', 'Animation' }
-      assert.same({ 'key_1', 'key' }, xmlcontainment.objectPath(hasIdentity, chain, 'key'))
-    end)
+  it('does not mark a tag reachable if nothing accepts it', function()
+    local xml = {
+      Frame = { contents = { tags = {} } },
+      Orphan = {},
+    }
+    local chains = xmlcontainment.chains(xml, 'Frame')
+    assert.is_nil(chains.Orphan)
   end)
 
-  describe('templateElement', function()
-    it('renders a single-hop leaf with its attribute', function()
-      local hasIdentity = { Slider = true }
-      local chain = { 'Frame', 'Frames', 'Slider' }
-      local element = xmlcontainment.templateElement(hasIdentity, chain, 'orientation', 'key', 'VERTICAL')
-      assert.same({
-        tag = 'Frames',
-        { orientation = 'VERTICAL', parentKey = 'key', tag = 'Slider' },
-      }, element)
-    end)
+  it('sealed stops extends-chain climbing for containment purposes', function()
+    local xml = {
+      Base = {},
+      Frame = { contents = { tags = { Base = true } } },
+      Sub = { extends = 'Base', sealed = true },
+    }
+    local chains = xmlcontainment.chains(xml, 'Frame')
+    assert.same({ 'Frame', 'Base' }, chains.Base)
+    assert.is_nil(chains.Sub)
+  end)
 
-    it('renders scaffolding hops with their own parentKey, nested down to the leaf', function()
-      local hasIdentity = { AnimationGroup = true, Animation = true }
-      local chain = { 'Frame', 'Animations', 'AnimationGroup', 'Animation' }
-      local element = xmlcontainment.templateElement(hasIdentity, chain, 'smoothing', 'key', 'NONE')
-      assert.same({
-        tag = 'Animations',
-        {
-          parentKey = 'key_1',
-          tag = 'AnimationGroup',
-          { parentKey = 'key', smoothing = 'NONE', tag = 'Animation' },
-        },
-      }, element)
-    end)
+  it('sealed does not affect a tag reachable via its own declared contents', function()
+    local xml = {
+      Base = {},
+      Frame = { contents = { tags = { Sub = true } } },
+      Sub = { extends = 'Base', sealed = true },
+    }
+    local chains = xmlcontainment.chains(xml, 'Frame')
+    assert.same({ 'Frame', 'Sub' }, chains.Sub)
+  end)
 
-    it('renders a wrapper-only chain with no parentKey', function()
-      local hasIdentity = {}
-      local chain = { 'Frame', 'Layers', 'Layer' }
-      local element = xmlcontainment.templateElement(hasIdentity, chain, 'level', 'key', 'ARTWORK')
-      assert.same({
-        tag = 'Layers',
-        { level = 'ARTWORK', tag = 'Layer' },
-      }, element)
-    end)
+  it('marks a tag ambiguous when two equally-shallow parents both accept it', function()
+    local xml = {
+      A = { contents = { tags = { Leaf = true } } },
+      B = { contents = { tags = { Leaf = true } } },
+      Frame = { contents = { tags = { A = true, B = true } } },
+      Leaf = {},
+    }
+    local chains, ambiguous = xmlcontainment.chains(xml, 'Frame')
+    assert.is_true(ambiguous.Leaf)
+    assert.is_not_nil(chains.Leaf)
+  end)
+
+  it('does not mark a tag ambiguous when a second route is strictly deeper', function()
+    local xml = {
+      A = { contents = { tags = { Leaf = true } } },
+      B = { contents = { tags = { Leaf = true } } },
+      C = { contents = { tags = { B = true } } },
+      Frame = { contents = { tags = { A = true, C = true } } },
+      Leaf = {},
+    }
+    local chains, ambiguous = xmlcontainment.chains(xml, 'Frame')
+    assert.same({ 'Frame', 'A', 'Leaf' }, chains.Leaf)
+    assert.is_nil(ambiguous.Leaf)
+  end)
+
+  it('preferParent resolves a tie without marking it ambiguous', function()
+    local xml = {
+      A = { contents = { tags = { Leaf = true } } },
+      B = { contents = { tags = { Leaf = true } } },
+      Frame = { contents = { tags = { A = true, B = true } } },
+      Leaf = {},
+    }
+    local chains, ambiguous = xmlcontainment.chains(xml, 'Frame', 'B')
+    assert.same({ 'Frame', 'B', 'Leaf' }, chains.Leaf)
+    assert.is_nil(ambiguous.Leaf)
+  end)
+
+  it('preferParent does not affect tags with only one candidate', function()
+    local xml = {
+      A = { contents = { tags = { Leaf = true } } },
+      Frame = { contents = { tags = { A = true } } },
+      Leaf = {},
+    }
+    local chains = xmlcontainment.chains(xml, 'Frame', 'NeverAppears')
+    assert.same({ 'Frame', 'A', 'Leaf' }, chains.Leaf)
+  end)
+
+  it('rediscovers the root tag as an ordinary two-hop descendant of itself', function()
+    local xml = {
+      Frame = { contents = { tags = { Wrap = true } } },
+      Wrap = { contents = { tags = { Frame = true } } },
+    }
+    local chains = xmlcontainment.chains(xml, 'Frame')
+    assert.same({ 'Frame', 'Wrap', 'Frame' }, chains.Frame)
   end)
 end)

--- a/spec/tools/xmlcontainment_spec.lua
+++ b/spec/tools/xmlcontainment_spec.lua
@@ -1,0 +1,206 @@
+describe('xmlcontainment', function()
+  local xmlcontainment = require('tools.xmlcontainment')
+
+  describe('frameChains', function()
+    it('finds a direct child', function()
+      local xml = {
+        Frame = { contents = { tags = { Leaf = true } } },
+        Leaf = {},
+      }
+      local chains, ambiguous = xmlcontainment.frameChains(xml, 'Frame')
+      assert.same({ 'Frame', 'Leaf' }, chains.Leaf)
+      assert.same({}, ambiguous)
+    end)
+
+    it('walks through wrapper tags to find the shortest chain', function()
+      local xml = {
+        Frame = { contents = { tags = { Wrap = true } } },
+        Wrap = { contents = { tags = { Leaf = true } } },
+        Leaf = {},
+      }
+      local chains = xmlcontainment.frameChains(xml, 'Frame')
+      assert.same({ 'Frame', 'Wrap', 'Leaf' }, chains.Leaf)
+    end)
+
+    it('matches a tag reachable only via its extends chain', function()
+      local xml = {
+        Base = {},
+        Frame = { contents = { tags = { Base = true } } },
+        Sub = { extends = 'Base' },
+      }
+      local chains = xmlcontainment.frameChains(xml, 'Frame')
+      assert.same({ 'Frame', 'Base' }, chains.Base)
+      assert.same({ 'Frame', 'Sub' }, chains.Sub)
+    end)
+
+    it('does not mark a tag reachable if nothing accepts it', function()
+      local xml = {
+        Frame = { contents = { tags = {} } },
+        Orphan = {},
+      }
+      local chains = xmlcontainment.frameChains(xml, 'Frame')
+      assert.is_nil(chains.Orphan)
+    end)
+
+    it('sealed stops extends-chain climbing for containment purposes', function()
+      local xml = {
+        Base = {},
+        Frame = { contents = { tags = { Base = true } } },
+        Sub = { extends = 'Base', sealed = true },
+      }
+      local chains = xmlcontainment.frameChains(xml, 'Frame')
+      assert.same({ 'Frame', 'Base' }, chains.Base)
+      assert.is_nil(chains.Sub)
+    end)
+
+    it('sealed does not affect a tag reachable via its own declared contents', function()
+      local xml = {
+        Base = {},
+        Frame = { contents = { tags = { Sub = true } } },
+        Sub = { extends = 'Base', sealed = true },
+      }
+      local chains = xmlcontainment.frameChains(xml, 'Frame')
+      assert.same({ 'Frame', 'Sub' }, chains.Sub)
+    end)
+
+    it('marks a tag ambiguous when two equally-shallow parents both accept it', function()
+      local xml = {
+        A = { contents = { tags = { Leaf = true } } },
+        B = { contents = { tags = { Leaf = true } } },
+        Frame = { contents = { tags = { A = true, B = true } } },
+        Leaf = {},
+      }
+      local chains, ambiguous = xmlcontainment.frameChains(xml, 'Frame')
+      assert.is_true(ambiguous.Leaf)
+      assert.is_not_nil(chains.Leaf)
+    end)
+
+    it('does not mark a tag ambiguous when a second route is strictly deeper', function()
+      local xml = {
+        A = { contents = { tags = { Leaf = true } } },
+        B = { contents = { tags = { Leaf = true } } },
+        C = { contents = { tags = { B = true } } },
+        Frame = { contents = { tags = { A = true, C = true } } },
+        Leaf = {},
+      }
+      local chains, ambiguous = xmlcontainment.frameChains(xml, 'Frame')
+      assert.same({ 'Frame', 'A', 'Leaf' }, chains.Leaf)
+      assert.is_nil(ambiguous.Leaf)
+    end)
+
+    it('preferParent resolves a tie without marking it ambiguous', function()
+      local xml = {
+        A = { contents = { tags = { Leaf = true } } },
+        B = { contents = { tags = { Leaf = true } } },
+        Frame = { contents = { tags = { A = true, B = true } } },
+        Leaf = {},
+      }
+      local chains, ambiguous = xmlcontainment.frameChains(xml, 'Frame', 'B')
+      assert.same({ 'Frame', 'B', 'Leaf' }, chains.Leaf)
+      assert.is_nil(ambiguous.Leaf)
+    end)
+
+    it('preferParent does not affect tags with only one candidate', function()
+      local xml = {
+        A = { contents = { tags = { Leaf = true } } },
+        Frame = { contents = { tags = { A = true } } },
+        Leaf = {},
+      }
+      local chains = xmlcontainment.frameChains(xml, 'Frame', 'NeverAppears')
+      assert.same({ 'Frame', 'A', 'Leaf' }, chains.Leaf)
+    end)
+
+    it('rediscovers the root tag as an ordinary two-hop descendant of itself', function()
+      local xml = {
+        Frame = { contents = { tags = { Wrap = true } } },
+        Wrap = { contents = { tags = { Frame = true } } },
+      }
+      local chains = xmlcontainment.frameChains(xml, 'Frame')
+      assert.same({ 'Frame', 'Wrap', 'Frame' }, chains.Frame)
+    end)
+  end)
+
+  describe('identityHops', function()
+    it('finds no hops when nothing in the chain has identity', function()
+      local hasIdentity = {}
+      assert.same({}, xmlcontainment.identityHops(hasIdentity, { 'Frame', 'Wrap', 'Leaf' }))
+    end)
+
+    it('finds every identity-bearing position after the root', function()
+      local hasIdentity = { B = true, D = true }
+      local chain = { 'Frame', 'Wrap', 'B', 'Wrap2', 'D' }
+      assert.same({ 3, 5 }, xmlcontainment.identityHops(hasIdentity, chain))
+    end)
+
+    it('ignores the root even if it has identity', function()
+      local hasIdentity = { Frame = true, Leaf = true }
+      assert.same({ 3 }, xmlcontainment.identityHops(hasIdentity, { 'Frame', 'Wrap', 'Leaf' }))
+    end)
+  end)
+
+  describe('hopKey', function()
+    it('uses the plain key for the last hop', function()
+      assert.equal('foo', xmlcontainment.hopKey('foo', 2, 2))
+      assert.equal('foo', xmlcontainment.hopKey('foo', 1, 1))
+    end)
+
+    it('suffixes earlier hops', function()
+      assert.equal('foo_1', xmlcontainment.hopKey('foo', 1, 2))
+      assert.equal('foo_2', xmlcontainment.hopKey('foo', 2, 3))
+    end)
+  end)
+
+  describe('objectPath', function()
+    it('is empty when the chain has no identity hops', function()
+      local hasIdentity = {}
+      assert.same({}, xmlcontainment.objectPath(hasIdentity, { 'Frame', 'Wrap', 'Leaf' }, 'key'))
+    end)
+
+    it('is a single hop when only the leaf has identity', function()
+      local hasIdentity = { Slider = true }
+      assert.same({ 'key' }, xmlcontainment.objectPath(hasIdentity, { 'Frame', 'Frames', 'Slider' }, 'key'))
+    end)
+
+    it('suffixes scaffolding hops and keeps the plain key for the leaf', function()
+      local hasIdentity = { AnimationGroup = true, Animation = true }
+      local chain = { 'Frame', 'Animations', 'AnimationGroup', 'Animation' }
+      assert.same({ 'key_1', 'key' }, xmlcontainment.objectPath(hasIdentity, chain, 'key'))
+    end)
+  end)
+
+  describe('templateElement', function()
+    it('renders a single-hop leaf with its attribute', function()
+      local hasIdentity = { Slider = true }
+      local chain = { 'Frame', 'Frames', 'Slider' }
+      local element = xmlcontainment.templateElement(hasIdentity, chain, 'orientation', 'key', 'VERTICAL')
+      assert.same({
+        tag = 'Frames',
+        { orientation = 'VERTICAL', parentKey = 'key', tag = 'Slider' },
+      }, element)
+    end)
+
+    it('renders scaffolding hops with their own parentKey, nested down to the leaf', function()
+      local hasIdentity = { AnimationGroup = true, Animation = true }
+      local chain = { 'Frame', 'Animations', 'AnimationGroup', 'Animation' }
+      local element = xmlcontainment.templateElement(hasIdentity, chain, 'smoothing', 'key', 'NONE')
+      assert.same({
+        tag = 'Animations',
+        {
+          parentKey = 'key_1',
+          tag = 'AnimationGroup',
+          { parentKey = 'key', smoothing = 'NONE', tag = 'Animation' },
+        },
+      }, element)
+    end)
+
+    it('renders a wrapper-only chain with no parentKey', function()
+      local hasIdentity = {}
+      local chain = { 'Frame', 'Layers', 'Layer' }
+      local element = xmlcontainment.templateElement(hasIdentity, chain, 'level', 'key', 'ARTWORK')
+      assert.same({
+        tag = 'Layers',
+        { level = 'ARTWORK', tag = 'Layer' },
+      }, element)
+    end)
+  end)
+end)

--- a/tools/gentest.lua
+++ b/tools/gentest.lua
@@ -56,10 +56,25 @@ local function renderXml(x)
   return table.concat(t, '\n')
 end
 
--- Which XML tags are reachable, recursively, as descendants of <Frame>?
--- Mirrors the supertypes/children containment logic wowless/modules/xml.lua
--- itself uses at runtime (built in tools/prep.lua's xmlflat).
-local function framesReachable(p)
+-- The shortest chain of tags from <Frame> down to each tag reachable, as a
+-- descendant, from it -- e.g. chains.Slider = { 'Frame', 'Frames', 'Slider'
+-- }, chains.Animation = { 'Frame', 'Animations', 'AnimationGroup',
+-- 'Animation' }. Mirrors the supertypes/children containment logic
+-- wowless/modules/xml.lua itself uses at runtime (built in tools/prep.lua's
+-- xmlflat) to determine which tags may legally nest inside which. Used by
+-- discoverCases below both for reachability (chains[tag] ~= nil) and to
+-- derive exactly how to place a case's tag in the synthetic test frame
+-- (see identityHops/objectPath/templateElement), instead of hand-picking a
+-- wrapper per xml tag.
+--
+-- A tag can genuinely have more than one equally-short path from Frame --
+-- the real UI.xsd often makes an element legal under several parents at
+-- once (see issue #781), so this doesn't error on that by itself. Instead
+-- it also returns `ambiguous`, the set of tags reached via more than one
+-- distinct parent at their shortest depth; discoverCases below only errors
+-- if a tag it actually needs a chain for is (transitively) affected,
+-- rather than requiring the whole schema to be unambiguous.
+local function frameChains(p)
   local xml = perproduct(p, 'xml')
   local function supertypesOf(tag)
     local st = { [tag:lower()] = true }
@@ -95,24 +110,78 @@ local function framesReachable(p)
     supertypes[tag] = supertypesOf(tag)
     children[tag] = childrenOf(tag)
   end
-  local reachable = { Frame = true }
+  -- chains.Frame starts as the trivial zero-hop "this is the synthetic
+  -- test frame itself" entry, needed to bootstrap its direct children
+  -- (Frames/Layers/Animations/...). But Frame is also a legitimate xml tag
+  -- in its own right (e.g. a Frame.framestrata case needs a *fresh* child
+  -- Frame instance, not the shared root re-carrying every candidate's
+  -- value at once) -- so `visited`, not `chains`, gates rediscovery, and
+  -- once Frame is found again for real (via Frames, same as any other
+  -- Frame-family tag), its chains entry is overwritten with that real,
+  -- reachable-as-a-child chain rather than staying at the trivial one.
+  local chains = { Frame = { 'Frame' } }
+  local visited = {}
+  local ambiguous = {}
   local frontier = { 'Frame' }
   while #frontier > 0 do
-    local from = table.remove(frontier)
-    local allowed = children[from]
-    for tag in pairs(xml) do
-      if not reachable[tag] then
-        for st in pairs(supertypes[tag]) do
-          if allowed[st] then
-            reachable[tag] = true
-            table.insert(frontier, tag)
-            break
+    -- Collect every candidate parent per newly-reachable tag from this
+    -- whole layer before resolving any of them, so resolution doesn't
+    -- depend on frontier iteration order (a tag seeing two non-Layer
+    -- candidates before Layer itself must still resolve to Layer, not
+    -- latch an early conflict).
+    local candidates = {}
+    for _, from in ipairs(frontier) do
+      local allowed = children[from]
+      for tag in pairs(xml) do
+        if not visited[tag] then
+          for st in pairs(supertypes[tag]) do
+            if allowed[st] then
+              candidates[tag] = candidates[tag] or {}
+              candidates[tag][from] = true
+              break
+            end
           end
         end
       end
     end
+    local parentOf = {}
+    for tag, froms in pairs(candidates) do
+      if froms.Layer then
+        -- <Layer> is the generic, impl:transparent container built for
+        -- LayeredRegion tags (Texture/FontString/...): whenever it's one
+        -- of the tied candidates, it's always a legal, no-extra-
+        -- object-identity placement, so prefer it over erroring -- e.g.
+        -- FontString is otherwise also tied between EditBox/MessageFrame/
+        -- SimpleHTML, each of which would need its own synthetic
+        -- instance for no benefit.
+        parentOf[tag] = 'Layer'
+      else
+        local only, count = nil, 0
+        for from in pairs(froms) do
+          only, count = from, count + 1
+        end
+        if count == 1 then
+          parentOf[tag] = only
+        else
+          ambiguous[tag] = true
+          parentOf[tag] = only
+        end
+      end
+    end
+    local nextFrontier = {}
+    for tag, from in pairs(parentOf) do
+      local chain = {}
+      for i, t in ipairs(chains[from]) do
+        chain[i] = t
+      end
+      table.insert(chain, tag)
+      chains[tag] = chain
+      visited[tag] = true
+      table.insert(nextFrontier, tag)
+    end
+    frontier = nextFrontier
   end
-  return reachable
+  return chains, ambiguous
 end
 
 -- Per-type field/method data (fields, their init defaults, and which
@@ -223,48 +292,81 @@ local function computeUiobjectApis(p)
   return t
 end
 
--- How a case's xml tag attaches to the synthetic root Frame built by the
--- 'templatexml' doit branch below, which determines both the wrapper
--- element it's nested in and how many objectPath hops are needed to reach
--- it back from the root (see ptablemap.templates and 'templatexml').
--- LayeredRegions (Texture/FontString/...) and Frames (Button/Slider/...)
--- attach directly to their owning frame even through the Layers/Layer and
--- Frames grouping tags, since those are `impl: transparent` -- so is
--- Animations, so an AnimationGroup also attaches directly to the frame.
--- Animation-typed children (Alpha/Animation/...) are only ever real
--- children of an AnimationGroup, never of a frame directly, so they need
--- an extra hop through a synthetic single-use AnimationGroup wrapper.
--- (LayeredRegion itself is `virtual: true` with no `objectType`, so it
--- never self-marks true in the isa table computeUiobjectApis builds --
--- isa.Region is used instead, which both Frame- and LayeredRegion-rooted
--- types inherit, with the isa.Frame check above it disambiguating.)
-local function classifyKind(uiobjectApis, tag)
-  local isa = uiobjectApis[tag].isa
-  if isa.Frame then
-    return 'frame'
-  elseif isa.Region then
-    return 'layerregion'
-  elseif tag == 'AnimationGroup' then
-    return 'animationgroup'
-  elseif isa.Animation then
-    return 'animationchild'
+-- Which positions (2..#chain, i.e. excluding the root Frame itself) in a
+-- frameChains chain create a real, separately-addressable uiobject -- the
+-- ones that need a parentKey in the generated XML and a hop in objectPath.
+-- Pure grouping tags in the chain (Layers/Layer/Frames/Animations/...) have
+-- no uiobjects.yaml entry: they splice their contents into the enclosing
+-- real object at runtime rather than creating one of their own, so they're
+-- skipped here.
+local function identityHops(uiobjectApis, chain)
+  local hops = {}
+  for i = 2, #chain do
+    if uiobjectApis[chain[i]] then
+      table.insert(hops, i)
+    end
   end
-  error('cannot classify xml tag ' .. tag .. ' for template test placement')
+  return hops
+end
+
+-- The parentKey for the n-th (1-indexed) of a case's `total` identity
+-- hops. The last hop is always the case's own test object and keeps the
+-- plain candidate key; any earlier identity hop (so far, only an
+-- AnimationGroup on the way to an Animation) is scaffolding required to
+-- legally nest the test object at all, and needs a per-candidate-unique
+-- key of its own so candidates don't collide by sharing one AnimationGroup
+-- (and, with it, its field defaults) -- the exact suffix scheme doesn't
+-- matter beyond that, since it's never read back, only used to link a
+-- wrapper element to its child in the same generated file.
+local function hopKey(key, n, total)
+  return n == total and key or (key .. '_' .. n)
 end
 
 -- objectPath hops from the root Frame to a case's generated test object,
--- keyed the same way in both ptablemap.templates and the 'templatexml'
--- doit branch below (see classifyKind for why 'animationchild' needs the
--- extra hop through its synthetic single-use AnimationGroup wrapper).
-local function objectPath(case, key)
-  if case.kind == 'animationchild' then
-    return { key .. '_group', key }
+-- keyed the same way ptablemap.templates and 'templatexml' below build the
+-- corresponding parentKey chain in the actual XML (see identityHops).
+local function objectPath(uiobjectApis, case, key)
+  local hops = identityHops(uiobjectApis, case.chain)
+  local path = {}
+  for n in ipairs(hops) do
+    table.insert(path, hopKey(key, n, #hops))
   end
-  return { key }
+  return path
+end
+
+-- Nests a candidate's XML element inside its case's full chain of wrapper
+-- tags (see frameChains), from the child directly under the root Frame
+-- down to the leaf that carries the tested attribute -- assigning
+-- parentKey to each identity hop along the way (see identityHops/hopKey,
+-- kept in sync with objectPath above) and the candidate's attribute value
+-- to the leaf.
+local function templateElement(uiobjectApis, case, key, value)
+  local chain = case.chain
+  local hops = identityHops(uiobjectApis, chain)
+  local hopIndex = {}
+  for n, i in ipairs(hops) do
+    hopIndex[i] = n
+  end
+  local total = #hops
+  local element
+  for i = #chain, 2, -1 do
+    local e = { tag = chain[i] }
+    if hopIndex[i] then
+      e.parentKey = hopKey(key, hopIndex[i], total)
+    end
+    if i == #chain then
+      e[case.xmlAttrKey] = value
+    end
+    if element then
+      table.insert(e, element)
+    end
+    element = e
+  end
+  return element
 end
 
 -- Every (tag, attribute) pair typed stringenum:/enum:, for tags reachable
--- from Frame (see framesReachable) -- these are eligible for per-product
+-- from Frame (see frameChains) -- these are eligible for per-product
 -- XML-attribute-value template tests. An eligible attribute's impl is
 -- required to be field-based (data/schemas/xml.yaml's attribute impl
 -- taggedunion also allows method/internal/loadfile/scope, but every
@@ -272,22 +374,31 @@ end
 -- `impl.field` directly) -- resolve the field's default and real getter
 -- method via computeUiobjectApis's already-computed, inherits-flattened
 -- field/getter data, rather than re-deriving either from string transforms.
+--
+-- frameChains doesn't guarantee every tag has one unambiguous chain (see
+-- its comment, and issue #781) -- only assert that here, lazily, for a
+-- chain a case actually needs, rather than requiring the whole schema to
+-- be unambiguous up front.
 local function discoverCases(p)
-  local reachable = framesReachable(p)
+  local chains, ambiguous = frameChains(p)
   local uiobjectApis = computeUiobjectApis(p)
   local cases = {}
   for tag, tdef in pairs(perproduct(p, 'xml')) do
-    if reachable[tag] then
+    if chains[tag] then
       for attrKey, attrDef in pairs(tdef.attributes or {}) do
         local ty = attrDef.type
         if ty.stringenum or ty.enum then
           local fieldName = assert(attrDef.impl.field, 'unsupported attribute impl for ' .. tag .. '.' .. attrKey)
           local fv = uiobjectApis[tag].fields[fieldName]
+          local chain = chains[tag]
+          for _, t in ipairs(chain) do
+            assert(not ambiguous[t], ('%s.%s: no unambiguous chain to %s (see #781)'):format(tag, attrKey, t))
+          end
           table.insert(cases, {
+            chain = chain,
             getter = fv.getters[1].method,
             id = tag:lower() .. '_' .. attrKey,
             init = fv.init,
-            kind = classifyKind(uiobjectApis, tag),
             xmlAttrKey = attrKey,
             xmlTag = tag,
           })
@@ -532,11 +643,12 @@ local ptablemap = {
     return 'NamespaceApis', t
   end,
   templates = function(p)
+    local uiobjectApis = computeUiobjectApis(p)
     local t = {}
     for _, case in ipairs(discoverCases(p)) do
       for _, c in ipairs(computeCandidates(p, case)) do
         local key = case.id .. '_' .. c.suffix
-        t[key] = { expected = c.expected, getter = case.getter, objectPath = objectPath(case, key) }
+        t[key] = { expected = c.expected, getter = case.getter, objectPath = objectPath(uiobjectApis, case, key) }
       end
     end
     return 'Templates', t
@@ -560,36 +672,15 @@ local function doit(k, p)
   elseif k == 'product' then
     return ('_G.WowlessData = { product = %q }'):format(p)
   elseif k == 'templatexml' then
-    local layer = { tag = 'Layer' }
-    local frames = { tag = 'Frames' }
-    local animations = { tag = 'Animations' }
+    local uiobjectApis = computeUiobjectApis(p)
+    local root = { name = 'WowlessGeneratedXmlTests', tag = 'Frame' }
     for _, case in ipairs(discoverCases(p)) do
       for _, c in ipairs(computeCandidates(p, case)) do
         local key = case.id .. '_' .. c.suffix
-        local element = {
-          [case.xmlAttrKey] = c.value,
-          parentKey = key,
-          tag = case.xmlTag,
-        }
-        if case.kind == 'layerregion' then
-          table.insert(layer, element)
-        elseif case.kind == 'frame' then
-          table.insert(frames, element)
-        elseif case.kind == 'animationgroup' then
-          table.insert(animations, element)
-        else
-          table.insert(animations, {
-            parentKey = key .. '_group',
-            tag = 'AnimationGroup',
-            element,
-          })
-        end
+        table.insert(root, templateElement(uiobjectApis, case, key, c.value))
       end
     end
-    return renderXml({
-      { name = 'WowlessGeneratedXmlTests', tag = 'Frame', { tag = 'Layers', layer }, frames, animations },
-      tag = 'Ui',
-    })
+    return renderXml({ root, tag = 'Ui' })
   elseif k == 'toc' then
     local tt = {}
     for kk in pairs(ptablemap) do

--- a/tools/gentest.lua
+++ b/tools/gentest.lua
@@ -223,6 +223,46 @@ local function computeUiobjectApis(p)
   return t
 end
 
+-- How a case's xml tag attaches to the synthetic root Frame built by the
+-- 'templatexml' doit branch below, which determines both the wrapper
+-- element it's nested in and how many objectPath hops are needed to reach
+-- it back from the root (see ptablemap.templates and 'templatexml').
+-- LayeredRegions (Texture/FontString/...) and Frames (Button/Slider/...)
+-- attach directly to their owning frame even through the Layers/Layer and
+-- Frames grouping tags, since those are `impl: transparent` -- so is
+-- Animations, so an AnimationGroup also attaches directly to the frame.
+-- Animation-typed children (Alpha/Animation/...) are only ever real
+-- children of an AnimationGroup, never of a frame directly, so they need
+-- an extra hop through a synthetic single-use AnimationGroup wrapper.
+-- (LayeredRegion itself is `virtual: true` with no `objectType`, so it
+-- never self-marks true in the isa table computeUiobjectApis builds --
+-- isa.Region is used instead, which both Frame- and LayeredRegion-rooted
+-- types inherit, with the isa.Frame check above it disambiguating.)
+local function classifyKind(uiobjectApis, tag)
+  local isa = uiobjectApis[tag].isa
+  if isa.Frame then
+    return 'frame'
+  elseif isa.Region then
+    return 'layerregion'
+  elseif tag == 'AnimationGroup' then
+    return 'animationgroup'
+  elseif isa.Animation then
+    return 'animationchild'
+  end
+  error('cannot classify xml tag ' .. tag .. ' for template test placement')
+end
+
+-- objectPath hops from the root Frame to a case's generated test object,
+-- keyed the same way in both ptablemap.templates and the 'templatexml'
+-- doit branch below (see classifyKind for why 'animationchild' needs the
+-- extra hop through its synthetic single-use AnimationGroup wrapper).
+local function objectPath(case, key)
+  if case.kind == 'animationchild' then
+    return { key .. '_group', key }
+  end
+  return { key }
+end
+
 -- Every (tag, attribute) pair typed stringenum:/enum:, for tags reachable
 -- from Frame (see framesReachable) -- these are eligible for per-product
 -- XML-attribute-value template tests. An eligible attribute's impl is
@@ -247,6 +287,7 @@ local function discoverCases(p)
             getter = fv.getters[1].method,
             id = tag:lower() .. '_' .. attrKey,
             init = fv.init,
+            kind = classifyKind(uiobjectApis, tag),
             xmlAttrKey = attrKey,
             xmlTag = tag,
           })
@@ -495,7 +536,7 @@ local ptablemap = {
     for _, case in ipairs(discoverCases(p)) do
       for _, c in ipairs(computeCandidates(p, case)) do
         local key = case.id .. '_' .. c.suffix
-        t[key] = { expected = c.expected, getter = case.getter, objectPath = { key } }
+        t[key] = { expected = c.expected, getter = case.getter, objectPath = objectPath(case, key) }
       end
     end
     return 'Templates', t
@@ -520,17 +561,33 @@ local function doit(k, p)
     return ('_G.WowlessData = { product = %q }'):format(p)
   elseif k == 'templatexml' then
     local layer = { tag = 'Layer' }
+    local frames = { tag = 'Frames' }
+    local animations = { tag = 'Animations' }
     for _, case in ipairs(discoverCases(p)) do
       for _, c in ipairs(computeCandidates(p, case)) do
-        table.insert(layer, {
+        local key = case.id .. '_' .. c.suffix
+        local element = {
           [case.xmlAttrKey] = c.value,
-          parentKey = case.id .. '_' .. c.suffix,
+          parentKey = key,
           tag = case.xmlTag,
-        })
+        }
+        if case.kind == 'layerregion' then
+          table.insert(layer, element)
+        elseif case.kind == 'frame' then
+          table.insert(frames, element)
+        elseif case.kind == 'animationgroup' then
+          table.insert(animations, element)
+        else
+          table.insert(animations, {
+            parentKey = key .. '_group',
+            tag = 'AnimationGroup',
+            element,
+          })
+        end
       end
     end
     return renderXml({
-      { name = 'WowlessGeneratedXmlTests', tag = 'Frame', { tag = 'Layers', layer } },
+      { name = 'WowlessGeneratedXmlTests', tag = 'Frame', { tag = 'Layers', layer }, frames, animations },
       tag = 'Ui',
     })
   elseif k == 'toc' then

--- a/tools/gentest.lua
+++ b/tools/gentest.lua
@@ -66,7 +66,7 @@ local xmlcontainment = require('tools.xmlcontainment')
 -- EditBox/MessageFrame/SimpleHTML, each of which would need its own
 -- synthetic instance for no benefit.
 local function frameChains(p)
-  return xmlcontainment.frameChains(perproduct(p, 'xml'), 'Frame', 'Layer')
+  return xmlcontainment.chains(perproduct(p, 'xml'), 'Frame', 'Layer')
 end
 
 -- Per-type field/method data (fields, their init defaults, and which
@@ -175,6 +175,78 @@ local function computeUiobjectApis(p)
     end
   end
   return t
+end
+
+-- Which positions (2..#chain, i.e. excluding the root Frame itself) in a
+-- frameChains chain create a real, separately-addressable uiobject -- the
+-- ones that need a parentKey in the generated XML and a hop in objectPath.
+-- Pure grouping tags in the chain (Layers/Layer/Frames/Animations/...) have
+-- no uiobjects.yaml entry: they splice their contents into the enclosing
+-- real object at runtime rather than creating one of their own, so they're
+-- skipped here.
+local function identityHops(uiobjectApis, chain)
+  local hops = {}
+  for i = 2, #chain do
+    if uiobjectApis[chain[i]] then
+      table.insert(hops, i)
+    end
+  end
+  return hops
+end
+
+-- The parentKey for the n-th (1-indexed) of a case's `total` identity
+-- hops. The last hop is always the case's own test object and keeps the
+-- plain candidate key; any earlier identity hop (so far, only an
+-- AnimationGroup on the way to an Animation) is scaffolding required to
+-- legally nest the test object at all, and needs a per-candidate-unique
+-- key of its own so candidates don't collide by sharing one AnimationGroup
+-- (and, with it, its field defaults) -- the exact suffix scheme doesn't
+-- matter beyond that, since it's never read back, only used to link a
+-- wrapper element to its child in the same generated file.
+local function hopKey(key, n, total)
+  return n == total and key or (key .. '_' .. n)
+end
+
+-- objectPath hops from the root Frame to a case's generated test object,
+-- keyed the same way ptablemap.templates and 'templatexml' below build the
+-- corresponding parentKey chain in the actual XML (see identityHops).
+local function objectPath(uiobjectApis, chain, key)
+  local hops = identityHops(uiobjectApis, chain)
+  local path = {}
+  for n in ipairs(hops) do
+    table.insert(path, hopKey(key, n, #hops))
+  end
+  return path
+end
+
+-- Nests a candidate's XML element inside its case's full chain of wrapper
+-- tags (see frameChains), from the child directly under the root Frame
+-- down to the leaf that carries the tested attribute -- assigning
+-- parentKey to each identity hop along the way (see identityHops/hopKey,
+-- kept in sync with objectPath above) and the candidate's attribute value
+-- to the leaf.
+local function templateElement(uiobjectApis, chain, attrKey, key, value)
+  local hops = identityHops(uiobjectApis, chain)
+  local hopIndex = {}
+  for n, i in ipairs(hops) do
+    hopIndex[i] = n
+  end
+  local total = #hops
+  local element
+  for i = #chain, 2, -1 do
+    local e = { tag = chain[i] }
+    if hopIndex[i] then
+      e.parentKey = hopKey(key, hopIndex[i], total)
+    end
+    if i == #chain then
+      e[attrKey] = value
+    end
+    if element then
+      table.insert(e, element)
+    end
+    element = e
+  end
+  return element
 end
 
 -- Every (tag, attribute) pair typed stringenum:/enum:, for tags reachable
@@ -463,7 +535,7 @@ local ptablemap = {
         t[key] = {
           expected = c.expected,
           getter = case.getter,
-          objectPath = xmlcontainment.objectPath(uiobjectApis, case.chain, key),
+          objectPath = objectPath(uiobjectApis, case.chain, key),
         }
       end
     end
@@ -493,7 +565,7 @@ local function doit(k, p)
     for _, case in ipairs(discoverCases(p)) do
       for _, c in ipairs(computeCandidates(p, case)) do
         local key = case.id .. '_' .. c.suffix
-        table.insert(root, xmlcontainment.templateElement(uiobjectApis, case.chain, case.xmlAttrKey, key, c.value))
+        table.insert(root, templateElement(uiobjectApis, case.chain, case.xmlAttrKey, key, c.value))
       end
     end
     return renderXml({ root, tag = 'Ui' })

--- a/tools/gentest.lua
+++ b/tools/gentest.lua
@@ -56,132 +56,17 @@ local function renderXml(x)
   return table.concat(t, '\n')
 end
 
--- The shortest chain of tags from <Frame> down to each tag reachable, as a
--- descendant, from it -- e.g. chains.Slider = { 'Frame', 'Frames', 'Slider'
--- }, chains.Animation = { 'Frame', 'Animations', 'AnimationGroup',
--- 'Animation' }. Mirrors the supertypes/children containment logic
--- wowless/modules/xml.lua itself uses at runtime (built in tools/prep.lua's
--- xmlflat) to determine which tags may legally nest inside which. Used by
--- discoverCases below both for reachability (chains[tag] ~= nil) and to
--- derive exactly how to place a case's tag in the synthetic test frame
--- (see identityHops/objectPath/templateElement), instead of hand-picking a
--- wrapper per xml tag.
---
--- A tag can genuinely have more than one equally-short path from Frame --
--- the real UI.xsd often makes an element legal under several parents at
--- once (see issue #781), so this doesn't error on that by itself. Instead
--- it also returns `ambiguous`, the set of tags reached via more than one
--- distinct parent at their shortest depth; discoverCases below only errors
--- if a tag it actually needs a chain for is (transitively) affected,
--- rather than requiring the whole schema to be unambiguous.
+local xmlcontainment = require('tools.xmlcontainment')
+
+-- <Layer> is the generic, impl:transparent container built for
+-- LayeredRegion tags (Texture/FontString/...): whenever it's one of a
+-- tag's tied shortest-path candidates, it's always a legal, no-extra-
+-- object-identity placement, so it's passed as frameChains's preferred
+-- tie-break -- e.g. FontString is otherwise also tied between
+-- EditBox/MessageFrame/SimpleHTML, each of which would need its own
+-- synthetic instance for no benefit.
 local function frameChains(p)
-  local xml = perproduct(p, 'xml')
-  local function supertypesOf(tag)
-    local st = { [tag:lower()] = true }
-    local t = xml[tag]
-    local climbing = not t.sealed
-    while t.extends do
-      if climbing then
-        st[t.extends:lower()] = true
-      end
-      t = xml[t.extends]
-      climbing = climbing and not t.sealed
-    end
-    return st
-  end
-  local function childrenOf(tag)
-    local kids = {}
-    local t = xml[tag]
-    while true do
-      if t.contents and t.contents ~= 'text' then
-        for kid in pairs(t.contents.tags) do
-          kids[kid:lower()] = true
-        end
-      end
-      if not t.extends then
-        break
-      end
-      t = xml[t.extends]
-    end
-    return kids
-  end
-  local supertypes, children = {}, {}
-  for tag in pairs(xml) do
-    supertypes[tag] = supertypesOf(tag)
-    children[tag] = childrenOf(tag)
-  end
-  -- chains.Frame starts as the trivial zero-hop "this is the synthetic
-  -- test frame itself" entry, needed to bootstrap its direct children
-  -- (Frames/Layers/Animations/...). But Frame is also a legitimate xml tag
-  -- in its own right (e.g. a Frame.framestrata case needs a *fresh* child
-  -- Frame instance, not the shared root re-carrying every candidate's
-  -- value at once) -- so `visited`, not `chains`, gates rediscovery, and
-  -- once Frame is found again for real (via Frames, same as any other
-  -- Frame-family tag), its chains entry is overwritten with that real,
-  -- reachable-as-a-child chain rather than staying at the trivial one.
-  local chains = { Frame = { 'Frame' } }
-  local visited = {}
-  local ambiguous = {}
-  local frontier = { 'Frame' }
-  while #frontier > 0 do
-    -- Collect every candidate parent per newly-reachable tag from this
-    -- whole layer before resolving any of them, so resolution doesn't
-    -- depend on frontier iteration order (a tag seeing two non-Layer
-    -- candidates before Layer itself must still resolve to Layer, not
-    -- latch an early conflict).
-    local candidates = {}
-    for _, from in ipairs(frontier) do
-      local allowed = children[from]
-      for tag in pairs(xml) do
-        if not visited[tag] then
-          for st in pairs(supertypes[tag]) do
-            if allowed[st] then
-              candidates[tag] = candidates[tag] or {}
-              candidates[tag][from] = true
-              break
-            end
-          end
-        end
-      end
-    end
-    local parentOf = {}
-    for tag, froms in pairs(candidates) do
-      if froms.Layer then
-        -- <Layer> is the generic, impl:transparent container built for
-        -- LayeredRegion tags (Texture/FontString/...): whenever it's one
-        -- of the tied candidates, it's always a legal, no-extra-
-        -- object-identity placement, so prefer it over erroring -- e.g.
-        -- FontString is otherwise also tied between EditBox/MessageFrame/
-        -- SimpleHTML, each of which would need its own synthetic
-        -- instance for no benefit.
-        parentOf[tag] = 'Layer'
-      else
-        local only, count = nil, 0
-        for from in pairs(froms) do
-          only, count = from, count + 1
-        end
-        if count == 1 then
-          parentOf[tag] = only
-        else
-          ambiguous[tag] = true
-          parentOf[tag] = only
-        end
-      end
-    end
-    local nextFrontier = {}
-    for tag, from in pairs(parentOf) do
-      local chain = {}
-      for i, t in ipairs(chains[from]) do
-        chain[i] = t
-      end
-      table.insert(chain, tag)
-      chains[tag] = chain
-      visited[tag] = true
-      table.insert(nextFrontier, tag)
-    end
-    frontier = nextFrontier
-  end
-  return chains, ambiguous
+  return xmlcontainment.frameChains(perproduct(p, 'xml'), 'Frame', 'Layer')
 end
 
 -- Per-type field/method data (fields, their init defaults, and which
@@ -290,79 +175,6 @@ local function computeUiobjectApis(p)
     end
   end
   return t
-end
-
--- Which positions (2..#chain, i.e. excluding the root Frame itself) in a
--- frameChains chain create a real, separately-addressable uiobject -- the
--- ones that need a parentKey in the generated XML and a hop in objectPath.
--- Pure grouping tags in the chain (Layers/Layer/Frames/Animations/...) have
--- no uiobjects.yaml entry: they splice their contents into the enclosing
--- real object at runtime rather than creating one of their own, so they're
--- skipped here.
-local function identityHops(uiobjectApis, chain)
-  local hops = {}
-  for i = 2, #chain do
-    if uiobjectApis[chain[i]] then
-      table.insert(hops, i)
-    end
-  end
-  return hops
-end
-
--- The parentKey for the n-th (1-indexed) of a case's `total` identity
--- hops. The last hop is always the case's own test object and keeps the
--- plain candidate key; any earlier identity hop (so far, only an
--- AnimationGroup on the way to an Animation) is scaffolding required to
--- legally nest the test object at all, and needs a per-candidate-unique
--- key of its own so candidates don't collide by sharing one AnimationGroup
--- (and, with it, its field defaults) -- the exact suffix scheme doesn't
--- matter beyond that, since it's never read back, only used to link a
--- wrapper element to its child in the same generated file.
-local function hopKey(key, n, total)
-  return n == total and key or (key .. '_' .. n)
-end
-
--- objectPath hops from the root Frame to a case's generated test object,
--- keyed the same way ptablemap.templates and 'templatexml' below build the
--- corresponding parentKey chain in the actual XML (see identityHops).
-local function objectPath(uiobjectApis, case, key)
-  local hops = identityHops(uiobjectApis, case.chain)
-  local path = {}
-  for n in ipairs(hops) do
-    table.insert(path, hopKey(key, n, #hops))
-  end
-  return path
-end
-
--- Nests a candidate's XML element inside its case's full chain of wrapper
--- tags (see frameChains), from the child directly under the root Frame
--- down to the leaf that carries the tested attribute -- assigning
--- parentKey to each identity hop along the way (see identityHops/hopKey,
--- kept in sync with objectPath above) and the candidate's attribute value
--- to the leaf.
-local function templateElement(uiobjectApis, case, key, value)
-  local chain = case.chain
-  local hops = identityHops(uiobjectApis, chain)
-  local hopIndex = {}
-  for n, i in ipairs(hops) do
-    hopIndex[i] = n
-  end
-  local total = #hops
-  local element
-  for i = #chain, 2, -1 do
-    local e = { tag = chain[i] }
-    if hopIndex[i] then
-      e.parentKey = hopKey(key, hopIndex[i], total)
-    end
-    if i == #chain then
-      e[case.xmlAttrKey] = value
-    end
-    if element then
-      table.insert(e, element)
-    end
-    element = e
-  end
-  return element
 end
 
 -- Every (tag, attribute) pair typed stringenum:/enum:, for tags reachable
@@ -648,7 +460,11 @@ local ptablemap = {
     for _, case in ipairs(discoverCases(p)) do
       for _, c in ipairs(computeCandidates(p, case)) do
         local key = case.id .. '_' .. c.suffix
-        t[key] = { expected = c.expected, getter = case.getter, objectPath = objectPath(uiobjectApis, case, key) }
+        t[key] = {
+          expected = c.expected,
+          getter = case.getter,
+          objectPath = xmlcontainment.objectPath(uiobjectApis, case.chain, key),
+        }
       end
     end
     return 'Templates', t
@@ -677,7 +493,7 @@ local function doit(k, p)
     for _, case in ipairs(discoverCases(p)) do
       for _, c in ipairs(computeCandidates(p, case)) do
         local key = case.id .. '_' .. c.suffix
-        table.insert(root, templateElement(uiobjectApis, case, key, c.value))
+        table.insert(root, xmlcontainment.templateElement(uiobjectApis, case.chain, case.xmlAttrKey, key, c.value))
       end
     end
     return renderXml({ root, tag = 'Ui' })

--- a/tools/xmlcontainment.lua
+++ b/tools/xmlcontainment.lua
@@ -1,12 +1,11 @@
--- Derives XML tag placement from an xml.yaml-shaped containment graph
--- (contents.tags/extends, including the `sealed` flag), mirroring the
--- containment check wowless/modules/xml.lua's runtime parser uses (see
--- also tools/prep.lua's xmlflat). Used by tools/gentest.lua's per-product
--- XML-attribute-value template-test generator to place a case's tag in a
--- synthetic test frame without hand-classifying every tag it covers.
+-- Derives XML tag containment from an xml.yaml-shaped schema (contents.tags/
+-- extends, including the `sealed` flag), mirroring the containment check
+-- wowless/modules/xml.lua's runtime parser uses (see also tools/prep.lua's
+-- xmlflat). Pure structural computation over that graph -- no notion of
+-- rendering, tests, or any particular caller's vocabulary.
 
 -- The shortest chain of tags from `root` down to every tag reachable, as a
--- descendant, from it -- e.g. frameChains(xml, 'Frame').Slider = { 'Frame',
+-- descendant, from it -- e.g. chains(xml, 'Frame').Slider = { 'Frame',
 -- 'Frames', 'Slider' }. `root` is itself a real tag in `xml` (not a
 -- separate sentinel), which matters when `root` is also reachable as an
 -- ordinary descendant of itself (e.g. a <Frame> nested inside <Frames>):
@@ -23,7 +22,7 @@
 -- tag is recorded in the second return value, `ambiguous`, the set of tags
 -- with no unique shortest path -- callers can then decide whether/when
 -- that matters for their own purposes.
-local function frameChains(xml, root, preferParent)
+local function chains(xml, root, preferParent)
   local function supertypesOf(tag)
     local st = { [tag:lower()] = true }
     local t = xml[tag]
@@ -58,7 +57,7 @@ local function frameChains(xml, root, preferParent)
     supertypes[tag] = supertypesOf(tag)
     children[tag] = childrenOf(tag)
   end
-  local chains = { [root] = { root } }
+  local result = { [root] = { root } }
   local visited = {}
   local ambiguous = {}
   local frontier = { root }
@@ -103,91 +102,19 @@ local function frameChains(xml, root, preferParent)
     local nextFrontier = {}
     for tag, from in pairs(parentOf) do
       local chain = {}
-      for i, t in ipairs(chains[from]) do
+      for i, t in ipairs(result[from]) do
         chain[i] = t
       end
       table.insert(chain, tag)
-      chains[tag] = chain
+      result[tag] = chain
       visited[tag] = true
       table.insert(nextFrontier, tag)
     end
     frontier = nextFrontier
   end
-  return chains, ambiguous
-end
-
--- Which positions (2..#chain, i.e. excluding chain[1], the root itself) in
--- a frameChains chain create a real, separately-addressable object -- the
--- ones that need their own identity (e.g. a parentKey in generated XML, or
--- a hop in an object lookup path). `hasIdentity` is a set (table truthy by
--- tag name) of tags that have one; pure grouping tags in the chain have no
--- entry, since they splice their contents into the enclosing real object
--- at runtime rather than creating one of their own.
-local function identityHops(hasIdentity, chain)
-  local hops = {}
-  for i = 2, #chain do
-    if hasIdentity[chain[i]] then
-      table.insert(hops, i)
-    end
-  end
-  return hops
-end
-
--- The key for the n-th (1-indexed) of `total` identity hops. The last hop
--- keeps the plain candidate key; any earlier identity hop is scaffolding
--- required to legally nest the target object at all, and needs a key of
--- its own so sibling candidates don't collide by sharing that scaffolding
--- (and, with it, its own field defaults) -- the exact suffix scheme
--- doesn't matter beyond that, since it's only used to link a wrapper
--- element to its child within the same generated output.
-local function hopKey(key, n, total)
-  return n == total and key or (key .. '_' .. n)
-end
-
--- The lookup path from `root` to `key`'s target object: one entry per
--- identity hop in `chain` (see identityHops/hopKey), naming each the same
--- way templateElement below builds the matching XML.
-local function objectPath(hasIdentity, chain, key)
-  local hops = identityHops(hasIdentity, chain)
-  local path = {}
-  for n in ipairs(hops) do
-    table.insert(path, hopKey(key, n, #hops))
-  end
-  return path
-end
-
--- Nests an element inside chain[2..], from the child directly under the
--- (pre-existing, not re-rendered) root down to the leaf that carries
--- `attrKey = value` -- assigning a key to each identity hop along the way
--- (see identityHops/hopKey, kept in sync with objectPath above).
-local function templateElement(hasIdentity, chain, attrKey, key, value)
-  local hops = identityHops(hasIdentity, chain)
-  local hopIndex = {}
-  for n, i in ipairs(hops) do
-    hopIndex[i] = n
-  end
-  local total = #hops
-  local element
-  for i = #chain, 2, -1 do
-    local e = { tag = chain[i] }
-    if hopIndex[i] then
-      e.parentKey = hopKey(key, hopIndex[i], total)
-    end
-    if i == #chain then
-      e[attrKey] = value
-    end
-    if element then
-      table.insert(e, element)
-    end
-    element = e
-  end
-  return element
+  return result, ambiguous
 end
 
 return {
-  frameChains = frameChains,
-  hopKey = hopKey,
-  identityHops = identityHops,
-  objectPath = objectPath,
-  templateElement = templateElement,
+  chains = chains,
 }

--- a/tools/xmlcontainment.lua
+++ b/tools/xmlcontainment.lua
@@ -1,0 +1,193 @@
+-- Derives XML tag placement from an xml.yaml-shaped containment graph
+-- (contents.tags/extends, including the `sealed` flag), mirroring the
+-- containment check wowless/modules/xml.lua's runtime parser uses (see
+-- also tools/prep.lua's xmlflat). Used by tools/gentest.lua's per-product
+-- XML-attribute-value template-test generator to place a case's tag in a
+-- synthetic test frame without hand-classifying every tag it covers.
+
+-- The shortest chain of tags from `root` down to every tag reachable, as a
+-- descendant, from it -- e.g. frameChains(xml, 'Frame').Slider = { 'Frame',
+-- 'Frames', 'Slider' }. `root` is itself a real tag in `xml` (not a
+-- separate sentinel), which matters when `root` is also reachable as an
+-- ordinary descendant of itself (e.g. a <Frame> nested inside <Frames>):
+-- `visited`, not the `chains` table, gates rediscovery, so `root`'s trivial
+-- zero-hop bootstrap entry gets overwritten once it's found again for
+-- real, the same way any other tag would be.
+--
+-- A tag can have more than one equally-short path from `root` -- some
+-- schemas legitimately allow an element under several parents at once, so
+-- this doesn't error on that by itself. If `preferParent` is given and is
+-- among a tag's tied candidates, that candidate wins (e.g. a generic,
+-- identity-free wrapper tag is always a safe, minimal choice over a more
+-- specific parent that also happens to accept the same tag); otherwise the
+-- tag is recorded in the second return value, `ambiguous`, the set of tags
+-- with no unique shortest path -- callers can then decide whether/when
+-- that matters for their own purposes.
+local function frameChains(xml, root, preferParent)
+  local function supertypesOf(tag)
+    local st = { [tag:lower()] = true }
+    local t = xml[tag]
+    local climbing = not t.sealed
+    while t.extends do
+      if climbing then
+        st[t.extends:lower()] = true
+      end
+      t = xml[t.extends]
+      climbing = climbing and not t.sealed
+    end
+    return st
+  end
+  local function childrenOf(tag)
+    local kids = {}
+    local t = xml[tag]
+    while true do
+      if t.contents and t.contents ~= 'text' then
+        for kid in pairs(t.contents.tags) do
+          kids[kid:lower()] = true
+        end
+      end
+      if not t.extends then
+        break
+      end
+      t = xml[t.extends]
+    end
+    return kids
+  end
+  local supertypes, children = {}, {}
+  for tag in pairs(xml) do
+    supertypes[tag] = supertypesOf(tag)
+    children[tag] = childrenOf(tag)
+  end
+  local chains = { [root] = { root } }
+  local visited = {}
+  local ambiguous = {}
+  local frontier = { root }
+  while #frontier > 0 do
+    -- Collect every candidate parent per newly-reachable tag from this
+    -- whole layer before resolving any of them, so resolution doesn't
+    -- depend on frontier iteration order (a tag seeing two non-preferred
+    -- candidates before the preferred one must still resolve to it, not
+    -- latch an early conflict).
+    local candidates = {}
+    for _, from in ipairs(frontier) do
+      local allowed = children[from]
+      for tag in pairs(xml) do
+        if not visited[tag] then
+          for st in pairs(supertypes[tag]) do
+            if allowed[st] then
+              candidates[tag] = candidates[tag] or {}
+              candidates[tag][from] = true
+              break
+            end
+          end
+        end
+      end
+    end
+    local parentOf = {}
+    for tag, froms in pairs(candidates) do
+      if preferParent and froms[preferParent] then
+        parentOf[tag] = preferParent
+      else
+        local only, count = nil, 0
+        for from in pairs(froms) do
+          only, count = from, count + 1
+        end
+        if count == 1 then
+          parentOf[tag] = only
+        else
+          ambiguous[tag] = true
+          parentOf[tag] = only
+        end
+      end
+    end
+    local nextFrontier = {}
+    for tag, from in pairs(parentOf) do
+      local chain = {}
+      for i, t in ipairs(chains[from]) do
+        chain[i] = t
+      end
+      table.insert(chain, tag)
+      chains[tag] = chain
+      visited[tag] = true
+      table.insert(nextFrontier, tag)
+    end
+    frontier = nextFrontier
+  end
+  return chains, ambiguous
+end
+
+-- Which positions (2..#chain, i.e. excluding chain[1], the root itself) in
+-- a frameChains chain create a real, separately-addressable object -- the
+-- ones that need their own identity (e.g. a parentKey in generated XML, or
+-- a hop in an object lookup path). `hasIdentity` is a set (table truthy by
+-- tag name) of tags that have one; pure grouping tags in the chain have no
+-- entry, since they splice their contents into the enclosing real object
+-- at runtime rather than creating one of their own.
+local function identityHops(hasIdentity, chain)
+  local hops = {}
+  for i = 2, #chain do
+    if hasIdentity[chain[i]] then
+      table.insert(hops, i)
+    end
+  end
+  return hops
+end
+
+-- The key for the n-th (1-indexed) of `total` identity hops. The last hop
+-- keeps the plain candidate key; any earlier identity hop is scaffolding
+-- required to legally nest the target object at all, and needs a key of
+-- its own so sibling candidates don't collide by sharing that scaffolding
+-- (and, with it, its own field defaults) -- the exact suffix scheme
+-- doesn't matter beyond that, since it's only used to link a wrapper
+-- element to its child within the same generated output.
+local function hopKey(key, n, total)
+  return n == total and key or (key .. '_' .. n)
+end
+
+-- The lookup path from `root` to `key`'s target object: one entry per
+-- identity hop in `chain` (see identityHops/hopKey), naming each the same
+-- way templateElement below builds the matching XML.
+local function objectPath(hasIdentity, chain, key)
+  local hops = identityHops(hasIdentity, chain)
+  local path = {}
+  for n in ipairs(hops) do
+    table.insert(path, hopKey(key, n, #hops))
+  end
+  return path
+end
+
+-- Nests an element inside chain[2..], from the child directly under the
+-- (pre-existing, not re-rendered) root down to the leaf that carries
+-- `attrKey = value` -- assigning a key to each identity hop along the way
+-- (see identityHops/hopKey, kept in sync with objectPath above).
+local function templateElement(hasIdentity, chain, attrKey, key, value)
+  local hops = identityHops(hasIdentity, chain)
+  local hopIndex = {}
+  for n, i in ipairs(hops) do
+    hopIndex[i] = n
+  end
+  local total = #hops
+  local element
+  for i = #chain, 2, -1 do
+    local e = { tag = chain[i] }
+    if hopIndex[i] then
+      e.parentKey = hopKey(key, hopIndex[i], total)
+    end
+    if i == #chain then
+      e[attrKey] = value
+    end
+    if element then
+      table.insert(e, element)
+    end
+    element = e
+  end
+  return element
+end
+
+return {
+  frameChains = frameChains,
+  hopKey = hopKey,
+  identityHops = identityHops,
+  objectPath = objectPath,
+  templateElement = templateElement,
+}


### PR DESCRIPTION
- **xml: type slider.orientation, animation.smoothing, animationgroup.looping, frame.framestrata as stringenum**
- **gentest: derive template-test XML placement from the containment graph**
- **gentest: extract XML containment placement logic into tools/xmlcontainment.lua**
- **gentest: narrow tools/xmlcontainment.lua to just the containment computation**
- **xml: revert animation.smoothing and frame.framestrata back to string**
