### PR TITLE
uiobjects: model Frame.frameStrata PARENT/BLIZZARD real-client behavior

### DIFF
--- a/addon/Wowless/test.lua
+++ b/addon/Wowless/test.lua
@@ -720,6 +720,14 @@ G.testsuite.sync = function()
             assertEquals(getmetatable(CreateFrame('Frame')), getmetatable(_G.WorldFrame))
           end
         end,
+        -- issue #782: WORLD is a real frameStrata value, but only WorldFrame
+        -- has it; it's ignored (falls back to inheritance) for every other
+        -- frame, confirmed against a real client.
+        ['has strata WORLD'] = function()
+          if _G.WorldFrame then
+            assertEquals('WORLD', _G.WorldFrame:GetFrameStrata())
+          end
+        end,
       }
     end,
   }

--- a/addon/Wowless/test.xml
+++ b/addon/Wowless/test.xml
@@ -159,11 +159,21 @@
     assertEquals('LOW,MEDIUM,HIGH,DIALOG', table.concat(WowlessLog, ','))
   </Script>
 
-  <!-- issue #782: frameStrata="BLIZZARD" set via XML attribute, the exact
-    path the bug was found through, no-ops the same as the SetFrameStrata()
-    method does, confirmed against a real client. -->
+  <!-- issue #782: frameStrata="PARENT"/"BLIZZARD" set via XML attribute, the
+    exact path the bug was found through. Both behave the same as they do via
+    the SetFrameStrata() method, confirmed against a real client: PARENT
+    isn't a real stratum, it just inherits the parent's current strata, same
+    as any other invalid value; BLIZZARD no-ops. -->
+  <Frame name='WowlessFrameStrataParent' frameStrata='HIGH'>
+    <Frames>
+      <Frame name='WowlessFrameStrataChild' frameStrata='PARENT' />
+    </Frames>
+  </Frame>
   <Frame name='WowlessFrameStrataBlizzard' frameStrata='BLIZZARD' />
   <Script>
+    assertEquals('HIGH', WowlessFrameStrataChild:GetFrameStrata())
+    WowlessFrameStrataParent:SetFrameStrata('LOW')
+    assertEquals('LOW', WowlessFrameStrataChild:GetFrameStrata())
     assertEquals('MEDIUM', WowlessFrameStrataBlizzard:GetFrameStrata())
   </Script>
 

--- a/addon/Wowless/test.xml
+++ b/addon/Wowless/test.xml
@@ -159,6 +159,20 @@
     assertEquals('LOW,MEDIUM,HIGH,DIALOG', table.concat(WowlessLog, ','))
   </Script>
 
+  <!-- issue #782: frameStrata="PARENT"/"BLIZZARD" set via XML attribute, the
+    exact path the bug was found through, must resolve the same way the
+    SetFrameStrata() method does. -->
+  <Frame name='WowlessFrameStrataParent' frameStrata='HIGH'>
+    <Frames>
+      <Frame name='WowlessFrameStrataChild' frameStrata='PARENT' />
+    </Frames>
+  </Frame>
+  <Frame name='WowlessFrameStrataBlizzard' frameStrata='BLIZZARD' />
+  <Script>
+    assertEquals('HIGH', WowlessFrameStrataChild:GetFrameStrata())
+    assertEquals('MEDIUM', WowlessFrameStrataBlizzard:GetFrameStrata())
+  </Script>
+
   <Button name='WowlessTemplate' registerForClicks='AnyUp,AnyDown' virtual='true'>
     <Scripts>
       <OnLoad>end, assertEquals('Frame', WowlessFrame:GetObjectType())--</OnLoad>

--- a/addon/Wowless/test.xml
+++ b/addon/Wowless/test.xml
@@ -160,8 +160,11 @@
   </Script>
 
   <!-- issue #782: frameStrata="PARENT"/"BLIZZARD" set via XML attribute, the
-    exact path the bug was found through, must resolve the same way the
-    SetFrameStrata() method does. -->
+    exact path the bug was found through. PARENT resolves to the parent's
+    strata here, confirmed against a real client, unlike the
+    SetFrameStrata() method, which doesn't resolve PARENT at all (see
+    uiobjects.lua's 'strata' test). BLIZZARD no-ops here too, same as the
+    method. -->
   <Frame name='WowlessFrameStrataParent' frameStrata='HIGH'>
     <Frames>
       <Frame name='WowlessFrameStrataChild' frameStrata='PARENT' />
@@ -171,6 +174,13 @@
   <Script>
     assertEquals('HIGH', WowlessFrameStrataChild:GetFrameStrata())
     assertEquals('MEDIUM', WowlessFrameStrataBlizzard:GetFrameStrata())
+    WowlessFrameStrataParent:SetFrameStrata('LOW')
+    -- issue #782: whether PARENT is a one-time snapshot or live-tracks the
+    -- parent's strata is unconfirmed; this is a probe for our current best
+    -- guess (a one-time snapshot taken when the XML attribute is applied).
+    -- If this fails on a real client, that's the answer: switch to live
+    -- tracking instead.
+    assertEquals('HIGH', WowlessFrameStrataChild:GetFrameStrata())
   </Script>
 
   <Button name='WowlessTemplate' registerForClicks='AnyUp,AnyDown' virtual='true'>

--- a/addon/Wowless/test.xml
+++ b/addon/Wowless/test.xml
@@ -159,28 +159,12 @@
     assertEquals('LOW,MEDIUM,HIGH,DIALOG', table.concat(WowlessLog, ','))
   </Script>
 
-  <!-- issue #782: frameStrata="PARENT"/"BLIZZARD" set via XML attribute, the
-    exact path the bug was found through. PARENT resolves to the parent's
-    strata here, confirmed against a real client, unlike the
-    SetFrameStrata() method, which doesn't resolve PARENT at all (see
-    uiobjects.lua's 'strata' test). BLIZZARD no-ops here too, same as the
-    method. -->
-  <Frame name='WowlessFrameStrataParent' frameStrata='HIGH'>
-    <Frames>
-      <Frame name='WowlessFrameStrataChild' frameStrata='PARENT' />
-    </Frames>
-  </Frame>
+  <!-- issue #782: frameStrata="BLIZZARD" set via XML attribute, the exact
+    path the bug was found through, no-ops the same as the SetFrameStrata()
+    method does, confirmed against a real client. -->
   <Frame name='WowlessFrameStrataBlizzard' frameStrata='BLIZZARD' />
   <Script>
-    assertEquals('HIGH', WowlessFrameStrataChild:GetFrameStrata())
     assertEquals('MEDIUM', WowlessFrameStrataBlizzard:GetFrameStrata())
-    WowlessFrameStrataParent:SetFrameStrata('LOW')
-    -- issue #782: whether PARENT is a one-time snapshot or live-tracks the
-    -- parent's strata is unconfirmed; this is a probe for our current best
-    -- guess (a one-time snapshot taken when the XML attribute is applied).
-    -- If this fails on a real client, that's the answer: switch to live
-    -- tracking instead.
-    assertEquals('HIGH', WowlessFrameStrataChild:GetFrameStrata())
   </Script>
 
   <Button name='WowlessTemplate' registerForClicks='AnyUp,AnyDown' virtual='true'>

--- a/addon/Wowless/uiobjects.lua
+++ b/addon/Wowless/uiobjects.lua
@@ -402,6 +402,17 @@ G.testsuite.uiobjects = function()
               child:SetFrameStrata('NONSENSE')
               assertEquals('DIALOG', child:GetFrameStrata())
             end,
+            -- issue #782: WORLD is a real frameStrata value, but only
+            -- WorldFrame has it (see test.lua); every other frame ignores
+            -- it, same as any other invalid value, confirmed against a
+            -- real client.
+            ['WORLD is ignored on a normal frame'] = function()
+              local parent = CreateFrame('Frame')
+              parent:SetFrameStrata('DIALOG')
+              local child = CreateFrame('Frame', nil, parent)
+              child:SetFrameStrata('WORLD')
+              assertEquals('DIALOG', child:GetFrameStrata())
+            end,
             ['BLIZZARD'] = function()
               local f = CreateFrame('Frame')
               f:SetFrameStrata('DIALOG')

--- a/addon/Wowless/uiobjects.lua
+++ b/addon/Wowless/uiobjects.lua
@@ -364,22 +364,82 @@ G.testsuite.uiobjects = function()
           return match(1, true, f:RegisterEventCallback('ENCOUNTER_STATE_CHANGED', ft))
         end,
         ['strata'] = function()
-          local f = CreateFrame('Frame')
-          f:SetFrameStrata('DIALOG')
-          f:SetFrameStrata('BLIZZARD')
-          assertEquals('DIALOG', f:GetFrameStrata())
+          local t = {
+            ['root has no parent to inherit from'] = function()
+              assertEquals('MEDIUM', (CreateFrame('Frame')):GetFrameStrata())
+            end,
+            ['a new child inherits its parent at creation'] = function()
+              local parent = CreateFrame('Frame')
+              parent:SetFrameStrata('HIGH')
+              local child = CreateFrame('Frame', nil, parent)
+              assertEquals('HIGH', child:GetFrameStrata())
+            end,
+            ['setting a parent cascades to children lacking a fixed strata'] = function()
+              local parent = CreateFrame('Frame')
+              local child = CreateFrame('Frame', nil, parent)
+              assertEquals('MEDIUM', child:GetFrameStrata())
+              parent:SetFrameStrata('HIGH')
+              assertEquals('HIGH', child:GetFrameStrata())
+              parent:SetFrameStrata('LOW')
+              assertEquals('LOW', child:GetFrameStrata())
+              child:SetFixedFrameStrata(true)
+              parent:SetFrameStrata('DIALOG')
+              assertEquals('LOW', child:GetFrameStrata())
+            end,
+            -- issue #782: "PARENT" isn't a real stratum -- confirmed against a
+            -- real client, it behaves the same as any other nonsense value:
+            -- it resolves to whatever the parent's current strata is, same as
+            -- if frameStrata had never been explicitly set at all.
+            ['an invalid value inherits from the parent, same as PARENT'] = function()
+              local parent = CreateFrame('Frame')
+              parent:SetFrameStrata('DIALOG')
+              local child = CreateFrame('Frame', nil, parent)
+              child:SetFrameStrata('HIGH')
+              assertEquals('HIGH', child:GetFrameStrata())
+              child:SetFrameStrata('PARENT')
+              assertEquals('DIALOG', child:GetFrameStrata())
+              child:SetFrameStrata('HIGH')
+              child:SetFrameStrata('NONSENSE')
+              assertEquals('DIALOG', child:GetFrameStrata())
+            end,
+            ['BLIZZARD'] = function()
+              local f = CreateFrame('Frame')
+              f:SetFrameStrata('DIALOG')
+              f:SetFrameStrata('BLIZZARD')
+              assertEquals('DIALOG', f:GetFrameStrata())
 
-          if _G.__wowless then
-            -- issue #782: BLIZZARD only takes effect on forbidden frames, which
-            -- addon Lua can't create/verify against a real client (calling
-            -- SetForbidden from insecure code there isn't safe to probe) --
-            -- confined to checking wowless's own model is internally consistent.
-            local forbidden = CreateFrame('Frame')
-            forbidden:SetForbidden()
-            forbidden:SetFrameStrata('DIALOG')
-            forbidden:SetFrameStrata('BLIZZARD')
-            assertEquals('BLIZZARD', forbidden:GetFrameStrata())
+              if _G.__wowless then
+                -- BLIZZARD only takes effect on forbidden frames, which addon
+                -- Lua can't create/verify against a real client (calling
+                -- SetForbidden from insecure code there isn't safe to probe) --
+                -- confined to checking wowless's own model is internally
+                -- consistent.
+                local forbidden = CreateFrame('Frame')
+                forbidden:SetForbidden()
+                forbidden:SetFrameStrata('DIALOG')
+                forbidden:SetFrameStrata('BLIZZARD')
+                assertEquals('BLIZZARD', forbidden:GetFrameStrata())
+              end
+            end,
+          }
+          for _, s in ipairs({
+            'BACKGROUND',
+            'DIALOG',
+            'FULLSCREEN',
+            'FULLSCREEN_DIALOG',
+            'HIGH',
+            'LOW',
+            'MEDIUM',
+            'TOOLTIP',
+          }) do
+            t[s] = function()
+              local parent = CreateFrame('Frame')
+              parent:SetFrameStrata(s)
+              local child = CreateFrame('Frame', nil, parent)
+              assertEquals(s, child:GetFrameStrata())
+            end
           end
+          return t
         end,
         ['support $parent in frame names'] = function()
           local parent = retn(1, CreateFrame('Frame', 'WowlessParentNameTestMoo'))

--- a/addon/Wowless/uiobjects.lua
+++ b/addon/Wowless/uiobjects.lua
@@ -364,14 +364,7 @@ G.testsuite.uiobjects = function()
           return match(1, true, f:RegisterEventCallback('ENCOUNTER_STATE_CHANGED', ft))
         end,
         ['strata'] = function()
-          -- issue #782: confirmed against a real client -- SetFrameStrata
-          -- doesn't resolve PARENT at all (see test.xml for the XML
-          -- attribute, which does).
           local f = CreateFrame('Frame')
-          f:SetFrameStrata('PARENT')
-          assertEquals('PARENT', f:GetFrameStrata())
-
-          f = CreateFrame('Frame')
           f:SetFrameStrata('DIALOG')
           f:SetFrameStrata('BLIZZARD')
           assertEquals('DIALOG', f:GetFrameStrata())

--- a/addon/Wowless/uiobjects.lua
+++ b/addon/Wowless/uiobjects.lua
@@ -363,6 +363,37 @@ G.testsuite.uiobjects = function()
           local ft = _G.C_FunctionContainers.CreateCallback(function() end)
           return match(1, true, f:RegisterEventCallback('ENCOUNTER_STATE_CHANGED', ft))
         end,
+        ['strata'] = function()
+          local parent = CreateFrame('Frame')
+          parent:SetFrameStrata('HIGH')
+          local child = CreateFrame('Frame', nil, parent)
+          child:SetFrameStrata('PARENT')
+          assertEquals('HIGH', child:GetFrameStrata())
+          parent:SetFrameStrata('LOW')
+          -- issue #782: PARENT's real-client resolution (one-time snapshot vs.
+          -- live tracking of the parent's strata) is unconfirmed; this encodes
+          -- our current best guess (a one-time snapshot taken when PARENT is
+          -- set). If this fails on a real client, that's the answer: switch to
+          -- live tracking instead.
+          assertEquals('HIGH', child:GetFrameStrata())
+
+          local f = CreateFrame('Frame')
+          f:SetFrameStrata('DIALOG')
+          f:SetFrameStrata('BLIZZARD')
+          assertEquals('DIALOG', f:GetFrameStrata())
+
+          if _G.__wowless then
+            -- issue #782: BLIZZARD only takes effect on forbidden frames, which
+            -- addon Lua can't create/verify against a real client (calling
+            -- SetForbidden from insecure code there isn't safe to probe) --
+            -- confined to checking wowless's own model is internally consistent.
+            local forbidden = CreateFrame('Frame')
+            forbidden:SetForbidden()
+            forbidden:SetFrameStrata('DIALOG')
+            forbidden:SetFrameStrata('BLIZZARD')
+            assertEquals('BLIZZARD', forbidden:GetFrameStrata())
+          end
+        end,
         ['support $parent in frame names'] = function()
           local parent = retn(1, CreateFrame('Frame', 'WowlessParentNameTestMoo'))
           local t = {

--- a/addon/Wowless/uiobjects.lua
+++ b/addon/Wowless/uiobjects.lua
@@ -364,20 +364,14 @@ G.testsuite.uiobjects = function()
           return match(1, true, f:RegisterEventCallback('ENCOUNTER_STATE_CHANGED', ft))
         end,
         ['strata'] = function()
-          local parent = CreateFrame('Frame')
-          parent:SetFrameStrata('HIGH')
-          local child = CreateFrame('Frame', nil, parent)
-          child:SetFrameStrata('PARENT')
-          assertEquals('HIGH', child:GetFrameStrata())
-          parent:SetFrameStrata('LOW')
-          -- issue #782: PARENT's real-client resolution (one-time snapshot vs.
-          -- live tracking of the parent's strata) is unconfirmed; this encodes
-          -- our current best guess (a one-time snapshot taken when PARENT is
-          -- set). If this fails on a real client, that's the answer: switch to
-          -- live tracking instead.
-          assertEquals('HIGH', child:GetFrameStrata())
-
+          -- issue #782: confirmed against a real client -- SetFrameStrata
+          -- doesn't resolve PARENT at all (see test.xml for the XML
+          -- attribute, which does).
           local f = CreateFrame('Frame')
+          f:SetFrameStrata('PARENT')
+          assertEquals('PARENT', f:GetFrameStrata())
+
+          f = CreateFrame('Frame')
           f:SetFrameStrata('DIALOG')
           f:SetFrameStrata('BLIZZARD')
           assertEquals('DIALOG', f:GetFrameStrata())

--- a/data/products/wow/stringenums.yaml
+++ b/data/products/wow/stringenums.yaml
@@ -37,6 +37,7 @@ FrameStrata:
   LOW:
   MEDIUM:
   TOOLTIP:
+  WORLD:
 InsertMode:
   BOTTOM:
   TOP:

--- a/data/products/wow/stringenums.yaml
+++ b/data/products/wow/stringenums.yaml
@@ -36,7 +36,6 @@ FrameStrata:
   HIGH:
   LOW:
   MEDIUM:
-  PARENT:
   TOOLTIP:
 InsertMode:
   BOTTOM:

--- a/data/products/wow/uiobjects.yaml
+++ b/data/products/wow/uiobjects.yaml
@@ -4580,8 +4580,7 @@ Frame:
         uiobjectimpl: Frame/SetFrameStrata
       inputs:
       - name: strata
-        type:
-          stringenum: FrameStrata
+        type: string
       outputs:
     SetHighlightLocked:
       inputs:

--- a/data/products/wow/uiobjects.yaml
+++ b/data/products/wow/uiobjects.yaml
@@ -4577,8 +4577,7 @@ Frame:
       outputs:
     SetFrameStrata:
       impl:
-        setter:
-        - name: frameStrata
+        uiobjectimpl: Frame/SetFrameStrata
       inputs:
       - name: strata
         type:

--- a/data/products/wow/xml.yaml
+++ b/data/products/wow/xml.yaml
@@ -517,7 +517,8 @@ Frame:
         method: SetFrameLevel
       type: number
     framestrata:
-      impl: internal
+      impl:
+        method: SetFrameStrata
       type: string
     hyperlinksenabled:
       impl:

--- a/data/products/wow/xml.yaml
+++ b/data/products/wow/xml.yaml
@@ -518,7 +518,7 @@ Frame:
       type: number
     framestrata:
       impl:
-        field: frameStrata
+        method: SetFrameStrata
       type: string
     hyperlinksenabled:
       impl:

--- a/data/products/wow/xml.yaml
+++ b/data/products/wow/xml.yaml
@@ -517,8 +517,7 @@ Frame:
         method: SetFrameLevel
       type: number
     framestrata:
-      impl:
-        method: SetFrameStrata
+      impl: internal
       type: string
     hyperlinksenabled:
       impl:

--- a/data/products/wow_anniversary/stringenums.yaml
+++ b/data/products/wow_anniversary/stringenums.yaml
@@ -37,6 +37,7 @@ FrameStrata:
   LOW:
   MEDIUM:
   TOOLTIP:
+  WORLD:
 InsertMode:
   BOTTOM:
   TOP:

--- a/data/products/wow_anniversary/stringenums.yaml
+++ b/data/products/wow_anniversary/stringenums.yaml
@@ -36,7 +36,6 @@ FrameStrata:
   HIGH:
   LOW:
   MEDIUM:
-  PARENT:
   TOOLTIP:
 InsertMode:
   BOTTOM:

--- a/data/products/wow_anniversary/uiobjects.yaml
+++ b/data/products/wow_anniversary/uiobjects.yaml
@@ -4520,8 +4520,7 @@ Frame:
       outputs:
     SetFrameStrata:
       impl:
-        setter:
-        - name: frameStrata
+        uiobjectimpl: Frame/SetFrameStrata
       inputs:
       - name: strata
         type:

--- a/data/products/wow_anniversary/uiobjects.yaml
+++ b/data/products/wow_anniversary/uiobjects.yaml
@@ -4523,8 +4523,7 @@ Frame:
         uiobjectimpl: Frame/SetFrameStrata
       inputs:
       - name: strata
-        type:
-          stringenum: FrameStrata
+        type: string
       outputs:
     SetHighlightLocked:
       inputs:

--- a/data/products/wow_anniversary/xml.yaml
+++ b/data/products/wow_anniversary/xml.yaml
@@ -517,7 +517,8 @@ Frame:
         method: SetFrameLevel
       type: number
     framestrata:
-      impl: internal
+      impl:
+        method: SetFrameStrata
       type: string
     hyperlinksenabled:
       impl:

--- a/data/products/wow_anniversary/xml.yaml
+++ b/data/products/wow_anniversary/xml.yaml
@@ -518,7 +518,7 @@ Frame:
       type: number
     framestrata:
       impl:
-        field: frameStrata
+        method: SetFrameStrata
       type: string
     hyperlinksenabled:
       impl:

--- a/data/products/wow_anniversary/xml.yaml
+++ b/data/products/wow_anniversary/xml.yaml
@@ -517,8 +517,7 @@ Frame:
         method: SetFrameLevel
       type: number
     framestrata:
-      impl:
-        method: SetFrameStrata
+      impl: internal
       type: string
     hyperlinksenabled:
       impl:

--- a/data/products/wow_classic/stringenums.yaml
+++ b/data/products/wow_classic/stringenums.yaml
@@ -37,6 +37,7 @@ FrameStrata:
   LOW:
   MEDIUM:
   TOOLTIP:
+  WORLD:
 InsertMode:
   BOTTOM:
   TOP:

--- a/data/products/wow_classic/stringenums.yaml
+++ b/data/products/wow_classic/stringenums.yaml
@@ -36,7 +36,6 @@ FrameStrata:
   HIGH:
   LOW:
   MEDIUM:
-  PARENT:
   TOOLTIP:
 InsertMode:
   BOTTOM:

--- a/data/products/wow_classic/uiobjects.yaml
+++ b/data/products/wow_classic/uiobjects.yaml
@@ -4526,8 +4526,7 @@ Frame:
       outputs:
     SetFrameStrata:
       impl:
-        setter:
-        - name: frameStrata
+        uiobjectimpl: Frame/SetFrameStrata
       inputs:
       - name: strata
         type:

--- a/data/products/wow_classic/uiobjects.yaml
+++ b/data/products/wow_classic/uiobjects.yaml
@@ -4529,8 +4529,7 @@ Frame:
         uiobjectimpl: Frame/SetFrameStrata
       inputs:
       - name: strata
-        type:
-          stringenum: FrameStrata
+        type: string
       outputs:
     SetHighlightLocked:
       inputs:

--- a/data/products/wow_classic/xml.yaml
+++ b/data/products/wow_classic/xml.yaml
@@ -517,7 +517,8 @@ Frame:
         method: SetFrameLevel
       type: number
     framestrata:
-      impl: internal
+      impl:
+        method: SetFrameStrata
       type: string
     hyperlinksenabled:
       impl:

--- a/data/products/wow_classic/xml.yaml
+++ b/data/products/wow_classic/xml.yaml
@@ -518,7 +518,7 @@ Frame:
       type: number
     framestrata:
       impl:
-        field: frameStrata
+        method: SetFrameStrata
       type: string
     hyperlinksenabled:
       impl:

--- a/data/products/wow_classic/xml.yaml
+++ b/data/products/wow_classic/xml.yaml
@@ -517,8 +517,7 @@ Frame:
         method: SetFrameLevel
       type: number
     framestrata:
-      impl:
-        method: SetFrameStrata
+      impl: internal
       type: string
     hyperlinksenabled:
       impl:

--- a/data/products/wow_classic_era/stringenums.yaml
+++ b/data/products/wow_classic_era/stringenums.yaml
@@ -37,6 +37,7 @@ FrameStrata:
   LOW:
   MEDIUM:
   TOOLTIP:
+  WORLD:
 InsertMode:
   BOTTOM:
   TOP:

--- a/data/products/wow_classic_era/stringenums.yaml
+++ b/data/products/wow_classic_era/stringenums.yaml
@@ -36,7 +36,6 @@ FrameStrata:
   HIGH:
   LOW:
   MEDIUM:
-  PARENT:
   TOOLTIP:
 InsertMode:
   BOTTOM:

--- a/data/products/wow_classic_era/uiobjects.yaml
+++ b/data/products/wow_classic_era/uiobjects.yaml
@@ -4130,8 +4130,7 @@ Frame:
       outputs:
     SetFrameStrata:
       impl:
-        setter:
-        - name: frameStrata
+        uiobjectimpl: Frame/SetFrameStrata
       inputs:
       - name: strata
         type:

--- a/data/products/wow_classic_era/uiobjects.yaml
+++ b/data/products/wow_classic_era/uiobjects.yaml
@@ -4133,8 +4133,7 @@ Frame:
         uiobjectimpl: Frame/SetFrameStrata
       inputs:
       - name: strata
-        type:
-          stringenum: FrameStrata
+        type: string
       outputs:
     SetHighlightLocked:
       inputs:

--- a/data/products/wow_classic_era/xml.yaml
+++ b/data/products/wow_classic_era/xml.yaml
@@ -512,7 +512,8 @@ Frame:
         method: SetFrameLevel
       type: number
     framestrata:
-      impl: internal
+      impl:
+        method: SetFrameStrata
       type: string
     hyperlinksenabled:
       impl:

--- a/data/products/wow_classic_era/xml.yaml
+++ b/data/products/wow_classic_era/xml.yaml
@@ -512,8 +512,7 @@ Frame:
         method: SetFrameLevel
       type: number
     framestrata:
-      impl:
-        method: SetFrameStrata
+      impl: internal
       type: string
     hyperlinksenabled:
       impl:

--- a/data/products/wow_classic_era/xml.yaml
+++ b/data/products/wow_classic_era/xml.yaml
@@ -513,7 +513,7 @@ Frame:
       type: number
     framestrata:
       impl:
-        field: frameStrata
+        method: SetFrameStrata
       type: string
     hyperlinksenabled:
       impl:

--- a/data/products/wow_classic_era_ptr/stringenums.yaml
+++ b/data/products/wow_classic_era_ptr/stringenums.yaml
@@ -37,6 +37,7 @@ FrameStrata:
   LOW:
   MEDIUM:
   TOOLTIP:
+  WORLD:
 InsertMode:
   BOTTOM:
   TOP:

--- a/data/products/wow_classic_era_ptr/stringenums.yaml
+++ b/data/products/wow_classic_era_ptr/stringenums.yaml
@@ -36,7 +36,6 @@ FrameStrata:
   HIGH:
   LOW:
   MEDIUM:
-  PARENT:
   TOOLTIP:
 InsertMode:
   BOTTOM:

--- a/data/products/wow_classic_era_ptr/uiobjects.yaml
+++ b/data/products/wow_classic_era_ptr/uiobjects.yaml
@@ -4520,8 +4520,7 @@ Frame:
       outputs:
     SetFrameStrata:
       impl:
-        setter:
-        - name: frameStrata
+        uiobjectimpl: Frame/SetFrameStrata
       inputs:
       - name: strata
         type:

--- a/data/products/wow_classic_era_ptr/uiobjects.yaml
+++ b/data/products/wow_classic_era_ptr/uiobjects.yaml
@@ -4523,8 +4523,7 @@ Frame:
         uiobjectimpl: Frame/SetFrameStrata
       inputs:
       - name: strata
-        type:
-          stringenum: FrameStrata
+        type: string
       outputs:
     SetHighlightLocked:
       inputs:

--- a/data/products/wow_classic_era_ptr/xml.yaml
+++ b/data/products/wow_classic_era_ptr/xml.yaml
@@ -517,7 +517,8 @@ Frame:
         method: SetFrameLevel
       type: number
     framestrata:
-      impl: internal
+      impl:
+        method: SetFrameStrata
       type: string
     hyperlinksenabled:
       impl:

--- a/data/products/wow_classic_era_ptr/xml.yaml
+++ b/data/products/wow_classic_era_ptr/xml.yaml
@@ -518,7 +518,7 @@ Frame:
       type: number
     framestrata:
       impl:
-        field: frameStrata
+        method: SetFrameStrata
       type: string
     hyperlinksenabled:
       impl:

--- a/data/products/wow_classic_era_ptr/xml.yaml
+++ b/data/products/wow_classic_era_ptr/xml.yaml
@@ -517,8 +517,7 @@ Frame:
         method: SetFrameLevel
       type: number
     framestrata:
-      impl:
-        method: SetFrameStrata
+      impl: internal
       type: string
     hyperlinksenabled:
       impl:

--- a/data/products/wow_classic_ptr/stringenums.yaml
+++ b/data/products/wow_classic_ptr/stringenums.yaml
@@ -37,6 +37,7 @@ FrameStrata:
   LOW:
   MEDIUM:
   TOOLTIP:
+  WORLD:
 InsertMode:
   BOTTOM:
   TOP:

--- a/data/products/wow_classic_ptr/stringenums.yaml
+++ b/data/products/wow_classic_ptr/stringenums.yaml
@@ -36,7 +36,6 @@ FrameStrata:
   HIGH:
   LOW:
   MEDIUM:
-  PARENT:
   TOOLTIP:
 InsertMode:
   BOTTOM:

--- a/data/products/wow_classic_ptr/uiobjects.yaml
+++ b/data/products/wow_classic_ptr/uiobjects.yaml
@@ -4526,8 +4526,7 @@ Frame:
       outputs:
     SetFrameStrata:
       impl:
-        setter:
-        - name: frameStrata
+        uiobjectimpl: Frame/SetFrameStrata
       inputs:
       - name: strata
         type:

--- a/data/products/wow_classic_ptr/uiobjects.yaml
+++ b/data/products/wow_classic_ptr/uiobjects.yaml
@@ -4529,8 +4529,7 @@ Frame:
         uiobjectimpl: Frame/SetFrameStrata
       inputs:
       - name: strata
-        type:
-          stringenum: FrameStrata
+        type: string
       outputs:
     SetHighlightLocked:
       inputs:

--- a/data/products/wow_classic_ptr/xml.yaml
+++ b/data/products/wow_classic_ptr/xml.yaml
@@ -517,7 +517,8 @@ Frame:
         method: SetFrameLevel
       type: number
     framestrata:
-      impl: internal
+      impl:
+        method: SetFrameStrata
       type: string
     hyperlinksenabled:
       impl:

--- a/data/products/wow_classic_ptr/xml.yaml
+++ b/data/products/wow_classic_ptr/xml.yaml
@@ -518,7 +518,7 @@ Frame:
       type: number
     framestrata:
       impl:
-        field: frameStrata
+        method: SetFrameStrata
       type: string
     hyperlinksenabled:
       impl:

--- a/data/products/wow_classic_ptr/xml.yaml
+++ b/data/products/wow_classic_ptr/xml.yaml
@@ -517,8 +517,7 @@ Frame:
         method: SetFrameLevel
       type: number
     framestrata:
-      impl:
-        method: SetFrameStrata
+      impl: internal
       type: string
     hyperlinksenabled:
       impl:

--- a/data/products/wowt/stringenums.yaml
+++ b/data/products/wowt/stringenums.yaml
@@ -37,6 +37,7 @@ FrameStrata:
   LOW:
   MEDIUM:
   TOOLTIP:
+  WORLD:
 InsertMode:
   BOTTOM:
   TOP:

--- a/data/products/wowt/stringenums.yaml
+++ b/data/products/wowt/stringenums.yaml
@@ -36,7 +36,6 @@ FrameStrata:
   HIGH:
   LOW:
   MEDIUM:
-  PARENT:
   TOOLTIP:
 InsertMode:
   BOTTOM:

--- a/data/products/wowt/uiobjects.yaml
+++ b/data/products/wowt/uiobjects.yaml
@@ -4621,8 +4621,7 @@ Frame:
         uiobjectimpl: Frame/SetFrameStrata
       inputs:
       - name: strata
-        type:
-          stringenum: FrameStrata
+        type: string
       outputs:
     SetHighlightLocked:
       inputs:

--- a/data/products/wowt/uiobjects.yaml
+++ b/data/products/wowt/uiobjects.yaml
@@ -4618,8 +4618,7 @@ Frame:
       outputs:
     SetFrameStrata:
       impl:
-        setter:
-        - name: frameStrata
+        uiobjectimpl: Frame/SetFrameStrata
       inputs:
       - name: strata
         type:

--- a/data/products/wowt/xml.yaml
+++ b/data/products/wowt/xml.yaml
@@ -517,7 +517,8 @@ Frame:
         method: SetFrameLevel
       type: number
     framestrata:
-      impl: internal
+      impl:
+        method: SetFrameStrata
       type: string
     hyperlinksenabled:
       impl:

--- a/data/products/wowt/xml.yaml
+++ b/data/products/wowt/xml.yaml
@@ -518,7 +518,7 @@ Frame:
       type: number
     framestrata:
       impl:
-        field: frameStrata
+        method: SetFrameStrata
       type: string
     hyperlinksenabled:
       impl:

--- a/data/products/wowt/xml.yaml
+++ b/data/products/wowt/xml.yaml
@@ -517,8 +517,7 @@ Frame:
         method: SetFrameLevel
       type: number
     framestrata:
-      impl:
-        method: SetFrameStrata
+      impl: internal
       type: string
     hyperlinksenabled:
       impl:

--- a/data/products/wowxptr/stringenums.yaml
+++ b/data/products/wowxptr/stringenums.yaml
@@ -37,6 +37,7 @@ FrameStrata:
   LOW:
   MEDIUM:
   TOOLTIP:
+  WORLD:
 InsertMode:
   BOTTOM:
   TOP:

--- a/data/products/wowxptr/stringenums.yaml
+++ b/data/products/wowxptr/stringenums.yaml
@@ -36,7 +36,6 @@ FrameStrata:
   HIGH:
   LOW:
   MEDIUM:
-  PARENT:
   TOOLTIP:
 InsertMode:
   BOTTOM:

--- a/data/products/wowxptr/uiobjects.yaml
+++ b/data/products/wowxptr/uiobjects.yaml
@@ -4580,8 +4580,7 @@ Frame:
         uiobjectimpl: Frame/SetFrameStrata
       inputs:
       - name: strata
-        type:
-          stringenum: FrameStrata
+        type: string
       outputs:
     SetHighlightLocked:
       inputs:

--- a/data/products/wowxptr/uiobjects.yaml
+++ b/data/products/wowxptr/uiobjects.yaml
@@ -4577,8 +4577,7 @@ Frame:
       outputs:
     SetFrameStrata:
       impl:
-        setter:
-        - name: frameStrata
+        uiobjectimpl: Frame/SetFrameStrata
       inputs:
       - name: strata
         type:

--- a/data/products/wowxptr/xml.yaml
+++ b/data/products/wowxptr/xml.yaml
@@ -517,7 +517,8 @@ Frame:
         method: SetFrameLevel
       type: number
     framestrata:
-      impl: internal
+      impl:
+        method: SetFrameStrata
       type: string
     hyperlinksenabled:
       impl:

--- a/data/products/wowxptr/xml.yaml
+++ b/data/products/wowxptr/xml.yaml
@@ -518,7 +518,7 @@ Frame:
       type: number
     framestrata:
       impl:
-        field: frameStrata
+        method: SetFrameStrata
       type: string
     hyperlinksenabled:
       impl:

--- a/data/products/wowxptr/xml.yaml
+++ b/data/products/wowxptr/xml.yaml
@@ -517,8 +517,7 @@ Frame:
         method: SetFrameLevel
       type: number
     framestrata:
-      impl:
-        method: SetFrameStrata
+      impl: internal
       type: string
     hyperlinksenabled:
       impl:

--- a/data/uiobjectimpl.yaml
+++ b/data/uiobjectimpl.yaml
@@ -112,6 +112,8 @@ Frame/SetAttributeNoHandler:
   luafile:
 Frame/SetFrameLevel:
   luafile:
+Frame/SetFrameStrata:
+  luafile:
 Frame/SetResizeBounds:
   luafile:
 Frame/UnregisterAllEvents:

--- a/data/uiobjectimpl.yaml
+++ b/data/uiobjectimpl.yaml
@@ -114,6 +114,8 @@ Frame/SetFrameLevel:
   luafile:
 Frame/SetFrameStrata:
   luafile:
+    modules:
+      datalua:
 Frame/SetResizeBounds:
   luafile:
 Frame/UnregisterAllEvents:

--- a/data/uiobjects/Frame/SetFrameStrata.lua
+++ b/data/uiobjects/Frame/SetFrameStrata.lua
@@ -1,9 +1,9 @@
 return function(self, strata)
-  if strata == 'PARENT' then
-    self.frameStrata = self.parent and self.parent:GetFrameStrata() or 'MEDIUM'
-  elseif strata ~= 'BLIZZARD' or self.forbidden then
-    -- issue #782: BLIZZARD is reserved for forbidden frames; it no-ops
-    -- otherwise
+  -- issue #782: BLIZZARD is reserved for forbidden frames; it no-ops
+  -- otherwise. PARENT resolution isn't supported here at all -- confirmed
+  -- against a real client -- only the XML frameStrata attribute (see
+  -- xmlattrlang.framestrata in loader.lua) resolves it.
+  if strata ~= 'BLIZZARD' or self.forbidden then
     self.frameStrata = strata
   end
 end

--- a/data/uiobjects/Frame/SetFrameStrata.lua
+++ b/data/uiobjects/Frame/SetFrameStrata.lua
@@ -1,8 +1,6 @@
 return function(self, strata)
   -- issue #782: BLIZZARD is reserved for forbidden frames; it no-ops
-  -- otherwise. PARENT resolution isn't supported here at all -- confirmed
-  -- against a real client -- only the XML frameStrata attribute (see
-  -- xmlattrlang.framestrata in loader.lua) resolves it.
+  -- otherwise, confirmed against a real client.
   if strata ~= 'BLIZZARD' or self.forbidden then
     self.frameStrata = strata
   end

--- a/data/uiobjects/Frame/SetFrameStrata.lua
+++ b/data/uiobjects/Frame/SetFrameStrata.lua
@@ -1,31 +1,26 @@
-local validStrata = {
-  BACKGROUND = 'BACKGROUND',
-  BLIZZARD = 'BLIZZARD',
-  DIALOG = 'DIALOG',
-  FULLSCREEN = 'FULLSCREEN',
-  FULLSCREEN_DIALOG = 'FULLSCREEN_DIALOG',
-  HIGH = 'HIGH',
-  LOW = 'LOW',
-  MEDIUM = 'MEDIUM',
-  TOOLTIP = 'TOOLTIP',
+local isRealStratum = {
+  BACKGROUND = true,
+  BLIZZARD = true,
+  DIALOG = true,
+  FULLSCREEN = true,
+  FULLSCREEN_DIALOG = true,
+  HIGH = true,
+  LOW = true,
+  MEDIUM = true,
+  TOOLTIP = true,
 }
 
 return function(self, strata)
-  local canonical = validStrata[strata:upper()]
-  local resolved
-  if canonical == 'BLIZZARD' and not self.forbidden then
+  local upper = strata:upper()
+  if upper == 'BLIZZARD' and not self.forbidden then
     -- issue #782: BLIZZARD is reserved for forbidden frames; it no-ops
     -- otherwise, confirmed against a real client.
     return
-  elseif canonical then
-    resolved = canonical
-  else
-    -- issue #782: any value that isn't a real stratum -- including the
-    -- literal string "PARENT" -- resolves the same as never having been
-    -- set at all: inherit the parent's current strata, confirmed against
-    -- a real client.
-    resolved = self.parent and self.parent:GetFrameStrata() or 'MEDIUM'
   end
+  -- issue #782: anything that isn't a real stratum -- including the literal
+  -- string "PARENT" -- resolves the same as never having been set at all:
+  -- inherit the parent's current strata, confirmed against a real client.
+  local resolved = isRealStratum[upper] and upper or (self.parent and self.parent:GetFrameStrata() or 'MEDIUM')
   self.frameStrata = resolved
   for kid in self.children:entries() do
     if kid:IsObjectType('frame') and not kid:HasFixedFrameStrata() then

--- a/data/uiobjects/Frame/SetFrameStrata.lua
+++ b/data/uiobjects/Frame/SetFrameStrata.lua
@@ -1,0 +1,9 @@
+return function(self, strata)
+  if strata == 'PARENT' then
+    self.frameStrata = self.parent and self.parent:GetFrameStrata() or 'MEDIUM'
+  elseif strata ~= 'BLIZZARD' or self.forbidden then
+    -- issue #782: BLIZZARD is reserved for forbidden frames; it no-ops
+    -- otherwise
+    self.frameStrata = strata
+  end
+end

--- a/data/uiobjects/Frame/SetFrameStrata.lua
+++ b/data/uiobjects/Frame/SetFrameStrata.lua
@@ -1,7 +1,35 @@
+local validStrata = {
+  BACKGROUND = 'BACKGROUND',
+  BLIZZARD = 'BLIZZARD',
+  DIALOG = 'DIALOG',
+  FULLSCREEN = 'FULLSCREEN',
+  FULLSCREEN_DIALOG = 'FULLSCREEN_DIALOG',
+  HIGH = 'HIGH',
+  LOW = 'LOW',
+  MEDIUM = 'MEDIUM',
+  TOOLTIP = 'TOOLTIP',
+}
+
 return function(self, strata)
-  -- issue #782: BLIZZARD is reserved for forbidden frames; it no-ops
-  -- otherwise, confirmed against a real client.
-  if strata ~= 'BLIZZARD' or self.forbidden then
-    self.frameStrata = strata
+  local canonical = validStrata[strata:upper()]
+  local resolved
+  if canonical == 'BLIZZARD' and not self.forbidden then
+    -- issue #782: BLIZZARD is reserved for forbidden frames; it no-ops
+    -- otherwise, confirmed against a real client.
+    return
+  elseif canonical then
+    resolved = canonical
+  else
+    -- issue #782: any value that isn't a real stratum -- including the
+    -- literal string "PARENT" -- resolves the same as never having been
+    -- set at all: inherit the parent's current strata, confirmed against
+    -- a real client.
+    resolved = self.parent and self.parent:GetFrameStrata() or 'MEDIUM'
+  end
+  self.frameStrata = resolved
+  for kid in self.children:entries() do
+    if kid:IsObjectType('frame') and not kid:HasFixedFrameStrata() then
+      kid:SetFrameStrata(resolved)
+    end
   end
 end

--- a/data/uiobjects/Frame/SetFrameStrata.lua
+++ b/data/uiobjects/Frame/SetFrameStrata.lua
@@ -1,15 +1,4 @@
-local isRealStratum = {
-  BACKGROUND = true,
-  BLIZZARD = true,
-  DIALOG = true,
-  FULLSCREEN = true,
-  FULLSCREEN_DIALOG = true,
-  HIGH = true,
-  LOW = true,
-  MEDIUM = true,
-  TOOLTIP = true,
-}
-
+local datalua = ...
 return function(self, strata)
   local upper = strata:upper()
   if upper == 'BLIZZARD' and not self.forbidden then
@@ -17,10 +6,14 @@ return function(self, strata)
     -- otherwise, confirmed against a real client.
     return
   end
-  -- issue #782: anything that isn't a real stratum -- including the literal
-  -- string "PARENT" -- resolves the same as never having been set at all:
-  -- inherit the parent's current strata, confirmed against a real client.
-  local resolved = isRealStratum[upper] and upper or (self.parent and self.parent:GetFrameStrata() or 'MEDIUM')
+  -- issue #782: WORLD is reserved for WorldFrame, which gets it directly at
+  -- creation (see loader.lua) -- it isn't settable through here, same as
+  -- any other invalid value (including the literal string "PARENT"),
+  -- confirmed against a real client: anything not settable resolves the
+  -- same as never having been set at all, inheriting the parent's current
+  -- strata.
+  local isValid = upper ~= 'WORLD' and datalua.stringenums.FrameStrata[upper]
+  local resolved = isValid and upper or (self.parent and self.parent:GetFrameStrata() or 'MEDIUM')
   self.frameStrata = resolved
   for kid in self.children:entries() do
     if kid:IsObjectType('frame') and not kid:HasFixedFrameStrata() then

--- a/spec/data/xml_spec.lua
+++ b/spec/data/xml_spec.lua
@@ -75,18 +75,17 @@ describe('xml', function()
             end)
             -- A field-impl attribute writes straight into the uiobject field with
             -- no coercion, so the attribute's declared type must exactly match the
-            -- field's declared type. Frame.framestrata and Animation.smoothing are
-            -- known exceptions (issues #782, #783): real-client behavior for both
-            -- (dynamic PARENT inheritance; OUT_IN normalizing to IN_OUT) can't be
-            -- modeled by a plain stringenum field yet.
-            local typeMismatchExceptions = { framestrata = true, smoothing = true }
+            -- field's declared type. Animation.smoothing is a known exception
+            -- (issue #783): real-client behavior (OUT_IN normalizing to IN_OUT)
+            -- can't be modeled by a plain stringenum field yet.
+            local typeMismatchExceptions = { smoothing = true }
             describe('field attribute impls match field types', function()
               for an, a in pairs(attrs) do
                 it(an, function()
                   local impl = type(a.impl) == 'table' and a.impl or nil
                   if impl and impl.field then
                     if typeMismatchExceptions[an] then
-                      -- Tripwire: once #782/#783 land a real fix, the type will
+                      -- Tripwire: once #783 lands a real fix, the type will
                       -- start matching and this fails, forcing the exception
                       -- (and this comment) to be removed instead of going stale.
                       assert.Not.same(fields[name][impl.field], a.type)

--- a/wowless/modules/api.lua
+++ b/wowless/modules/api.lua
@@ -64,6 +64,9 @@ return function(
     if parent and parent.frameLevel and obj.frameLevel and not obj.hasFixedFrameLevel then
       obj:SetFrameLevel(parent.frameLevel + 1)
     end
+    if parent and parent.frameStrata and obj.frameStrata and not obj.hasFixedFrameStrata then
+      obj:SetFrameStrata(parent.frameStrata)
+    end
   end
 
   local parentMatch = '^$[pP][aA][rR][eE][nN][tT]'

--- a/wowless/modules/loader.lua
+++ b/wowless/modules/loader.lua
@@ -639,7 +639,14 @@ return function(
               end
               local ety = e.type == 'worldframe' and 'frame' or e.type
               local env = ctx.useAddonEnv and addonEnv or ctx.useSecureEnv and secureenv or genv
-              return api.CreateUIObject(ety, name, parent, env, { template }, nil, ctx.layer, ctx.sublevel)
+              local obj = api.CreateUIObject(ety, name, parent, env, { template }, nil, ctx.layer, ctx.sublevel)
+              if e.type == 'worldframe' then
+                -- issue #782: WORLD isn't settable through SetFrameStrata;
+                -- WorldFrame gets it directly, confirmed against a real
+                -- client.
+                obj.frameStrata = 'WORLD'
+              end
+              return obj
             end
           end
         else

--- a/wowless/modules/loader.lua
+++ b/wowless/modules/loader.lua
@@ -431,16 +431,6 @@ return function(
   }
 
   local xmlattrlang = {
-    -- issue #782: PARENT resolves to the parent's current strata (a
-    -- one-time snapshot, not live-tracked); this is XML-only, unlike
-    -- BLIZZARD, which SetFrameStrata itself already models.
-    framestrata = function(_, obj, value)
-      if value:upper() == 'PARENT' then
-        obj.frameStrata = obj.parent and obj.parent:GetFrameStrata() or 'MEDIUM'
-      else
-        obj:SetFrameStrata(value)
-      end
-    end,
     hidden = function(_, obj, value)
       obj.shown = not value
     end,

--- a/wowless/modules/loader.lua
+++ b/wowless/modules/loader.lua
@@ -431,6 +431,16 @@ return function(
   }
 
   local xmlattrlang = {
+    -- issue #782: PARENT resolves to the parent's current strata (a
+    -- one-time snapshot, not live-tracked); this is XML-only, unlike
+    -- BLIZZARD, which SetFrameStrata itself already models.
+    framestrata = function(_, obj, value)
+      if value:upper() == 'PARENT' then
+        obj.frameStrata = obj.parent and obj.parent:GetFrameStrata() or 'MEDIUM'
+      else
+        obj:SetFrameStrata(value)
+      end
+    end,
     hidden = function(_, obj, value)
       obj.shown = not value
     end,


### PR DESCRIPTION
## Summary

`Frame.frameStrata` isn't a flat per-frame value with a hardcoded `MEDIUM` default — confirmed against a real client, it's inherited from the parent frame by default, the same way `frameLevel` already is. `BLIZZARD` and `WORLD` are the two real exceptions, both confirmed against a real client.

- **`DoSetParent`** (`wowless/modules/api.lua`) now seeds a new/reparented frame's `frameStrata` from its parent's current value (unless `HasFixedFrameStrata`), mirroring the existing `frameLevel` logic immediately next to it. This single shared function covers both frame creation and `SetParent`.
- **`SetFrameStrata`** (`data/uiobjects/Frame/SetFrameStrata.lua`, a custom impl replacing the generated field setter) cascades its resolved value down to children lacking a fixed strata, mirroring `SetFrameLevel`'s existing cascade. Its valid-member check now reads from `datalua.stringenums.FrameStrata` (injected via `uiobjectimpl.yaml`, the same pattern `points.lua` already uses for `FramePoint`) instead of a hardcoded list.
- **Any value that isn't settable — including the literal string `"PARENT"`** — resolves the same as never having explicitly set it at all: inherit the parent's current strata. `PARENT` was removed from the `FrameStrata` stringenum entirely (all 8 products) since it isn't a real member, just ordinary invalid input. This required loosening `SetFrameStrata`'s declared input type from `stringenum: FrameStrata` to plain `string` in all 8 products, so invalid values reach the Lua impl instead of erroring at the C typecheck layer.
- **`WORLD`** is a real `FrameStrata` member (added to all 8 products), but it's reserved for `WorldFrame`: it gets set directly at creation (`wowless/modules/loader.lua`), and is never settable through `SetFrameStrata` for any frame — attempting it falls back to parent inheritance like any other invalid value.
- The XML `frameStrata="..."` attribute routes through the same `SetFrameStrata` method (`impl.method`, all 8 products) instead of writing the field directly — the exact path the original bug was found through — so both entry points share identical behavior.
- Removed the now-dead `framestrata` entry from `spec/data/xml_spec.lua`'s `typeMismatchExceptions` tripwire.

## Test plan

- [x] `cmake --build --preset default --target test` — covers creation-time inheritance across every concrete stratum value, the cascade (including `HasFixedFrameStrata` gating), invalid values (`PARENT`, `WORLD`, and otherwise) falling back to inheritance via both the Lua method and the XML attribute, and `WorldFrame` having strata `WORLD`
- [x] `pre-commit run -a`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CyyTB9wqHfaioNUEvHQ2c5