### PR TITLE
xml_spec: assert the framestrata/smoothing type exceptions are still mismatched

### DIFF
--- a/spec/data/xml_spec.lua
+++ b/spec/data/xml_spec.lua
@@ -84,8 +84,15 @@ describe('xml', function()
               for an, a in pairs(attrs) do
                 it(an, function()
                   local impl = type(a.impl) == 'table' and a.impl or nil
-                  if impl and impl.field and not typeMismatchExceptions[an] then
-                    assert.same(fields[name][impl.field], a.type)
+                  if impl and impl.field then
+                    if typeMismatchExceptions[an] then
+                      -- Tripwire: once #782/#783 land a real fix, the type will
+                      -- start matching and this fails, forcing the exception
+                      -- (and this comment) to be removed instead of going stale.
+                      assert.Not.same(fields[name][impl.field], a.type)
+                    else
+                      assert.same(fields[name][impl.field], a.type)
+                    end
                   end
                 end)
               end


### PR DESCRIPTION
A tripwire so the exception list can't go stale: if #782/#783 land a real fix
and the attribute/field types start matching, this now fails instead of
silently continuing to skip the check, forcing the exception to be removed.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01M71bL4U1ntN4o11RfYZhNk
