### PR TITLE
luaobjects: add negative method presence tests

### DIFF
--- a/addon/Wowless/luaobjects.lua
+++ b/addon/Wowless/luaobjects.lua
@@ -3,6 +3,7 @@ local _, G = ...
 local assertEquals = G.assertEquals
 
 local alltypes = _G.WowlessData.LuaObjects.types
+local allmethodnames = _G.WowlessData.LuaObjects.allmethodnames
 
 local metamethods = {
   __eq = true,
@@ -75,6 +76,17 @@ local function checkLuaObject(ty, o)
         assertEquals(nil, seen[fn], k)
         seen[fn] = k
       end
+    end,
+    unknownmethods = function()
+      local t = {}
+      for k in pairs(allmethodnames) do
+        if not alltypes[ty][k] then
+          t[k] = function()
+            assertEquals(nil, o[k])
+          end
+        end
+      end
+      return t
     end,
     field_type = function()
       assertEquals(nil, o.type)

--- a/addon/Wowless/luaobjects.lua
+++ b/addon/Wowless/luaobjects.lua
@@ -82,7 +82,20 @@ local function checkLuaObject(ty, o)
       for k in pairs(allmethodnames) do
         if not alltypes[ty][k] then
           t[k] = function()
-            assertEquals(nil, o[k])
+            return {
+              index = function()
+                assertEquals(nil, o[k])
+              end,
+              newindex = function()
+                local v = {}
+                local success = pcall(function()
+                  o[k] = v
+                end)
+                assertEquals(true, success, k)
+                assertEquals(v, o[k])
+                o[k] = nil
+              end,
+            }
           end
         end
       end

--- a/addon/Wowless/luaobjects.lua
+++ b/addon/Wowless/luaobjects.lua
@@ -82,20 +82,12 @@ local function checkLuaObject(ty, o)
       for k in pairs(allmethodnames) do
         if not alltypes[ty][k] then
           t[k] = function()
-            return {
-              index = function()
-                assertEquals(nil, o[k])
-              end,
-              newindex = function()
-                local v = {}
-                local success = pcall(function()
-                  o[k] = v
-                end)
-                assertEquals(true, success, k)
-                assertEquals(v, o[k])
-                o[k] = nil
-              end,
-            }
+            assertEquals(nil, o[k])
+            local v = {}
+            o[k] = v
+            assertEquals(v, o[k])
+            o[k] = nil
+            assertEquals(nil, o[k])
           end
         end
       end

--- a/tools/gentest.lua
+++ b/tools/gentest.lua
@@ -496,10 +496,24 @@ local ptablemap = {
       end
       types[k] = m
     end
-    return 'LuaObjects', {
-      methodpartition = cmp,
-      types = types,
-    }
+    -- Universe of method names across all luaobject types in all products, so
+    -- the addon can negative-test that a type lacks methods it doesn't own,
+    -- even ones it can't otherwise learn about from this product alone
+    -- (mirrors the events ptablemap entry above).
+    local allmethodnames = {}
+    for _, product in ipairs(readyaml('data/products.yaml')) do
+      for _, v in pairs(perproduct(product, 'luaobjects')) do
+        for mk in pairs(v.methods or {}) do
+          allmethodnames[mk] = true
+        end
+      end
+    end
+    return 'LuaObjects',
+      {
+        allmethodnames = allmethodnames,
+        methodpartition = cmp,
+        types = types,
+      }
   end,
   namespaceapis = function(p)
     local platform = dofile('build/runtime/platform.lua')


### PR DESCRIPTION
## Summary
- The luaobject `methods` test only ever checks that expected methods are present; it can't do if-and-only-if since it has no way to enumerate all of an object's actual methods.
- Adds a cross-product universe of luaobject method names (`LuaObjects.allmethodnames` in `gentest.lua`, mirroring the existing `Events` cross-product pattern) and a new `unknownmethods` addon test that asserts any universe method name not owned by a given type is actually `nil` on instances of that type.
- Expands negative coverage without requiring exhaustive enumeration of all possible strings.

## Test plan
- [x] `cmake --build --preset default --target test` passes (also ran as part of the pre-commit `build and test` hook)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0191HaZSVq5uGHfsJTiaTyuN