### PR TITLE
uiobjects: move the regions field from ParentedObjectBase to Frame

### DIFF
--- a/data/products/wow/uiobjects.yaml
+++ b/data/products/wow/uiobjects.yaml
@@ -3906,6 +3906,8 @@ Frame:
     propagateKeyboardInput:
       init: false
       type: boolean
+    regions:
+      type: hlist
     resizable:
       init: false
       type: boolean
@@ -6517,8 +6519,6 @@ ParentedObjectBase:
       nilable: true
       type:
         uiobject: UIObject
-    regions:
-      type: hlist
   inherits:
     UIObject:
   methods:

--- a/data/products/wow_anniversary/uiobjects.yaml
+++ b/data/products/wow_anniversary/uiobjects.yaml
@@ -3843,6 +3843,8 @@ Frame:
     propagateKeyboardInput:
       init: false
       type: boolean
+    regions:
+      type: hlist
     resizable:
       init: false
       type: boolean
@@ -6436,8 +6438,6 @@ ParentedObjectBase:
       nilable: true
       type:
         uiobject: UIObject
-    regions:
-      type: hlist
   inherits:
     UIObject:
   methods:

--- a/data/products/wow_classic/uiobjects.yaml
+++ b/data/products/wow_classic/uiobjects.yaml
@@ -3849,6 +3849,8 @@ Frame:
     propagateKeyboardInput:
       init: false
       type: boolean
+    regions:
+      type: hlist
     resizable:
       init: false
       type: boolean
@@ -6446,8 +6448,6 @@ ParentedObjectBase:
       nilable: true
       type:
         uiobject: UIObject
-    regions:
-      type: hlist
   inherits:
     UIObject:
   methods:

--- a/data/products/wow_classic_era/uiobjects.yaml
+++ b/data/products/wow_classic_era/uiobjects.yaml
@@ -3483,6 +3483,8 @@ Frame:
     propagateKeyboardInput:
       init: false
       type: boolean
+    regions:
+      type: hlist
     resizable:
       init: false
       type: boolean
@@ -5962,8 +5964,6 @@ ParentedObjectBase:
       nilable: true
       type:
         uiobject: UIObject
-    regions:
-      type: hlist
   inherits:
     UIObject:
   methods:

--- a/data/products/wow_classic_era_ptr/uiobjects.yaml
+++ b/data/products/wow_classic_era_ptr/uiobjects.yaml
@@ -3843,6 +3843,8 @@ Frame:
     propagateKeyboardInput:
       init: false
       type: boolean
+    regions:
+      type: hlist
     resizable:
       init: false
       type: boolean
@@ -6436,8 +6438,6 @@ ParentedObjectBase:
       nilable: true
       type:
         uiobject: UIObject
-    regions:
-      type: hlist
   inherits:
     UIObject:
   methods:

--- a/data/products/wow_classic_ptr/uiobjects.yaml
+++ b/data/products/wow_classic_ptr/uiobjects.yaml
@@ -3849,6 +3849,8 @@ Frame:
     propagateKeyboardInput:
       init: false
       type: boolean
+    regions:
+      type: hlist
     resizable:
       init: false
       type: boolean
@@ -6446,8 +6448,6 @@ ParentedObjectBase:
       nilable: true
       type:
         uiobject: UIObject
-    regions:
-      type: hlist
   inherits:
     UIObject:
   methods:

--- a/data/products/wowt/uiobjects.yaml
+++ b/data/products/wowt/uiobjects.yaml
@@ -3906,6 +3906,8 @@ Frame:
     propagateKeyboardInput:
       init: false
       type: boolean
+    regions:
+      type: hlist
     resizable:
       init: false
       type: boolean
@@ -6575,8 +6577,6 @@ ParentedObjectBase:
       nilable: true
       type:
         uiobject: UIObject
-    regions:
-      type: hlist
   inherits:
     UIObject:
   methods:

--- a/data/products/wowxptr/uiobjects.yaml
+++ b/data/products/wowxptr/uiobjects.yaml
@@ -3906,6 +3906,8 @@ Frame:
     propagateKeyboardInput:
       init: false
       type: boolean
+    regions:
+      type: hlist
     resizable:
       init: false
       type: boolean
@@ -6517,8 +6519,6 @@ ParentedObjectBase:
       nilable: true
       type:
         uiobject: UIObject
-    regions:
-      type: hlist
   inherits:
     UIObject:
   methods:

--- a/wowless/modules/visibility.lua
+++ b/wowless/modules/visibility.lua
@@ -12,9 +12,11 @@ return function(scripts)
   end
 
   local function DoUpdateVisible(obj, script)
-    for kid in obj.regions:entries() do
-      if kid.shown then
-        DoUpdateVisible(kid, script)
+    if obj.regions then
+      for kid in obj.regions:entries() do
+        if kid.shown then
+          DoUpdateVisible(kid, script)
+        end
       end
     end
     for kid in obj.children:entries() do


### PR DESCRIPTION
## Summary
- Child regions are a Frame-specific concept in the real client — `AnimationGroup` and `Path` (the other types that inherit `ParentedObjectBase`) can't own regions. The `regions` `hlist` field (added in #793) shouldn't live on the generic `ParentedObjectBase`; moved it to `Frame`, where `CreateTexture`/`CreateFontString`/`CreateMaskTexture`/`CreateLine`/`GetRegions`/`GetNumRegions` are already declared.
- `wowless/modules/visibility.lua`'s `DoUpdateVisible` recurses generically over any `ParentedObjectBase`-ish node, including into the regions themselves once reached (a `Texture`/`FontString` node also gets visited). It unconditionally read `obj.regions`, which broke once `regions` stopped being universal — added a guard.
- `wowless/modules/api.lua`'s `DoSetParent` field-routing logic is unaffected (it already indexed `parent.regions`/`parent.children`/`parent.animationGroups` by name; only the field's schema location changed).

## Test plan
- [x] `cmake --build --preset default --target test` — exit 0, no output, across all products
- [x] `pre-commit run` on all changed files — all hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)