### PR TITLE
cvars: mark platform-specific cvars

### DIFF
--- a/addon/Wowless/generated.lua
+++ b/addon/Wowless/generated.lua
@@ -168,8 +168,11 @@ G.testsuite.generated = function()
 
   local function cvars()
     local toskipin = _G.WowlessData.Config.addon.ignore_cvar_value or {}
+    local platform = _G.IsMacClient() and 'mac' or _G.IsWindowsClient() and 'windows' or 'linux'
     local expectedCVars = {}
+    local cvarPlatforms = {}
     for k, v in pairs(_G.WowlessData.CVars) do
+      cvarPlatforms[k] = v.platform
       expectedCVars[k] = {
         account = not not v.account,
         character = not not v.character,
@@ -204,9 +207,16 @@ G.testsuite.generated = function()
     end
     local tests = {}
     for k, v in pairs(expectedCVars) do
-      tests[k] = function()
-        local actual = assert(actualCVars[k], 'extra cvar')
-        return G.assertRecursivelyEqual(v, actual)
+      local wantPlatform = cvarPlatforms[k]
+      if wantPlatform and wantPlatform ~= platform then
+        -- Cross-platform runs (e.g. wowless itself, or a real client on the
+        -- other platform) can't confirm this cvar's presence or value.
+        tests[k] = function() end
+      else
+        tests[k] = function()
+          local actual = assert(actualCVars[k], 'extra cvar')
+          return G.assertRecursivelyEqual(v, actual)
+        end
       end
     end
     local toskipout = {

--- a/data/products/wow/cvars.yaml
+++ b/data/products/wow/cvars.yaml
@@ -2485,10 +2485,13 @@ m2usethreads:
   default: '1'
 macdisableosshortcuts:
   default: '0'
+  platform: mac
 macusecommandleftclickasrightclick:
   default: '1'
+  platform: mac
 macwindowtogglehotkey:
   default: '1'
+  platform: mac
 majorfactionrenownmap:
   account: true
   default: ''

--- a/data/products/wow_anniversary/cvars.yaml
+++ b/data/products/wow_anniversary/cvars.yaml
@@ -2339,10 +2339,13 @@ m2usethreads:
   default: '1'
 macdisableosshortcuts:
   default: '0'
+  platform: mac
 macusecommandleftclickasrightclick:
   default: '1'
+  platform: mac
 macwindowtogglehotkey:
   default: '1'
+  platform: mac
 mapfade:
   character: true
   default: '1'

--- a/data/products/wow_classic/cvars.yaml
+++ b/data/products/wow_classic/cvars.yaml
@@ -2345,10 +2345,13 @@ m2usethreads:
   default: '1'
 macdisableosshortcuts:
   default: '0'
+  platform: mac
 macusecommandleftclickasrightclick:
   default: '1'
+  platform: mac
 macwindowtogglehotkey:
   default: '1'
+  platform: mac
 mapfade:
   character: true
   default: '1'

--- a/data/products/wow_classic_era/cvars.yaml
+++ b/data/products/wow_classic_era/cvars.yaml
@@ -2339,10 +2339,13 @@ m2usethreads:
   default: '1'
 macdisableosshortcuts:
   default: '0'
+  platform: mac
 macusecommandleftclickasrightclick:
   default: '1'
+  platform: mac
 macwindowtogglehotkey:
   default: '1'
+  platform: mac
 mapfade:
   character: true
   default: '1'

--- a/data/products/wow_classic_era_ptr/cvars.yaml
+++ b/data/products/wow_classic_era_ptr/cvars.yaml
@@ -2311,10 +2311,13 @@ m2usethreads:
   default: '1'
 macdisableosshortcuts:
   default: '0'
+  platform: mac
 macusecommandleftclickasrightclick:
   default: '1'
+  platform: mac
 macwindowtogglehotkey:
   default: '1'
+  platform: mac
 mapfade:
   character: true
   default: '1'

--- a/data/products/wow_classic_ptr/cvars.yaml
+++ b/data/products/wow_classic_ptr/cvars.yaml
@@ -2326,10 +2326,13 @@ m2usethreads:
   default: '1'
 macdisableosshortcuts:
   default: '0'
+  platform: mac
 macusecommandleftclickasrightclick:
   default: '1'
+  platform: mac
 macwindowtogglehotkey:
   default: '1'
+  platform: mac
 mapfade:
   character: true
   default: '1'

--- a/data/products/wowt/cvars.yaml
+++ b/data/products/wowt/cvars.yaml
@@ -2488,10 +2488,13 @@ m2usethreads:
   default: '1'
 macdisableosshortcuts:
   default: '0'
+  platform: mac
 macusecommandleftclickasrightclick:
   default: '1'
+  platform: mac
 macwindowtogglehotkey:
   default: '1'
+  platform: mac
 majorfactionrenownmap:
   account: true
   default: ''

--- a/data/products/wowxptr/cvars.yaml
+++ b/data/products/wowxptr/cvars.yaml
@@ -2485,10 +2485,13 @@ m2usethreads:
   default: '1'
 macdisableosshortcuts:
   default: '0'
+  platform: mac
 macusecommandleftclickasrightclick:
   default: '1'
+  platform: mac
 macwindowtogglehotkey:
   default: '1'
+  platform: mac
 majorfactionrenownmap:
   account: true
   default: ''

--- a/data/schemas/cvars.yaml
+++ b/data/schemas/cvars.yaml
@@ -12,6 +12,10 @@ type:
           type: string
         locked:
           type: flag
+        platform:
+          type:
+            taggedunion:
+              mac: tag
         readonly:
           type: flag
         secure:


### PR DESCRIPTION
## Summary
- Add an optional `platform` tag directly on a cvar's own record in `cvars.yaml` (schema: `data/schemas/cvars.yaml`), mirroring the existing `platform: mac` tag already used on API definitions in `apis.yaml`.
- Wire it into the generated in-game consistency check (`addon/Wowless/generated.lua`): when the running platform (detected via `IsMacClient`/`IsWindowsClient`) doesn't match a cvar's configured platform, its presence/value check is skipped instead of being flagged as extra/missing.
- Tag the three real mac-only cvars paired with `C_MacOptions` (`MacDisableOsShortcuts`, `MacUseCommandLeftClickAsRightClick`, `MacWindowToggleHotkey`) across all 8 products, both as the first real users of the facility and to satisfy `schema_coverage_spec`.

## Test plan
- [x] `cmake --build --preset default --target test` (full suite, clean exit)
- [x] pre-commit `build and test` hook passed on commit

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

https://claude.ai/code/session_01AtXRasLdFCaMxbiHw9KKVm