### PR TITLE
impl: copy default DiscordChatInfo struct from datalua instead of hand-writing it

### DIFF
--- a/data/impl/C_ChatInfo.PerformEmote.lua
+++ b/data/impl/C_ChatInfo.PerformEmote.lua
@@ -1,4 +1,5 @@
 local datalua, events, log, sql = ...
+local deepcopy = require('pl.tablex').deepcopy
 return function(token, user, hold)
   local text = sql(token)
   if text then
@@ -22,25 +23,7 @@ return function(token, user, hold)
       false,
     }
     if datalua.config.runtime.discord then
-      table.insert(args, {
-        forwardedMessage = '',
-        fromDiscord = false,
-        globalName = '',
-        hasAttachment = false,
-        hasEmbed = false,
-        hasEmoji = false,
-        hasForwardedMessage = false,
-        hasPoll = false,
-        hasSticker = false,
-        lastOnlineGUID = '',
-        lastOnlineName = '',
-        type = 0,
-        userID = '',
-        username = '',
-      })
-    end
-    if datalua.product == 'wowt' then
-      args[#args].hasError = false
+      table.insert(args, deepcopy(datalua.structdefaults.DiscordChatInfo))
     end
     events.SendEvent('CHAT_MSG_TEXT_EMOTE', unpack(args))
   else

--- a/data/impl/SendSystemMessage.lua
+++ b/data/impl/SendSystemMessage.lua
@@ -1,4 +1,5 @@
 local datalua, eventqueue, units = ...
+local deepcopy = require('pl.tablex').deepcopy
 return function(msg)
   local args = {
     'CHAT_MSG_SYSTEM',
@@ -21,25 +22,7 @@ return function(msg)
     false,
   }
   if datalua.config.runtime.discord then
-    table.insert(args, {
-      forwardedMessage = '',
-      fromDiscord = false,
-      globalName = '',
-      hasAttachment = false,
-      hasEmbed = false,
-      hasEmoji = false,
-      hasForwardedMessage = false,
-      hasPoll = false,
-      hasSticker = false,
-      lastOnlineGUID = '',
-      lastOnlineName = '',
-      type = 0,
-      userID = '',
-      username = '',
-    })
-  end
-  if datalua.product == 'wowt' then
-    args[#args].hasError = false
+    table.insert(args, deepcopy(datalua.structdefaults.DiscordChatInfo))
   end
   eventqueue.QueueEvent(unpack(args))
 end

--- a/tools/prep.lua
+++ b/tools/prep.lua
@@ -448,30 +448,6 @@ local xmlflat = (function()
   return newtree
 end)()
 
-local data = {
-  build = parseYaml('data/products/' .. product .. '/build.yaml'),
-  config = parseYaml('data/products/' .. product .. '/config.yaml'),
-  cvars = cvars,
-  events = events,
-  globals = globals,
-  luaobjects = luaobjects,
-  product = product,
-  sqls = sqls,
-  stringenums = stringenums,
-  structures = structures,
-  uiobjects = uiobjects,
-  xmlflat = xmlflat,
-  xmlimpls = xmlimpls,
-}
-
-local function safename(s)
-  return s:gsub('[%.:]', '_')
-end
-
-local function cstring(s)
-  return '"' .. s:gsub('\\', '\\\\'):gsub('"', '\\"'):gsub('\n', '\\n'):gsub('\r', '\\r'):gsub('\t', '\\t') .. '"'
-end
-
 local coutdefaults
 coutdefaults = {
   arrayof = function(inner)
@@ -486,6 +462,9 @@ coutdefaults = {
   enum = function(enumname)
     local meta = assert(globals.Enum[enumname .. 'Meta'], 'missing meta enum for ' .. enumname)
     return (assert(meta.MinValue, 'missing MinValue in meta for ' .. enumname))
+  end,
+  ['function'] = function()
+    return nil
   end,
   ['nil'] = function()
     return nil
@@ -540,6 +519,36 @@ coutdefaults = {
     return nil
   end,
 }
+
+local structdefaults = {}
+for name in pairs(structures) do
+  structdefaults[name] = coutdefaults.structure(name)
+end
+
+local data = {
+  build = parseYaml('data/products/' .. product .. '/build.yaml'),
+  config = parseYaml('data/products/' .. product .. '/config.yaml'),
+  cvars = cvars,
+  events = events,
+  globals = globals,
+  luaobjects = luaobjects,
+  product = product,
+  sqls = sqls,
+  stringenums = stringenums,
+  structdefaults = structdefaults,
+  structures = structures,
+  uiobjects = uiobjects,
+  xmlflat = xmlflat,
+  xmlimpls = xmlimpls,
+}
+
+local function safename(s)
+  return s:gsub('[%.:]', '_')
+end
+
+local function cstring(s)
+  return '"' .. s:gsub('\\', '\\\\'):gsub('"', '\\"'):gsub('\n', '\\n'):gsub('\r', '\\r'):gsub('\t', '\\t') .. '"'
+end
 
 local function simple_cinputtype(suffix)
   local fn = function(verb, nilable, idx)


### PR DESCRIPTION
## Summary
- `data/impl/C_ChatInfo.PerformEmote.lua` and `data/impl/SendSystemMessage.lua` both hand-built an identical `DiscordChatInfo` struct literal, plus a `datalua.product == 'wowt'` hack to set the extra `hasError` field that only wowt's `structures.yaml` defines.
- `tools/prep.lua` already computed fully-defaulted structure instances for C-stub codegen (`coutdefaults.structure`); this now runs it for every structure of every product up front, as part of the `data` initializer (not a mutation afterward), exposing the result as `datalua.structdefaults`. Added a `function` default handler (returns `nil`, same as `oneornil`/`unknown`) so it also covers structures with callback-typed fields.
- The two impl files now just `deepcopy(datalua.structdefaults.DiscordChatInfo)`, so any future per-product field differences on this struct (or any other) are picked up automatically instead of needing another hand-coded product check.

## Test plan
- [x] `cmake --build --preset default --target test` — passes for all 8 products (no output, exit 0)
- [x] `pre-commit run` on changed files — all hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)