### PR TITLE
uiobjects: give animations and control points their own ordered lists

### DIFF
--- a/addon/Wowless/uiobjects.lua
+++ b/addon/Wowless/uiobjects.lua
@@ -23,6 +23,22 @@ G.testsuite.uiobjects = function()
       }
     end,
 
+    AnimationGroup = function()
+      return {
+        ['animation order'] = function()
+          local g = CreateFrame('Frame'):CreateAnimationGroup()
+          local a = g:CreateAnimation()
+          local b = g:CreateAnimation()
+          local c = g:CreateAnimation()
+          check3(a, b, c, g:GetAnimations())
+          b:SetParent(nil)
+          check2(a, c, g:GetAnimations())
+          b:SetParent(g)
+          check3(a, c, b, g:GetAnimations())
+        end,
+      }
+    end,
+
     EditBox = function()
       return {
         fontobject = function()
@@ -585,6 +601,22 @@ G.testsuite.uiobjects = function()
           check0(mf:SetFontObject(fo2))
           check1(fo, mf:GetFontObject())
           assert(not pcall(mf.SetFontObject, mf, nil))
+        end,
+      }
+    end,
+
+    Path = function()
+      return {
+        ['control point order'] = function()
+          local p = CreateFrame('Frame'):CreateAnimationGroup():CreateAnimation('Path')
+          local a = p:CreateControlPoint()
+          local b = p:CreateControlPoint()
+          local c = p:CreateControlPoint()
+          check3(a, b, c, p:GetControlPoints())
+          b:SetParent(nil)
+          check2(a, c, p:GetControlPoints())
+          b:SetParent(p)
+          check3(a, c, b, p:GetControlPoints())
         end,
       }
     end,

--- a/addon/Wowless/uiobjects.lua
+++ b/addon/Wowless/uiobjects.lua
@@ -26,15 +26,17 @@ G.testsuite.uiobjects = function()
     AnimationGroup = function()
       return {
         ['animation order'] = function()
+          -- Animations cannot be unparented (confirmed against a real
+          -- client: Animation:SetParent(nil) errors), so only creation
+          -- order is testable here -- no swap-remove reordering to
+          -- exercise from addon code.
           local g = CreateFrame('Frame'):CreateAnimationGroup()
           local a = g:CreateAnimation()
           local b = g:CreateAnimation()
           local c = g:CreateAnimation()
           check3(a, b, c, g:GetAnimations())
-          b:SetParent(nil)
-          check2(a, c, g:GetAnimations())
-          b:SetParent(g)
-          check3(a, c, b, g:GetAnimations())
+          assert(not pcall(b.SetParent, b, nil))
+          check3(a, b, c, g:GetAnimations())
         end,
       }
     end,
@@ -608,10 +610,15 @@ G.testsuite.uiobjects = function()
     Path = function()
       return {
         ['control point order'] = function()
+          -- order defaults to the same value (99) for every control point,
+          -- and a real client only kept the last one created when all three
+          -- shared it -- control points look to be keyed by order, not a
+          -- plain append list. Pass distinct order values to sidestep that
+          -- here.
           local p = CreateFrame('Frame'):CreateAnimationGroup():CreateAnimation('Path')
-          local a = p:CreateControlPoint()
-          local b = p:CreateControlPoint()
-          local c = p:CreateControlPoint()
+          local a = p:CreateControlPoint(nil, nil, 1)
+          local b = p:CreateControlPoint(nil, nil, 2)
+          local c = p:CreateControlPoint(nil, nil, 3)
           check3(a, b, c, p:GetControlPoints())
           b:SetParent(nil)
           check2(a, c, p:GetControlPoints())

--- a/data/products/wow/uiobjects.yaml
+++ b/data/products/wow/uiobjects.yaml
@@ -930,6 +930,8 @@ Animation:
     OnUpdate:
 AnimationGroup:
   fields:
+    animations:
+      type: hlist
     animationSpeedMultiplier:
       init: 1
       type: number
@@ -6569,6 +6571,8 @@ ParentedObjectBase:
   virtual: true
 Path:
   fields:
+    controlPoints:
+      type: hlist
     curveType:
       init: NONE
       type:

--- a/data/products/wow_anniversary/uiobjects.yaml
+++ b/data/products/wow_anniversary/uiobjects.yaml
@@ -875,6 +875,8 @@ Animation:
     OnUpdate:
 AnimationGroup:
   fields:
+    animations:
+      type: hlist
     animationSpeedMultiplier:
       init: 1
       type: number
@@ -6488,6 +6490,8 @@ ParentedObjectBase:
   virtual: true
 Path:
   fields:
+    controlPoints:
+      type: hlist
     curveType:
       init: NONE
       type:

--- a/data/products/wow_classic/uiobjects.yaml
+++ b/data/products/wow_classic/uiobjects.yaml
@@ -875,6 +875,8 @@ Animation:
     OnUpdate:
 AnimationGroup:
   fields:
+    animations:
+      type: hlist
     animationSpeedMultiplier:
       init: 1
       type: number
@@ -6498,6 +6500,8 @@ ParentedObjectBase:
   virtual: true
 Path:
   fields:
+    controlPoints:
+      type: hlist
     curveType:
       init: NONE
       type:

--- a/data/products/wow_classic_era/uiobjects.yaml
+++ b/data/products/wow_classic_era/uiobjects.yaml
@@ -659,6 +659,8 @@ Animation:
     OnUpdate:
 AnimationGroup:
   fields:
+    animations:
+      type: hlist
     animationSpeedMultiplier:
       init: 1
       type: number
@@ -6014,6 +6016,8 @@ ParentedObjectBase:
   virtual: true
 Path:
   fields:
+    controlPoints:
+      type: hlist
     curveType:
       init: NONE
       type:

--- a/data/products/wow_classic_era_ptr/uiobjects.yaml
+++ b/data/products/wow_classic_era_ptr/uiobjects.yaml
@@ -875,6 +875,8 @@ Animation:
     OnUpdate:
 AnimationGroup:
   fields:
+    animations:
+      type: hlist
     animationSpeedMultiplier:
       init: 1
       type: number
@@ -6488,6 +6490,8 @@ ParentedObjectBase:
   virtual: true
 Path:
   fields:
+    controlPoints:
+      type: hlist
     curveType:
       init: NONE
       type:

--- a/data/products/wow_classic_ptr/uiobjects.yaml
+++ b/data/products/wow_classic_ptr/uiobjects.yaml
@@ -875,6 +875,8 @@ Animation:
     OnUpdate:
 AnimationGroup:
   fields:
+    animations:
+      type: hlist
     animationSpeedMultiplier:
       init: 1
       type: number
@@ -6498,6 +6500,8 @@ ParentedObjectBase:
   virtual: true
 Path:
   fields:
+    controlPoints:
+      type: hlist
     curveType:
       init: NONE
       type:

--- a/data/products/wowt/uiobjects.yaml
+++ b/data/products/wowt/uiobjects.yaml
@@ -930,6 +930,8 @@ Animation:
     OnUpdate:
 AnimationGroup:
   fields:
+    animations:
+      type: hlist
     animationSpeedMultiplier:
       init: 1
       type: number
@@ -6627,6 +6629,8 @@ ParentedObjectBase:
   virtual: true
 Path:
   fields:
+    controlPoints:
+      type: hlist
     curveType:
       init: NONE
       type:

--- a/data/products/wowxptr/uiobjects.yaml
+++ b/data/products/wowxptr/uiobjects.yaml
@@ -930,6 +930,8 @@ Animation:
     OnUpdate:
 AnimationGroup:
   fields:
+    animations:
+      type: hlist
     animationSpeedMultiplier:
       init: 1
       type: number
@@ -6569,6 +6571,8 @@ ParentedObjectBase:
   virtual: true
 Path:
   fields:
+    controlPoints:
+      type: hlist
     curveType:
       init: NONE
       type:

--- a/data/uiobjects/AnimationGroup/GetAnimations.lua
+++ b/data/uiobjects/AnimationGroup/GetAnimations.lua
@@ -1,9 +1,7 @@
 return function(self)
   local ret = {}
-  for kid in self.children:entries() do
-    if kid:IsObjectType('animation') then
-      table.insert(ret, kid)
-    end
+  for kid in self.animations:entries() do
+    table.insert(ret, kid)
   end
   return unpack(ret)
 end

--- a/data/uiobjects/Path/CreateControlPoint.lua
+++ b/data/uiobjects/Path/CreateControlPoint.lua
@@ -1,4 +1,8 @@
 local api = ...
-return function(self, name)
-  return api.CreateUIObject('controlpoint', name, self)
+return function(self, name, templateName, order)
+  local point = api.CreateChildUIObject('controlpoint', self, name, templateName)
+  if order then
+    point.order = order
+  end
+  return point
 end

--- a/data/uiobjects/Path/GetControlPoints.lua
+++ b/data/uiobjects/Path/GetControlPoints.lua
@@ -1,9 +1,7 @@
 return function(self)
   local ret = {}
-  for kid in self.children:entries() do
-    if kid:IsObjectType('controlpoint') then
-      table.insert(ret, kid)
-    end
+  for kid in self.controlPoints:entries() do
+    table.insert(ret, kid)
   end
   return unpack(ret)
 end

--- a/wowless/modules/api.lua
+++ b/wowless/modules/api.lua
@@ -27,6 +27,7 @@ return function(
     end
   end)()
 
+  local GetObjectType = uiobjecttypes.GetObjectType
   local InheritsFrom = uiobjecttypes.InheritsFrom
   local IsIntrinsicType = uiobjecttypes.IsIntrinsicType
   local IsObjectType = uiobjecttypes.IsObjectType
@@ -110,6 +111,9 @@ return function(
   end
 
   local function SetParent(obj, parent)
+    if parent == nil and IsObjectType(obj, 'animation') then
+      error(('%s:SetParent(): Cannot set a \'nil\' parent'):format(GetObjectType(obj)), 0)
+    end
     local p = parent
     while p do
       if obj == p then

--- a/wowless/modules/api.lua
+++ b/wowless/modules/api.lua
@@ -51,6 +51,8 @@ return function(
     end
     local field = IsObjectType(obj, 'layeredregion') and 'regions'
       or IsObjectType(obj, 'animationgroup') and 'animationGroups'
+      or IsObjectType(obj, 'controlpoint') and 'controlPoints'
+      or IsObjectType(obj, 'animation') and 'animations'
       or 'children'
     if obj.parent then
       local up = obj.parent


### PR DESCRIPTION
## Summary
- `AnimationGroup/GetAnimations.lua` and `Path/GetControlPoints.lua` were filtering the generic `ParentedObjectBase.children` list by object type — the same shape already fixed for frame children/regions (#793) and animation groups (#793)/actors (tracked in #795).
- Added dedicated `animations` (`AnimationGroup`) and `controlPoints` (`Path`) `hlist` fields, routed to by `IsObjectType` in `DoSetParent` (`wowless/modules/api.lua`), alongside the existing `regions`/`animationGroups` routing.
- `GetAnimations`/`GetControlPoints` now read their dedicated list directly — no filter needed, since each list is provably pure (nothing else is ever parented onto an `AnimationGroup` or `Path`).
- Added ordering tests for both under new `AnimationGroup`/`Path` describe blocks in `addon/Wowless/uiobjects.lua`, which surfaced two real-client mismatches:
  - **`Animation:SetParent(nil)` errors** on a real client (`"Cannot set a 'nil' parent"`) — animations can't be unparented, unlike frames/regions/control points. Added the same restriction to wowless's `SetParent`, and the animation order test now asserts the error instead of exercising reordering (there's no other public way to observe list-reordering on an `Animation`).
  - **`Path:CreateControlPoint()` ignored its `templateName` and `order` parameters entirely**, so every control point ended up at the same default `order` (99). On a real client, creating three control points that way left only the last one — control points look to be keyed by `order`, not appended to a plain list. Fixed `CreateControlPoint` to actually apply `templateName`/`order`, and the control point order test now passes distinct `order` values to sidestep the same-order collision case, which isn't modeled yet (would need confirmation of the exact replace semantics before implementing).

## Test plan
- [x] `cmake --build --preset default --target test` — exit 0, no output, across all products
- [x] `pre-commit run` on all changed files — all hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)