### PR TITLE
schema: add hierarchy construct for self-referential domains

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -757,6 +757,7 @@ list(
   luaobjects
   modules
   products
+  record
   schema
   schematype
   scripttypes

--- a/data/schemas/luaobjects.yaml
+++ b/data/schemas/luaobjects.yaml
@@ -1,55 +1,54 @@
 name: luaobjects
 type:
   hierarchy:
+    fields:
+      impl:
+        type:
+          ref:
+            schema: module
+      inherits:
+        type:
+          ref:
+            schema: luaobject
+      methods:
+        required: true
+        type:
+          mapof:
+            key: string
+            value:
+              record:
+                inputs:
+                  type:
+                    sequenceof:
+                      record:
+                        default:
+                          type: any
+                        name:
+                          required: true
+                          type: string
+                        nilable:
+                          type: flag
+                        type:
+                          required: true
+                          type:
+                            schema: type
+                mayreturnnothing:
+                  type: flag
+                outputs:
+                  type:
+                    sequenceof:
+                      record:
+                        name:
+                          required: true
+                          type: string
+                        nilable:
+                          type: flag
+                        type:
+                          required: true
+                          type:
+                            schema: type
+      virtual:
+        type: flag
     parent: inherits
     unique:
       methods:
-    value:
-      record:
-        impl:
-          type:
-            ref:
-              schema: module
-        inherits:
-          type:
-            ref:
-              schema: luaobject
-        methods:
-          required: true
-          type:
-            mapof:
-              key: string
-              value:
-                record:
-                  inputs:
-                    type:
-                      sequenceof:
-                        record:
-                          default:
-                            type: any
-                          name:
-                            required: true
-                            type: string
-                          nilable:
-                            type: flag
-                          type:
-                            required: true
-                            type:
-                              schema: type
-                  mayreturnnothing:
-                    type: flag
-                  outputs:
-                    type:
-                      sequenceof:
-                        record:
-                          name:
-                            required: true
-                            type: string
-                          nilable:
-                            type: flag
-                          type:
-                            required: true
-                            type:
-                              schema: type
-        virtual:
-          type: flag

--- a/data/schemas/luaobjects.yaml
+++ b/data/schemas/luaobjects.yaml
@@ -1,58 +1,55 @@
 name: luaobjects
 type:
   hierarchy:
-    of:
-      mapof:
-        key: string
-        value:
-          record:
-            impl:
-              type:
-                ref:
-                  schema: module
-            inherits:
-              type:
-                ref:
-                  schema: luaobject
-            methods:
-              required: true
-              type:
-                mapof:
-                  key: string
-                  value:
-                    record:
-                      inputs:
-                        type:
-                          sequenceof:
-                            record:
-                              default:
-                                type: any
-                              name:
-                                required: true
-                                type: string
-                              nilable:
-                                type: flag
-                              type:
-                                required: true
-                                type:
-                                  schema: type
-                      mayreturnnothing:
-                        type: flag
-                      outputs:
-                        type:
-                          sequenceof:
-                            record:
-                              name:
-                                required: true
-                                type: string
-                              nilable:
-                                type: flag
-                              type:
-                                required: true
-                                type:
-                                  schema: type
-            virtual:
-              type: flag
     parent: inherits
     unique:
       methods:
+    value:
+      record:
+        impl:
+          type:
+            ref:
+              schema: module
+        inherits:
+          type:
+            ref:
+              schema: luaobject
+        methods:
+          required: true
+          type:
+            mapof:
+              key: string
+              value:
+                record:
+                  inputs:
+                    type:
+                      sequenceof:
+                        record:
+                          default:
+                            type: any
+                          name:
+                            required: true
+                            type: string
+                          nilable:
+                            type: flag
+                          type:
+                            required: true
+                            type:
+                              schema: type
+                  mayreturnnothing:
+                    type: flag
+                  outputs:
+                    type:
+                      sequenceof:
+                        record:
+                          name:
+                            required: true
+                            type: string
+                          nilable:
+                            type: flag
+                          type:
+                            required: true
+                            type:
+                              schema: type
+        virtual:
+          type: flag

--- a/data/schemas/luaobjects.yaml
+++ b/data/schemas/luaobjects.yaml
@@ -1,53 +1,58 @@
 name: luaobjects
 type:
-  mapof:
-    key: string
-    value:
-      record:
-        impl:
-          type:
-            ref:
-              schema: module
-        inherits:
-          type:
-            ref:
-              schema: luaobject
-        methods:
-          required: true
-          type:
-            mapof:
-              key: string
-              value:
-                record:
-                  inputs:
-                    type:
-                      sequenceof:
-                        record:
-                          default:
-                            type: any
-                          name:
-                            required: true
-                            type: string
-                          nilable:
-                            type: flag
-                          type:
-                            required: true
-                            type:
-                              schema: type
-                  mayreturnnothing:
-                    type: flag
-                  outputs:
-                    type:
-                      sequenceof:
-                        record:
-                          name:
-                            required: true
-                            type: string
-                          nilable:
-                            type: flag
-                          type:
-                            required: true
-                            type:
-                              schema: type
-        virtual:
-          type: flag
+  hierarchy:
+    of:
+      mapof:
+        key: string
+        value:
+          record:
+            impl:
+              type:
+                ref:
+                  schema: module
+            inherits:
+              type:
+                ref:
+                  schema: luaobject
+            methods:
+              required: true
+              type:
+                mapof:
+                  key: string
+                  value:
+                    record:
+                      inputs:
+                        type:
+                          sequenceof:
+                            record:
+                              default:
+                                type: any
+                              name:
+                                required: true
+                                type: string
+                              nilable:
+                                type: flag
+                              type:
+                                required: true
+                                type:
+                                  schema: type
+                      mayreturnnothing:
+                        type: flag
+                      outputs:
+                        type:
+                          sequenceof:
+                            record:
+                              name:
+                                required: true
+                                type: string
+                              nilable:
+                                type: flag
+                              type:
+                                required: true
+                                type:
+                                  schema: type
+            virtual:
+              type: flag
+    parent: inherits
+    unique:
+      methods:

--- a/data/schemas/record.yaml
+++ b/data/schemas/record.yaml
@@ -1,0 +1,12 @@
+name: record
+type:
+  mapof:
+    key: string
+    value:
+      record:
+        required:
+          type: flag
+        type:
+          required: true
+          type:
+            schema: schematype

--- a/data/schemas/schematype.yaml
+++ b/data/schemas/schematype.yaml
@@ -6,10 +6,6 @@ type:
     flag: tag
     hierarchy:
       record:
-        of:
-          required: true
-          type:
-            schema: schematype
         parent:
           required: true
           type: string
@@ -17,6 +13,10 @@ type:
           required: true
           type:
             setof: string
+        value:
+          required: true
+          type:
+            schema: schematype
     literal: string
     mapof:
       record:

--- a/data/schemas/schematype.yaml
+++ b/data/schemas/schematype.yaml
@@ -6,6 +6,10 @@ type:
     flag: tag
     hierarchy:
       record:
+        fields:
+          required: true
+          type:
+            schema: record
         parent:
           required: true
           type: string
@@ -13,10 +17,6 @@ type:
           required: true
           type:
             setof: string
-        value:
-          required: true
-          type:
-            schema: schematype
     literal: string
     mapof:
       record:
@@ -30,16 +30,7 @@ type:
             schema: schematype
     number: tag
     record:
-      mapof:
-        key: string
-        value:
-          record:
-            required:
-              type: flag
-            type:
-              required: true
-              type:
-                schema: schematype
+      schema: record
     ref:
       record:
         negative:

--- a/data/schemas/schematype.yaml
+++ b/data/schemas/schematype.yaml
@@ -4,6 +4,19 @@ type:
     any: tag
     boolean: tag
     flag: tag
+    hierarchy:
+      record:
+        of:
+          required: true
+          type:
+            schema: schematype
+        parent:
+          required: true
+          type: string
+        unique:
+          required: true
+          type:
+            setof: string
     literal: string
     mapof:
       record:

--- a/data/schemas/uiobjects.yaml
+++ b/data/schemas/uiobjects.yaml
@@ -1,131 +1,128 @@
 name: uiobjects
 type:
   hierarchy:
-    of:
-      mapof:
-        key: string
-        value:
-          record:
-            fieldinitoverrides:
-              type:
-                mapof:
-                  key: string
-                  value: any
-            fields:
-              required: true
-              type:
-                mapof:
-                  key: string
-                  value:
-                    record:
-                      dynamicinit:
-                        type: flag
-                      init:
-                        type: any
-                      nilable:
-                        type: flag
-                      type:
-                        required: true
-                        type:
-                          schema: type
-            inherits:
-              required: true
-              type:
-                setof:
-                  ref:
-                    schema: uiobject
-            methods:
-              required: true
-              type:
-                mapof:
-                  key: string
-                  value:
-                    record:
-                      impl:
-                        type:
-                          taggedunion:
-                            getter:
-                              sequenceof:
-                                record:
-                                  name:
-                                    required: true
-                                    type: string
-                            setter:
-                              sequenceof:
-                                record:
-                                  name:
-                                    required: true
-                                    type: string
-                            settexture:
-                              record:
-                                extra:
-                                  type: string
-                                field:
-                                  required: true
-                                  type: string
-                                return:
-                                  type: flag
-                                shown:
-                                  type: string
-                            uiobjectimpl:
-                              ref:
-                                schema: uiobjectimpl
-                      inputs:
-                        type:
-                          sequenceof:
-                            record:
-                              default:
-                                type: any
-                              name:
-                                required: true
-                                type: string
-                              nilable:
-                                type: flag
-                              permissive:
-                                type: flag
-                              type:
-                                required: true
-                                type:
-                                  schema: type
-                      instride:
-                        type: number
-                      manualinputs:
-                        type: flag
-                      mayreturnnothing:
-                        type: flag
-                      outputs:
-                        type:
-                          sequenceof:
-                            record:
-                              name:
-                                required: true
-                                type: string
-                              nilable:
-                                type: flag
-                              stub:
-                                type: any
-                              stubnotnil:
-                                type: flag
-                              type:
-                                required: true
-                                type:
-                                  schema: type
-                      outstride:
-                        type: number
-                      stuboutstrides:
-                        type: number
-            objectType:
-              type: string
-            scripts:
-              type:
-                setof:
-                  ref:
-                    schema: scripttype
-            singleton:
-              type: flag
-            virtual:
-              type: flag
     parent: inherits
     unique:
       fields:
       methods:
+    value:
+      record:
+        fieldinitoverrides:
+          type:
+            mapof:
+              key: string
+              value: any
+        fields:
+          required: true
+          type:
+            mapof:
+              key: string
+              value:
+                record:
+                  dynamicinit:
+                    type: flag
+                  init:
+                    type: any
+                  nilable:
+                    type: flag
+                  type:
+                    required: true
+                    type:
+                      schema: type
+        inherits:
+          required: true
+          type:
+            setof:
+              ref:
+                schema: uiobject
+        methods:
+          required: true
+          type:
+            mapof:
+              key: string
+              value:
+                record:
+                  impl:
+                    type:
+                      taggedunion:
+                        getter:
+                          sequenceof:
+                            record:
+                              name:
+                                required: true
+                                type: string
+                        setter:
+                          sequenceof:
+                            record:
+                              name:
+                                required: true
+                                type: string
+                        settexture:
+                          record:
+                            extra:
+                              type: string
+                            field:
+                              required: true
+                              type: string
+                            return:
+                              type: flag
+                            shown:
+                              type: string
+                        uiobjectimpl:
+                          ref:
+                            schema: uiobjectimpl
+                  inputs:
+                    type:
+                      sequenceof:
+                        record:
+                          default:
+                            type: any
+                          name:
+                            required: true
+                            type: string
+                          nilable:
+                            type: flag
+                          permissive:
+                            type: flag
+                          type:
+                            required: true
+                            type:
+                              schema: type
+                  instride:
+                    type: number
+                  manualinputs:
+                    type: flag
+                  mayreturnnothing:
+                    type: flag
+                  outputs:
+                    type:
+                      sequenceof:
+                        record:
+                          name:
+                            required: true
+                            type: string
+                          nilable:
+                            type: flag
+                          stub:
+                            type: any
+                          stubnotnil:
+                            type: flag
+                          type:
+                            required: true
+                            type:
+                              schema: type
+                  outstride:
+                    type: number
+                  stuboutstrides:
+                    type: number
+        objectType:
+          type: string
+        scripts:
+          type:
+            setof:
+              ref:
+                schema: scripttype
+        singleton:
+          type: flag
+        virtual:
+          type: flag

--- a/data/schemas/uiobjects.yaml
+++ b/data/schemas/uiobjects.yaml
@@ -1,125 +1,131 @@
 name: uiobjects
 type:
-  mapof:
-    key: string
-    value:
-      record:
-        fieldinitoverrides:
-          type:
-            mapof:
-              key: string
-              value: any
-        fields:
-          required: true
-          type:
-            mapof:
-              key: string
-              value:
-                record:
-                  dynamicinit:
-                    type: flag
-                  init:
-                    type: any
-                  nilable:
-                    type: flag
-                  type:
-                    required: true
-                    type:
-                      schema: type
-        inherits:
-          required: true
-          type:
-            setof:
-              ref:
-                schema: uiobject
-        methods:
-          required: true
-          type:
-            mapof:
-              key: string
-              value:
-                record:
-                  impl:
-                    type:
-                      taggedunion:
-                        getter:
+  hierarchy:
+    of:
+      mapof:
+        key: string
+        value:
+          record:
+            fieldinitoverrides:
+              type:
+                mapof:
+                  key: string
+                  value: any
+            fields:
+              required: true
+              type:
+                mapof:
+                  key: string
+                  value:
+                    record:
+                      dynamicinit:
+                        type: flag
+                      init:
+                        type: any
+                      nilable:
+                        type: flag
+                      type:
+                        required: true
+                        type:
+                          schema: type
+            inherits:
+              required: true
+              type:
+                setof:
+                  ref:
+                    schema: uiobject
+            methods:
+              required: true
+              type:
+                mapof:
+                  key: string
+                  value:
+                    record:
+                      impl:
+                        type:
+                          taggedunion:
+                            getter:
+                              sequenceof:
+                                record:
+                                  name:
+                                    required: true
+                                    type: string
+                            setter:
+                              sequenceof:
+                                record:
+                                  name:
+                                    required: true
+                                    type: string
+                            settexture:
+                              record:
+                                extra:
+                                  type: string
+                                field:
+                                  required: true
+                                  type: string
+                                return:
+                                  type: flag
+                                shown:
+                                  type: string
+                            uiobjectimpl:
+                              ref:
+                                schema: uiobjectimpl
+                      inputs:
+                        type:
+                          sequenceof:
+                            record:
+                              default:
+                                type: any
+                              name:
+                                required: true
+                                type: string
+                              nilable:
+                                type: flag
+                              permissive:
+                                type: flag
+                              type:
+                                required: true
+                                type:
+                                  schema: type
+                      instride:
+                        type: number
+                      manualinputs:
+                        type: flag
+                      mayreturnnothing:
+                        type: flag
+                      outputs:
+                        type:
                           sequenceof:
                             record:
                               name:
                                 required: true
                                 type: string
-                        setter:
-                          sequenceof:
-                            record:
-                              name:
+                              nilable:
+                                type: flag
+                              stub:
+                                type: any
+                              stubnotnil:
+                                type: flag
+                              type:
                                 required: true
-                                type: string
-                        settexture:
-                          record:
-                            extra:
-                              type: string
-                            field:
-                              required: true
-                              type: string
-                            return:
-                              type: flag
-                            shown:
-                              type: string
-                        uiobjectimpl:
-                          ref:
-                            schema: uiobjectimpl
-                  inputs:
-                    type:
-                      sequenceof:
-                        record:
-                          default:
-                            type: any
-                          name:
-                            required: true
-                            type: string
-                          nilable:
-                            type: flag
-                          permissive:
-                            type: flag
-                          type:
-                            required: true
-                            type:
-                              schema: type
-                  instride:
-                    type: number
-                  manualinputs:
-                    type: flag
-                  mayreturnnothing:
-                    type: flag
-                  outputs:
-                    type:
-                      sequenceof:
-                        record:
-                          name:
-                            required: true
-                            type: string
-                          nilable:
-                            type: flag
-                          stub:
-                            type: any
-                          stubnotnil:
-                            type: flag
-                          type:
-                            required: true
-                            type:
-                              schema: type
-                  outstride:
-                    type: number
-                  stuboutstrides:
-                    type: number
-        objectType:
-          type: string
-        scripts:
-          type:
-            setof:
-              ref:
-                schema: scripttype
-        singleton:
-          type: flag
-        virtual:
-          type: flag
+                                type:
+                                  schema: type
+                      outstride:
+                        type: number
+                      stuboutstrides:
+                        type: number
+            objectType:
+              type: string
+            scripts:
+              type:
+                setof:
+                  ref:
+                    schema: scripttype
+            singleton:
+              type: flag
+            virtual:
+              type: flag
+    parent: inherits
+    unique:
+      fields:
+      methods:

--- a/data/schemas/uiobjects.yaml
+++ b/data/schemas/uiobjects.yaml
@@ -1,128 +1,127 @@
 name: uiobjects
 type:
   hierarchy:
+    fields:
+      fieldinitoverrides:
+        type:
+          mapof:
+            key: string
+            value: any
+      fields:
+        required: true
+        type:
+          mapof:
+            key: string
+            value:
+              record:
+                dynamicinit:
+                  type: flag
+                init:
+                  type: any
+                nilable:
+                  type: flag
+                type:
+                  required: true
+                  type:
+                    schema: type
+      inherits:
+        required: true
+        type:
+          setof:
+            ref:
+              schema: uiobject
+      methods:
+        required: true
+        type:
+          mapof:
+            key: string
+            value:
+              record:
+                impl:
+                  type:
+                    taggedunion:
+                      getter:
+                        sequenceof:
+                          record:
+                            name:
+                              required: true
+                              type: string
+                      setter:
+                        sequenceof:
+                          record:
+                            name:
+                              required: true
+                              type: string
+                      settexture:
+                        record:
+                          extra:
+                            type: string
+                          field:
+                            required: true
+                            type: string
+                          return:
+                            type: flag
+                          shown:
+                            type: string
+                      uiobjectimpl:
+                        ref:
+                          schema: uiobjectimpl
+                inputs:
+                  type:
+                    sequenceof:
+                      record:
+                        default:
+                          type: any
+                        name:
+                          required: true
+                          type: string
+                        nilable:
+                          type: flag
+                        permissive:
+                          type: flag
+                        type:
+                          required: true
+                          type:
+                            schema: type
+                instride:
+                  type: number
+                manualinputs:
+                  type: flag
+                mayreturnnothing:
+                  type: flag
+                outputs:
+                  type:
+                    sequenceof:
+                      record:
+                        name:
+                          required: true
+                          type: string
+                        nilable:
+                          type: flag
+                        stub:
+                          type: any
+                        stubnotnil:
+                          type: flag
+                        type:
+                          required: true
+                          type:
+                            schema: type
+                outstride:
+                  type: number
+                stuboutstrides:
+                  type: number
+      objectType:
+        type: string
+      scripts:
+        type:
+          setof:
+            ref:
+              schema: scripttype
+      singleton:
+        type: flag
+      virtual:
+        type: flag
     parent: inherits
     unique:
       fields:
       methods:
-    value:
-      record:
-        fieldinitoverrides:
-          type:
-            mapof:
-              key: string
-              value: any
-        fields:
-          required: true
-          type:
-            mapof:
-              key: string
-              value:
-                record:
-                  dynamicinit:
-                    type: flag
-                  init:
-                    type: any
-                  nilable:
-                    type: flag
-                  type:
-                    required: true
-                    type:
-                      schema: type
-        inherits:
-          required: true
-          type:
-            setof:
-              ref:
-                schema: uiobject
-        methods:
-          required: true
-          type:
-            mapof:
-              key: string
-              value:
-                record:
-                  impl:
-                    type:
-                      taggedunion:
-                        getter:
-                          sequenceof:
-                            record:
-                              name:
-                                required: true
-                                type: string
-                        setter:
-                          sequenceof:
-                            record:
-                              name:
-                                required: true
-                                type: string
-                        settexture:
-                          record:
-                            extra:
-                              type: string
-                            field:
-                              required: true
-                              type: string
-                            return:
-                              type: flag
-                            shown:
-                              type: string
-                        uiobjectimpl:
-                          ref:
-                            schema: uiobjectimpl
-                  inputs:
-                    type:
-                      sequenceof:
-                        record:
-                          default:
-                            type: any
-                          name:
-                            required: true
-                            type: string
-                          nilable:
-                            type: flag
-                          permissive:
-                            type: flag
-                          type:
-                            required: true
-                            type:
-                              schema: type
-                  instride:
-                    type: number
-                  manualinputs:
-                    type: flag
-                  mayreturnnothing:
-                    type: flag
-                  outputs:
-                    type:
-                      sequenceof:
-                        record:
-                          name:
-                            required: true
-                            type: string
-                          nilable:
-                            type: flag
-                          stub:
-                            type: any
-                          stubnotnil:
-                            type: flag
-                          type:
-                            required: true
-                            type:
-                              schema: type
-                  outstride:
-                    type: number
-                  stuboutstrides:
-                    type: number
-        objectType:
-          type: string
-        scripts:
-          type:
-            setof:
-              ref:
-                schema: scripttype
-        singleton:
-          type: flag
-        virtual:
-          type: flag

--- a/spec/data/luaobjects_spec.lua
+++ b/spec/data/luaobjects_spec.lua
@@ -9,46 +9,21 @@ describe('luaobjects', function()
             nr[v.inherits] = (nr[v.inherits] or 0) + 1
           end
         end
-        local function process(t, root, k)
-          assert(not t[k], ('cycle from %s to %s'):format(root, k))
-          t[k] = true
-          local parent = luaobjects[k] and luaobjects[k].inherits
-          if parent then
-            process(t, root, parent)
-          end
-        end
+        -- Cycle-freedom is enforced by the luaobjects schema's `hierarchy`
+        -- construct.
         for k in pairs(luaobjects) do
           describe(k, function()
-            local t = {}
-            it('is a chain', function()
-              process(t, k, k)
-            end)
             it('is not leaf if virtual', function()
               assert.True(not luaobjects[k].virtual or nr[k] > 0)
             end)
           end)
         end
       end)
-      local function hasMember(k, f)
-        local v = luaobjects[k]
-        if v.methods[f] then
-          return true
-        end
-        if v.inherits then
-          return hasMember(v.inherits, f)
-        end
-        return false
-      end
       for k, v in pairs(luaobjects) do
         describe(k, function()
           describe('methods', function()
             for mk, mv in pairs(v.methods) do
               describe(mk, function()
-                it('is not defined up inheritance tree', function()
-                  if v.inherits then
-                    assert.False(hasMember(v.inherits, mk))
-                  end
-                end)
                 describe('inputs', function()
                   for _, input in ipairs(mv.inputs or {}) do
                     describe(input.name, function()

--- a/spec/data/schema_coverage_spec.lua
+++ b/spec/data/schema_coverage_spec.lua
@@ -17,6 +17,9 @@ local function collectType(st, path, known, visited)
         collectType(mval, path .. '.' .. mname, known, visited)
       end
     end
+  elseif k == 'hierarchy' then
+    known[path .. '.of'] = true
+    collectType(v.of, path .. '.of', known, visited)
   elseif k == 'mapof' then
     collectType(v.key, path .. '.__key', known, visited)
     collectType(v.value, path .. '.__val', known, visited)
@@ -63,6 +66,9 @@ local function trackType(st, value, path, used)
         end
       end
     end
+  elseif k == 'hierarchy' then
+    used[path .. '.of'] = true
+    trackType(v.of, value, path .. '.of', used)
   elseif k == 'mapof' then
     if type(value) == 'table' then
       for mk, mv in pairs(value) do

--- a/spec/data/schema_coverage_spec.lua
+++ b/spec/data/schema_coverage_spec.lua
@@ -18,7 +18,7 @@ local function collectType(st, path, known, visited)
       end
     end
   elseif k == 'hierarchy' then
-    collectType({ mapof = { key = 'string', value = v.value } }, path, known, visited)
+    collectType({ mapof = { key = 'string', value = { record = v.fields } } }, path, known, visited)
   elseif k == 'mapof' then
     collectType(v.key, path .. '.__key', known, visited)
     collectType(v.value, path .. '.__val', known, visited)
@@ -66,7 +66,7 @@ local function trackType(st, value, path, used)
       end
     end
   elseif k == 'hierarchy' then
-    trackType({ mapof = { key = 'string', value = v.value } }, value, path, used)
+    trackType({ mapof = { key = 'string', value = { record = v.fields } } }, value, path, used)
   elseif k == 'mapof' then
     if type(value) == 'table' then
       for mk, mv in pairs(value) do

--- a/spec/data/schema_coverage_spec.lua
+++ b/spec/data/schema_coverage_spec.lua
@@ -18,8 +18,7 @@ local function collectType(st, path, known, visited)
       end
     end
   elseif k == 'hierarchy' then
-    known[path .. '.of'] = true
-    collectType(v.of, path .. '.of', known, visited)
+    collectType({ mapof = { key = 'string', value = v.value } }, path, known, visited)
   elseif k == 'mapof' then
     collectType(v.key, path .. '.__key', known, visited)
     collectType(v.value, path .. '.__val', known, visited)
@@ -67,8 +66,7 @@ local function trackType(st, value, path, used)
       end
     end
   elseif k == 'hierarchy' then
-    used[path .. '.of'] = true
-    trackType(v.of, value, path .. '.of', used)
+    trackType({ mapof = { key = 'string', value = v.value } }, value, path, used)
   elseif k == 'mapof' then
     if type(value) == 'table' then
       for mk, mv in pairs(value) do

--- a/spec/data/uiobjects_spec.lua
+++ b/spec/data/uiobjects_spec.lua
@@ -40,19 +40,20 @@ describe('uiobjects', function()
             nr[ik] = (nr[ik] or 0) + 1
           end
         end
-        local function process(t, root, k)
-          assert(not t[k], ('multiple paths from %s to %s'):format(root, k))
-          t[k] = true
-          for ik in pairs(g[k]) do
-            process(t, root, ik)
+        -- Cycle- and diamond-freedom is enforced by the uiobjects schema's
+        -- `hierarchy` construct; this walk only needs the ancestor set.
+        local function ancestors(t, k)
+          if not t[k] then
+            t[k] = true
+            for ik in pairs(g[k]) do
+              ancestors(t, ik)
+            end
           end
         end
         for k in pairs(g) do
           describe(k, function()
             local t = {}
-            it('is a tree', function()
-              process(t, k, k)
-            end)
+            ancestors(t, k)
             if not nr[k] then
               it('is not virtual', function()
                 assert.Nil(uiobjects[k].virtual)
@@ -83,30 +84,11 @@ describe('uiobjects', function()
           end
         end
       end
-      local function hasMember(k, m, f)
-        return getMember(k, m, f) ~= nil
-      end
       for k, v in pairs(uiobjects) do
         describe(k, function()
-          describe('fields', function()
-            for fk in pairs(v.fields) do
-              describe(fk, function()
-                it('is not defined up inheritance tree', function()
-                  for inh in pairs(v.inherits) do
-                    assert.False(hasMember(inh, 'fields', fk))
-                  end
-                end)
-              end)
-            end
-          end)
           describe('methods', function()
             for mk, mv in pairs(v.methods) do
               describe(mk, function()
-                it('is not defined up inheritance tree', function()
-                  for inh in pairs(v.inherits) do
-                    assert.False(hasMember(inh, 'methods', mk))
-                  end
-                end)
                 if mv.impl then
                   describe('impl', function()
                     if mv.impl.uiobjectimpl then

--- a/wowapi/schema.lua
+++ b/wowapi/schema.lua
@@ -50,6 +50,77 @@ local compile
 local schemas = {}
 
 local complex = {
+  hierarchy = function(s)
+    local of = compile(s.of)
+    local parentfield = s.parent
+    local function parentsof(node)
+      if type(node) ~= 'table' then
+        return {}
+      end
+      local p = node[parentfield]
+      if p == nil then
+        return {}
+      elseif type(p) == 'string' then
+        return { p }
+      end
+      local ps = {}
+      for pk in pairs(p) do
+        ps[#ps + 1] = pk
+      end
+      return ps
+    end
+    return function(v, product)
+      local baseerrors = of(v, product)
+      if type(v) ~= 'table' then
+        return baseerrors
+      end
+      local errors = baseerrors or {}
+      local function shapeerror(root, k, seen)
+        if seen[k] then
+          return ('multiple paths from %s to %s'):format(root, k)
+        end
+        seen[k] = true
+        for _, p in ipairs(parentsof(v[k])) do
+          local e = shapeerror(root, p, seen)
+          if e then
+            return e
+          end
+        end
+      end
+      local function ancestorsof(k, seen)
+        for _, p in ipairs(parentsof(v[k])) do
+          if not seen[p] then
+            seen[p] = true
+            ancestorsof(p, seen)
+          end
+        end
+        return seen
+      end
+      for k, node in pairs(v) do
+        local e = shapeerror(k, k, {})
+        if e then
+          errors[k] = e
+        else
+          local anc = ancestorsof(k, {})
+          for f in pairs(s.unique) do
+            local mine = node[f]
+            if type(mine) == 'table' then
+              for ik in pairs(mine) do
+                for a in pairs(anc) do
+                  local an = v[a]
+                  if an and type(an[f]) == 'table' and an[f][ik] ~= nil then
+                    errors[k] = errors[k] or {}
+                    errors[k][f] = ('%s already defined by ancestor %s'):format(ik, a)
+                  end
+                end
+              end
+            end
+          end
+        end
+      end
+      return next(errors) and errors or nil
+    end
+  end,
   literal = function(s)
     return function(v)
       if v ~= s then

--- a/wowapi/schema.lua
+++ b/wowapi/schema.lua
@@ -51,7 +51,7 @@ local schemas = {}
 
 local complex = {
   hierarchy = function(s)
-    local of = compile({ mapof = { key = 'string', value = s.value } })
+    local of = compile({ mapof = { key = 'string', value = { record = s.fields } } })
     local parentfield = s.parent
     local function parentsof(node)
       if type(node) ~= 'table' then

--- a/wowapi/schema.lua
+++ b/wowapi/schema.lua
@@ -51,7 +51,7 @@ local schemas = {}
 
 local complex = {
   hierarchy = function(s)
-    local of = compile(s.of)
+    local of = compile({ mapof = { key = 'string', value = s.value } })
     local parentfield = s.parent
     local function parentsof(node)
       if type(node) ~= 'table' then


### PR DESCRIPTION
## Summary
- Adds a `hierarchy` schematype tag (`data/schemas/schematype.yaml`) for domains that are self-referential mapofs (a `parent` field pointing back into the same domain), with a `unique` list naming member maps that must not be redeclared by any descendant.
- Implements `complex.hierarchy` in `wowapi/schema.lua`: wraps the normal per-entry validation, then walks `parent` edges across the whole domain (available in one call, since `mapof` already validates the entire map at once) to catch cycles/diamond inheritance and ancestor-field/method shadowing.
- Converts `uiobjects.yaml` (`parent: inherits`, `unique: [fields, methods]`) and `luaobjects.yaml` (`parent: inherits`, `unique: [methods]`) to use it.
- Retires the duplicated hand-written graph-walking logic in `spec/data/uiobjects_spec.lua` and `spec/data/luaobjects_spec.lua` that previously checked "is a tree"/"is a chain" and "is not defined up inheritance tree" — those invariants are now enforced by schema validation itself (`spec/data/yaml_spec.lua` already validates every product's `uiobjects`/`luaobjects` data against these schemas). Domain-specific rules that aren't generic hierarchy shape (root must reach `UIObject`, virtual types reused more than once, getter/setter/settexture prototype matching) are kept.
- Adds a `hierarchy` traversal case to `spec/data/schema_coverage_spec.lua` so coverage tracking doesn't go dark for these two domains.

## Test plan
- [x] `cmake --build --preset default --target test` (exit 0, no output)
- [x] `pre-commit run -a` (all hooks pass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Pe5cmoUxmLSeKQdrRYeqDg