### PR TITLE
points: format anchor error pointers per Windows client convention

### DIFF
--- a/addon/Wowless/uiobjects.lua
+++ b/addon/Wowless/uiobjects.lua
@@ -623,7 +623,8 @@ G.testsuite.uiobjects = function()
           return {
             dag = function()
               local function rstr(r)
-                return tostring(r):gsub('^.*0x(.*)$', '%1')
+                local hex = tostring(r):gsub('^.*0x(.*)$', '%1')
+                return _G.IsWindowsClient() and hex:sub(-8):lower() or hex
               end
               return {
                 ['0'] = function()

--- a/data/modules.yaml
+++ b/data/modules.yaml
@@ -144,6 +144,7 @@ points:
     dirty:
     env:
     log:
+    platform:
     uiobjects:
 region:
   deps:

--- a/wowless/modules/points.lua
+++ b/wowless/modules/points.lua
@@ -1,7 +1,8 @@
-return function(api, datalua, dirty, env, log, uiobjects)
+return function(api, datalua, dirty, env, log, platform, uiobjects)
   local genv = env.genv
   local ParentSub = api.ParentSub
   local SetDirty = dirty.SetDirty
+  local IsWindowsClient = platform.IsWindowsClient
   local UserData = uiobjects.UserData
 
   local validPoints = datalua.stringenums.FramePoint
@@ -94,7 +95,8 @@ return function(api, datalua, dirty, env, log, uiobjects)
   end
 
   local function rstr(r)
-    return tostring(r):gsub('^.*0x(.*)$', '%1')
+    local hex = tostring(r):gsub('^.*0x(.*)$', '%1')
+    return IsWindowsClient() and hex:sub(-8):lower() or hex
   end
 
   local function cycleCheck(r, relativeTo, fn)


### PR DESCRIPTION
## Summary
- Windows WoW clients print SetPoint cycle-error region pointers (`Relative: [...]`, `Dependent: [...]`) truncated to the lower 8 hex digits, lowercase — unlike other platforms, which print the full pointer.
- `points.lua`'s `rstr` helper now truncates via `IsWindowsClient()` (new `platform` module dependency), and the matching in-game test in `addon/Wowless/uiobjects.lua` mirrors the same logic via `_G.IsWindowsClient()`.

## Test plan
- [x] `cmake --build --preset default --target test` — exits 0, no output
- [x] `pre-commit run` on changed files — all hooks pass