### PR TITLE
luaobjects: remove tostring_metamethod config, always enable it

### DIFF
--- a/addon/Wowless/asynctests.lua
+++ b/addon/Wowless/asynctests.lua
@@ -113,12 +113,7 @@ G.asynctests = {
         assertEquals(t, args[1]) -- because of eq metamethod
         assertEquals(nil, ({ [t] = true })[args[1]]) -- they're still not the same object
         assertEquals('bar', args[1].foo)
-        local cfg = _G.WowlessData.Config.modules and _G.WowlessData.Config.modules.luaobjects or {}
-        if cfg.tostring_metamethod then
-          assertEquals(tostring(t), tostring(args[1]))
-        else
-          assert(tostring(t) ~= tostring(args[1]))
-        end
+        assertEquals(tostring(t), tostring(args[1]))
       end)
     end
     t = G.retn(1, _G.C_Timer.NewTimer(0, cb))

--- a/addon/Wowless/luaobjects.lua
+++ b/addon/Wowless/luaobjects.lua
@@ -2,7 +2,6 @@ local _, G = ...
 
 local assertEquals = G.assertEquals
 
-local config = _G.WowlessData.Config.modules and _G.WowlessData.Config.modules.luaobjects or {}
 local alltypes = _G.WowlessData.LuaObjects.types
 
 local metamethods = {
@@ -10,7 +9,7 @@ local metamethods = {
   __index = true,
   __metatable = true,
   __newindex = true,
-  __tostring = config.tostring_metamethod or nil,
+  __tostring = true,
 }
 
 local function checkReadonly(o, k)
@@ -85,11 +84,7 @@ local function checkLuaObject(ty, o)
     end,
     tostring = function()
       local s = tostring(o)
-      if config.tostring_metamethod then
-        assert(s:match('^' .. ty .. ': 0x[0-9a-f]+$'), s)
-      else
-        assert(s:match('^userdata: 0[xX]?%x+$'), s)
-      end
+      assert(s:match('^' .. ty .. ': 0x[0-9a-f]+$'), s)
     end,
     type = function()
       assertEquals('userdata', type(o))

--- a/data/products/wow/config.yaml
+++ b/data/products/wow/config.yaml
@@ -79,9 +79,6 @@ addon:
     C_Traits.GetConditionInfo:
     C_Traits.GetEntryInfo:
     C_Traits.GetTreeInfo:
-modules:
-  luaobjects:
-    tostring_metamethod: true
 runner:
   skip_bindings:
     TOGGLECOLLECTIONSWARDROBE: requires better implementation of transmog slots

--- a/data/products/wow_anniversary/config.yaml
+++ b/data/products/wow_anniversary/config.yaml
@@ -55,9 +55,6 @@ addon:
     C_Traits.GetConditionInfo:
     C_Traits.GetEntryInfo:
     C_Traits.GetTreeInfo:
-modules:
-  luaobjects:
-    tostring_metamethod: true
 runner:
   skip_events:
     AJ_PVP_RBG_ACTION: missing HonorFrame_SetType

--- a/data/products/wow_classic/config.yaml
+++ b/data/products/wow_classic/config.yaml
@@ -56,9 +56,6 @@ addon:
     C_Traits.GetConditionInfo:
     C_Traits.GetEntryInfo:
     C_Traits.GetTreeInfo:
-modules:
-  luaobjects:
-    tostring_metamethod: true
 runner:
   skip_bindings:
     TOGGLECOLLECTIONSWARDROBE: requires better implementation of transmog slots

--- a/data/products/wow_classic_era/config.yaml
+++ b/data/products/wow_classic_era/config.yaml
@@ -55,9 +55,6 @@ addon:
     C_Traits.GetConditionInfo:
     C_Traits.GetEntryInfo:
     C_Traits.GetTreeInfo:
-modules:
-  luaobjects:
-    tostring_metamethod: true
 runner:
   skip_events:
     AJ_PVP_RBG_ACTION: missing HonorFrame_SetType

--- a/data/products/wow_classic_era_ptr/config.yaml
+++ b/data/products/wow_classic_era_ptr/config.yaml
@@ -58,9 +58,6 @@ addon:
     C_Traits.GetConditionInfo:
     C_Traits.GetEntryInfo:
     C_Traits.GetTreeInfo:
-modules:
-  luaobjects:
-    tostring_metamethod: true
 runner:
   skip_events:
     AJ_PVP_RBG_ACTION: missing HonorFrame_SetType

--- a/data/products/wow_classic_ptr/config.yaml
+++ b/data/products/wow_classic_ptr/config.yaml
@@ -59,9 +59,6 @@ addon:
     C_Traits.GetConditionInfo:
     C_Traits.GetEntryInfo:
     C_Traits.GetTreeInfo:
-modules:
-  luaobjects:
-    tostring_metamethod: true
 runner:
   skip_bindings:
     TOGGLECOLLECTIONSWARDROBE: requires better implementation of transmog slots

--- a/data/products/wowt/config.yaml
+++ b/data/products/wowt/config.yaml
@@ -86,8 +86,6 @@ addon:
     C_Traits.GetEntryInfo:
     C_Traits.GetTreeInfo:
 modules:
-  luaobjects:
-    tostring_metamethod: true
   parentkey:
     rawset: true
 runner:

--- a/data/products/wowxptr/config.yaml
+++ b/data/products/wowxptr/config.yaml
@@ -80,9 +80,6 @@ addon:
     C_Traits.GetConditionInfo:
     C_Traits.GetEntryInfo:
     C_Traits.GetTreeInfo:
-modules:
-  luaobjects:
-    tostring_metamethod: true
 runner:
   skip_bindings:
     TOGGLECOLLECTIONSWARDROBE: requires better implementation of transmog slots

--- a/data/schemas/config.yaml
+++ b/data/schemas/config.yaml
@@ -50,11 +50,6 @@ type:
     modules:
       type:
         record:
-          luaobjects:
-            type:
-              record:
-                tostring_metamethod:
-                  type: flag
           parentkey:
             type:
               record:

--- a/wowless/luaobject.c
+++ b/wowless/luaobject.c
@@ -86,11 +86,9 @@ void wowless_luaobject_make_mt(lua_State *L, int methods_idx,
   lua_pushvalue(L, methods_idx);
   lua_pushcclosure(L, luaobject_newindex, 1);
   lua_setfield(L, -2, "__newindex");
-  if (typename_str) {
-    lua_pushstring(L, typename_str);
-    lua_pushcclosure(L, luaobject_tostring, 1);
-    lua_setfield(L, -2, "__tostring");
-  }
+  lua_pushstring(L, typename_str);
+  lua_pushcclosure(L, luaobject_tostring, 1);
+  lua_setfield(L, -2, "__tostring");
 }
 
 /* upvalue 1: metatables (type_id -> metatable) */

--- a/wowless/modules/luaobjects.lua
+++ b/wowless/modules/luaobjects.lua
@@ -1,12 +1,11 @@
 local luaobject = require('wowless.luaobject')
 
 return function(cstubs, datalua)
-  local config = datalua.config.modules and datalua.config.modules.luaobjects or {}
   local typeids = {}
   local impltypes = {}
 
   local function LoadTypes(modules)
-    local type_stubs = cstubs.loadluaobjects(modules, luaobject, config.tostring_metamethod)
+    local type_stubs = cstubs.loadluaobjects(modules, luaobject)
     for k, ts in pairs(type_stubs) do
       typeids[k] = ts.typeid
     end

--- a/wowless/stubs.cpp
+++ b/wowless/stubs.cpp
@@ -128,26 +128,25 @@ static void load_entries_dedup(lua_State *L, const struct wowless_stub_entry *e,
 int wowless_load_luaobject_stubs(lua_State *L) {
   const auto *spec = static_cast<const wowless_luaobject_type_entry *>(
       lua_touserdata(L, lua_upvalueindex(1)));
-  /* arg 1: modules, arg 2: luaobject module, arg 3: tostring_enabled */
-  bool tostring_enabled = lua_toboolean(L, 3);
+  /* arg 1: modules, arg 2: luaobject module */
   lua_getfield(L, 1, "cgencode");
   lua_insert(L, 1);
-  /* Stack: [cgencode=1, modules=2, luaobject=3, bool=4] */
+  /* Stack: [cgencode=1, modules=2, luaobject=3] */
   lua_getfield(L, 3, "metatables");
-  /* Stack: [cgencode=1, modules=2, luaobject=3, bool=4, metatables=5] */
-  lua_newtable(L); /* dedup=6 */
-  lua_newtable(L); /* result=7 */
+  /* Stack: [cgencode=1, modules=2, luaobject=3, metatables=4] */
+  lua_newtable(L); /* dedup=5 */
+  lua_newtable(L); /* result=6 */
   for (const wowless_luaobject_type_entry *t = spec; t->type_name; t++) {
-    load_entries_dedup(L, t->methods, 6); /* pushes methods=8 */
-    wowless_luaobject_make_mt(L, 8, tostring_enabled ? t->type_name : nullptr);
-    lua_rawseti(L, 5, t->type_id);
-    lua_pop(L, 1); /* pop methods=8 */
+    load_entries_dedup(L, t->methods, 5); /* pushes methods=7 */
+    wowless_luaobject_make_mt(L, 7, t->type_name);
+    lua_rawseti(L, 4, t->type_id);
+    lua_pop(L, 1); /* pop methods=7 */
     lua_newtable(L);
     lua_pushinteger(L, t->type_id);
     lua_setfield(L, -2, "typeid");
-    lua_setfield(L, 7, t->type_name);
+    lua_setfield(L, 6, t->type_name);
   }
-  lua_remove(L, 6); /* remove dedup */
+  lua_remove(L, 5); /* remove dedup */
   return 1;
 }
 


### PR DESCRIPTION
## Summary
- All products already set `tostring_metamethod: true` in their `config.yaml`, so the config knob and the disabled-path logic were dead weight.
- Removed the `modules.luaobjects.tostring_metamethod` config field from the schema and all 8 products' `config.yaml`.
- Simplified `wowless_load_luaobject_stubs`/`wowless_luaobject_make_mt` in C to always set `__tostring` (no longer conditional on a runtime flag).
- Simplified `wowless/modules/luaobjects.lua` to drop the now-unused config lookup.
- Updated `addon/Wowless/luaobjects.lua` and `addon/Wowless/asynctests.lua` tests to assert the tostring behavior unconditionally instead of branching on config.

## Test plan
- [x] `cmake --build --preset default --target test` (exit 0, no output)
- [x] `pre-commit run -a` (all hooks pass)

https://claude.ai/code/session_01BoU3bt7CwryqNp4PVR6SRd