### PR TITLE
uiobjects: declare DoSetParent's child field in the yaml, not code

### DIFF
--- a/data/products/wow/uiobjects.yaml
+++ b/data/products/wow/uiobjects.yaml
@@ -1,4 +1,5 @@
 Actor:
+  childField: actors
   fields:
     animationBlendOperation:
       init: 1
@@ -702,6 +703,7 @@ AnimatableObject:
       outputs:
   virtual: true
 Animation:
+  childField: animations
   fields:
     endDelay:
       init: 0
@@ -929,6 +931,7 @@ Animation:
     OnStop:
     OnUpdate:
 AnimationGroup:
+  childField: animationGroups
   fields:
     animations:
       type: hlist
@@ -1998,6 +2001,7 @@ ColorSelect:
   scripts:
     OnColorSelect:
 ControlPoint:
+  childField: controlPoints
   fields:
     offsetX:
       init: 0
@@ -3840,6 +3844,7 @@ FontString:
         type: boolean
       outputs:
 Frame:
+  childField: children
   fields:
     attributes:
       init:
@@ -4927,6 +4932,7 @@ GameTooltip:
     OnTooltipSetDefaultAnchor:
     OnTooltipSetFrameStack:
 LayeredRegion:
+  childField: regions
   fields:
     layer:
       init: ARTWORK

--- a/data/products/wow_anniversary/uiobjects.yaml
+++ b/data/products/wow_anniversary/uiobjects.yaml
@@ -1,4 +1,5 @@
 Actor:
+  childField: actors
   fields:
     animationBlendOperation:
       init: 1
@@ -647,6 +648,7 @@ AnimatableObject:
       outputs:
   virtual: true
 Animation:
+  childField: animations
   fields:
     endDelay:
       init: 0
@@ -874,6 +876,7 @@ Animation:
     OnStop:
     OnUpdate:
 AnimationGroup:
+  childField: animationGroups
   fields:
     animations:
       type: hlist
@@ -1937,6 +1940,7 @@ ColorSelect:
   scripts:
     OnColorSelect:
 ControlPoint:
+  childField: controlPoints
   fields:
     offsetX:
       init: 0
@@ -3777,6 +3781,7 @@ FontString:
         type: boolean
       outputs:
 Frame:
+  childField: children
   fields:
     attributes:
       init:
@@ -4921,6 +4926,7 @@ GameTooltip:
     OnTooltipSetSpell:
     OnTooltipSetUnit:
 LayeredRegion:
+  childField: regions
   fields:
     layer:
       init: ARTWORK

--- a/data/products/wow_classic/uiobjects.yaml
+++ b/data/products/wow_classic/uiobjects.yaml
@@ -1,4 +1,5 @@
 Actor:
+  childField: actors
   fields:
     animationBlendOperation:
       init: 1
@@ -647,6 +648,7 @@ AnimatableObject:
       outputs:
   virtual: true
 Animation:
+  childField: animations
   fields:
     endDelay:
       init: 0
@@ -874,6 +876,7 @@ Animation:
     OnStop:
     OnUpdate:
 AnimationGroup:
+  childField: animationGroups
   fields:
     animations:
       type: hlist
@@ -1943,6 +1946,7 @@ ColorSelect:
   scripts:
     OnColorSelect:
 ControlPoint:
+  childField: controlPoints
   fields:
     offsetX:
       init: 0
@@ -3783,6 +3787,7 @@ FontString:
         type: boolean
       outputs:
 Frame:
+  childField: children
   fields:
     attributes:
       init:
@@ -4931,6 +4936,7 @@ GameTooltip:
     OnTooltipSetSpell:
     OnTooltipSetUnit:
 LayeredRegion:
+  childField: regions
   fields:
     layer:
       init: ARTWORK

--- a/data/products/wow_classic_era/uiobjects.yaml
+++ b/data/products/wow_classic_era/uiobjects.yaml
@@ -1,4 +1,5 @@
 Actor:
+  childField: actors
   fields:
     animationBlendOperation:
       init: 1
@@ -431,6 +432,7 @@ AnimatableObject:
       outputs:
   virtual: true
 Animation:
+  childField: animations
   fields:
     endDelay:
       init: 0
@@ -658,6 +660,7 @@ Animation:
     OnStop:
     OnUpdate:
 AnimationGroup:
+  childField: animationGroups
   fields:
     animations:
       type: hlist
@@ -1721,6 +1724,7 @@ ColorSelect:
   scripts:
     OnColorSelect:
 ControlPoint:
+  childField: controlPoints
   fields:
     offsetX:
       init: 0
@@ -3417,6 +3421,7 @@ FontString:
         type: boolean
       outputs:
 Frame:
+  childField: children
   fields:
     attributes:
       init:
@@ -4474,6 +4479,7 @@ GameTooltip:
     OnTooltipSetSpell:
     OnTooltipSetUnit:
 LayeredRegion:
+  childField: regions
   fields:
     layer:
       init: ARTWORK

--- a/data/products/wow_classic_era_ptr/uiobjects.yaml
+++ b/data/products/wow_classic_era_ptr/uiobjects.yaml
@@ -1,4 +1,5 @@
 Actor:
+  childField: actors
   fields:
     animationBlendOperation:
       init: 1
@@ -647,6 +648,7 @@ AnimatableObject:
       outputs:
   virtual: true
 Animation:
+  childField: animations
   fields:
     endDelay:
       init: 0
@@ -874,6 +876,7 @@ Animation:
     OnStop:
     OnUpdate:
 AnimationGroup:
+  childField: animationGroups
   fields:
     animations:
       type: hlist
@@ -1937,6 +1940,7 @@ ColorSelect:
   scripts:
     OnColorSelect:
 ControlPoint:
+  childField: controlPoints
   fields:
     offsetX:
       init: 0
@@ -3777,6 +3781,7 @@ FontString:
         type: boolean
       outputs:
 Frame:
+  childField: children
   fields:
     attributes:
       init:
@@ -4921,6 +4926,7 @@ GameTooltip:
     OnTooltipSetSpell:
     OnTooltipSetUnit:
 LayeredRegion:
+  childField: regions
   fields:
     layer:
       init: ARTWORK

--- a/data/products/wow_classic_ptr/uiobjects.yaml
+++ b/data/products/wow_classic_ptr/uiobjects.yaml
@@ -1,4 +1,5 @@
 Actor:
+  childField: actors
   fields:
     animationBlendOperation:
       init: 1
@@ -647,6 +648,7 @@ AnimatableObject:
       outputs:
   virtual: true
 Animation:
+  childField: animations
   fields:
     endDelay:
       init: 0
@@ -874,6 +876,7 @@ Animation:
     OnStop:
     OnUpdate:
 AnimationGroup:
+  childField: animationGroups
   fields:
     animations:
       type: hlist
@@ -1943,6 +1946,7 @@ ColorSelect:
   scripts:
     OnColorSelect:
 ControlPoint:
+  childField: controlPoints
   fields:
     offsetX:
       init: 0
@@ -3783,6 +3787,7 @@ FontString:
         type: boolean
       outputs:
 Frame:
+  childField: children
   fields:
     attributes:
       init:
@@ -4931,6 +4936,7 @@ GameTooltip:
     OnTooltipSetSpell:
     OnTooltipSetUnit:
 LayeredRegion:
+  childField: regions
   fields:
     layer:
       init: ARTWORK

--- a/data/products/wowt/uiobjects.yaml
+++ b/data/products/wowt/uiobjects.yaml
@@ -1,4 +1,5 @@
 Actor:
+  childField: actors
   fields:
     animationBlendOperation:
       init: 1
@@ -702,6 +703,7 @@ AnimatableObject:
       outputs:
   virtual: true
 Animation:
+  childField: animations
   fields:
     endDelay:
       init: 0
@@ -929,6 +931,7 @@ Animation:
     OnStop:
     OnUpdate:
 AnimationGroup:
+  childField: animationGroups
   fields:
     animations:
       type: hlist
@@ -1998,6 +2001,7 @@ ColorSelect:
   scripts:
     OnColorSelect:
 ControlPoint:
+  childField: controlPoints
   fields:
     offsetX:
       init: 0
@@ -3840,6 +3844,7 @@ FontString:
         type: boolean
       outputs:
 Frame:
+  childField: children
   fields:
     attributes:
       init:
@@ -4980,6 +4985,7 @@ GameTooltip:
     OnTooltipSetDefaultAnchor:
     OnTooltipSetFrameStack:
 LayeredRegion:
+  childField: regions
   fields:
     layer:
       init: ARTWORK

--- a/data/products/wowxptr/uiobjects.yaml
+++ b/data/products/wowxptr/uiobjects.yaml
@@ -1,4 +1,5 @@
 Actor:
+  childField: actors
   fields:
     animationBlendOperation:
       init: 1
@@ -702,6 +703,7 @@ AnimatableObject:
       outputs:
   virtual: true
 Animation:
+  childField: animations
   fields:
     endDelay:
       init: 0
@@ -929,6 +931,7 @@ Animation:
     OnStop:
     OnUpdate:
 AnimationGroup:
+  childField: animationGroups
   fields:
     animations:
       type: hlist
@@ -1998,6 +2001,7 @@ ColorSelect:
   scripts:
     OnColorSelect:
 ControlPoint:
+  childField: controlPoints
   fields:
     offsetX:
       init: 0
@@ -3840,6 +3844,7 @@ FontString:
         type: boolean
       outputs:
 Frame:
+  childField: children
   fields:
     attributes:
       init:
@@ -4927,6 +4932,7 @@ GameTooltip:
     OnTooltipSetDefaultAnchor:
     OnTooltipSetFrameStack:
 LayeredRegion:
+  childField: regions
   fields:
     layer:
       init: ARTWORK

--- a/data/schemas/uiobjects.yaml
+++ b/data/schemas/uiobjects.yaml
@@ -2,6 +2,8 @@ name: uiobjects
 type:
   hierarchy:
     fields:
+      childField:
+        type: string
       fieldinitoverrides:
         type:
           mapof:

--- a/spec/data/uiobjects_spec.lua
+++ b/spec/data/uiobjects_spec.lua
@@ -84,8 +84,70 @@ describe('uiobjects', function()
           end
         end
       end
+      local function inheritsType(k, target)
+        if k == target then
+          return true
+        end
+        for inh in pairs(uiobjects[k].inherits) do
+          if inheritsType(inh, target) then
+            return true
+          end
+        end
+        return false
+      end
+      local function collectChildFields(k, seen)
+        seen = seen or {}
+        if seen[k] then
+          return {}
+        end
+        seen[k] = true
+        local result = {}
+        if uiobjects[k].childField then
+          result[uiobjects[k].childField] = true
+        end
+        for inh in pairs(uiobjects[k].inherits) do
+          for cf in pairs(collectChildFields(inh, seen)) do
+            result[cf] = true
+          end
+        end
+        return result
+      end
+      describe('childField values', function()
+        local allValues = {}
+        for k in pairs(uiobjects) do
+          for cf in pairs(collectChildFields(k)) do
+            allValues[cf] = true
+          end
+        end
+        for cf in pairs(allValues) do
+          it(cf .. ' is a real hlist field on some uiobject', function()
+            local found = false
+            for _, tv in pairs(uiobjects) do
+              local f = tv.fields[cf]
+              if f and f.type == 'hlist' then
+                found = true
+              end
+            end
+            assert.True(found)
+          end)
+        end
+      end)
       for k, v in pairs(uiobjects) do
         describe(k, function()
+          describe('childField', function()
+            local names = {}
+            for cf in pairs(collectChildFields(k)) do
+              table.insert(names, cf)
+            end
+            it('has at most one value across the inheritance tree', function()
+              assert.True(#names <= 1, ('%s has conflicting child fields: %s'):format(k, table.concat(names, ', ')))
+            end)
+            if names[1] == 'children' then
+              it('is only used by frames', function()
+                assert.True(inheritsType(k, 'Frame'))
+              end)
+            end
+          end)
           describe('methods', function()
             for mk, mv in pairs(v.methods) do
               describe(mk, function()

--- a/spec/data/uiobjects_spec.lua
+++ b/spec/data/uiobjects_spec.lua
@@ -84,17 +84,6 @@ describe('uiobjects', function()
           end
         end
       end
-      local function inheritsType(k, target)
-        if k == target then
-          return true
-        end
-        for inh in pairs(uiobjects[k].inherits) do
-          if inheritsType(inh, target) then
-            return true
-          end
-        end
-        return false
-      end
       local function collectChildFields(k, seen)
         seen = seen or {}
         if seen[k] then
@@ -142,11 +131,6 @@ describe('uiobjects', function()
             it('has at most one value across the inheritance tree', function()
               assert.True(#names <= 1, ('%s has conflicting child fields: %s'):format(k, table.concat(names, ', ')))
             end)
-            if names[1] == 'children' then
-              it('is only used by frames', function()
-                assert.True(inheritsType(k, 'Frame'))
-              end)
-            end
           end)
           describe('methods', function()
             for mk, mv in pairs(v.methods) do

--- a/tools/prep.lua
+++ b/tools/prep.lua
@@ -332,6 +332,7 @@ for k, v in pairs(uiobjectdata) do
     scripts[sk:lower()] = true
   end
   uiobjects[k] = {
+    childField = v.childField,
     constructor = table.concat(constructor),
     inherits = v.inherits,
     objectType = v.objectType,

--- a/wowless/modules/api.lua
+++ b/wowless/modules/api.lua
@@ -28,6 +28,7 @@ return function(
     end
   end)()
 
+  local GetChildField = uiobjecttypes.GetChildField
   local GetIntrinsic = intrinsics.Get
   local GetObjectType = uiobjecttypes.GetObjectType
   local HasType = uiobjecttypes.Has
@@ -52,12 +53,7 @@ return function(
     if obj.parent == parent then
       return
     end
-    local field = IsObjectType(obj, 'layeredregion') and 'regions'
-      or IsObjectType(obj, 'animationgroup') and 'animationGroups'
-      or IsObjectType(obj, 'controlpoint') and 'controlPoints'
-      or IsObjectType(obj, 'animation') and 'animations'
-      or IsObjectType(obj, 'actor') and 'actors'
-      or 'children'
+    local field = GetChildField(obj.type)
     if obj.parent then
       local up = obj.parent
       up[field]:remove(obj)

--- a/wowless/modules/uiobjectloader.lua
+++ b/wowless/modules/uiobjectloader.lua
@@ -12,6 +12,7 @@ return function(cstubs, datalua, gencode)
         local scripts = Mixin({}, ty.scripts or {})
         local hostindex = {}
         local sandboxindex = {}
+        local childField = ty.cfg.childField
         for inh in pairs(ty.inherits) do
           flattenOne(inh)
           local r = result[string.lower(inh)]
@@ -19,10 +20,12 @@ return function(cstubs, datalua, gencode)
           Mixin(scripts, r.scripts)
           Mixin(hostindex, r.hostindex)
           Mixin(sandboxindex, r.sandboxindex)
+          childField = childField or r.childField
         end
         Mixin(hostindex, ty.hostindex) -- do this last in case of overrides
         Mixin(sandboxindex, ty.sandboxindex)
         result[lk] = {
+          childField = childField,
           constructor = ty.constructor,
           ctype = ty.cfg.uitype_bit,
           hostindex = hostindex,
@@ -43,6 +46,7 @@ return function(cstubs, datalua, gencode)
         sandboxMTindex[n] = factory()
       end
       t[k] = {
+        childField = v.childField,
         constructor = v.constructor,
         ctype = v.ctype,
         hostMT = { __index = v.hostindex }, -- issue #657

--- a/wowless/modules/uiobjecttypes.lua
+++ b/wowless/modules/uiobjecttypes.lua
@@ -5,6 +5,10 @@ return function()
     uiobjectTypes[name] = t
   end
 
+  local function GetChildField(name)
+    return uiobjectTypes[name].childField
+  end
+
   local function GetObjectType(obj)
     return uiobjectTypes[obj.type].name
   end
@@ -44,6 +48,7 @@ return function()
 
   return {
     Add = Add,
+    GetChildField = GetChildField,
     GetObjectType = GetObjectType,
     GetOrThrow = GetOrThrow,
     GetSandboxMetatable = GetSandboxMetatable,


### PR DESCRIPTION
## Summary
Supersedes #807. Moves the child-field categorization data itself into the yaml, rather than computing it from the type hierarchy at load time.

- **`data/products/*/uiobjects.yaml`**: add a `childField` property to the six type definitions that actually own one — `Frame` → `children`, `LayeredRegion` → `regions`, `AnimationGroup` → `animationGroups`, `Animation` → `animations`, `ControlPoint` → `controlPoints`, `Actor` → `actors`.
- **`wowless/modules/uiobjectloader.lua`**: `flatten()` already merges each type's data through the inheritance tree (`isa`, `scripts`, `hostindex`, ...) before it reaches `uiobjecttypes.Add`; merge `childField` the same way — own declaration takes precedence over inherited.
- **`wowless/modules/api.lua`**: unchanged from #807's last state — `DoSetParent` still does a single `uiobjecttypes.GetChildField(obj.type)` lookup, now backed by yaml-declared data instead of a runtime `isa`-based computation.
- **`tools/prep.lua`**: its `uiobjects` table construction whitelists which fields survive from the parsed yaml into the runtime data module — `childField` needed adding there too, or it was silently dropped. Caught immediately by the full `outs` eval, which crashed on the very first parented frame with `attempt to index field '?' (a nil value)`.
- **`spec/data/uiobjects_spec.lua`**: asserts the design is actually consistent — each uiobject has at most one distinct `childField` value across its own declaration and all transitive ancestors (multiple inheritance could otherwise let conflicting values reach the same type unnoticed), and every `childField` value used anywhere corresponds to a real `hlist`-typed field on some uiobject (catches typos). Deliberately does *not* separately assert `'children'` is Frame-only — that's just a fact of which single yaml line declares it, visible by inspection, not a computed invariant that could drift.
- **`data/schemas/uiobjects.yaml`**: rebased onto #810's new `hierarchy` schema construct (merged into `main` after this work started) — added `childField` to the same `fields:` shape, no other changes needed since `unique`/cycle detection there is about per-key redeclaration in map-typed members like `fields`/`methods`, not scalar properties like this one.

## Test plan
- [x] `cmake --build --preset default --target test` — exit 0, no output, across all products
- [x] `cmake --build --preset default --target outs` — all 8 products' `log.txt` empty
- [x] `pre-commit run` on all changed files — all hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)