### PR TITLE
schema: derive ref domain registry from data/datafiles.yaml

### DIFF
--- a/data/schemas/build.yaml
+++ b/data/schemas/build.yaml
@@ -11,7 +11,7 @@ type:
       required: true
       type:
         ref:
-          schema: gametype
+          schema: gametypes
     hash:
       required: true
       type: string

--- a/data/schemas/config.yaml
+++ b/data/schemas/config.yaml
@@ -14,18 +14,18 @@ type:
                   type:
                     setof:
                       ref:
-                        schema: enum
+                        schema: enums
                 globalapis:
                   type:
                     setof:
                       ref:
-                        schema: api
+                        schema: apis
           enum_values_set_in_framexml:
             type:
               mapof:
                 key:
                   ref:
-                    schema: enum
+                    schema: enums
                 value:
                   setof: string
           enums_set_in_framexml:
@@ -33,7 +33,7 @@ type:
               setof:
                 ref:
                   negative: true
-                  schema: enum
+                  schema: enums
           hooked_globals:
             type:
               setof: string
@@ -41,12 +41,12 @@ type:
             type:
               setof:
                 ref:
-                  schema: cvar
+                  schema: cvars
           overwritten_apis:
             type:
               setof:
                 ref:
-                  schema: api
+                  schema: apis
     modules:
       type:
         record:
@@ -70,7 +70,7 @@ type:
               mapof:
                 key:
                   ref:
-                    schema: event
+                    schema: events
                 value: string
           skip_slashcmds:
             type:

--- a/data/schemas/docs.yaml
+++ b/data/schemas/docs.yaml
@@ -15,33 +15,33 @@ type:
               mapof:
                 key:
                   ref:
-                    schema: api
+                    schema: apis
                 value: any
           events:
             type:
               mapof:
                 key:
                   ref:
-                    schema: event
+                    schema: events
                 value: any
           extra_apis:
             type:
               setof:
                 ref:
                   negative: true
-                  schema: api
+                  schema: apis
           extra_enums:
             type:
               setof:
                 ref:
                   negative: true
-                  schema: enum
+                  schema: enums
           extra_events:
             type:
               setof:
                 ref:
                   negative: true
-                  schema: event
+                  schema: events
           extra_script_objects:
             type:
               setof: string
@@ -50,7 +50,7 @@ type:
               mapof:
                 key:
                   ref:
-                    schema: uiobject
+                    schema: uiobjects
                 value:
                   mapof:
                     key: string
@@ -63,10 +63,10 @@ type:
             taggedunion:
               luaobject:
                 ref:
-                  schema: luaobject
+                  schema: luaobjects
               uiobject:
                 ref:
-                  schema: uiobject
+                  schema: uiobjects
     typedefs:
       type:
         mapof:
@@ -84,10 +84,10 @@ type:
         mapof:
           key:
             ref:
-              schema: uiobject
+              schema: uiobjects
           value:
             mapof:
               key: string
               value:
                 ref:
-                  schema: uiobject
+                  schema: uiobjects

--- a/data/schemas/gametypes.yaml
+++ b/data/schemas/gametypes.yaml
@@ -11,4 +11,4 @@ type:
           required: true
           type:
             ref:
-              schema: family
+              schema: families

--- a/data/schemas/impl.yaml
+++ b/data/schemas/impl.yaml
@@ -16,7 +16,7 @@ type:
               type:
                 setof:
                   ref:
-                    schema: module
+                    schema: modules
             sqls:
               type:
                 sequenceof:
@@ -37,7 +37,7 @@ type:
               required: true
               type:
                 ref:
-                  schema: module
+                  schema: modules
             nobubblewrap:
               type: flag
             nowrap:

--- a/data/schemas/luaobjects.yaml
+++ b/data/schemas/luaobjects.yaml
@@ -5,11 +5,11 @@ type:
       impl:
         type:
           ref:
-            schema: module
+            schema: modules
       inherits:
         type:
           ref:
-            schema: luaobject
+            schema: luaobjects
       methods:
         required: true
         type:

--- a/data/schemas/modules.yaml
+++ b/data/schemas/modules.yaml
@@ -7,7 +7,7 @@ type:
         deps:
           setof:
             ref:
-              schema: module
+              schema: modules
         root:
           record:
             default:

--- a/data/schemas/schematype.yaml
+++ b/data/schemas/schematype.yaml
@@ -38,27 +38,11 @@ type:
         schema:
           required: true
           type:
-            taggedunion:
-              api: tag
-              cvar: tag
-              enum: tag
-              event: tag
-              family: tag
-              gametype: tag
-              impl: tag
-              luaobject: tag
-              module: tag
-              schema: tag
-              scripttype: tag
-              sql: tag
-              stringenum: tag
-              structure: tag
-              uiobject: tag
-              uiobjectimpl: tag
-              xml: tag
+            ref:
+              schema: domains
     schema:
       ref:
-        schema: schema
+        schema: schemas
     sequenceof:
       schema: schematype
     setof:

--- a/data/schemas/type.yaml
+++ b/data/schemas/type.yaml
@@ -7,29 +7,29 @@ type:
     boolean: tag
     enum:
       ref:
-        schema: enum
+        schema: enums
     FileAsset: tag
     function: tag
     gender: tag
     hlist: tag
     luaobject:
       ref:
-        schema: luaobject
+        schema: luaobjects
     nil: tag
     number: tag
     oneornil: tag
     string: tag
     stringenum:
       ref:
-        schema: stringenum
+        schema: stringenums
     structure:
       ref:
-        schema: structure
+        schema: structures
     table: tag
     TextureAsset: tag
     uiAddon: tag
     uiobject:
       ref:
-        schema: uiobject
+        schema: uiobjects
     unit: tag
     unknown: tag

--- a/data/schemas/uiobjectimpl.yaml
+++ b/data/schemas/uiobjectimpl.yaml
@@ -10,7 +10,7 @@ type:
               type:
                 setof:
                   ref:
-                    schema: module
+                    schema: modules
             sqls:
               type:
                 sequenceof:
@@ -22,4 +22,4 @@ type:
               required: true
               type:
                 ref:
-                  schema: module
+                  schema: modules

--- a/data/schemas/uiobjects.yaml
+++ b/data/schemas/uiobjects.yaml
@@ -31,7 +31,7 @@ type:
         type:
           setof:
             ref:
-              schema: uiobject
+              schema: uiobjects
       methods:
         required: true
         type:
@@ -118,7 +118,7 @@ type:
         type:
           setof:
             ref:
-              schema: scripttype
+              schema: scripttypes
       singleton:
         type: flag
       virtual:

--- a/data/schemas/xml.yaml
+++ b/data/schemas/xml.yaml
@@ -30,12 +30,12 @@ type:
                       boolean: tag
                       enum:
                         ref:
-                          schema: enum
+                          schema: enums
                       number: tag
                       string: tag
                       stringenum:
                         ref:
-                          schema: stringenum
+                          schema: stringenums
                       stringlist: tag
       contents:
         type:
@@ -67,7 +67,7 @@ type:
                   required: true
                   type:
                     ref:
-                      schema: uiobject
+                      schema: uiobjects
             loadstring: tag
             script:
               record:
@@ -76,7 +76,7 @@ type:
             transparent: tag
             uiobject:
               ref:
-                schema: uiobject
+                schema: uiobjects
       phase:
         type:
           taggedunion:

--- a/wowapi/schema.lua
+++ b/wowapi/schema.lua
@@ -23,17 +23,6 @@ for name in pairs(extradomains) do
   domainnames[name] = true
 end
 
-local function resolvedomain(name)
-  local extra = extradomains[name]
-  if extra then
-    return extra.kind, extra.domain
-  end
-  local dtype = wdata.datafiles[name]
-  if dtype then
-    return dtype, wdata[name]
-  end
-end
-
 local function mksimple(ty)
   return function(v)
     local vty = type(v)
@@ -184,13 +173,22 @@ local complex = {
     end
   end,
   ref = function(s)
-    local kind, domain = resolvedomain(s.schema)
+    local extra = extradomains[s.schema]
+    local kind, domain
+    if extra then
+      kind, domain = extra.kind, extra.domain
+    elseif wdata.datafiles[s.schema] then
+      kind, domain = wdata.datafiles[s.schema], wdata[s.schema]
+    end
     local mustexist = not s.negative
     return function(v, product)
       if type(v) ~= 'string' then
         return 'expected string'
       end
-      local d = kind == 'global' and domain or kind == 'product' and domain[product]
+      if not domain then
+        return 'invalid domain'
+      end
+      local d = kind == 'global' and domain or domain[product]
       if not d then
         return 'invalid domain'
       end

--- a/wowapi/schema.lua
+++ b/wowapi/schema.lua
@@ -180,15 +180,10 @@ local complex = {
     elseif wdata.datafiles[s.schema] then
       kind, domain = wdata.datafiles[s.schema], wdata[s.schema]
     end
-    local mustexist = not s.negative
     if not domain then
-      return function(v)
-        if type(v) ~= 'string' then
-          return 'expected string'
-        end
-        return 'invalid domain'
-      end
+      error('bad domain: ' .. s.schema)
     end
+    local mustexist = not s.negative
     return function(v, product)
       if type(v) ~= 'string' then
         return 'expected string'

--- a/wowapi/schema.lua
+++ b/wowapi/schema.lua
@@ -1,25 +1,54 @@
 local wdata = require('wowapi.data')
-local domains = {
-  family = wdata.families,
-  gametype = wdata.gametypes,
-  impl = wdata.impl,
-  module = wdata.modules,
-  schema = wdata.schemas,
-  scripttype = wdata.scripttypes,
-  sql = wdata.sql,
-  uiobjectimpl = wdata.uiobjectimpl,
+
+-- Domain names used by the 'ref' schematype match data/datafiles.yaml keys,
+-- so global-vs-product is looked up there. A few domains aren't declared in
+-- datafiles.yaml because they aren't simple per-file loads (see
+-- wowapi/data.lua):
+--  - 'schemas' is assembled from the data/schemas directory
+--  - 'enums' is extracted from each product's globals.yaml
+--  - 'domains' is the set of valid domain names itself, letting
+--    schematype.yaml check that a schema's ref.schema field names a real
+--    domain without separately enumerating them
+local domainnames = {}
+for name in pairs(wdata.datafiles) do
+  domainnames[name] = true
+end
+
+local extradomains = {
+  schemas = {
+    kind = 'global',
+    get = function()
+      return wdata.schemas
+    end,
+  },
+  enums = {
+    kind = 'product',
+    get = function()
+      return wdata.enums
+    end,
+  },
+  domains = {
+    kind = 'global',
+    get = function()
+      return domainnames
+    end,
+  },
 }
-local productDomains = {
-  api = wdata.apis,
-  cvar = wdata.cvars,
-  enum = wdata.enums,
-  event = wdata.events,
-  luaobject = wdata.luaobjects,
-  stringenum = wdata.stringenums,
-  structure = wdata.structures,
-  uiobject = wdata.uiobjects,
-  xml = wdata.xml,
-}
+for name in pairs(extradomains) do
+  domainnames[name] = true
+end
+
+local function resolvedomain(name)
+  local extra = extradomains[name]
+  if extra then
+    return extra.kind, extra.get
+  end
+  if wdata.datafiles[name] then
+    return wdata.datafiles[name], function()
+      return wdata[name]
+    end
+  end
+end
 
 local function mksimple(ty)
   return function(v)
@@ -171,8 +200,9 @@ local complex = {
     end
   end,
   ref = function(s)
-    local gdomain = domains[s.schema]
-    local pdomains = productDomains[s.schema]
+    local kind, getdomain = resolvedomain(s.schema)
+    local gdomain = kind == 'global' and getdomain()
+    local pdomains = kind == 'product' and getdomain()
     local mustexist = not s.negative
     return function(v, product)
       if type(v) ~= 'string' then

--- a/wowapi/schema.lua
+++ b/wowapi/schema.lua
@@ -181,12 +181,17 @@ local complex = {
       kind, domain = wdata.datafiles[s.schema], wdata[s.schema]
     end
     local mustexist = not s.negative
+    if not domain then
+      return function(v)
+        if type(v) ~= 'string' then
+          return 'expected string'
+        end
+        return 'invalid domain'
+      end
+    end
     return function(v, product)
       if type(v) ~= 'string' then
         return 'expected string'
-      end
-      if not domain then
-        return 'invalid domain'
       end
       local d = kind == 'global' and domain or domain[product]
       if not d then

--- a/wowapi/schema.lua
+++ b/wowapi/schema.lua
@@ -15,24 +15,9 @@ for name in pairs(wdata.datafiles) do
 end
 
 local extradomains = {
-  schemas = {
-    kind = 'global',
-    get = function()
-      return wdata.schemas
-    end,
-  },
-  enums = {
-    kind = 'product',
-    get = function()
-      return wdata.enums
-    end,
-  },
-  domains = {
-    kind = 'global',
-    get = function()
-      return domainnames
-    end,
-  },
+  schemas = { kind = 'global', domain = wdata.schemas },
+  enums = { kind = 'product', domain = wdata.enums },
+  domains = { kind = 'global', domain = domainnames },
 }
 for name in pairs(extradomains) do
   domainnames[name] = true
@@ -41,12 +26,11 @@ end
 local function resolvedomain(name)
   local extra = extradomains[name]
   if extra then
-    return extra.kind, extra.get
+    return extra.kind, extra.domain
   end
-  if wdata.datafiles[name] then
-    return wdata.datafiles[name], function()
-      return wdata[name]
-    end
+  local dtype = wdata.datafiles[name]
+  if dtype then
+    return dtype, wdata[name]
   end
 end
 
@@ -200,17 +184,17 @@ local complex = {
     end
   end,
   ref = function(s)
-    local kind, getdomain = resolvedomain(s.schema)
+    local kind, domain = resolvedomain(s.schema)
     local mustexist = not s.negative
     return function(v, product)
       if type(v) ~= 'string' then
         return 'expected string'
       end
-      local domain = kind == 'global' and getdomain() or kind == 'product' and getdomain()[product]
-      if not domain then
+      local d = kind == 'global' and domain or kind == 'product' and domain[product]
+      if not d then
         return 'invalid domain'
       end
-      if (domain[v] ~= nil) ~= mustexist then
+      if (d[v] ~= nil) ~= mustexist then
         return (mustexist and 'unknown' or 'known') .. ' domain value'
       end
     end

--- a/wowapi/schema.lua
+++ b/wowapi/schema.lua
@@ -201,14 +201,12 @@ local complex = {
   end,
   ref = function(s)
     local kind, getdomain = resolvedomain(s.schema)
-    local gdomain = kind == 'global' and getdomain()
-    local pdomains = kind == 'product' and getdomain()
     local mustexist = not s.negative
     return function(v, product)
       if type(v) ~= 'string' then
         return 'expected string'
       end
-      local domain = gdomain or pdomains and pdomains[product]
+      local domain = kind == 'global' and getdomain() or kind == 'product' and getdomain()[product]
       if not domain then
         return 'invalid domain'
       end


### PR DESCRIPTION
wowapi/schema.lua hand-maintained two tables mapping ref schematype
domain names to their backing wdata tables, split by global vs.
per-product -- an easy thing to forget to update when adding a new
domain. data/datafiles.yaml already declares that same global/product
split for every top-level data file, so derive the registry from it
instead (plus 'schemas' and 'enums', the two domains that aren't
simple per-file loads).

Domain names used in ref.schema now match the datafiles.yaml/wdata
keys directly (e.g. 'apis' instead of 'api'), so data/schemas/*.yaml
is updated accordingly. schematype.yaml's own closed taggedunion of
valid domain names is replaced with a ref against a new synthetic
'domains' domain (the set of datafiles.yaml keys plus the two
exceptions), removing the last spot where that list needed to be
kept in sync by hand.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Jdbp5fEptcS6bFLaQ9PL23
