### PR TITLE
xml: model Animation.smoothing's OUT_IN as an alias for IN_OUT

### DIFF
--- a/data/products/wow/stringenums.yaml
+++ b/data/products/wow/stringenums.yaml
@@ -66,6 +66,7 @@ SmoothingType:
   NONE:
   OUT:
   OUT_IN:
+    alias: IN_OUT
 WrapMode:
   CLAMP:
   CLAMPTOBLACK:

--- a/data/products/wow/xml.yaml
+++ b/data/products/wow/xml.yaml
@@ -80,7 +80,8 @@ Animation:
     smoothing:
       impl:
         field: smoothing
-      type: string
+      type:
+        stringenum: SmoothingType
     startdelay:
       type: number
     target:

--- a/data/products/wow_anniversary/stringenums.yaml
+++ b/data/products/wow_anniversary/stringenums.yaml
@@ -66,6 +66,7 @@ SmoothingType:
   NONE:
   OUT:
   OUT_IN:
+    alias: IN_OUT
 WrapMode:
   CLAMP:
   CLAMPTOBLACK:

--- a/data/products/wow_anniversary/xml.yaml
+++ b/data/products/wow_anniversary/xml.yaml
@@ -80,7 +80,8 @@ Animation:
     smoothing:
       impl:
         field: smoothing
-      type: string
+      type:
+        stringenum: SmoothingType
     startdelay:
       type: number
     target:

--- a/data/products/wow_classic/stringenums.yaml
+++ b/data/products/wow_classic/stringenums.yaml
@@ -66,6 +66,7 @@ SmoothingType:
   NONE:
   OUT:
   OUT_IN:
+    alias: IN_OUT
 WrapMode:
   CLAMP:
   CLAMPTOBLACK:

--- a/data/products/wow_classic/xml.yaml
+++ b/data/products/wow_classic/xml.yaml
@@ -80,7 +80,8 @@ Animation:
     smoothing:
       impl:
         field: smoothing
-      type: string
+      type:
+        stringenum: SmoothingType
     startdelay:
       type: number
     target:

--- a/data/products/wow_classic_era/stringenums.yaml
+++ b/data/products/wow_classic_era/stringenums.yaml
@@ -66,6 +66,7 @@ SmoothingType:
   NONE:
   OUT:
   OUT_IN:
+    alias: IN_OUT
 StatusBarFillStyle:
   CENTER:
   REVERSE:

--- a/data/products/wow_classic_era/xml.yaml
+++ b/data/products/wow_classic_era/xml.yaml
@@ -80,7 +80,8 @@ Animation:
     smoothing:
       impl:
         field: smoothing
-      type: string
+      type:
+        stringenum: SmoothingType
     startdelay:
       type: number
     target:

--- a/data/products/wow_classic_era_ptr/stringenums.yaml
+++ b/data/products/wow_classic_era_ptr/stringenums.yaml
@@ -66,6 +66,7 @@ SmoothingType:
   NONE:
   OUT:
   OUT_IN:
+    alias: IN_OUT
 WrapMode:
   CLAMP:
   CLAMPTOBLACK:

--- a/data/products/wow_classic_era_ptr/xml.yaml
+++ b/data/products/wow_classic_era_ptr/xml.yaml
@@ -80,7 +80,8 @@ Animation:
     smoothing:
       impl:
         field: smoothing
-      type: string
+      type:
+        stringenum: SmoothingType
     startdelay:
       type: number
     target:

--- a/data/products/wow_classic_ptr/stringenums.yaml
+++ b/data/products/wow_classic_ptr/stringenums.yaml
@@ -66,6 +66,7 @@ SmoothingType:
   NONE:
   OUT:
   OUT_IN:
+    alias: IN_OUT
 WrapMode:
   CLAMP:
   CLAMPTOBLACK:

--- a/data/products/wow_classic_ptr/xml.yaml
+++ b/data/products/wow_classic_ptr/xml.yaml
@@ -80,7 +80,8 @@ Animation:
     smoothing:
       impl:
         field: smoothing
-      type: string
+      type:
+        stringenum: SmoothingType
     startdelay:
       type: number
     target:

--- a/data/products/wowt/stringenums.yaml
+++ b/data/products/wowt/stringenums.yaml
@@ -66,6 +66,7 @@ SmoothingType:
   NONE:
   OUT:
   OUT_IN:
+    alias: IN_OUT
 WrapMode:
   CLAMP:
   CLAMPTOBLACK:

--- a/data/products/wowt/xml.yaml
+++ b/data/products/wowt/xml.yaml
@@ -80,7 +80,8 @@ Animation:
     smoothing:
       impl:
         field: smoothing
-      type: string
+      type:
+        stringenum: SmoothingType
     startdelay:
       type: number
     target:

--- a/data/products/wowxptr/stringenums.yaml
+++ b/data/products/wowxptr/stringenums.yaml
@@ -66,6 +66,7 @@ SmoothingType:
   NONE:
   OUT:
   OUT_IN:
+    alias: IN_OUT
 WrapMode:
   CLAMP:
   CLAMPTOBLACK:

--- a/data/products/wowxptr/xml.yaml
+++ b/data/products/wowxptr/xml.yaml
@@ -80,7 +80,8 @@ Animation:
     smoothing:
       impl:
         field: smoothing
-      type: string
+      type:
+        stringenum: SmoothingType
     startdelay:
       type: number
     target:

--- a/data/schemas/stringenums.yaml
+++ b/data/schemas/stringenums.yaml
@@ -3,4 +3,9 @@ type:
   mapof:
     key: string
     value:
-      setof: string
+      mapof:
+        key: string
+        value:
+          record:
+            alias:
+              type: string

--- a/spec/data/stringenums_spec.lua
+++ b/spec/data/stringenums_spec.lua
@@ -55,6 +55,15 @@ describe('stringenums', function()
               end)
             end
           end)
+          describe('alias', function()
+            for value, def in pairs(v) do
+              if def.alias then
+                it(value, function()
+                  assert.True(v[def.alias] ~= nil)
+                end)
+              end
+            end
+          end)
         end)
       end
     end)

--- a/spec/data/xml_spec.lua
+++ b/spec/data/xml_spec.lua
@@ -75,20 +75,19 @@ describe('xml', function()
             end)
             -- A field-impl attribute writes straight into the uiobject field with
             -- no coercion, so the attribute's declared type must exactly match the
-            -- field's declared type. Frame.framestrata and Animation.smoothing are
-            -- known exceptions (issues #782, #783): real-client behavior for both
-            -- (dynamic PARENT inheritance; OUT_IN normalizing to IN_OUT) can't be
+            -- field's declared type. Frame.framestrata is a known exception (issue
+            -- #782): real-client behavior (dynamic PARENT inheritance) can't be
             -- modeled by a plain stringenum field yet.
-            local typeMismatchExceptions = { framestrata = true, smoothing = true }
+            local typeMismatchExceptions = { framestrata = true }
             describe('field attribute impls match field types', function()
               for an, a in pairs(attrs) do
                 it(an, function()
                   local impl = type(a.impl) == 'table' and a.impl or nil
                   if impl and impl.field then
                     if typeMismatchExceptions[an] then
-                      -- Tripwire: once #782/#783 land a real fix, the type will
-                      -- start matching and this fails, forcing the exception
-                      -- (and this comment) to be removed instead of going stale.
+                      -- Tripwire: once #782 lands a real fix, the type will start
+                      -- matching and this fails, forcing the exception (and this
+                      -- comment) to be removed instead of going stale.
                       assert.Not.same(fields[name][impl.field], a.type)
                     else
                       assert.same(fields[name][impl.field], a.type)

--- a/tools/gentest.lua
+++ b/tools/gentest.lua
@@ -302,8 +302,8 @@ local function attrMembers(p, case)
   local ty = attrDef.type
   if ty.stringenum then
     local members = {}
-    for name in pairs(perproduct(p, 'stringenums')[ty.stringenum]) do
-      members[name] = name
+    for name, v in pairs(perproduct(p, 'stringenums')[ty.stringenum]) do
+      members[name] = v.alias or name
     end
     return members
   elseif ty.enum then

--- a/tools/prep.lua
+++ b/tools/prep.lua
@@ -587,6 +587,17 @@ cinputtypes = {
       n = n + 1
     end
     return function(verb, nilable, idx)
+      if verb == 'implcheck' then
+        return string.format(
+          'wowless_%s%sstringenum(L, %s, wowless_stringenum_%s_values, wowless_stringenum_%s_canonical, %d)',
+          verb,
+          nilable and 'nilable' or '',
+          idx,
+          safename(name),
+          safename(name),
+          n
+        )
+      end
       return string.format(
         'wowless_%s%sstringenum(L, %s, wowless_stringenum_%s_values, %d)',
         verb,
@@ -801,14 +812,24 @@ for sename, sevalues in sorted(stringenums) do
     values[#values + 1] = k
   end
   table.sort(values)
-  local entries = {}
+  local entries, canonical = {}, {}
   for _, v in ipairs(values) do
     entries[#entries + 1] = cstring(v)
+    local alias = sevalues[v].alias
+    if alias then
+      assert(sevalues[alias], 'alias target ' .. alias .. ' is not a member of ' .. sename)
+    end
+    canonical[#canonical + 1] = cstring(alias or v)
   end
   emit(
     'static const char * const wowless_stringenum_%s_values[] = {%s};',
     safename(sename),
     table.concat(entries, ', ')
+  )
+  emit(
+    'static const char * const wowless_stringenum_%s_canonical[] = {%s};',
+    safename(sename),
+    table.concat(canonical, ', ')
   )
 end
 if next(stringenums) then

--- a/wowless/modules/xml.lua
+++ b/wowless/modules/xml.lua
@@ -68,7 +68,8 @@ return function(datalua)
     stringenum = function(name, s)
       local set = stringenums[name]
       local upper = s:upper()
-      return set[upper] and upper or nil
+      local entry = set[upper]
+      return entry and (entry.alias or upper) or nil
     end,
     stringlist = function(s)
       local result = {}

--- a/wowless/typecheck.h
+++ b/wowless/typecheck.h
@@ -445,6 +445,7 @@ static inline void wowless_stubchecknilablestringenum(lua_State *L, int idx,
 
 static inline void wowless_implcheckstringenum(lua_State *L, int idx,
                                                const char *const *values,
+                                               const char *const *canonical,
                                                int n) {
   if (lua_type(L, idx) != LUA_TSTRING) {
     luaL_typerror(L, idx, lua_typename(L, LUA_TSTRING));
@@ -456,7 +457,7 @@ static inline void wowless_implcheckstringenum(lua_State *L, int idx,
     int mid = (lo + hi) / 2;
     int cmp = wowless_strcasecmp(s, values[mid]);
     if (cmp == 0) {
-      lua_pushstring(L, values[mid]);
+      lua_pushstring(L, canonical[mid]);
       lua_replace(L, idx);
       return;
     }
@@ -469,11 +470,11 @@ static inline void wowless_implcheckstringenum(lua_State *L, int idx,
   luaL_argerror(L, idx, "invalid string enum value");
 }
 
-static inline void wowless_implchecknilablestringenum(lua_State *L, int idx,
-                                                      const char *const *values,
-                                                      int n) {
+static inline void wowless_implchecknilablestringenum(
+    lua_State *L, int idx, const char *const *values,
+    const char *const *canonical, int n) {
   if (!lua_isnoneornil(L, idx)) {
-    wowless_implcheckstringenum(L, idx, values, n);
+    wowless_implcheckstringenum(L, idx, values, canonical, n);
   }
 }
 


### PR DESCRIPTION
## Summary

Fixes #783. The real client normalizes `smoothing="OUT_IN"` to `IN_OUT`
when read back via `GetSmoothing()` -- every other `SmoothingType`
value round-trips to itself, but this one doesn't.

- Adds a generic `alias` field to stringenum members
  (`data/schemas/stringenums.yaml` changes from `setof string` to a
  `mapof` of records), and sets `OUT_IN: {alias: IN_OUT}` in each
  product's `stringenums.yaml`.
- Wires the alias through both places a value can be set: the
  XML-attribute coercion path (`wowless/modules/xml.lua`) and the
  generated uiobject field setter/getter stub
  (`wowless_implcheckstringenum`'s new canonical array, in
  `wowless/typecheck.h` / `tools/prep.lua`), so both `smoothing="OUT_IN"`
  in XML and a plain `SetSmoothing("OUT_IN")` Lua call normalize the
  same way.
- Re-enables `Animation.smoothing` as `stringenum`-typed in `xml.yaml`
  (undoing the temporary revert from #777) now that the round-trip
  quirk is modeled, and drops the now-passing type-mismatch tripwire
  exception in `spec/data/xml_spec.lua`.
- Adds an alias-consistency check to `spec/data/stringenums_spec.lua`
  (an alias must point at another real member of the same stringenum).

Built on top of #777's `tools/xmlcontainment.lua` containment-chain
generator, which already anticipated this fix and needed no changes
here beyond one line in `attrMembers` to resolve a member's alias.

## Test plan

- [x] `cmake --build --preset default --target test` clean
- [x] `pre-commit run -a` clean
- [x] Verified generated `templates.lua`/`templates.xml` for `wow`:
      `animation_smoothing_out_in` (and its lowercase variant) now
      expect `IN_OUT`, exercising the alias for real

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>