### PR TITLE
xml_spec: assert the framestrata/smoothing exceptions are still mismatched

### DIFF
--- a/spec/data/xml_spec.lua
+++ b/spec/data/xml_spec.lua
@@ -84,8 +84,15 @@ describe('xml', function()
               for an, a in pairs(attrs) do
                 it(an, function()
                   local impl = type(a.impl) == 'table' and a.impl or nil
-                  if impl and impl.field and not typeMismatchExceptions[an] then
-                    assert.same(fields[name][impl.field], a.type)
+                  if impl and impl.field then
+                    if typeMismatchExceptions[an] then
+                      -- Tripwire: once #782/#783 land a real fix, the type will
+                      -- start matching and this fails, forcing the exception
+                      -- (and this comment) to be removed instead of going stale.
+                      assert.Not.same(fields[name][impl.field], a.type)
+                    else
+                      assert.same(fields[name][impl.field], a.type)
+                    end
                   end
                 end)
               end


### PR DESCRIPTION
## Summary
- Follow-up to #785: the `framestrata`/`smoothing` type-mismatch exception list is now itself asserted to actually be mismatched (`assert.Not.same`), so it can't quietly go stale.
- If #782/#783 land a real fix and the attribute/field types start matching, this check fails instead of silently continuing to skip the type-match assertion, forcing the exception (and its comment) to be removed.

## Test plan
- [x] `cmake --build --preset default --target test` passes (via pre-commit hook, exit 0)
- [x] `stylua --check` / `luacheck` clean on the changed file

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M71bL4U1ntN4o11RfYZhNk