### PR TITLE
schema: apply hierarchy construct to xml extends attribute

### DIFF
--- a/data/schemas/xml.yaml
+++ b/data/schemas/xml.yaml
@@ -1,86 +1,86 @@
 name: xml
 type:
-  mapof:
-    key: string
-    value:
-      record:
-        attributes:
-          type:
-            mapof:
-              key: string
-              value:
-                record:
-                  impl:
-                    type:
-                      taggedunion:
-                        field: string
-                        internal: tag
-                        loadfile: tag
-                        method: string
-                        scope: string
-                  phase:
-                    type:
-                      taggedunion:
-                        early: tag
-                        late: tag
-                  required:
-                    type: flag
+  hierarchy:
+    fields:
+      attributes:
+        type:
+          mapof:
+            key: string
+            value:
+              record:
+                impl:
                   type:
-                    required: true
-                    type:
-                      taggedunion:
-                        boolean: tag
-                        enum:
-                          ref:
-                            schema: enum
-                        number: tag
-                        string: tag
-                        stringenum:
-                          ref:
-                            schema: stringenum
-                        stringlist: tag
-        contents:
-          type:
-            taggedunion:
-              tags:
-                setof:
-                  ref:
-                    schema: xml
-              text: tag
-        extends:
-          type:
-            ref:
-              schema: xml
-        impl:
-          type:
-            taggedunion:
-              call:
-                record:
-                  argument:
-                    required: true
-                    type:
-                      taggedunion:
-                        lastkid: tag
-                        self: tag
-                  parentmethod:
-                    required: true
-                    type: string
-                  parenttype:
-                    required: true
-                    type:
-                      ref:
-                        schema: uiobject
-              loadstring: tag
-              script:
-                record:
-                  args:
-                    type: string
-              transparent: tag
-        phase:
-          type:
-            taggedunion:
-              late: tag
-        sealed:
-          type: flag
-        virtual:
-          type: flag
+                    taggedunion:
+                      field: string
+                      internal: tag
+                      loadfile: tag
+                      method: string
+                      scope: string
+                phase:
+                  type:
+                    taggedunion:
+                      early: tag
+                      late: tag
+                required:
+                  type: flag
+                type:
+                  required: true
+                  type:
+                    taggedunion:
+                      boolean: tag
+                      enum:
+                        ref:
+                          schema: enum
+                      number: tag
+                      string: tag
+                      stringenum:
+                        ref:
+                          schema: stringenum
+                      stringlist: tag
+      contents:
+        type:
+          taggedunion:
+            tags:
+              setof:
+                ref:
+                  schema: xml
+            text: tag
+      extends:
+        type:
+          ref:
+            schema: xml
+      impl:
+        type:
+          taggedunion:
+            call:
+              record:
+                argument:
+                  required: true
+                  type:
+                    taggedunion:
+                      lastkid: tag
+                      self: tag
+                parentmethod:
+                  required: true
+                  type: string
+                parenttype:
+                  required: true
+                  type:
+                    ref:
+                      schema: uiobject
+            loadstring: tag
+            script:
+              record:
+                args:
+                  type: string
+            transparent: tag
+      phase:
+        type:
+          taggedunion:
+            late: tag
+      sealed:
+        type: flag
+      virtual:
+        type: flag
+    parent: extends
+    unique:


### PR DESCRIPTION
## Summary
- The `xml` schema (`data/schemas/xml.yaml`) already modeled `extends` as a self-referential `ref: schema: xml` field — exactly the shape the `hierarchy` schematype (#810) was introduced for.
- Switches the top-level `xml` schema from a bare `mapof` to `hierarchy`, with `parent: extends`, so cycle/shape checking (no diamond/cyclic `extends` chains) now runs via schema validation instead of relying on ad hoc code.
- `unique` is left empty: unlike `uiobjects`/`luaobjects`, xml tags are allowed to redeclare an ancestor's `attributes` entry (see `xml_spec.lua`'s `attrs[an] = attrs[an] or a` merge, which lets a descendant's definition override its ancestor's).

## Test plan
- [x] `cmake --build --preset default --target test` (clean exit, no output)
- [x] `pre-commit run --files data/schemas/xml.yaml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T9KqqkH2qqAGRJSqEniep6