### PR TITLE
impl: fix CHAT_MSG_TEXT_EMOTE missing discordInfo arg on wowt

### DIFF
--- a/data/impl.yaml
+++ b/data/impl.yaml
@@ -32,6 +32,7 @@ C_Calendar.SetMonth:
 C_ChatInfo.PerformEmote:
   impl:
     modules:
+      datalua:
       events:
       log:
     sqls:

--- a/data/impl/C_ChatInfo.PerformEmote.lua
+++ b/data/impl/C_ChatInfo.PerformEmote.lua
@@ -1,8 +1,45 @@
-local events, log, sql = ...
+local datalua, events, log, sql = ...
 return function(token, user, hold)
   local text = sql(token)
   if text then
-    events.SendEvent('CHAT_MSG_TEXT_EMOTE', text, '', '', '', '', '', 0, 0, '', 0, 0, '', 0, false, false, false, false)
+    local args = {
+      text,
+      '',
+      '',
+      '',
+      '',
+      '',
+      0,
+      0,
+      '',
+      0,
+      0,
+      '',
+      0,
+      false,
+      false,
+      false,
+      false,
+    }
+    if datalua.config.runtime.discord then
+      table.insert(args, {
+        forwardedMessage = '',
+        fromDiscord = false,
+        globalName = '',
+        hasAttachment = false,
+        hasEmbed = false,
+        hasEmoji = false,
+        hasForwardedMessage = false,
+        hasPoll = false,
+        hasSticker = false,
+        lastOnlineGUID = '',
+        lastOnlineName = '',
+        type = 0,
+        userID = '',
+        username = '',
+      })
+    end
+    events.SendEvent('CHAT_MSG_TEXT_EMOTE', unpack(args))
   else
     log(1, 'DoEmote(%s) called', token, tostring(user), tostring(hold))
   end


### PR DESCRIPTION
## Summary
- `CHAT_MSG_TEXT_EMOTE` gained a `discordInfo` payload field on `wowt` (18 args vs 17 on all other products), causing a "missing a value" event dispatch error there.
- `CHAT_MSG_SYSTEM` had the exact same issue previously, fixed by conditionally appending a `discordInfo` structure table when `datalua.config.runtime.discord` is set (see `data/impl/SendSystemMessage.lua`).
- Applied the same pattern to `data/impl/C_ChatInfo.PerformEmote.lua`, adding `datalua` as a module dependency.

## Test plan
- [x] `cmake --build --preset default --target test` passes (exit 0, no output)
- [x] `pre-commit run --files data/impl.yaml data/impl/C_ChatInfo.PerformEmote.lua` passes, including the `build and test` hook

https://claude.ai/code/session_01UV1DSDXD1jW6zuTjWFHgsQ