### PR TITLE
test: drop redundant per-test WorldFrame guards

### DIFF
--- a/addon/Wowless/test.lua
+++ b/addon/Wowless/test.lua
@@ -741,17 +741,16 @@ G.testsuite.sync = function()
     end,
 
     WorldFrame = function()
+      if not _G.WorldFrame then
+        return
+      end
       return {
         ['is a normal frame'] = function()
-          if _G.WorldFrame then
-            assertEquals('Frame', _G.WorldFrame:GetObjectType())
-            assertEquals(getmetatable(CreateFrame('Frame')), getmetatable(_G.WorldFrame))
-          end
+          assertEquals('Frame', _G.WorldFrame:GetObjectType())
+          assertEquals(getmetatable(CreateFrame('Frame')), getmetatable(_G.WorldFrame))
         end,
         ['has strata WORLD'] = function()
-          if _G.WorldFrame then
-            assertEquals('WORLD', _G.WorldFrame:GetFrameStrata())
-          end
+          assertEquals('WORLD', _G.WorldFrame:GetFrameStrata())
         end,
       }
     end,


### PR DESCRIPTION
## Summary
- `WorldFrame()` in `addon/Wowless/test.lua` now returns early (no sub-tests) when `_G.WorldFrame` doesn't exist, instead of guarding each sub-test individually with `if _G.WorldFrame then ... end`.

## Test plan
- [x] `cmake --build --preset default --target test` (via pre-commit `build and test` hook) — exits 0, no output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M73uWqtGizF43KH58VFhnv