### PR TITLE
loader: make xml-tag-to-uiobject dispatch explicit via impl.uiobject

### DIFF
--- a/data/products/wow/xml.yaml
+++ b/data/products/wow/xml.yaml
@@ -31,6 +31,8 @@ Actor:
   contents:
     tags:
       Scripts:
+  impl:
+    uiobject: Actor
 Alpha:
   attributes:
     fromalpha:
@@ -42,6 +44,8 @@ Alpha:
         field: toAlpha
       type: number
   extends: Animation
+  impl:
+    uiobject: Alpha
 Anchor:
   attributes:
     point:
@@ -89,6 +93,8 @@ Animation:
     tags:
       KeyValues:
       Scripts:
+  impl:
+    uiobject: Animation
 AnimationGroup:
   attributes:
     inherits:
@@ -119,6 +125,8 @@ AnimationGroup:
       Animation:
       KeyValues:
       Scripts:
+  impl:
+    uiobject: AnimationGroup
 Animations:
   contents:
     tags:
@@ -180,6 +188,8 @@ Browser:
     imefont:
       type: string
   extends: Frame
+  impl:
+    uiobject: Browser
 Button:
   attributes:
     motionscriptswhiledisabled:
@@ -205,6 +215,8 @@ Button:
       PushedTextOffset:
       PushedTexture:
   extends: Frame
+  impl:
+    uiobject: Button
 ButtonFont:
   attributes:
     style:
@@ -232,6 +244,8 @@ CheckButton:
       CheckedTexture:
       DisabledCheckedTexture:
   extends: Button
+  impl:
+    uiobject: CheckButton
 CheckedTexture:
   extends: Texture
   impl:
@@ -245,8 +259,12 @@ Checkout:
     imefont:
       type: string
   extends: Frame
+  impl:
+    uiobject: Checkout
 CinematicModel:
   extends: Frame
+  impl:
+    uiobject: CinematicModel
 Color:
   attributes:
     a:
@@ -267,6 +285,8 @@ ColorSelect:
       ColorWheelTexture:
       ColorWheelThumbTexture:
   extends: Frame
+  impl:
+    uiobject: ColorSelect
 ColorValueTexture:
   extends: Texture
   impl:
@@ -305,6 +325,8 @@ ControlPoint:
       type: number
     offsety:
       type: number
+  impl:
+    uiobject: ControlPoint
 ControlPoints:
   contents:
     tags:
@@ -324,6 +346,8 @@ Cooldown:
       EdgeTexture:
       SwipeTexture:
   extends: Frame
+  impl:
+    uiobject: Cooldown
 Dimension:
   contents:
     tags:
@@ -358,6 +382,8 @@ DressUpModel:
     modelscale:
       type: number
   extends: Frame
+  impl:
+    uiobject: DressUpModel
 EdgeTexture:
   extends: Texture
   sealed: true
@@ -389,10 +415,16 @@ EditBox:
       HighlightColor:
       TextInsets:
   extends: Frame
+  impl:
+    uiobject: EditBox
 FlipBook:
   extends: Animation
+  impl:
+    uiobject: FlipBook
 FogOfWarFrame:
   extends: Frame
+  impl:
+    uiobject: FogOfWarFrame
 Font:
   attributes:
     filter:
@@ -429,6 +461,8 @@ Font:
     tags:
       Color:
       Shadow:
+  impl:
+    uiobject: Font
 FontFamily:
   attributes:
     name:
@@ -475,6 +509,8 @@ FontString:
       FontHeight:
       Shadow:
   extends: LayoutFrame
+  impl:
+    uiobject: FontString
 FontStringHeader1:
   extends: FontString
   sealed: true
@@ -566,6 +602,8 @@ Frame:
       Layers:
       ResizeBounds:
   extends: LayoutFrame
+  impl:
+    uiobject: Frame
 Frames:
   contents:
     tags:
@@ -574,6 +612,8 @@ Frames:
   phase: late
 GameTooltip:
   extends: Frame
+  impl:
+    uiobject: GameTooltip
 Gradient:
   attributes:
     orientation:
@@ -719,6 +759,8 @@ Line:
     thickness:
       type: number
   extends: LayoutFrame
+  impl:
+    uiobject: Line
 LineScale:
   attributes:
     fromscalex:
@@ -733,6 +775,8 @@ LineScale:
     tags:
       Origin:
   extends: Animation
+  impl:
+    uiobject: LineScale
 MaskedTexture:
   attributes:
     childkey:
@@ -752,6 +796,8 @@ MaskTexture:
     tags:
       MaskedTextures:
   extends: Texture
+  impl:
+    uiobject: MaskTexture
 MaxColor:
   extends: Color
 MaxResize:
@@ -778,19 +824,27 @@ MessageFrame:
     tags:
       FontString:
   extends: Frame
+  impl:
+    uiobject: MessageFrame
 MinColor:
   extends: Color
 Minimap:
   extends: Frame
+  impl:
+    uiobject: Minimap
 MinResize:
   extends: Dimension
 Model:
   extends: Frame
+  impl:
+    uiobject: Model
 ModelScene:
   contents:
     tags:
       ViewInsets:
   extends: Frame
+  impl:
+    uiobject: ModelScene
 ModifiedClick:
   attributes:
     action:
@@ -799,6 +853,8 @@ ModifiedClick:
       type: string
 MovieFrame:
   extends: Frame
+  impl:
+    uiobject: MovieFrame
 NormalFont:
   extends: ButtonFont
   impl:
@@ -816,6 +872,8 @@ NormalTexture:
   sealed: true
 OffScreenFrame:
   extends: Frame
+  impl:
+    uiobject: OffScreenFrame
 Offset:
   attributes:
     x:
@@ -1124,10 +1182,16 @@ Path:
     tags:
       ControlPoints:
   extends: Animation
+  impl:
+    uiobject: Path
 PlayerModel:
   extends: Frame
+  impl:
+    uiobject: PlayerModel
 POIFrame:
   extends: Frame
+  impl:
+    uiobject: POIFrame
   virtual: true
 PostClick:
   extends: ScriptType
@@ -1154,6 +1218,8 @@ PushedTexture:
   sealed: true
 QuestPOIFrame:
   extends: POIFrame
+  impl:
+    uiobject: QuestPOIFrame
 Rect:
   attributes:
     llx:
@@ -1199,6 +1265,8 @@ Rotation:
     degrees:
       type: number
   extends: Animation
+  impl:
+    uiobject: Rotation
 Scale:
   attributes:
     fromscalex:
@@ -1217,8 +1285,12 @@ Scale:
     tags:
       Origin:
   extends: Animation
+  impl:
+    uiobject: Scale
 ScenarioPOIFrame:
   extends: POIFrame
+  impl:
+    uiobject: ScenarioPOIFrame
 ScopedModifier:
   attributes:
     forbidden:
@@ -1276,6 +1348,8 @@ ScrollFrame:
     tags:
       ScrollChild:
   extends: Frame
+  impl:
+    uiobject: ScrollFrame
 Shadow:
   attributes:
     x:
@@ -1294,6 +1368,8 @@ SimpleHTML:
       FontStringHeader2:
       FontStringHeader3:
   extends: Frame
+  impl:
+    uiobject: SimpleHTML
 Size:
   attributes:
     x:
@@ -1330,6 +1406,8 @@ Slider:
     tags:
       ThumbTexture:
   extends: Frame
+  impl:
+    uiobject: Slider
 StatusBar:
   attributes:
     defaultvalue:
@@ -1349,11 +1427,15 @@ StatusBar:
       BarColor:
       BarTexture:
   extends: Frame
+  impl:
+    uiobject: StatusBar
 SwipeTexture:
   extends: Texture
   sealed: true
 TabardModel:
   extends: Frame
+  impl:
+    uiobject: TabardModel
 TexCoords:
   attributes:
     bottom:
@@ -1410,8 +1492,12 @@ Texture:
       Gradient:
       TexCoords:
   extends: LayoutFrame
+  impl:
+    uiobject: Texture
 TextureCoordTranslation:
   extends: Animation
+  impl:
+    uiobject: TextureCoordTranslation
 ThumbTexture:
   extends: Texture
   impl:
@@ -1427,6 +1513,8 @@ Translation:
     offsety:
       type: number
   extends: Animation
+  impl:
+    uiobject: Translation
 Ui:
   contents:
     tags:
@@ -1441,6 +1529,8 @@ Ui:
   impl: transparent
 UnitPositionFrame:
   extends: Frame
+  impl:
+    uiobject: UnitPositionFrame
 Value:
   contents:
     tags:
@@ -1457,3 +1547,5 @@ ViewInsets:
       type: number
 WorldFrame:
   extends: Frame
+  impl:
+    uiobject: Frame

--- a/data/products/wow_anniversary/xml.yaml
+++ b/data/products/wow_anniversary/xml.yaml
@@ -31,6 +31,8 @@ Actor:
   contents:
     tags:
       Scripts:
+  impl:
+    uiobject: Actor
 Alpha:
   attributes:
     fromalpha:
@@ -42,6 +44,8 @@ Alpha:
         field: toAlpha
       type: number
   extends: Animation
+  impl:
+    uiobject: Alpha
 Anchor:
   attributes:
     point:
@@ -89,6 +93,8 @@ Animation:
     tags:
       KeyValues:
       Scripts:
+  impl:
+    uiobject: Animation
 AnimationGroup:
   attributes:
     inherits:
@@ -119,6 +125,8 @@ AnimationGroup:
       Animation:
       KeyValues:
       Scripts:
+  impl:
+    uiobject: AnimationGroup
 Animations:
   contents:
     tags:
@@ -180,6 +188,8 @@ Browser:
     imefont:
       type: string
   extends: Frame
+  impl:
+    uiobject: Browser
 Button:
   attributes:
     motionscriptswhiledisabled:
@@ -205,6 +215,8 @@ Button:
       PushedTextOffset:
       PushedTexture:
   extends: Frame
+  impl:
+    uiobject: Button
 ButtonFont:
   attributes:
     style:
@@ -232,6 +244,8 @@ CheckButton:
       CheckedTexture:
       DisabledCheckedTexture:
   extends: Button
+  impl:
+    uiobject: CheckButton
 CheckedTexture:
   extends: Texture
   impl:
@@ -245,8 +259,12 @@ Checkout:
     imefont:
       type: string
   extends: Frame
+  impl:
+    uiobject: Checkout
 CinematicModel:
   extends: Frame
+  impl:
+    uiobject: CinematicModel
 Color:
   attributes:
     a:
@@ -267,6 +285,8 @@ ColorSelect:
       ColorWheelTexture:
       ColorWheelThumbTexture:
   extends: Frame
+  impl:
+    uiobject: ColorSelect
 ColorValueTexture:
   extends: Texture
   impl:
@@ -305,6 +325,8 @@ ControlPoint:
       type: number
     offsety:
       type: number
+  impl:
+    uiobject: ControlPoint
 ControlPoints:
   contents:
     tags:
@@ -324,6 +346,8 @@ Cooldown:
       EdgeTexture:
       SwipeTexture:
   extends: Frame
+  impl:
+    uiobject: Cooldown
 Dimension:
   contents:
     tags:
@@ -358,6 +382,8 @@ DressUpModel:
     modelscale:
       type: number
   extends: Frame
+  impl:
+    uiobject: DressUpModel
 EdgeTexture:
   extends: Texture
   sealed: true
@@ -389,10 +415,16 @@ EditBox:
       HighlightColor:
       TextInsets:
   extends: Frame
+  impl:
+    uiobject: EditBox
 FlipBook:
   extends: Animation
+  impl:
+    uiobject: FlipBook
 FogOfWarFrame:
   extends: Frame
+  impl:
+    uiobject: FogOfWarFrame
 Font:
   attributes:
     filter:
@@ -429,6 +461,8 @@ Font:
     tags:
       Color:
       Shadow:
+  impl:
+    uiobject: Font
 FontFamily:
   attributes:
     name:
@@ -475,6 +509,8 @@ FontString:
       FontHeight:
       Shadow:
   extends: LayoutFrame
+  impl:
+    uiobject: FontString
 FontStringHeader1:
   extends: FontString
   sealed: true
@@ -566,6 +602,8 @@ Frame:
       Layers:
       ResizeBounds:
   extends: LayoutFrame
+  impl:
+    uiobject: Frame
 Frames:
   contents:
     tags:
@@ -574,6 +612,8 @@ Frames:
   phase: late
 GameTooltip:
   extends: Frame
+  impl:
+    uiobject: GameTooltip
 Gradient:
   attributes:
     orientation:
@@ -719,6 +759,8 @@ Line:
     thickness:
       type: number
   extends: LayoutFrame
+  impl:
+    uiobject: Line
 LineScale:
   attributes:
     fromscalex:
@@ -733,6 +775,8 @@ LineScale:
     tags:
       Origin:
   extends: Animation
+  impl:
+    uiobject: LineScale
 MaskedTexture:
   attributes:
     childkey:
@@ -752,6 +796,8 @@ MaskTexture:
     tags:
       MaskedTextures:
   extends: Texture
+  impl:
+    uiobject: MaskTexture
 MaxColor:
   extends: Color
 MaxResize:
@@ -778,19 +824,27 @@ MessageFrame:
     tags:
       FontString:
   extends: Frame
+  impl:
+    uiobject: MessageFrame
 MinColor:
   extends: Color
 Minimap:
   extends: Frame
+  impl:
+    uiobject: Minimap
 MinResize:
   extends: Dimension
 Model:
   extends: Frame
+  impl:
+    uiobject: Model
 ModelScene:
   contents:
     tags:
       ViewInsets:
   extends: Frame
+  impl:
+    uiobject: ModelScene
 ModifiedClick:
   attributes:
     action:
@@ -799,6 +853,8 @@ ModifiedClick:
       type: string
 MovieFrame:
   extends: Frame
+  impl:
+    uiobject: MovieFrame
 NormalFont:
   extends: ButtonFont
   impl:
@@ -816,6 +872,8 @@ NormalTexture:
   sealed: true
 OffScreenFrame:
   extends: Frame
+  impl:
+    uiobject: OffScreenFrame
 Offset:
   attributes:
     x:
@@ -1124,8 +1182,12 @@ Path:
     tags:
       ControlPoints:
   extends: Animation
+  impl:
+    uiobject: Path
 PlayerModel:
   extends: Frame
+  impl:
+    uiobject: PlayerModel
 POIFrame:
   extends: Frame
   virtual: true
@@ -1199,6 +1261,8 @@ Rotation:
     degrees:
       type: number
   extends: Animation
+  impl:
+    uiobject: Rotation
 Scale:
   attributes:
     fromscalex:
@@ -1217,6 +1281,8 @@ Scale:
     tags:
       Origin:
   extends: Animation
+  impl:
+    uiobject: Scale
 ScenarioPOIFrame:
   extends: POIFrame
 ScopedModifier:
@@ -1276,6 +1342,8 @@ ScrollFrame:
     tags:
       ScrollChild:
   extends: Frame
+  impl:
+    uiobject: ScrollFrame
 Shadow:
   attributes:
     x:
@@ -1294,6 +1362,8 @@ SimpleHTML:
       FontStringHeader2:
       FontStringHeader3:
   extends: Frame
+  impl:
+    uiobject: SimpleHTML
 Size:
   attributes:
     x:
@@ -1330,6 +1400,8 @@ Slider:
     tags:
       ThumbTexture:
   extends: Frame
+  impl:
+    uiobject: Slider
 StatusBar:
   attributes:
     defaultvalue:
@@ -1349,11 +1421,15 @@ StatusBar:
       BarColor:
       BarTexture:
   extends: Frame
+  impl:
+    uiobject: StatusBar
 SwipeTexture:
   extends: Texture
   sealed: true
 TabardModel:
   extends: Frame
+  impl:
+    uiobject: TabardModel
 TexCoords:
   attributes:
     bottom:
@@ -1410,8 +1486,12 @@ Texture:
       Gradient:
       TexCoords:
   extends: LayoutFrame
+  impl:
+    uiobject: Texture
 TextureCoordTranslation:
   extends: Animation
+  impl:
+    uiobject: TextureCoordTranslation
 ThumbTexture:
   extends: Texture
   impl:
@@ -1427,6 +1507,8 @@ Translation:
     offsety:
       type: number
   extends: Animation
+  impl:
+    uiobject: Translation
 Ui:
   contents:
     tags:
@@ -1441,6 +1523,8 @@ Ui:
   impl: transparent
 UnitPositionFrame:
   extends: Frame
+  impl:
+    uiobject: UnitPositionFrame
 Value:
   contents:
     tags:
@@ -1457,3 +1541,5 @@ ViewInsets:
       type: number
 WorldFrame:
   extends: Frame
+  impl:
+    uiobject: Frame

--- a/data/products/wow_classic/xml.yaml
+++ b/data/products/wow_classic/xml.yaml
@@ -31,6 +31,8 @@ Actor:
   contents:
     tags:
       Scripts:
+  impl:
+    uiobject: Actor
 Alpha:
   attributes:
     fromalpha:
@@ -42,6 +44,8 @@ Alpha:
         field: toAlpha
       type: number
   extends: Animation
+  impl:
+    uiobject: Alpha
 Anchor:
   attributes:
     point:
@@ -89,6 +93,8 @@ Animation:
     tags:
       KeyValues:
       Scripts:
+  impl:
+    uiobject: Animation
 AnimationGroup:
   attributes:
     inherits:
@@ -119,6 +125,8 @@ AnimationGroup:
       Animation:
       KeyValues:
       Scripts:
+  impl:
+    uiobject: AnimationGroup
 Animations:
   contents:
     tags:
@@ -180,6 +188,8 @@ Browser:
     imefont:
       type: string
   extends: Frame
+  impl:
+    uiobject: Browser
 Button:
   attributes:
     motionscriptswhiledisabled:
@@ -205,6 +215,8 @@ Button:
       PushedTextOffset:
       PushedTexture:
   extends: Frame
+  impl:
+    uiobject: Button
 ButtonFont:
   attributes:
     style:
@@ -232,6 +244,8 @@ CheckButton:
       CheckedTexture:
       DisabledCheckedTexture:
   extends: Button
+  impl:
+    uiobject: CheckButton
 CheckedTexture:
   extends: Texture
   impl:
@@ -245,8 +259,12 @@ Checkout:
     imefont:
       type: string
   extends: Frame
+  impl:
+    uiobject: Checkout
 CinematicModel:
   extends: Frame
+  impl:
+    uiobject: CinematicModel
 Color:
   attributes:
     a:
@@ -267,6 +285,8 @@ ColorSelect:
       ColorWheelTexture:
       ColorWheelThumbTexture:
   extends: Frame
+  impl:
+    uiobject: ColorSelect
 ColorValueTexture:
   extends: Texture
   impl:
@@ -305,6 +325,8 @@ ControlPoint:
       type: number
     offsety:
       type: number
+  impl:
+    uiobject: ControlPoint
 ControlPoints:
   contents:
     tags:
@@ -324,6 +346,8 @@ Cooldown:
       EdgeTexture:
       SwipeTexture:
   extends: Frame
+  impl:
+    uiobject: Cooldown
 Dimension:
   contents:
     tags:
@@ -358,6 +382,8 @@ DressUpModel:
     modelscale:
       type: number
   extends: Frame
+  impl:
+    uiobject: DressUpModel
 EdgeTexture:
   extends: Texture
   sealed: true
@@ -389,10 +415,16 @@ EditBox:
       HighlightColor:
       TextInsets:
   extends: Frame
+  impl:
+    uiobject: EditBox
 FlipBook:
   extends: Animation
+  impl:
+    uiobject: FlipBook
 FogOfWarFrame:
   extends: Frame
+  impl:
+    uiobject: FogOfWarFrame
 Font:
   attributes:
     filter:
@@ -429,6 +461,8 @@ Font:
     tags:
       Color:
       Shadow:
+  impl:
+    uiobject: Font
 FontFamily:
   attributes:
     name:
@@ -475,6 +509,8 @@ FontString:
       FontHeight:
       Shadow:
   extends: LayoutFrame
+  impl:
+    uiobject: FontString
 FontStringHeader1:
   extends: FontString
   sealed: true
@@ -566,6 +602,8 @@ Frame:
       Layers:
       ResizeBounds:
   extends: LayoutFrame
+  impl:
+    uiobject: Frame
 Frames:
   contents:
     tags:
@@ -574,6 +612,8 @@ Frames:
   phase: late
 GameTooltip:
   extends: Frame
+  impl:
+    uiobject: GameTooltip
 Gradient:
   attributes:
     orientation:
@@ -719,6 +759,8 @@ Line:
     thickness:
       type: number
   extends: LayoutFrame
+  impl:
+    uiobject: Line
 LineScale:
   attributes:
     fromscalex:
@@ -733,6 +775,8 @@ LineScale:
     tags:
       Origin:
   extends: Animation
+  impl:
+    uiobject: LineScale
 MaskedTexture:
   attributes:
     childkey:
@@ -752,6 +796,8 @@ MaskTexture:
     tags:
       MaskedTextures:
   extends: Texture
+  impl:
+    uiobject: MaskTexture
 MaxColor:
   extends: Color
 MaxResize:
@@ -778,19 +824,27 @@ MessageFrame:
     tags:
       FontString:
   extends: Frame
+  impl:
+    uiobject: MessageFrame
 MinColor:
   extends: Color
 Minimap:
   extends: Frame
+  impl:
+    uiobject: Minimap
 MinResize:
   extends: Dimension
 Model:
   extends: Frame
+  impl:
+    uiobject: Model
 ModelScene:
   contents:
     tags:
       ViewInsets:
   extends: Frame
+  impl:
+    uiobject: ModelScene
 ModifiedClick:
   attributes:
     action:
@@ -799,6 +853,8 @@ ModifiedClick:
       type: string
 MovieFrame:
   extends: Frame
+  impl:
+    uiobject: MovieFrame
 NormalFont:
   extends: ButtonFont
   impl:
@@ -816,6 +872,8 @@ NormalTexture:
   sealed: true
 OffScreenFrame:
   extends: Frame
+  impl:
+    uiobject: OffScreenFrame
 Offset:
   attributes:
     x:
@@ -1124,10 +1182,16 @@ Path:
     tags:
       ControlPoints:
   extends: Animation
+  impl:
+    uiobject: Path
 PlayerModel:
   extends: Frame
+  impl:
+    uiobject: PlayerModel
 POIFrame:
   extends: Frame
+  impl:
+    uiobject: POIFrame
   virtual: true
 PostClick:
   extends: ScriptType
@@ -1154,6 +1218,8 @@ PushedTexture:
   sealed: true
 QuestPOIFrame:
   extends: POIFrame
+  impl:
+    uiobject: QuestPOIFrame
 Rect:
   attributes:
     llx:
@@ -1199,6 +1265,8 @@ Rotation:
     degrees:
       type: number
   extends: Animation
+  impl:
+    uiobject: Rotation
 Scale:
   attributes:
     fromscalex:
@@ -1217,8 +1285,12 @@ Scale:
     tags:
       Origin:
   extends: Animation
+  impl:
+    uiobject: Scale
 ScenarioPOIFrame:
   extends: POIFrame
+  impl:
+    uiobject: ScenarioPOIFrame
 ScopedModifier:
   attributes:
     forbidden:
@@ -1276,6 +1348,8 @@ ScrollFrame:
     tags:
       ScrollChild:
   extends: Frame
+  impl:
+    uiobject: ScrollFrame
 Shadow:
   attributes:
     x:
@@ -1294,6 +1368,8 @@ SimpleHTML:
       FontStringHeader2:
       FontStringHeader3:
   extends: Frame
+  impl:
+    uiobject: SimpleHTML
 Size:
   attributes:
     x:
@@ -1330,6 +1406,8 @@ Slider:
     tags:
       ThumbTexture:
   extends: Frame
+  impl:
+    uiobject: Slider
 StatusBar:
   attributes:
     defaultvalue:
@@ -1349,11 +1427,15 @@ StatusBar:
       BarColor:
       BarTexture:
   extends: Frame
+  impl:
+    uiobject: StatusBar
 SwipeTexture:
   extends: Texture
   sealed: true
 TabardModel:
   extends: Frame
+  impl:
+    uiobject: TabardModel
 TexCoords:
   attributes:
     bottom:
@@ -1410,8 +1492,12 @@ Texture:
       Gradient:
       TexCoords:
   extends: LayoutFrame
+  impl:
+    uiobject: Texture
 TextureCoordTranslation:
   extends: Animation
+  impl:
+    uiobject: TextureCoordTranslation
 ThumbTexture:
   extends: Texture
   impl:
@@ -1427,6 +1513,8 @@ Translation:
     offsety:
       type: number
   extends: Animation
+  impl:
+    uiobject: Translation
 Ui:
   contents:
     tags:
@@ -1441,6 +1529,8 @@ Ui:
   impl: transparent
 UnitPositionFrame:
   extends: Frame
+  impl:
+    uiobject: UnitPositionFrame
 Value:
   contents:
     tags:
@@ -1457,3 +1547,5 @@ ViewInsets:
       type: number
 WorldFrame:
   extends: Frame
+  impl:
+    uiobject: Frame

--- a/data/products/wow_classic_era/xml.yaml
+++ b/data/products/wow_classic_era/xml.yaml
@@ -31,6 +31,8 @@ Actor:
   contents:
     tags:
       Scripts:
+  impl:
+    uiobject: Actor
 Alpha:
   attributes:
     fromalpha:
@@ -42,6 +44,8 @@ Alpha:
         field: toAlpha
       type: number
   extends: Animation
+  impl:
+    uiobject: Alpha
 Anchor:
   attributes:
     point:
@@ -89,6 +93,8 @@ Animation:
     tags:
       KeyValues:
       Scripts:
+  impl:
+    uiobject: Animation
 AnimationGroup:
   attributes:
     inherits:
@@ -119,6 +125,8 @@ AnimationGroup:
       Animation:
       KeyValues:
       Scripts:
+  impl:
+    uiobject: AnimationGroup
 Animations:
   contents:
     tags:
@@ -180,6 +188,8 @@ Browser:
     imefont:
       type: string
   extends: Frame
+  impl:
+    uiobject: Browser
 Button:
   attributes:
     motionscriptswhiledisabled:
@@ -205,6 +215,8 @@ Button:
       PushedTextOffset:
       PushedTexture:
   extends: Frame
+  impl:
+    uiobject: Button
 ButtonFont:
   attributes:
     style:
@@ -232,6 +244,8 @@ CheckButton:
       CheckedTexture:
       DisabledCheckedTexture:
   extends: Button
+  impl:
+    uiobject: CheckButton
 CheckedTexture:
   extends: Texture
   impl:
@@ -245,8 +259,12 @@ Checkout:
     imefont:
       type: string
   extends: Frame
+  impl:
+    uiobject: Checkout
 CinematicModel:
   extends: Frame
+  impl:
+    uiobject: CinematicModel
 Color:
   attributes:
     a:
@@ -267,6 +285,8 @@ ColorSelect:
       ColorWheelTexture:
       ColorWheelThumbTexture:
   extends: Frame
+  impl:
+    uiobject: ColorSelect
 ColorValueTexture:
   extends: Texture
   impl:
@@ -305,6 +325,8 @@ ControlPoint:
       type: number
     offsety:
       type: number
+  impl:
+    uiobject: ControlPoint
 ControlPoints:
   contents:
     tags:
@@ -324,6 +346,8 @@ Cooldown:
       EdgeTexture:
       SwipeTexture:
   extends: Frame
+  impl:
+    uiobject: Cooldown
 Dimension:
   contents:
     tags:
@@ -358,6 +382,8 @@ DressUpModel:
     modelscale:
       type: number
   extends: Frame
+  impl:
+    uiobject: DressUpModel
 EdgeTexture:
   extends: Texture
   sealed: true
@@ -389,10 +415,16 @@ EditBox:
       HighlightColor:
       TextInsets:
   extends: Frame
+  impl:
+    uiobject: EditBox
 FlipBook:
   extends: Animation
+  impl:
+    uiobject: FlipBook
 FogOfWarFrame:
   extends: Frame
+  impl:
+    uiobject: FogOfWarFrame
 Font:
   attributes:
     filter:
@@ -429,6 +461,8 @@ Font:
     tags:
       Color:
       Shadow:
+  impl:
+    uiobject: Font
 FontFamily:
   attributes:
     name:
@@ -470,6 +504,8 @@ FontString:
       FontHeight:
       Shadow:
   extends: LayoutFrame
+  impl:
+    uiobject: FontString
 FontStringHeader1:
   extends: FontString
   sealed: true
@@ -561,6 +597,8 @@ Frame:
       Layers:
       ResizeBounds:
   extends: LayoutFrame
+  impl:
+    uiobject: Frame
 Frames:
   contents:
     tags:
@@ -569,6 +607,8 @@ Frames:
   phase: late
 GameTooltip:
   extends: Frame
+  impl:
+    uiobject: GameTooltip
 Gradient:
   attributes:
     orientation:
@@ -714,6 +754,8 @@ Line:
     thickness:
       type: number
   extends: LayoutFrame
+  impl:
+    uiobject: Line
 LineScale:
   attributes:
     fromscalex:
@@ -728,6 +770,8 @@ LineScale:
     tags:
       Origin:
   extends: Animation
+  impl:
+    uiobject: LineScale
 MaskedTexture:
   attributes:
     childkey:
@@ -747,6 +791,8 @@ MaskTexture:
     tags:
       MaskedTextures:
   extends: Texture
+  impl:
+    uiobject: MaskTexture
 MaxColor:
   extends: Color
 MaxResize:
@@ -773,19 +819,27 @@ MessageFrame:
     tags:
       FontString:
   extends: Frame
+  impl:
+    uiobject: MessageFrame
 MinColor:
   extends: Color
 Minimap:
   extends: Frame
+  impl:
+    uiobject: Minimap
 MinResize:
   extends: Dimension
 Model:
   extends: Frame
+  impl:
+    uiobject: Model
 ModelScene:
   contents:
     tags:
       ViewInsets:
   extends: Frame
+  impl:
+    uiobject: ModelScene
 ModifiedClick:
   attributes:
     action:
@@ -794,6 +848,8 @@ ModifiedClick:
       type: string
 MovieFrame:
   extends: Frame
+  impl:
+    uiobject: MovieFrame
 NormalFont:
   extends: ButtonFont
   impl:
@@ -811,6 +867,8 @@ NormalTexture:
   sealed: true
 OffScreenFrame:
   extends: Frame
+  impl:
+    uiobject: OffScreenFrame
 Offset:
   attributes:
     x:
@@ -1119,8 +1177,12 @@ Path:
     tags:
       ControlPoints:
   extends: Animation
+  impl:
+    uiobject: Path
 PlayerModel:
   extends: Frame
+  impl:
+    uiobject: PlayerModel
 POIFrame:
   extends: Frame
   virtual: true
@@ -1194,6 +1256,8 @@ Rotation:
     degrees:
       type: number
   extends: Animation
+  impl:
+    uiobject: Rotation
 Scale:
   attributes:
     fromscalex:
@@ -1212,6 +1276,8 @@ Scale:
     tags:
       Origin:
   extends: Animation
+  impl:
+    uiobject: Scale
 ScenarioPOIFrame:
   extends: POIFrame
 ScopedModifier:
@@ -1271,6 +1337,8 @@ ScrollFrame:
     tags:
       ScrollChild:
   extends: Frame
+  impl:
+    uiobject: ScrollFrame
 Shadow:
   attributes:
     x:
@@ -1289,6 +1357,8 @@ SimpleHTML:
       FontStringHeader2:
       FontStringHeader3:
   extends: Frame
+  impl:
+    uiobject: SimpleHTML
 Size:
   attributes:
     x:
@@ -1325,6 +1395,8 @@ Slider:
     tags:
       ThumbTexture:
   extends: Frame
+  impl:
+    uiobject: Slider
 StatusBar:
   attributes:
     defaultvalue:
@@ -1344,11 +1416,15 @@ StatusBar:
       BarColor:
       BarTexture:
   extends: Frame
+  impl:
+    uiobject: StatusBar
 SwipeTexture:
   extends: Texture
   sealed: true
 TabardModel:
   extends: Frame
+  impl:
+    uiobject: TabardModel
 TexCoords:
   attributes:
     bottom:
@@ -1405,8 +1481,12 @@ Texture:
       Gradient:
       TexCoords:
   extends: LayoutFrame
+  impl:
+    uiobject: Texture
 TextureCoordTranslation:
   extends: Animation
+  impl:
+    uiobject: TextureCoordTranslation
 ThumbTexture:
   extends: Texture
   impl:
@@ -1422,6 +1502,8 @@ Translation:
     offsety:
       type: number
   extends: Animation
+  impl:
+    uiobject: Translation
 Ui:
   contents:
     tags:
@@ -1436,6 +1518,8 @@ Ui:
   impl: transparent
 UnitPositionFrame:
   extends: Frame
+  impl:
+    uiobject: UnitPositionFrame
 Value:
   contents:
     tags:
@@ -1452,3 +1536,5 @@ ViewInsets:
       type: number
 WorldFrame:
   extends: Frame
+  impl:
+    uiobject: Frame

--- a/data/products/wow_classic_era_ptr/xml.yaml
+++ b/data/products/wow_classic_era_ptr/xml.yaml
@@ -31,6 +31,8 @@ Actor:
   contents:
     tags:
       Scripts:
+  impl:
+    uiobject: Actor
 Alpha:
   attributes:
     fromalpha:
@@ -42,6 +44,8 @@ Alpha:
         field: toAlpha
       type: number
   extends: Animation
+  impl:
+    uiobject: Alpha
 Anchor:
   attributes:
     point:
@@ -89,6 +93,8 @@ Animation:
     tags:
       KeyValues:
       Scripts:
+  impl:
+    uiobject: Animation
 AnimationGroup:
   attributes:
     inherits:
@@ -119,6 +125,8 @@ AnimationGroup:
       Animation:
       KeyValues:
       Scripts:
+  impl:
+    uiobject: AnimationGroup
 Animations:
   contents:
     tags:
@@ -180,6 +188,8 @@ Browser:
     imefont:
       type: string
   extends: Frame
+  impl:
+    uiobject: Browser
 Button:
   attributes:
     motionscriptswhiledisabled:
@@ -205,6 +215,8 @@ Button:
       PushedTextOffset:
       PushedTexture:
   extends: Frame
+  impl:
+    uiobject: Button
 ButtonFont:
   attributes:
     style:
@@ -232,6 +244,8 @@ CheckButton:
       CheckedTexture:
       DisabledCheckedTexture:
   extends: Button
+  impl:
+    uiobject: CheckButton
 CheckedTexture:
   extends: Texture
   impl:
@@ -245,8 +259,12 @@ Checkout:
     imefont:
       type: string
   extends: Frame
+  impl:
+    uiobject: Checkout
 CinematicModel:
   extends: Frame
+  impl:
+    uiobject: CinematicModel
 Color:
   attributes:
     a:
@@ -267,6 +285,8 @@ ColorSelect:
       ColorWheelTexture:
       ColorWheelThumbTexture:
   extends: Frame
+  impl:
+    uiobject: ColorSelect
 ColorValueTexture:
   extends: Texture
   impl:
@@ -305,6 +325,8 @@ ControlPoint:
       type: number
     offsety:
       type: number
+  impl:
+    uiobject: ControlPoint
 ControlPoints:
   contents:
     tags:
@@ -324,6 +346,8 @@ Cooldown:
       EdgeTexture:
       SwipeTexture:
   extends: Frame
+  impl:
+    uiobject: Cooldown
 Dimension:
   contents:
     tags:
@@ -358,6 +382,8 @@ DressUpModel:
     modelscale:
       type: number
   extends: Frame
+  impl:
+    uiobject: DressUpModel
 EdgeTexture:
   extends: Texture
   sealed: true
@@ -389,10 +415,16 @@ EditBox:
       HighlightColor:
       TextInsets:
   extends: Frame
+  impl:
+    uiobject: EditBox
 FlipBook:
   extends: Animation
+  impl:
+    uiobject: FlipBook
 FogOfWarFrame:
   extends: Frame
+  impl:
+    uiobject: FogOfWarFrame
 Font:
   attributes:
     filter:
@@ -429,6 +461,8 @@ Font:
     tags:
       Color:
       Shadow:
+  impl:
+    uiobject: Font
 FontFamily:
   attributes:
     name:
@@ -475,6 +509,8 @@ FontString:
       FontHeight:
       Shadow:
   extends: LayoutFrame
+  impl:
+    uiobject: FontString
 FontStringHeader1:
   extends: FontString
   sealed: true
@@ -566,6 +602,8 @@ Frame:
       Layers:
       ResizeBounds:
   extends: LayoutFrame
+  impl:
+    uiobject: Frame
 Frames:
   contents:
     tags:
@@ -574,6 +612,8 @@ Frames:
   phase: late
 GameTooltip:
   extends: Frame
+  impl:
+    uiobject: GameTooltip
 Gradient:
   attributes:
     orientation:
@@ -719,6 +759,8 @@ Line:
     thickness:
       type: number
   extends: LayoutFrame
+  impl:
+    uiobject: Line
 LineScale:
   attributes:
     fromscalex:
@@ -733,6 +775,8 @@ LineScale:
     tags:
       Origin:
   extends: Animation
+  impl:
+    uiobject: LineScale
 MaskedTexture:
   attributes:
     childkey:
@@ -752,6 +796,8 @@ MaskTexture:
     tags:
       MaskedTextures:
   extends: Texture
+  impl:
+    uiobject: MaskTexture
 MaxColor:
   extends: Color
 MaxResize:
@@ -778,19 +824,27 @@ MessageFrame:
     tags:
       FontString:
   extends: Frame
+  impl:
+    uiobject: MessageFrame
 MinColor:
   extends: Color
 Minimap:
   extends: Frame
+  impl:
+    uiobject: Minimap
 MinResize:
   extends: Dimension
 Model:
   extends: Frame
+  impl:
+    uiobject: Model
 ModelScene:
   contents:
     tags:
       ViewInsets:
   extends: Frame
+  impl:
+    uiobject: ModelScene
 ModifiedClick:
   attributes:
     action:
@@ -799,6 +853,8 @@ ModifiedClick:
       type: string
 MovieFrame:
   extends: Frame
+  impl:
+    uiobject: MovieFrame
 NormalFont:
   extends: ButtonFont
   impl:
@@ -816,6 +872,8 @@ NormalTexture:
   sealed: true
 OffScreenFrame:
   extends: Frame
+  impl:
+    uiobject: OffScreenFrame
 Offset:
   attributes:
     x:
@@ -1124,8 +1182,12 @@ Path:
     tags:
       ControlPoints:
   extends: Animation
+  impl:
+    uiobject: Path
 PlayerModel:
   extends: Frame
+  impl:
+    uiobject: PlayerModel
 POIFrame:
   extends: Frame
   virtual: true
@@ -1199,6 +1261,8 @@ Rotation:
     degrees:
       type: number
   extends: Animation
+  impl:
+    uiobject: Rotation
 Scale:
   attributes:
     fromscalex:
@@ -1217,6 +1281,8 @@ Scale:
     tags:
       Origin:
   extends: Animation
+  impl:
+    uiobject: Scale
 ScenarioPOIFrame:
   extends: POIFrame
 ScopedModifier:
@@ -1276,6 +1342,8 @@ ScrollFrame:
     tags:
       ScrollChild:
   extends: Frame
+  impl:
+    uiobject: ScrollFrame
 Shadow:
   attributes:
     x:
@@ -1294,6 +1362,8 @@ SimpleHTML:
       FontStringHeader2:
       FontStringHeader3:
   extends: Frame
+  impl:
+    uiobject: SimpleHTML
 Size:
   attributes:
     x:
@@ -1330,6 +1400,8 @@ Slider:
     tags:
       ThumbTexture:
   extends: Frame
+  impl:
+    uiobject: Slider
 StatusBar:
   attributes:
     defaultvalue:
@@ -1349,11 +1421,15 @@ StatusBar:
       BarColor:
       BarTexture:
   extends: Frame
+  impl:
+    uiobject: StatusBar
 SwipeTexture:
   extends: Texture
   sealed: true
 TabardModel:
   extends: Frame
+  impl:
+    uiobject: TabardModel
 TexCoords:
   attributes:
     bottom:
@@ -1410,8 +1486,12 @@ Texture:
       Gradient:
       TexCoords:
   extends: LayoutFrame
+  impl:
+    uiobject: Texture
 TextureCoordTranslation:
   extends: Animation
+  impl:
+    uiobject: TextureCoordTranslation
 ThumbTexture:
   extends: Texture
   impl:
@@ -1427,6 +1507,8 @@ Translation:
     offsety:
       type: number
   extends: Animation
+  impl:
+    uiobject: Translation
 Ui:
   contents:
     tags:
@@ -1441,6 +1523,8 @@ Ui:
   impl: transparent
 UnitPositionFrame:
   extends: Frame
+  impl:
+    uiobject: UnitPositionFrame
 Value:
   contents:
     tags:
@@ -1457,3 +1541,5 @@ ViewInsets:
       type: number
 WorldFrame:
   extends: Frame
+  impl:
+    uiobject: Frame

--- a/data/products/wow_classic_ptr/xml.yaml
+++ b/data/products/wow_classic_ptr/xml.yaml
@@ -31,6 +31,8 @@ Actor:
   contents:
     tags:
       Scripts:
+  impl:
+    uiobject: Actor
 Alpha:
   attributes:
     fromalpha:
@@ -42,6 +44,8 @@ Alpha:
         field: toAlpha
       type: number
   extends: Animation
+  impl:
+    uiobject: Alpha
 Anchor:
   attributes:
     point:
@@ -89,6 +93,8 @@ Animation:
     tags:
       KeyValues:
       Scripts:
+  impl:
+    uiobject: Animation
 AnimationGroup:
   attributes:
     inherits:
@@ -119,6 +125,8 @@ AnimationGroup:
       Animation:
       KeyValues:
       Scripts:
+  impl:
+    uiobject: AnimationGroup
 Animations:
   contents:
     tags:
@@ -180,6 +188,8 @@ Browser:
     imefont:
       type: string
   extends: Frame
+  impl:
+    uiobject: Browser
 Button:
   attributes:
     motionscriptswhiledisabled:
@@ -205,6 +215,8 @@ Button:
       PushedTextOffset:
       PushedTexture:
   extends: Frame
+  impl:
+    uiobject: Button
 ButtonFont:
   attributes:
     style:
@@ -232,6 +244,8 @@ CheckButton:
       CheckedTexture:
       DisabledCheckedTexture:
   extends: Button
+  impl:
+    uiobject: CheckButton
 CheckedTexture:
   extends: Texture
   impl:
@@ -245,8 +259,12 @@ Checkout:
     imefont:
       type: string
   extends: Frame
+  impl:
+    uiobject: Checkout
 CinematicModel:
   extends: Frame
+  impl:
+    uiobject: CinematicModel
 Color:
   attributes:
     a:
@@ -267,6 +285,8 @@ ColorSelect:
       ColorWheelTexture:
       ColorWheelThumbTexture:
   extends: Frame
+  impl:
+    uiobject: ColorSelect
 ColorValueTexture:
   extends: Texture
   impl:
@@ -305,6 +325,8 @@ ControlPoint:
       type: number
     offsety:
       type: number
+  impl:
+    uiobject: ControlPoint
 ControlPoints:
   contents:
     tags:
@@ -324,6 +346,8 @@ Cooldown:
       EdgeTexture:
       SwipeTexture:
   extends: Frame
+  impl:
+    uiobject: Cooldown
 Dimension:
   contents:
     tags:
@@ -358,6 +382,8 @@ DressUpModel:
     modelscale:
       type: number
   extends: Frame
+  impl:
+    uiobject: DressUpModel
 EdgeTexture:
   extends: Texture
   sealed: true
@@ -389,10 +415,16 @@ EditBox:
       HighlightColor:
       TextInsets:
   extends: Frame
+  impl:
+    uiobject: EditBox
 FlipBook:
   extends: Animation
+  impl:
+    uiobject: FlipBook
 FogOfWarFrame:
   extends: Frame
+  impl:
+    uiobject: FogOfWarFrame
 Font:
   attributes:
     filter:
@@ -429,6 +461,8 @@ Font:
     tags:
       Color:
       Shadow:
+  impl:
+    uiobject: Font
 FontFamily:
   attributes:
     name:
@@ -475,6 +509,8 @@ FontString:
       FontHeight:
       Shadow:
   extends: LayoutFrame
+  impl:
+    uiobject: FontString
 FontStringHeader1:
   extends: FontString
   sealed: true
@@ -566,6 +602,8 @@ Frame:
       Layers:
       ResizeBounds:
   extends: LayoutFrame
+  impl:
+    uiobject: Frame
 Frames:
   contents:
     tags:
@@ -574,6 +612,8 @@ Frames:
   phase: late
 GameTooltip:
   extends: Frame
+  impl:
+    uiobject: GameTooltip
 Gradient:
   attributes:
     orientation:
@@ -719,6 +759,8 @@ Line:
     thickness:
       type: number
   extends: LayoutFrame
+  impl:
+    uiobject: Line
 LineScale:
   attributes:
     fromscalex:
@@ -733,6 +775,8 @@ LineScale:
     tags:
       Origin:
   extends: Animation
+  impl:
+    uiobject: LineScale
 MaskedTexture:
   attributes:
     childkey:
@@ -752,6 +796,8 @@ MaskTexture:
     tags:
       MaskedTextures:
   extends: Texture
+  impl:
+    uiobject: MaskTexture
 MaxColor:
   extends: Color
 MaxResize:
@@ -778,19 +824,27 @@ MessageFrame:
     tags:
       FontString:
   extends: Frame
+  impl:
+    uiobject: MessageFrame
 MinColor:
   extends: Color
 Minimap:
   extends: Frame
+  impl:
+    uiobject: Minimap
 MinResize:
   extends: Dimension
 Model:
   extends: Frame
+  impl:
+    uiobject: Model
 ModelScene:
   contents:
     tags:
       ViewInsets:
   extends: Frame
+  impl:
+    uiobject: ModelScene
 ModifiedClick:
   attributes:
     action:
@@ -799,6 +853,8 @@ ModifiedClick:
       type: string
 MovieFrame:
   extends: Frame
+  impl:
+    uiobject: MovieFrame
 NormalFont:
   extends: ButtonFont
   impl:
@@ -816,6 +872,8 @@ NormalTexture:
   sealed: true
 OffScreenFrame:
   extends: Frame
+  impl:
+    uiobject: OffScreenFrame
 Offset:
   attributes:
     x:
@@ -1124,10 +1182,16 @@ Path:
     tags:
       ControlPoints:
   extends: Animation
+  impl:
+    uiobject: Path
 PlayerModel:
   extends: Frame
+  impl:
+    uiobject: PlayerModel
 POIFrame:
   extends: Frame
+  impl:
+    uiobject: POIFrame
   virtual: true
 PostClick:
   extends: ScriptType
@@ -1154,6 +1218,8 @@ PushedTexture:
   sealed: true
 QuestPOIFrame:
   extends: POIFrame
+  impl:
+    uiobject: QuestPOIFrame
 Rect:
   attributes:
     llx:
@@ -1199,6 +1265,8 @@ Rotation:
     degrees:
       type: number
   extends: Animation
+  impl:
+    uiobject: Rotation
 Scale:
   attributes:
     fromscalex:
@@ -1217,8 +1285,12 @@ Scale:
     tags:
       Origin:
   extends: Animation
+  impl:
+    uiobject: Scale
 ScenarioPOIFrame:
   extends: POIFrame
+  impl:
+    uiobject: ScenarioPOIFrame
 ScopedModifier:
   attributes:
     forbidden:
@@ -1276,6 +1348,8 @@ ScrollFrame:
     tags:
       ScrollChild:
   extends: Frame
+  impl:
+    uiobject: ScrollFrame
 Shadow:
   attributes:
     x:
@@ -1294,6 +1368,8 @@ SimpleHTML:
       FontStringHeader2:
       FontStringHeader3:
   extends: Frame
+  impl:
+    uiobject: SimpleHTML
 Size:
   attributes:
     x:
@@ -1330,6 +1406,8 @@ Slider:
     tags:
       ThumbTexture:
   extends: Frame
+  impl:
+    uiobject: Slider
 StatusBar:
   attributes:
     defaultvalue:
@@ -1349,11 +1427,15 @@ StatusBar:
       BarColor:
       BarTexture:
   extends: Frame
+  impl:
+    uiobject: StatusBar
 SwipeTexture:
   extends: Texture
   sealed: true
 TabardModel:
   extends: Frame
+  impl:
+    uiobject: TabardModel
 TexCoords:
   attributes:
     bottom:
@@ -1410,8 +1492,12 @@ Texture:
       Gradient:
       TexCoords:
   extends: LayoutFrame
+  impl:
+    uiobject: Texture
 TextureCoordTranslation:
   extends: Animation
+  impl:
+    uiobject: TextureCoordTranslation
 ThumbTexture:
   extends: Texture
   impl:
@@ -1427,6 +1513,8 @@ Translation:
     offsety:
       type: number
   extends: Animation
+  impl:
+    uiobject: Translation
 Ui:
   contents:
     tags:
@@ -1441,6 +1529,8 @@ Ui:
   impl: transparent
 UnitPositionFrame:
   extends: Frame
+  impl:
+    uiobject: UnitPositionFrame
 Value:
   contents:
     tags:
@@ -1457,3 +1547,5 @@ ViewInsets:
       type: number
 WorldFrame:
   extends: Frame
+  impl:
+    uiobject: Frame

--- a/data/products/wowt/xml.yaml
+++ b/data/products/wowt/xml.yaml
@@ -31,6 +31,8 @@ Actor:
   contents:
     tags:
       Scripts:
+  impl:
+    uiobject: Actor
 Alpha:
   attributes:
     fromalpha:
@@ -42,6 +44,8 @@ Alpha:
         field: toAlpha
       type: number
   extends: Animation
+  impl:
+    uiobject: Alpha
 Anchor:
   attributes:
     point:
@@ -89,6 +93,8 @@ Animation:
     tags:
       KeyValues:
       Scripts:
+  impl:
+    uiobject: Animation
 AnimationGroup:
   attributes:
     inherits:
@@ -119,6 +125,8 @@ AnimationGroup:
       Animation:
       KeyValues:
       Scripts:
+  impl:
+    uiobject: AnimationGroup
 Animations:
   contents:
     tags:
@@ -180,6 +188,8 @@ Browser:
     imefont:
       type: string
   extends: Frame
+  impl:
+    uiobject: Browser
 Button:
   attributes:
     motionscriptswhiledisabled:
@@ -205,6 +215,8 @@ Button:
       PushedTextOffset:
       PushedTexture:
   extends: Frame
+  impl:
+    uiobject: Button
 ButtonFont:
   attributes:
     style:
@@ -232,6 +244,8 @@ CheckButton:
       CheckedTexture:
       DisabledCheckedTexture:
   extends: Button
+  impl:
+    uiobject: CheckButton
 CheckedTexture:
   extends: Texture
   impl:
@@ -245,8 +259,12 @@ Checkout:
     imefont:
       type: string
   extends: Frame
+  impl:
+    uiobject: Checkout
 CinematicModel:
   extends: Frame
+  impl:
+    uiobject: CinematicModel
 Color:
   attributes:
     a:
@@ -267,6 +285,8 @@ ColorSelect:
       ColorWheelTexture:
       ColorWheelThumbTexture:
   extends: Frame
+  impl:
+    uiobject: ColorSelect
 ColorValueTexture:
   extends: Texture
   impl:
@@ -305,6 +325,8 @@ ControlPoint:
       type: number
     offsety:
       type: number
+  impl:
+    uiobject: ControlPoint
 ControlPoints:
   contents:
     tags:
@@ -324,6 +346,8 @@ Cooldown:
       EdgeTexture:
       SwipeTexture:
   extends: Frame
+  impl:
+    uiobject: Cooldown
 Dimension:
   contents:
     tags:
@@ -358,6 +382,8 @@ DressUpModel:
     modelscale:
       type: number
   extends: Frame
+  impl:
+    uiobject: DressUpModel
 EdgeTexture:
   extends: Texture
   sealed: true
@@ -389,10 +415,16 @@ EditBox:
       HighlightColor:
       TextInsets:
   extends: Frame
+  impl:
+    uiobject: EditBox
 FlipBook:
   extends: Animation
+  impl:
+    uiobject: FlipBook
 FogOfWarFrame:
   extends: Frame
+  impl:
+    uiobject: FogOfWarFrame
 Font:
   attributes:
     filter:
@@ -429,6 +461,8 @@ Font:
     tags:
       Color:
       Shadow:
+  impl:
+    uiobject: Font
 FontFamily:
   attributes:
     name:
@@ -475,6 +509,8 @@ FontString:
       FontHeight:
       Shadow:
   extends: LayoutFrame
+  impl:
+    uiobject: FontString
 FontStringHeader1:
   extends: FontString
   sealed: true
@@ -566,6 +602,8 @@ Frame:
       Layers:
       ResizeBounds:
   extends: LayoutFrame
+  impl:
+    uiobject: Frame
 Frames:
   contents:
     tags:
@@ -574,6 +612,8 @@ Frames:
   phase: late
 GameTooltip:
   extends: Frame
+  impl:
+    uiobject: GameTooltip
 Gradient:
   attributes:
     orientation:
@@ -720,6 +760,8 @@ Line:
     thickness:
       type: number
   extends: LayoutFrame
+  impl:
+    uiobject: Line
 LineScale:
   attributes:
     fromscalex:
@@ -734,6 +776,8 @@ LineScale:
     tags:
       Origin:
   extends: Animation
+  impl:
+    uiobject: LineScale
 MaskedTexture:
   attributes:
     childkey:
@@ -753,6 +797,8 @@ MaskTexture:
     tags:
       MaskedTextures:
   extends: Texture
+  impl:
+    uiobject: MaskTexture
 MaxColor:
   extends: Color
 MaxResize:
@@ -779,10 +825,14 @@ MessageFrame:
     tags:
       FontString:
   extends: Frame
+  impl:
+    uiobject: MessageFrame
 MinColor:
   extends: Color
 Minimap:
   extends: Frame
+  impl:
+    uiobject: Minimap
 MinResize:
   extends: Dimension
 Mixin:
@@ -805,11 +855,15 @@ Mixins:
   impl: transparent
 Model:
   extends: Frame
+  impl:
+    uiobject: Model
 ModelScene:
   contents:
     tags:
       ViewInsets:
   extends: Frame
+  impl:
+    uiobject: ModelScene
 ModifiedClick:
   attributes:
     action:
@@ -818,6 +872,8 @@ ModifiedClick:
       type: string
 MovieFrame:
   extends: Frame
+  impl:
+    uiobject: MovieFrame
 NormalFont:
   extends: ButtonFont
   impl:
@@ -835,6 +891,8 @@ NormalTexture:
   sealed: true
 OffScreenFrame:
   extends: Frame
+  impl:
+    uiobject: OffScreenFrame
 Offset:
   attributes:
     x:
@@ -1143,10 +1201,16 @@ Path:
     tags:
       ControlPoints:
   extends: Animation
+  impl:
+    uiobject: Path
 PlayerModel:
   extends: Frame
+  impl:
+    uiobject: PlayerModel
 POIFrame:
   extends: Frame
+  impl:
+    uiobject: POIFrame
   virtual: true
 PostClick:
   extends: ScriptType
@@ -1173,6 +1237,8 @@ PushedTexture:
   sealed: true
 QuestPOIFrame:
   extends: POIFrame
+  impl:
+    uiobject: QuestPOIFrame
 Rect:
   attributes:
     llx:
@@ -1218,6 +1284,8 @@ Rotation:
     degrees:
       type: number
   extends: Animation
+  impl:
+    uiobject: Rotation
 Scale:
   attributes:
     fromscalex:
@@ -1236,8 +1304,12 @@ Scale:
     tags:
       Origin:
   extends: Animation
+  impl:
+    uiobject: Scale
 ScenarioPOIFrame:
   extends: POIFrame
+  impl:
+    uiobject: ScenarioPOIFrame
 ScopedModifier:
   attributes:
     forbidden:
@@ -1299,6 +1371,8 @@ ScrollFrame:
     tags:
       ScrollChild:
   extends: Frame
+  impl:
+    uiobject: ScrollFrame
 Shadow:
   attributes:
     x:
@@ -1317,6 +1391,8 @@ SimpleHTML:
       FontStringHeader2:
       FontStringHeader3:
   extends: Frame
+  impl:
+    uiobject: SimpleHTML
 Size:
   attributes:
     x:
@@ -1353,6 +1429,8 @@ Slider:
     tags:
       ThumbTexture:
   extends: Frame
+  impl:
+    uiobject: Slider
 StatusBar:
   attributes:
     defaultvalue:
@@ -1372,11 +1450,15 @@ StatusBar:
       BarColor:
       BarTexture:
   extends: Frame
+  impl:
+    uiobject: StatusBar
 SwipeTexture:
   extends: Texture
   sealed: true
 TabardModel:
   extends: Frame
+  impl:
+    uiobject: TabardModel
 TexCoords:
   attributes:
     bottom:
@@ -1433,8 +1515,12 @@ Texture:
       Gradient:
       TexCoords:
   extends: LayoutFrame
+  impl:
+    uiobject: Texture
 TextureCoordTranslation:
   extends: Animation
+  impl:
+    uiobject: TextureCoordTranslation
 ThumbTexture:
   extends: Texture
   impl:
@@ -1450,6 +1536,8 @@ Translation:
     offsety:
       type: number
   extends: Animation
+  impl:
+    uiobject: Translation
 Ui:
   contents:
     tags:
@@ -1464,6 +1552,8 @@ Ui:
   impl: transparent
 UnitPositionFrame:
   extends: Frame
+  impl:
+    uiobject: UnitPositionFrame
 Value:
   contents:
     tags:
@@ -1480,3 +1570,5 @@ ViewInsets:
       type: number
 WorldFrame:
   extends: Frame
+  impl:
+    uiobject: Frame

--- a/data/products/wowxptr/xml.yaml
+++ b/data/products/wowxptr/xml.yaml
@@ -31,6 +31,8 @@ Actor:
   contents:
     tags:
       Scripts:
+  impl:
+    uiobject: Actor
 Alpha:
   attributes:
     fromalpha:
@@ -42,6 +44,8 @@ Alpha:
         field: toAlpha
       type: number
   extends: Animation
+  impl:
+    uiobject: Alpha
 Anchor:
   attributes:
     point:
@@ -89,6 +93,8 @@ Animation:
     tags:
       KeyValues:
       Scripts:
+  impl:
+    uiobject: Animation
 AnimationGroup:
   attributes:
     inherits:
@@ -119,6 +125,8 @@ AnimationGroup:
       Animation:
       KeyValues:
       Scripts:
+  impl:
+    uiobject: AnimationGroup
 Animations:
   contents:
     tags:
@@ -180,6 +188,8 @@ Browser:
     imefont:
       type: string
   extends: Frame
+  impl:
+    uiobject: Browser
 Button:
   attributes:
     motionscriptswhiledisabled:
@@ -205,6 +215,8 @@ Button:
       PushedTextOffset:
       PushedTexture:
   extends: Frame
+  impl:
+    uiobject: Button
 ButtonFont:
   attributes:
     style:
@@ -232,6 +244,8 @@ CheckButton:
       CheckedTexture:
       DisabledCheckedTexture:
   extends: Button
+  impl:
+    uiobject: CheckButton
 CheckedTexture:
   extends: Texture
   impl:
@@ -245,8 +259,12 @@ Checkout:
     imefont:
       type: string
   extends: Frame
+  impl:
+    uiobject: Checkout
 CinematicModel:
   extends: Frame
+  impl:
+    uiobject: CinematicModel
 Color:
   attributes:
     a:
@@ -267,6 +285,8 @@ ColorSelect:
       ColorWheelTexture:
       ColorWheelThumbTexture:
   extends: Frame
+  impl:
+    uiobject: ColorSelect
 ColorValueTexture:
   extends: Texture
   impl:
@@ -305,6 +325,8 @@ ControlPoint:
       type: number
     offsety:
       type: number
+  impl:
+    uiobject: ControlPoint
 ControlPoints:
   contents:
     tags:
@@ -324,6 +346,8 @@ Cooldown:
       EdgeTexture:
       SwipeTexture:
   extends: Frame
+  impl:
+    uiobject: Cooldown
 Dimension:
   contents:
     tags:
@@ -358,6 +382,8 @@ DressUpModel:
     modelscale:
       type: number
   extends: Frame
+  impl:
+    uiobject: DressUpModel
 EdgeTexture:
   extends: Texture
   sealed: true
@@ -389,10 +415,16 @@ EditBox:
       HighlightColor:
       TextInsets:
   extends: Frame
+  impl:
+    uiobject: EditBox
 FlipBook:
   extends: Animation
+  impl:
+    uiobject: FlipBook
 FogOfWarFrame:
   extends: Frame
+  impl:
+    uiobject: FogOfWarFrame
 Font:
   attributes:
     filter:
@@ -429,6 +461,8 @@ Font:
     tags:
       Color:
       Shadow:
+  impl:
+    uiobject: Font
 FontFamily:
   attributes:
     name:
@@ -475,6 +509,8 @@ FontString:
       FontHeight:
       Shadow:
   extends: LayoutFrame
+  impl:
+    uiobject: FontString
 FontStringHeader1:
   extends: FontString
   sealed: true
@@ -566,6 +602,8 @@ Frame:
       Layers:
       ResizeBounds:
   extends: LayoutFrame
+  impl:
+    uiobject: Frame
 Frames:
   contents:
     tags:
@@ -574,6 +612,8 @@ Frames:
   phase: late
 GameTooltip:
   extends: Frame
+  impl:
+    uiobject: GameTooltip
 Gradient:
   attributes:
     orientation:
@@ -719,6 +759,8 @@ Line:
     thickness:
       type: number
   extends: LayoutFrame
+  impl:
+    uiobject: Line
 LineScale:
   attributes:
     fromscalex:
@@ -733,6 +775,8 @@ LineScale:
     tags:
       Origin:
   extends: Animation
+  impl:
+    uiobject: LineScale
 MaskedTexture:
   attributes:
     childkey:
@@ -752,6 +796,8 @@ MaskTexture:
     tags:
       MaskedTextures:
   extends: Texture
+  impl:
+    uiobject: MaskTexture
 MaxColor:
   extends: Color
 MaxResize:
@@ -778,19 +824,27 @@ MessageFrame:
     tags:
       FontString:
   extends: Frame
+  impl:
+    uiobject: MessageFrame
 MinColor:
   extends: Color
 Minimap:
   extends: Frame
+  impl:
+    uiobject: Minimap
 MinResize:
   extends: Dimension
 Model:
   extends: Frame
+  impl:
+    uiobject: Model
 ModelScene:
   contents:
     tags:
       ViewInsets:
   extends: Frame
+  impl:
+    uiobject: ModelScene
 ModifiedClick:
   attributes:
     action:
@@ -799,6 +853,8 @@ ModifiedClick:
       type: string
 MovieFrame:
   extends: Frame
+  impl:
+    uiobject: MovieFrame
 NormalFont:
   extends: ButtonFont
   impl:
@@ -816,6 +872,8 @@ NormalTexture:
   sealed: true
 OffScreenFrame:
   extends: Frame
+  impl:
+    uiobject: OffScreenFrame
 Offset:
   attributes:
     x:
@@ -1124,10 +1182,16 @@ Path:
     tags:
       ControlPoints:
   extends: Animation
+  impl:
+    uiobject: Path
 PlayerModel:
   extends: Frame
+  impl:
+    uiobject: PlayerModel
 POIFrame:
   extends: Frame
+  impl:
+    uiobject: POIFrame
   virtual: true
 PostClick:
   extends: ScriptType
@@ -1154,6 +1218,8 @@ PushedTexture:
   sealed: true
 QuestPOIFrame:
   extends: POIFrame
+  impl:
+    uiobject: QuestPOIFrame
 Rect:
   attributes:
     llx:
@@ -1199,6 +1265,8 @@ Rotation:
     degrees:
       type: number
   extends: Animation
+  impl:
+    uiobject: Rotation
 Scale:
   attributes:
     fromscalex:
@@ -1217,8 +1285,12 @@ Scale:
     tags:
       Origin:
   extends: Animation
+  impl:
+    uiobject: Scale
 ScenarioPOIFrame:
   extends: POIFrame
+  impl:
+    uiobject: ScenarioPOIFrame
 ScopedModifier:
   attributes:
     forbidden:
@@ -1276,6 +1348,8 @@ ScrollFrame:
     tags:
       ScrollChild:
   extends: Frame
+  impl:
+    uiobject: ScrollFrame
 Shadow:
   attributes:
     x:
@@ -1294,6 +1368,8 @@ SimpleHTML:
       FontStringHeader2:
       FontStringHeader3:
   extends: Frame
+  impl:
+    uiobject: SimpleHTML
 Size:
   attributes:
     x:
@@ -1330,6 +1406,8 @@ Slider:
     tags:
       ThumbTexture:
   extends: Frame
+  impl:
+    uiobject: Slider
 StatusBar:
   attributes:
     defaultvalue:
@@ -1349,11 +1427,15 @@ StatusBar:
       BarColor:
       BarTexture:
   extends: Frame
+  impl:
+    uiobject: StatusBar
 SwipeTexture:
   extends: Texture
   sealed: true
 TabardModel:
   extends: Frame
+  impl:
+    uiobject: TabardModel
 TexCoords:
   attributes:
     bottom:
@@ -1410,8 +1492,12 @@ Texture:
       Gradient:
       TexCoords:
   extends: LayoutFrame
+  impl:
+    uiobject: Texture
 TextureCoordTranslation:
   extends: Animation
+  impl:
+    uiobject: TextureCoordTranslation
 ThumbTexture:
   extends: Texture
   impl:
@@ -1427,6 +1513,8 @@ Translation:
     offsety:
       type: number
   extends: Animation
+  impl:
+    uiobject: Translation
 Ui:
   contents:
     tags:
@@ -1441,6 +1529,8 @@ Ui:
   impl: transparent
 UnitPositionFrame:
   extends: Frame
+  impl:
+    uiobject: UnitPositionFrame
 Value:
   contents:
     tags:
@@ -1457,3 +1547,5 @@ ViewInsets:
       type: number
 WorldFrame:
   extends: Frame
+  impl:
+    uiobject: Frame

--- a/data/schemas/xml.yaml
+++ b/data/schemas/xml.yaml
@@ -74,6 +74,9 @@ type:
                 args:
                   type: string
             transparent: tag
+            uiobject:
+              ref:
+                schema: uiobject
       phase:
         type:
           taggedunion:

--- a/wowless/modules/loader.lua
+++ b/wowless/modules/loader.lua
@@ -530,6 +530,11 @@ return function(
 
       local loadElement
 
+      local function implUiobjectType(e)
+        local entry = xmlimpls[e.type] and xmlimpls[e.type].tag
+        return type(entry) == 'table' and entry.uiobject and string.lower(entry.uiobject) or nil
+      end
+
       local function loadElements(ctx, t, parent)
         for _, v in ipairs(t) do
           loadElement(ctx, v, parent)
@@ -594,8 +599,10 @@ return function(
       function loadElement(ctx, e, parent)
         local ltype = string.lower(e.type)
         local intrinsicEntry = intrinsics.Get(ltype)
-        -- uiobject types and intrinsic types share the same xml element namespace.
-        if uiobjecttypes.Has(ltype) or intrinsicEntry or e.type == 'worldframe' then
+        local implBasetype = implUiobjectType(e)
+        -- e.type dispatches to either a declared uiobject-creating tag (impl.uiobject
+        -- in xml.yaml) or a previously-registered intrinsic (same name namespace).
+        if implBasetype or intrinsicEntry then
           ctx = not e.attr.intrinsic and ctx or mixin({}, ctx, { intrinsic = true })
           local template = {
             inherits = e.attr.inherits,
@@ -611,7 +618,7 @@ return function(
             assert(virtual ~= false, 'intrinsics cannot be explicitly non-virtual: ' .. e.type)
             assert(e.attr.name, 'cannot create anonymous intrinsic')
             local name = string.lower(e.attr.name)
-            local basetype = intrinsicEntry and intrinsicEntry.basetype or ltype
+            local basetype = intrinsicEntry and intrinsicEntry.basetype or implBasetype
             uiobjecttypes.GetOrThrow(basetype) -- validate basetype exists
             intrinsics.Add(name, basetype, template)
           else
@@ -624,8 +631,7 @@ return function(
               if virtual and ctx.ignoreVirtual then
                 log(1, 'ignoring virtual on %s', tostring(name))
               end
-              local basetype = intrinsicEntry and intrinsicEntry.basetype
-                or (e.type == 'worldframe' and 'frame' or ltype)
+              local basetype = intrinsicEntry and intrinsicEntry.basetype or implBasetype
               local env = ctx.useAddonEnv and addonEnv or ctx.useSecureEnv and secureenv or genv
               local tmpls = intrinsicEntry and { intrinsicEntry.template, template } or { template }
               local objParent = uiobjecttypes.InheritsFrom(basetype, 'parentedobjectbase') and parent or nil


### PR DESCRIPTION
## Summary

- The loader used to decide whether an XML tag creates a uiobject via `uiobjecttypes.Has(ltype)` — a coincidence that the tag's lowercased name matches a key in `uiobjects.yaml` — plus a hard-coded `e.type == 'worldframe'` special case (twice) since `WorldFrame` has no `uiobjects.yaml` entry of its own.
- Every uiobject-creating XML tag now declares `impl: {uiobject: <TypeName>}` in `data/products/*/xml.yaml`, the same convention already used for `impl: transparent`/`loadstring`/`call`/`script` on other tags. `data/schemas/xml.yaml` gained a matching `uiobject` variant on the `impl` taggedunion, validated against the product's `uiobjects.yaml` via the existing `ref: {schema: uiobject}` mechanism.
- `wowless/modules/loader.lua`'s `loadElement` now dispatches off `xmlimpls[e.type].tag.uiobject` instead of the name-coincidence lookup. `WorldFrame`'s impl explicitly names `Frame`, so it flows through the exact same code path as any other tag — no `worldframe` special-casing left in the loader.

## Test plan

- [x] `cmake --build --preset default --target test` — exits 0, no output (includes schema validation of all 8 products' `xml.yaml` against the updated schema, and the existing `WorldFrame` sub-test in `addon/Wowless/test.lua`)
- [x] `pre-commit run -a` — all hooks pass, including the `build and test` hook

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0159HnT85BQYscDv4Df6Ybig