### PR TITLE
uiobjects: give actors their own ordered list

### DIFF
--- a/data/products/wow/uiobjects.yaml
+++ b/data/products/wow/uiobjects.yaml
@@ -5964,6 +5964,8 @@ Model:
     OnModelLoaded:
 ModelScene:
   fields:
+    actors:
+      type: hlist
     allowOverlappedModels:
       init: false
       type: boolean

--- a/data/products/wow_anniversary/uiobjects.yaml
+++ b/data/products/wow_anniversary/uiobjects.yaml
@@ -5883,6 +5883,8 @@ Model:
     OnModelLoaded:
 ModelScene:
   fields:
+    actors:
+      type: hlist
     allowOverlappedModels:
       init: false
       type: boolean

--- a/data/products/wow_classic/uiobjects.yaml
+++ b/data/products/wow_classic/uiobjects.yaml
@@ -5893,6 +5893,8 @@ Model:
     OnModelLoaded:
 ModelScene:
   fields:
+    actors:
+      type: hlist
     allowOverlappedModels:
       init: false
       type: boolean

--- a/data/products/wow_classic_era/uiobjects.yaml
+++ b/data/products/wow_classic_era/uiobjects.yaml
@@ -5409,6 +5409,8 @@ Model:
     OnModelLoaded:
 ModelScene:
   fields:
+    actors:
+      type: hlist
     allowOverlappedModels:
       init: false
       type: boolean

--- a/data/products/wow_classic_era_ptr/uiobjects.yaml
+++ b/data/products/wow_classic_era_ptr/uiobjects.yaml
@@ -5883,6 +5883,8 @@ Model:
     OnModelLoaded:
 ModelScene:
   fields:
+    actors:
+      type: hlist
     allowOverlappedModels:
       init: false
       type: boolean

--- a/data/products/wow_classic_ptr/uiobjects.yaml
+++ b/data/products/wow_classic_ptr/uiobjects.yaml
@@ -5893,6 +5893,8 @@ Model:
     OnModelLoaded:
 ModelScene:
   fields:
+    actors:
+      type: hlist
     allowOverlappedModels:
       init: false
       type: boolean

--- a/data/products/wowt/uiobjects.yaml
+++ b/data/products/wowt/uiobjects.yaml
@@ -6022,6 +6022,8 @@ Model:
     OnModelLoaded:
 ModelScene:
   fields:
+    actors:
+      type: hlist
     allowOverlappedModels:
       init: false
       type: boolean

--- a/data/products/wowxptr/uiobjects.yaml
+++ b/data/products/wowxptr/uiobjects.yaml
@@ -5964,6 +5964,8 @@ Model:
     OnModelLoaded:
 ModelScene:
   fields:
+    actors:
+      type: hlist
     allowOverlappedModels:
       init: false
       type: boolean

--- a/wowless/modules/api.lua
+++ b/wowless/modules/api.lua
@@ -54,6 +54,7 @@ return function(
       or IsObjectType(obj, 'animationgroup') and 'animationGroups'
       or IsObjectType(obj, 'controlpoint') and 'controlPoints'
       or IsObjectType(obj, 'animation') and 'animations'
+      or IsObjectType(obj, 'actor') and 'actors'
       or 'children'
     if obj.parent then
       local up = obj.parent


### PR DESCRIPTION
## Summary
- `ModelScene:CreateActor` was parenting actors into the same generic `ParentedObjectBase.children` list as real frame children — the same shape already fixed for regions (#793), animation groups (#793), animations (#799), and control points (#800).
- Added a dedicated `actors` `hlist` field on `ModelScene`, routed to by `IsObjectType` in `DoSetParent` (`wowless/modules/api.lua`).
- `GetActors`/`GetNumActors` have no `impl` in the schema (unimplemented stubs — calling them errors), so there's no existing consumer to update. This is purely structural, same minimal scope as the control points change (#800): no ordering behavior implemented or tested, since there's nothing to read the list yet.
- This was the last known non-frame type still landing in the generic `children` bucket, closing out issue #795.

## Test plan
- [x] `cmake --build --preset default --target test` — exit 0, no output, across all products
- [x] `pre-commit run` on all changed files — all hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)