### PR TITLE
uiobjects: move the children field from ParentedObjectBase to Frame

### DIFF
--- a/data/products/wow/uiobjects.yaml
+++ b/data/products/wow/uiobjects.yaml
@@ -3844,6 +3844,8 @@ Frame:
     attributes:
       init:
       type: table
+    children:
+      type: hlist
     dontSavePosition:
       init: false
       type: boolean
@@ -6517,8 +6519,6 @@ ParentedObject:
   virtual: true
 ParentedObjectBase:
   fields:
-    children:
-      type: hlist
     parent:
       nilable: true
       type:

--- a/data/products/wow_anniversary/uiobjects.yaml
+++ b/data/products/wow_anniversary/uiobjects.yaml
@@ -3781,6 +3781,8 @@ Frame:
     attributes:
       init:
       type: table
+    children:
+      type: hlist
     dontSavePosition:
       init: false
       type: boolean
@@ -6436,8 +6438,6 @@ ParentedObject:
   virtual: true
 ParentedObjectBase:
   fields:
-    children:
-      type: hlist
     parent:
       nilable: true
       type:

--- a/data/products/wow_classic/uiobjects.yaml
+++ b/data/products/wow_classic/uiobjects.yaml
@@ -3787,6 +3787,8 @@ Frame:
     attributes:
       init:
       type: table
+    children:
+      type: hlist
     dontSavePosition:
       init: false
       type: boolean
@@ -6446,8 +6448,6 @@ ParentedObject:
   virtual: true
 ParentedObjectBase:
   fields:
-    children:
-      type: hlist
     parent:
       nilable: true
       type:

--- a/data/products/wow_classic_era/uiobjects.yaml
+++ b/data/products/wow_classic_era/uiobjects.yaml
@@ -3421,6 +3421,8 @@ Frame:
     attributes:
       init:
       type: table
+    children:
+      type: hlist
     dontSavePosition:
       init: false
       type: boolean
@@ -5962,8 +5964,6 @@ ParentedObject:
   virtual: true
 ParentedObjectBase:
   fields:
-    children:
-      type: hlist
     parent:
       nilable: true
       type:

--- a/data/products/wow_classic_era_ptr/uiobjects.yaml
+++ b/data/products/wow_classic_era_ptr/uiobjects.yaml
@@ -3781,6 +3781,8 @@ Frame:
     attributes:
       init:
       type: table
+    children:
+      type: hlist
     dontSavePosition:
       init: false
       type: boolean
@@ -6436,8 +6438,6 @@ ParentedObject:
   virtual: true
 ParentedObjectBase:
   fields:
-    children:
-      type: hlist
     parent:
       nilable: true
       type:

--- a/data/products/wow_classic_ptr/uiobjects.yaml
+++ b/data/products/wow_classic_ptr/uiobjects.yaml
@@ -3787,6 +3787,8 @@ Frame:
     attributes:
       init:
       type: table
+    children:
+      type: hlist
     dontSavePosition:
       init: false
       type: boolean
@@ -6446,8 +6448,6 @@ ParentedObject:
   virtual: true
 ParentedObjectBase:
   fields:
-    children:
-      type: hlist
     parent:
       nilable: true
       type:

--- a/data/products/wowt/uiobjects.yaml
+++ b/data/products/wowt/uiobjects.yaml
@@ -3844,6 +3844,8 @@ Frame:
     attributes:
       init:
       type: table
+    children:
+      type: hlist
     dontSavePosition:
       init: false
       type: boolean
@@ -6575,8 +6577,6 @@ ParentedObject:
   virtual: true
 ParentedObjectBase:
   fields:
-    children:
-      type: hlist
     parent:
       nilable: true
       type:

--- a/data/products/wowxptr/uiobjects.yaml
+++ b/data/products/wowxptr/uiobjects.yaml
@@ -3844,6 +3844,8 @@ Frame:
     attributes:
       init:
       type: table
+    children:
+      type: hlist
     dontSavePosition:
       init: false
       type: boolean
@@ -6517,8 +6519,6 @@ ParentedObject:
   virtual: true
 ParentedObjectBase:
   fields:
-    children:
-      type: hlist
     parent:
       nilable: true
       type:

--- a/data/uiobjects/Frame/GetChildren.lua
+++ b/data/uiobjects/Frame/GetChildren.lua
@@ -1,9 +1,7 @@
 return function(self)
   local ret = {}
   for kid in self.children:entries() do
-    if kid:IsObjectType('frame') then
-      table.insert(ret, kid)
-    end
+    table.insert(ret, kid)
   end
   return unpack(ret)
 end

--- a/data/uiobjects/Frame/GetNumChildren.lua
+++ b/data/uiobjects/Frame/GetNumChildren.lua
@@ -1,9 +1,7 @@
 return function(self)
   local n = 0
-  for kid in self.children:entries() do
-    if kid:IsObjectType('frame') then
-      n = n + 1
-    end
+  for _ in self.children:entries() do
+    n = n + 1
   end
   return n
 end

--- a/data/uiobjects/Frame/SetFrameLevel.lua
+++ b/data/uiobjects/Frame/SetFrameLevel.lua
@@ -1,7 +1,7 @@
 return function(self, level)
   self.frameLevel = assert(tonumber(level), 'invalid level')
   for kid in self.children:entries() do
-    if kid:IsObjectType('frame') and not kid:HasFixedFrameLevel() then
+    if not kid:HasFixedFrameLevel() then
       kid:SetFrameLevel(self.frameLevel + 1)
     end
   end

--- a/wowless/modules/loader.lua
+++ b/wowless/modules/loader.lua
@@ -639,7 +639,8 @@ return function(
               end
               local ety = e.type == 'worldframe' and 'frame' or e.type
               local env = ctx.useAddonEnv and addonEnv or ctx.useSecureEnv and secureenv or genv
-              return api.CreateUIObject(ety, name, parent, env, { template }, nil, ctx.layer, ctx.sublevel)
+              local objParent = uiobjecttypes.InheritsFrom(ety, 'parentedobjectbase') and parent or nil
+              return api.CreateUIObject(ety, name, objParent, env, { template }, nil, ctx.layer, ctx.sublevel)
             end
           end
         else

--- a/wowless/modules/visibility.lua
+++ b/wowless/modules/visibility.lua
@@ -11,24 +11,29 @@ return function(scripts)
     return true
   end
 
-  local function DoUpdateVisible(obj, script)
-    if obj.regions then
-      for kid in obj.regions:entries() do
-        if kid.shown then
-          DoUpdateVisible(kid, script)
-        end
+  -- Regions can't have their own children or regions, so their scripts
+  -- fire directly rather than recursing; only frames reach this function.
+  local function DoUpdateVisible(frame, script)
+    for kid in frame.regions:entries() do
+      if kid.shown then
+        RunScript(kid, script)
       end
     end
-    for kid in obj.children:entries() do
+    for kid in frame.children:entries() do
       if kid.shown then
         DoUpdateVisible(kid, script)
       end
     end
-    RunScript(obj, script)
+    RunScript(frame, script)
   end
 
   local function UpdateVisible(obj, visible)
-    DoUpdateVisible(obj, visible and 'OnShow' or 'OnHide')
+    local script = visible and 'OnShow' or 'OnHide'
+    if obj.children then
+      DoUpdateVisible(obj, script)
+    else
+      RunScript(obj, script)
+    end
   end
 
   local function SetShown(obj, shown)


### PR DESCRIPTION
## Summary
Second attempt — the first (#804) was closed because it removed the `IsObjectType('frame')` filters based on an incomplete audit (only Lua-level `Create*.lua` methods, not the generic XML loader) and broke on a real regression caught by the full `outs` eval, not just the unit test suite. Root-caused and fixed properly this time.

**Commit 1 — the actual bug**: `wowless/modules/loader.lua`'s generic XML element handler (used for `<NormalFont>`/`<HighlightFont>`/`<DisabledFont>`, among others) was passing the enclosing element's `parent` straight through to `CreateUIObject`, the same as real widget children like `NormalTexture`. That's correct for `Texture`/`FontString` extensions, but `Font` is a style descriptor, not a visual widget — it has no frame level, no shown/hidden state tied to its button, and doesn't inherit `ParentedObjectBase` at all. The standalone `CreateFont()` global already creates fonts with no parent; this made the inline-XML path (`argument: self` in `xml.yaml`) consistent with it, checking `uiobjecttypes.InheritsFrom(ety, 'parentedobjectbase')` rather than special-casing `font` by name.

Verified exhaustively, both ways:
- **Static**: audited all 60 uiobject types — every concrete (non-`virtual: true`) type falls under `frame`/`layeredregion`/`animationgroup`/`controlpoint`/`animation`/`actor`, with `Font` the sole exception.
- **Dynamic**: ran the full `outs` eval across all 8 products with a temporary diagnostic logging any child failing `IsObjectType('parentedobjectbase')` — before the fix, every hit was `font` (597–919 occurrences per product, thousands total); after, zero.

**Commit 2 — the structural move**: with the loader bug fixed, `children` really is exclusively a `Frame` concept. Moves it there (alongside `regions`/etc.), drops the now-genuinely-redundant `IsObjectType('frame')` filters in `GetChildren`/`GetNumChildren`/`SetFrameLevel`, and simplifies `visibility.lua`'s `DoUpdateVisible` (regions can't have their own children/regions, so recursing into them was pointless — fires the script directly instead; the function is now only ever called with a frame, so it needs no guards, with the one necessary type check moved up into `UpdateVisible`).

## Test plan
- [x] `cmake --build --preset default --target test` — exit 0, no output, across all products
- [x] `cmake --build --preset default --target outs` — all 8 products' `log.txt` empty except `wow_anniversary`, which has exactly one pre-existing, unrelated error (`UNIT_NAMEPLATES_CLASS_COLOR` setting-name type mismatch)
- [x] `pre-commit run` on all changed files — all hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)