### PR TITLE
uiobjects: move the regions field from ParentedObjectBase to Frame

### DIFF
--- a/data/products/wow/uiobjects.yaml
+++ b/data/products/wow/uiobjects.yaml
@@ -3906,6 +3906,8 @@ Frame:
     propagateKeyboardInput:
       init: false
       type: boolean
+    regions:
+      type: hlist
     resizable:
       init: false
       type: boolean
@@ -6517,8 +6519,6 @@ ParentedObjectBase:
       nilable: true
       type:
         uiobject: UIObject
-    regions:
-      type: hlist
   inherits:
     UIObject:
   methods:

--- a/data/products/wow_anniversary/uiobjects.yaml
+++ b/data/products/wow_anniversary/uiobjects.yaml
@@ -3843,6 +3843,8 @@ Frame:
     propagateKeyboardInput:
       init: false
       type: boolean
+    regions:
+      type: hlist
     resizable:
       init: false
       type: boolean
@@ -6436,8 +6438,6 @@ ParentedObjectBase:
       nilable: true
       type:
         uiobject: UIObject
-    regions:
-      type: hlist
   inherits:
     UIObject:
   methods:

--- a/data/products/wow_classic/uiobjects.yaml
+++ b/data/products/wow_classic/uiobjects.yaml
@@ -3849,6 +3849,8 @@ Frame:
     propagateKeyboardInput:
       init: false
       type: boolean
+    regions:
+      type: hlist
     resizable:
       init: false
       type: boolean
@@ -6446,8 +6448,6 @@ ParentedObjectBase:
       nilable: true
       type:
         uiobject: UIObject
-    regions:
-      type: hlist
   inherits:
     UIObject:
   methods:

--- a/data/products/wow_classic_era/uiobjects.yaml
+++ b/data/products/wow_classic_era/uiobjects.yaml
@@ -3483,6 +3483,8 @@ Frame:
     propagateKeyboardInput:
       init: false
       type: boolean
+    regions:
+      type: hlist
     resizable:
       init: false
       type: boolean
@@ -5962,8 +5964,6 @@ ParentedObjectBase:
       nilable: true
       type:
         uiobject: UIObject
-    regions:
-      type: hlist
   inherits:
     UIObject:
   methods:

--- a/data/products/wow_classic_era_ptr/uiobjects.yaml
+++ b/data/products/wow_classic_era_ptr/uiobjects.yaml
@@ -3843,6 +3843,8 @@ Frame:
     propagateKeyboardInput:
       init: false
       type: boolean
+    regions:
+      type: hlist
     resizable:
       init: false
       type: boolean
@@ -6436,8 +6438,6 @@ ParentedObjectBase:
       nilable: true
       type:
         uiobject: UIObject
-    regions:
-      type: hlist
   inherits:
     UIObject:
   methods:

--- a/data/products/wow_classic_ptr/uiobjects.yaml
+++ b/data/products/wow_classic_ptr/uiobjects.yaml
@@ -3849,6 +3849,8 @@ Frame:
     propagateKeyboardInput:
       init: false
       type: boolean
+    regions:
+      type: hlist
     resizable:
       init: false
       type: boolean
@@ -6446,8 +6448,6 @@ ParentedObjectBase:
       nilable: true
       type:
         uiobject: UIObject
-    regions:
-      type: hlist
   inherits:
     UIObject:
   methods:

--- a/data/products/wowt/uiobjects.yaml
+++ b/data/products/wowt/uiobjects.yaml
@@ -3906,6 +3906,8 @@ Frame:
     propagateKeyboardInput:
       init: false
       type: boolean
+    regions:
+      type: hlist
     resizable:
       init: false
       type: boolean
@@ -6575,8 +6577,6 @@ ParentedObjectBase:
       nilable: true
       type:
         uiobject: UIObject
-    regions:
-      type: hlist
   inherits:
     UIObject:
   methods:

--- a/data/products/wowxptr/uiobjects.yaml
+++ b/data/products/wowxptr/uiobjects.yaml
@@ -3906,6 +3906,8 @@ Frame:
     propagateKeyboardInput:
       init: false
       type: boolean
+    regions:
+      type: hlist
     resizable:
       init: false
       type: boolean
@@ -6517,8 +6519,6 @@ ParentedObjectBase:
       nilable: true
       type:
         uiobject: UIObject
-    regions:
-      type: hlist
   inherits:
     UIObject:
   methods:

--- a/wowless/modules/visibility.lua
+++ b/wowless/modules/visibility.lua
@@ -12,9 +12,11 @@ return function(scripts)
   end
 
   local function DoUpdateVisible(obj, script)
-    for kid in obj.regions:entries() do
-      if kid.shown then
-        DoUpdateVisible(kid, script)
+    if obj.regions then
+      for kid in obj.regions:entries() do
+        if kid.shown then
+          DoUpdateVisible(kid, script)
+        end
       end
     end
     for kid in obj.children:entries() do


### PR DESCRIPTION
Child regions (textures, font strings, etc.) are a Frame-specific concept
in the real client -- nothing else can own them -- so the field shouldn't
live on the generic ParentedObjectBase that AnimationGroup and Path also
inherit. Move it to Frame, next to CreateTexture/CreateFontString/etc.,
which are already declared there.

visibility.lua's DoUpdateVisible recurses generically over any
ParentedObjectBase-ish node, including regions themselves once reached --
it now guards the obj.regions walk since a Texture/FontString no longer
has that field.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
