### PR TITLE
loader: give WorldFrame a WORLD frameStrata

### DIFF
--- a/addon/Wowless/test.lua
+++ b/addon/Wowless/test.lua
@@ -748,6 +748,11 @@ G.testsuite.sync = function()
             assertEquals(getmetatable(CreateFrame('Frame')), getmetatable(_G.WorldFrame))
           end
         end,
+        ['has strata WORLD'] = function()
+          if _G.WorldFrame then
+            assertEquals('WORLD', _G.WorldFrame:GetFrameStrata())
+          end
+        end,
       }
     end,
   }

--- a/data/products/wow/stringenums.yaml
+++ b/data/products/wow/stringenums.yaml
@@ -38,6 +38,7 @@ FrameStrata:
   MEDIUM:
   PARENT:
   TOOLTIP:
+  WORLD:
 InsertMode:
   BOTTOM:
   TOP:

--- a/data/products/wow_anniversary/stringenums.yaml
+++ b/data/products/wow_anniversary/stringenums.yaml
@@ -38,6 +38,7 @@ FrameStrata:
   MEDIUM:
   PARENT:
   TOOLTIP:
+  WORLD:
 InsertMode:
   BOTTOM:
   TOP:

--- a/data/products/wow_classic/stringenums.yaml
+++ b/data/products/wow_classic/stringenums.yaml
@@ -38,6 +38,7 @@ FrameStrata:
   MEDIUM:
   PARENT:
   TOOLTIP:
+  WORLD:
 InsertMode:
   BOTTOM:
   TOP:

--- a/data/products/wow_classic_era/stringenums.yaml
+++ b/data/products/wow_classic_era/stringenums.yaml
@@ -38,6 +38,7 @@ FrameStrata:
   MEDIUM:
   PARENT:
   TOOLTIP:
+  WORLD:
 InsertMode:
   BOTTOM:
   TOP:

--- a/data/products/wow_classic_era_ptr/stringenums.yaml
+++ b/data/products/wow_classic_era_ptr/stringenums.yaml
@@ -38,6 +38,7 @@ FrameStrata:
   MEDIUM:
   PARENT:
   TOOLTIP:
+  WORLD:
 InsertMode:
   BOTTOM:
   TOP:

--- a/data/products/wow_classic_ptr/stringenums.yaml
+++ b/data/products/wow_classic_ptr/stringenums.yaml
@@ -38,6 +38,7 @@ FrameStrata:
   MEDIUM:
   PARENT:
   TOOLTIP:
+  WORLD:
 InsertMode:
   BOTTOM:
   TOP:

--- a/data/products/wowt/stringenums.yaml
+++ b/data/products/wowt/stringenums.yaml
@@ -38,6 +38,7 @@ FrameStrata:
   MEDIUM:
   PARENT:
   TOOLTIP:
+  WORLD:
 InsertMode:
   BOTTOM:
   TOP:

--- a/data/products/wowxptr/stringenums.yaml
+++ b/data/products/wowxptr/stringenums.yaml
@@ -38,6 +38,7 @@ FrameStrata:
   MEDIUM:
   PARENT:
   TOOLTIP:
+  WORLD:
 InsertMode:
   BOTTOM:
   TOP:

--- a/wowless/modules/loader.lua
+++ b/wowless/modules/loader.lua
@@ -635,7 +635,14 @@ return function(
               local env = ctx.useAddonEnv and addonEnv or ctx.useSecureEnv and secureenv or genv
               local tmpls = intrinsicEntry and { intrinsicEntry.template, template } or { template }
               local objParent = uiobjecttypes.InheritsFrom(basetype, 'parentedobjectbase') and parent or nil
-              return api.CreateUIObject(basetype, name, objParent, env, tmpls, nil, ctx.layer, ctx.sublevel)
+              local obj = api.CreateUIObject(basetype, name, objParent, env, tmpls, nil, ctx.layer, ctx.sublevel)
+              if ltype == 'worldframe' then
+                -- WORLD is a real frameStrata value, but only WorldFrame has it,
+                -- confirmed against a real client; it isn't reachable through
+                -- SetFrameStrata.
+                obj.frameStrata = 'WORLD'
+              end
+              return obj
             end
           end
         else


### PR DESCRIPTION
## Summary
- Add `WORLD` to the `FrameStrata` stringenum in every product's `stringenums.yaml`.
- Set `frameStrata = 'WORLD'` directly on the created object when the loader dispatches a `<WorldFrame>` XML tag, since `WORLD` is reserved for `WorldFrame` and isn't reachable through `SetFrameStrata` on a real client.
- Add an addon test (`WorldFrame['has strata WORLD']`) asserting `_G.WorldFrame:GetFrameStrata() == 'WORLD'`.

Scoped narrowly per issue #782/PR #789's findings: this only makes `WorldFrame` itself carry `WORLD`. It does not implement the broader `SetFrameStrata`/`PARENT`/`BLIZZARD` inheritance semantics from #789, which is a larger change tracked separately.

## Test plan
- [x] `cmake --build --preset default --target test` (also runs as the `build and test` pre-commit hook) — exits 0, no output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M73uWqtGizF43KH58VFhnv