### PR TITLE
uiobjects: give actors their own ordered list

### DIFF
--- a/data/products/wow/uiobjects.yaml
+++ b/data/products/wow/uiobjects.yaml
@@ -5964,6 +5964,8 @@ Model:
     OnModelLoaded:
 ModelScene:
   fields:
+    actors:
+      type: hlist
     allowOverlappedModels:
       init: false
       type: boolean

--- a/data/products/wow_anniversary/uiobjects.yaml
+++ b/data/products/wow_anniversary/uiobjects.yaml
@@ -5883,6 +5883,8 @@ Model:
     OnModelLoaded:
 ModelScene:
   fields:
+    actors:
+      type: hlist
     allowOverlappedModels:
       init: false
       type: boolean

--- a/data/products/wow_classic/uiobjects.yaml
+++ b/data/products/wow_classic/uiobjects.yaml
@@ -5893,6 +5893,8 @@ Model:
     OnModelLoaded:
 ModelScene:
   fields:
+    actors:
+      type: hlist
     allowOverlappedModels:
       init: false
       type: boolean

--- a/data/products/wow_classic_era/uiobjects.yaml
+++ b/data/products/wow_classic_era/uiobjects.yaml
@@ -5409,6 +5409,8 @@ Model:
     OnModelLoaded:
 ModelScene:
   fields:
+    actors:
+      type: hlist
     allowOverlappedModels:
       init: false
       type: boolean

--- a/data/products/wow_classic_era_ptr/uiobjects.yaml
+++ b/data/products/wow_classic_era_ptr/uiobjects.yaml
@@ -5883,6 +5883,8 @@ Model:
     OnModelLoaded:
 ModelScene:
   fields:
+    actors:
+      type: hlist
     allowOverlappedModels:
       init: false
       type: boolean

--- a/data/products/wow_classic_ptr/uiobjects.yaml
+++ b/data/products/wow_classic_ptr/uiobjects.yaml
@@ -5893,6 +5893,8 @@ Model:
     OnModelLoaded:
 ModelScene:
   fields:
+    actors:
+      type: hlist
     allowOverlappedModels:
       init: false
       type: boolean

--- a/data/products/wowt/uiobjects.yaml
+++ b/data/products/wowt/uiobjects.yaml
@@ -6022,6 +6022,8 @@ Model:
     OnModelLoaded:
 ModelScene:
   fields:
+    actors:
+      type: hlist
     allowOverlappedModels:
       init: false
       type: boolean

--- a/data/products/wowxptr/uiobjects.yaml
+++ b/data/products/wowxptr/uiobjects.yaml
@@ -5964,6 +5964,8 @@ Model:
     OnModelLoaded:
 ModelScene:
   fields:
+    actors:
+      type: hlist
     allowOverlappedModels:
       init: false
       type: boolean

--- a/wowless/modules/api.lua
+++ b/wowless/modules/api.lua
@@ -54,6 +54,7 @@ return function(
       or IsObjectType(obj, 'animationgroup') and 'animationGroups'
       or IsObjectType(obj, 'controlpoint') and 'controlPoints'
       or IsObjectType(obj, 'animation') and 'animations'
+      or IsObjectType(obj, 'actor') and 'actors'
       or 'children'
     if obj.parent then
       local up = obj.parent


### PR DESCRIPTION
ModelScene:CreateActor was parenting actors into the same generic
ParentedObjectBase.children list as real frame children, the same shape
already fixed for regions/animation groups/animations/control points.
Adds a dedicated actors hlist field on ModelScene, routed to by
IsObjectType in DoSetParent. GetActors/GetNumActors have no impl in the
schema (unimplemented stubs), so there's no existing consumer to update --
this is purely structural, closing out the last known non-frame use of the
generic children list (tracked in #795).

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
