### PR TITLE
api: cache DoSetParent's child-field lookup per type

### DIFF
--- a/wowless/modules/api.lua
+++ b/wowless/modules/api.lua
@@ -28,6 +28,7 @@ return function(
     end
   end)()
 
+  local GetChildField = uiobjecttypes.GetChildField
   local GetIntrinsic = intrinsics.Get
   local GetObjectType = uiobjecttypes.GetObjectType
   local HasType = uiobjecttypes.Has
@@ -48,31 +49,11 @@ return function(
     'statusBarTexture',
   }
 
-  -- The set of uiobject types is fixed once loaded (intrinsics resolve to a
-  -- real base type rather than registering new ones), so this only needs
-  -- computing once; delayed until first use since types aren't all
-  -- registered yet while this module is still being constructed.
-  local childFieldByType
-  local function ChildFieldByType()
-    if not childFieldByType then
-      childFieldByType = {}
-      for _, name in ipairs(uiobjecttypes.Names()) do
-        childFieldByType[name] = InheritsFrom(name, 'layeredregion') and 'regions'
-          or InheritsFrom(name, 'animationgroup') and 'animationGroups'
-          or InheritsFrom(name, 'controlpoint') and 'controlPoints'
-          or InheritsFrom(name, 'animation') and 'animations'
-          or InheritsFrom(name, 'actor') and 'actors'
-          or 'children'
-      end
-    end
-    return childFieldByType
-  end
-
   local function DoSetParent(obj, parent)
     if obj.parent == parent then
       return
     end
-    local field = ChildFieldByType()[obj.type]
+    local field = GetChildField(obj.type)
     if obj.parent then
       local up = obj.parent
       up[field]:remove(obj)

--- a/wowless/modules/api.lua
+++ b/wowless/modules/api.lua
@@ -48,29 +48,31 @@ return function(
     'statusBarTexture',
   }
 
-  -- Types can be registered on the fly (addon-defined intrinsics), so this
-  -- can't be precomputed for every type up front; cache each type's field
-  -- the first time it's actually used instead.
-  local childFieldByType = {}
-  local function ChildField(typename)
-    local field = childFieldByType[typename]
-    if not field then
-      field = InheritsFrom(typename, 'layeredregion') and 'regions'
-        or InheritsFrom(typename, 'animationgroup') and 'animationGroups'
-        or InheritsFrom(typename, 'controlpoint') and 'controlPoints'
-        or InheritsFrom(typename, 'animation') and 'animations'
-        or InheritsFrom(typename, 'actor') and 'actors'
-        or 'children'
-      childFieldByType[typename] = field
+  -- The set of uiobject types is fixed once loaded (intrinsics resolve to a
+  -- real base type rather than registering new ones), so this only needs
+  -- computing once; delayed until first use since types aren't all
+  -- registered yet while this module is still being constructed.
+  local childFieldByType
+  local function ChildFieldByType()
+    if not childFieldByType then
+      childFieldByType = {}
+      for _, name in ipairs(uiobjecttypes.Names()) do
+        childFieldByType[name] = InheritsFrom(name, 'layeredregion') and 'regions'
+          or InheritsFrom(name, 'animationgroup') and 'animationGroups'
+          or InheritsFrom(name, 'controlpoint') and 'controlPoints'
+          or InheritsFrom(name, 'animation') and 'animations'
+          or InheritsFrom(name, 'actor') and 'actors'
+          or 'children'
+      end
     end
-    return field
+    return childFieldByType
   end
 
   local function DoSetParent(obj, parent)
     if obj.parent == parent then
       return
     end
-    local field = ChildField(obj.type)
+    local field = ChildFieldByType()[obj.type]
     if obj.parent then
       local up = obj.parent
       up[field]:remove(obj)

--- a/wowless/modules/api.lua
+++ b/wowless/modules/api.lua
@@ -48,16 +48,29 @@ return function(
     'statusBarTexture',
   }
 
+  -- Types can be registered on the fly (addon-defined intrinsics), so this
+  -- can't be precomputed for every type up front; cache each type's field
+  -- the first time it's actually used instead.
+  local childFieldByType = {}
+  local function ChildField(typename)
+    local field = childFieldByType[typename]
+    if not field then
+      field = InheritsFrom(typename, 'layeredregion') and 'regions'
+        or InheritsFrom(typename, 'animationgroup') and 'animationGroups'
+        or InheritsFrom(typename, 'controlpoint') and 'controlPoints'
+        or InheritsFrom(typename, 'animation') and 'animations'
+        or InheritsFrom(typename, 'actor') and 'actors'
+        or 'children'
+      childFieldByType[typename] = field
+    end
+    return field
+  end
+
   local function DoSetParent(obj, parent)
     if obj.parent == parent then
       return
     end
-    local field = IsObjectType(obj, 'layeredregion') and 'regions'
-      or IsObjectType(obj, 'animationgroup') and 'animationGroups'
-      or IsObjectType(obj, 'controlpoint') and 'controlPoints'
-      or IsObjectType(obj, 'animation') and 'animations'
-      or IsObjectType(obj, 'actor') and 'actors'
-      or 'children'
+    local field = ChildField(obj.type)
     if obj.parent then
       local up = obj.parent
       up[field]:remove(obj)

--- a/wowless/modules/uiobjectloader.lua
+++ b/wowless/modules/uiobjectloader.lua
@@ -1,6 +1,15 @@
 local util = require('wowless.util')
 local Mixin = util.mixin
 
+local function childField(isa)
+  return isa.layeredregion and 'regions'
+    or isa.animationgroup and 'animationGroups'
+    or isa.controlpoint and 'controlPoints'
+    or isa.animation and 'animations'
+    or isa.actor and 'actors'
+    or 'children'
+end
+
 return function(cstubs, datalua, gencode)
   local function flatten(types)
     local result = {}
@@ -43,6 +52,7 @@ return function(cstubs, datalua, gencode)
         sandboxMTindex[n] = factory()
       end
       t[k] = {
+        childField = childField(v.isa),
         constructor = v.constructor,
         ctype = v.ctype,
         hostMT = { __index = v.hostindex }, -- issue #657

--- a/wowless/modules/uiobjecttypes.lua
+++ b/wowless/modules/uiobjecttypes.lua
@@ -5,6 +5,10 @@ return function()
     uiobjectTypes[name] = t
   end
 
+  local function GetChildField(name)
+    return uiobjectTypes[name].childField
+  end
+
   local function GetObjectType(obj)
     return uiobjectTypes[obj.type].name
   end
@@ -42,16 +46,9 @@ return function()
     return uiobjectTypes[obj.type].isa[ty] or false
   end
 
-  local function Names()
-    local names = {}
-    for name in pairs(uiobjectTypes) do
-      table.insert(names, name)
-    end
-    return names
-  end
-
   return {
     Add = Add,
+    GetChildField = GetChildField,
     GetObjectType = GetObjectType,
     GetOrThrow = GetOrThrow,
     GetSandboxMetatable = GetSandboxMetatable,
@@ -59,6 +56,5 @@ return function()
     HasScript = HasScript,
     InheritsFrom = InheritsFrom,
     IsObjectType = IsObjectType,
-    Names = Names,
   }
 end

--- a/wowless/modules/uiobjecttypes.lua
+++ b/wowless/modules/uiobjecttypes.lua
@@ -42,6 +42,14 @@ return function()
     return uiobjectTypes[obj.type].isa[ty] or false
   end
 
+  local function Names()
+    local names = {}
+    for name in pairs(uiobjectTypes) do
+      table.insert(names, name)
+    end
+    return names
+  end
+
   return {
     Add = Add,
     GetObjectType = GetObjectType,
@@ -51,5 +59,6 @@ return function()
     HasScript = HasScript,
     InheritsFrom = InheritsFrom,
     IsObjectType = IsObjectType,
+    Names = Names,
   }
 end


### PR DESCRIPTION
## Summary
Replaces the `IsObjectType(obj, X) and 'field' or ...` chain in `DoSetParent` with a single table lookup — computed by the module that actually knows about every uiobject type, not recomputed in `api.lua`.

- **`wowless/modules/uiobjectloader.lua`**: `flatten()` already computes each type's fully-merged `isa` set (every ancestor, including itself) before the type ever reaches `uiobjecttypes.Add`. Compute the child-field category there, once per type, as part of the type's own data (alongside `constructor`/`ctype`/`isa`/etc.) — no separate `InheritsFrom` calls needed, since `isa['layeredregion']` etc. is already exactly that check.
- **`wowless/modules/uiobjecttypes.lua`**: added a thin `GetChildField(name)` accessor, matching the existing `GetSandboxMetatable` pattern.
- **`wowless/modules/api.lua`**: `DoSetParent` is now just `GetChildField(obj.type)` — no precompute step, memoization, or type enumeration in `api.lua` at all.

Earlier revisions of this PR tried precomputing from `api.lua`'s side (first eagerly, then a per-type lazy cache after finding intrinsics used to register as new types on the fly — since fixed by #658, which let a genuine eager version work safely too). Moving the computation to where the type data is actually built removes the need for any of that machinery in `api.lua` in the first place.

## Test plan
- [x] `cmake --build --preset default --target test` — exit 0, no output, across all products
- [x] `cmake --build --preset default --target outs` — all 8 products' `log.txt` empty
- [x] `pre-commit run` on all changed files — all hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)