### PR TITLE
uiobjects: move the children field from ParentedObjectBase to Frame

### DIFF
--- a/data/products/wow/uiobjects.yaml
+++ b/data/products/wow/uiobjects.yaml
@@ -3844,6 +3844,8 @@ Frame:
     attributes:
       init:
       type: table
+    children:
+      type: hlist
     dontSavePosition:
       init: false
       type: boolean
@@ -6517,8 +6519,6 @@ ParentedObject:
   virtual: true
 ParentedObjectBase:
   fields:
-    children:
-      type: hlist
     parent:
       nilable: true
       type:

--- a/data/products/wow_anniversary/uiobjects.yaml
+++ b/data/products/wow_anniversary/uiobjects.yaml
@@ -3781,6 +3781,8 @@ Frame:
     attributes:
       init:
       type: table
+    children:
+      type: hlist
     dontSavePosition:
       init: false
       type: boolean
@@ -6436,8 +6438,6 @@ ParentedObject:
   virtual: true
 ParentedObjectBase:
   fields:
-    children:
-      type: hlist
     parent:
       nilable: true
       type:

--- a/data/products/wow_classic/uiobjects.yaml
+++ b/data/products/wow_classic/uiobjects.yaml
@@ -3787,6 +3787,8 @@ Frame:
     attributes:
       init:
       type: table
+    children:
+      type: hlist
     dontSavePosition:
       init: false
       type: boolean
@@ -6446,8 +6448,6 @@ ParentedObject:
   virtual: true
 ParentedObjectBase:
   fields:
-    children:
-      type: hlist
     parent:
       nilable: true
       type:

--- a/data/products/wow_classic_era/uiobjects.yaml
+++ b/data/products/wow_classic_era/uiobjects.yaml
@@ -3421,6 +3421,8 @@ Frame:
     attributes:
       init:
       type: table
+    children:
+      type: hlist
     dontSavePosition:
       init: false
       type: boolean
@@ -5962,8 +5964,6 @@ ParentedObject:
   virtual: true
 ParentedObjectBase:
   fields:
-    children:
-      type: hlist
     parent:
       nilable: true
       type:

--- a/data/products/wow_classic_era_ptr/uiobjects.yaml
+++ b/data/products/wow_classic_era_ptr/uiobjects.yaml
@@ -3781,6 +3781,8 @@ Frame:
     attributes:
       init:
       type: table
+    children:
+      type: hlist
     dontSavePosition:
       init: false
       type: boolean
@@ -6436,8 +6438,6 @@ ParentedObject:
   virtual: true
 ParentedObjectBase:
   fields:
-    children:
-      type: hlist
     parent:
       nilable: true
       type:

--- a/data/products/wow_classic_ptr/uiobjects.yaml
+++ b/data/products/wow_classic_ptr/uiobjects.yaml
@@ -3787,6 +3787,8 @@ Frame:
     attributes:
       init:
       type: table
+    children:
+      type: hlist
     dontSavePosition:
       init: false
       type: boolean
@@ -6446,8 +6448,6 @@ ParentedObject:
   virtual: true
 ParentedObjectBase:
   fields:
-    children:
-      type: hlist
     parent:
       nilable: true
       type:

--- a/data/products/wowt/uiobjects.yaml
+++ b/data/products/wowt/uiobjects.yaml
@@ -3844,6 +3844,8 @@ Frame:
     attributes:
       init:
       type: table
+    children:
+      type: hlist
     dontSavePosition:
       init: false
       type: boolean
@@ -6575,8 +6577,6 @@ ParentedObject:
   virtual: true
 ParentedObjectBase:
   fields:
-    children:
-      type: hlist
     parent:
       nilable: true
       type:

--- a/data/products/wowxptr/uiobjects.yaml
+++ b/data/products/wowxptr/uiobjects.yaml
@@ -3844,6 +3844,8 @@ Frame:
     attributes:
       init:
       type: table
+    children:
+      type: hlist
     dontSavePosition:
       init: false
       type: boolean
@@ -6517,8 +6519,6 @@ ParentedObject:
   virtual: true
 ParentedObjectBase:
   fields:
-    children:
-      type: hlist
     parent:
       nilable: true
       type:

--- a/data/uiobjects/Frame/GetChildren.lua
+++ b/data/uiobjects/Frame/GetChildren.lua
@@ -1,9 +1,7 @@
 return function(self)
   local ret = {}
   for kid in self.children:entries() do
-    if kid:IsObjectType('frame') then
-      table.insert(ret, kid)
-    end
+    table.insert(ret, kid)
   end
   return unpack(ret)
 end

--- a/data/uiobjects/Frame/GetNumChildren.lua
+++ b/data/uiobjects/Frame/GetNumChildren.lua
@@ -1,9 +1,7 @@
 return function(self)
   local n = 0
-  for kid in self.children:entries() do
-    if kid:IsObjectType('frame') then
-      n = n + 1
-    end
+  for _ in self.children:entries() do
+    n = n + 1
   end
   return n
 end

--- a/data/uiobjects/Frame/SetFrameLevel.lua
+++ b/data/uiobjects/Frame/SetFrameLevel.lua
@@ -1,7 +1,7 @@
 return function(self, level)
   self.frameLevel = assert(tonumber(level), 'invalid level')
   for kid in self.children:entries() do
-    if kid:IsObjectType('frame') and not kid:HasFixedFrameLevel() then
+    if not kid:HasFixedFrameLevel() then
       kid:SetFrameLevel(self.frameLevel + 1)
     end
   end

--- a/wowless/modules/visibility.lua
+++ b/wowless/modules/visibility.lua
@@ -19,9 +19,11 @@ return function(scripts)
         end
       end
     end
-    for kid in obj.children:entries() do
-      if kid.shown then
-        DoUpdateVisible(kid, script)
+    if obj.children then
+      for kid in obj.children:entries() do
+        if kid.shown then
+          DoUpdateVisible(kid, script)
+        end
       end
     end
     RunScript(obj, script)

--- a/wowless/modules/visibility.lua
+++ b/wowless/modules/visibility.lua
@@ -11,26 +11,29 @@ return function(scripts)
     return true
   end
 
-  local function DoUpdateVisible(obj, script)
-    if obj.regions then
-      for kid in obj.regions:entries() do
-        if kid.shown then
-          DoUpdateVisible(kid, script)
-        end
+  -- Regions can't have their own children or regions, so their scripts
+  -- fire directly rather than recursing; only frames reach this function.
+  local function DoUpdateVisible(frame, script)
+    for kid in frame.regions:entries() do
+      if kid.shown then
+        RunScript(kid, script)
       end
     end
-    if obj.children then
-      for kid in obj.children:entries() do
-        if kid.shown then
-          DoUpdateVisible(kid, script)
-        end
+    for kid in frame.children:entries() do
+      if kid.shown then
+        DoUpdateVisible(kid, script)
       end
     end
-    RunScript(obj, script)
+    RunScript(frame, script)
   end
 
   local function UpdateVisible(obj, visible)
-    DoUpdateVisible(obj, visible and 'OnShow' or 'OnHide')
+    local script = visible and 'OnShow' or 'OnHide'
+    if obj.children then
+      DoUpdateVisible(obj, script)
+    else
+      RunScript(obj, script)
+    end
   end
 
   local function SetShown(obj, shown)


### PR DESCRIPTION
## Summary
- With actors (#802) getting their own list, every type that can be parented onto something now has a dedicated `hlist` (`regions`, `animationGroups`, `animations`, `controlPoints`, `actors`) except actual frame children — `children` (`ParentedObjectBase.children`) is now exclusively a `Frame` concept.
- Confirmed exhaustively: audited every type that inherits `ParentedObject` (i.e., has a public `SetParent`) plus the two internal-only-parented types (`AnimationGroup`, `Actor`, neither of which expose `SetParent`) — every one of them falls under `frame`, `layeredregion`, `animationgroup`, `controlpoint`, `animation`, or `actor`, with no leftover category.
- Moved `children` to `Frame`, alongside `regions`/etc., matching #796's move of `regions`. Dropped the now-genuinely-redundant `IsObjectType('frame')` filters in `GetChildren`/`GetNumChildren`/`SetFrameLevel` — the field can no longer hold anything else.
- Simplified `wowless/modules/visibility.lua`'s `DoUpdateVisible`: regions can't have their own children or regions, so recursing into them was pointless — it always just bottomed out at firing the script. Calls `RunScript` directly in the regions loop instead. This also means `DoUpdateVisible` is now only ever called with a frame, so it needs no guards at all — moved the one necessary type check (`Show`/`Hide`/`SetShown` are also callable directly on regions, via `RegionBase`) up into `UpdateVisible`, where it runs once instead of on every recursive call.

## Test plan
- [x] `cmake --build --preset default --target test` — exit 0, no output, across all products
- [x] `pre-commit run` on all changed files — all hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)