### PR TITLE
uiobjects: rename TextureCoordTranslation to TextureCoord

### DIFF
--- a/addon/Wowless/generated.lua
+++ b/addon/Wowless/generated.lua
@@ -474,9 +474,8 @@ G.testsuite.generated = function()
       Texture = function()
         return CreateFrame('Frame'):CreateTexture()
       end,
-      TextureCoordTranslation = function()
-        local frame = CreateFrame('Frame', nil, nil, 'WowlessTextureCoordTranslationFactory')
-        return frame.AnimationGroup.TextureCoordTranslation
+      TextureCoord = function()
+        return CreateFrame('Frame'):CreateAnimationGroup():CreateAnimation('TextureCoord')
       end,
       Translation = function()
         return CreateFrame('Frame'):CreateAnimationGroup():CreateAnimation('Translation')

--- a/addon/Wowless/test.xml
+++ b/addon/Wowless/test.xml
@@ -659,14 +659,6 @@
     </Frames>
   </Frame>
 
-  <Frame name='WowlessTextureCoordTranslationFactory' virtual='true'>
-    <Animations>
-      <AnimationGroup parentKey='AnimationGroup'>
-        <TextureCoordTranslation parentKey='TextureCoordTranslation' />
-      </AnimationGroup>
-    </Animations>
-  </Frame>
-
   <Script>
     WowlessLog = {}
   </Script>

--- a/addon/Wowless/uiobjects.lua
+++ b/addon/Wowless/uiobjects.lua
@@ -1457,7 +1457,8 @@ G.testsuite.uiobjects = function()
         end,
       }
     end,
-    TextureCoord = function()
+    TextureCoordTranslation = function()
+      -- The XML name doesn't work from Lua.
       local ag = retn(1, CreateFrame('Frame'):CreateAnimationGroup())
       local tct = retn(1, ag:CreateAnimation('TextureCoordTranslation'))
       return {

--- a/addon/Wowless/uiobjects.lua
+++ b/addon/Wowless/uiobjects.lua
@@ -1457,11 +1457,7 @@ G.testsuite.uiobjects = function()
         end,
       }
     end,
-    TextureCoordTranslation = function()
-      if _G.__wowless then
-        return
-      end
-      -- Cannot be created via Lua CreateAnimation.
+    TextureCoord = function()
       local ag = retn(1, CreateFrame('Frame'):CreateAnimationGroup())
       local tct = retn(1, ag:CreateAnimation('TextureCoordTranslation'))
       return {

--- a/data/products/wow/docs.yaml
+++ b/data/products/wow/docs.yaml
@@ -479,7 +479,7 @@ script_objects:
   SimpleAnimScaleLineAPI:
     uiobject: LineScale
   SimpleAnimTextureCoordTranslationAPI:
-    uiobject: TextureCoordTranslation
+    uiobject: TextureCoord
   SimpleAnimTranslationAPI:
     uiobject: Translation
   SimpleAnimTranslationLineAPI:

--- a/data/products/wow/uiobjects.yaml
+++ b/data/products/wow/uiobjects.yaml
@@ -9091,6 +9091,7 @@ TextureCoord:
   inherits:
     TranslationBase:
   methods:
+  objectType: TextureCoordTranslation
 Translation:
   fields:
   inherits:

--- a/data/products/wow/uiobjects.yaml
+++ b/data/products/wow/uiobjects.yaml
@@ -9086,7 +9086,7 @@ TextureBase:
       outputs:
   objectType: Texture
   virtual: true
-TextureCoordTranslation:
+TextureCoord:
   fields:
   inherits:
     TranslationBase:

--- a/data/products/wow/xml.yaml
+++ b/data/products/wow/xml.yaml
@@ -1497,7 +1497,7 @@ Texture:
 TextureCoordTranslation:
   extends: Animation
   impl:
-    uiobject: TextureCoordTranslation
+    uiobject: TextureCoord
 ThumbTexture:
   extends: Texture
   impl:

--- a/data/products/wow_anniversary/docs.yaml
+++ b/data/products/wow_anniversary/docs.yaml
@@ -614,7 +614,7 @@ script_objects:
   SimpleAnimScaleLineAPI:
     uiobject: LineScale
   SimpleAnimTextureCoordTranslationAPI:
-    uiobject: TextureCoordTranslation
+    uiobject: TextureCoord
   SimpleAnimTranslationAPI:
     uiobject: Translation
   SimpleAnimTranslationLineAPI:

--- a/data/products/wow_anniversary/uiobjects.yaml
+++ b/data/products/wow_anniversary/uiobjects.yaml
@@ -8870,6 +8870,7 @@ TextureCoord:
   inherits:
     TranslationBase:
   methods:
+  objectType: TextureCoordTranslation
 Translation:
   fields:
   inherits:

--- a/data/products/wow_anniversary/uiobjects.yaml
+++ b/data/products/wow_anniversary/uiobjects.yaml
@@ -8865,7 +8865,7 @@ TextureBase:
       outputs:
   objectType: Texture
   virtual: true
-TextureCoordTranslation:
+TextureCoord:
   fields:
   inherits:
     TranslationBase:

--- a/data/products/wow_anniversary/xml.yaml
+++ b/data/products/wow_anniversary/xml.yaml
@@ -1491,7 +1491,7 @@ Texture:
 TextureCoordTranslation:
   extends: Animation
   impl:
-    uiobject: TextureCoordTranslation
+    uiobject: TextureCoord
 ThumbTexture:
   extends: Texture
   impl:

--- a/data/products/wow_classic/docs.yaml
+++ b/data/products/wow_classic/docs.yaml
@@ -496,7 +496,7 @@ script_objects:
   SimpleAnimScaleLineAPI:
     uiobject: LineScale
   SimpleAnimTextureCoordTranslationAPI:
-    uiobject: TextureCoordTranslation
+    uiobject: TextureCoord
   SimpleAnimTranslationAPI:
     uiobject: Translation
   SimpleAnimTranslationLineAPI:

--- a/data/products/wow_classic/uiobjects.yaml
+++ b/data/products/wow_classic/uiobjects.yaml
@@ -9017,6 +9017,7 @@ TextureCoord:
   inherits:
     TranslationBase:
   methods:
+  objectType: TextureCoordTranslation
 Translation:
   fields:
   inherits:

--- a/data/products/wow_classic/uiobjects.yaml
+++ b/data/products/wow_classic/uiobjects.yaml
@@ -9012,7 +9012,7 @@ TextureBase:
       outputs:
   objectType: Texture
   virtual: true
-TextureCoordTranslation:
+TextureCoord:
   fields:
   inherits:
     TranslationBase:

--- a/data/products/wow_classic/xml.yaml
+++ b/data/products/wow_classic/xml.yaml
@@ -1497,7 +1497,7 @@ Texture:
 TextureCoordTranslation:
   extends: Animation
   impl:
-    uiobject: TextureCoordTranslation
+    uiobject: TextureCoord
 ThumbTexture:
   extends: Texture
   impl:

--- a/data/products/wow_classic_era/docs.yaml
+++ b/data/products/wow_classic_era/docs.yaml
@@ -603,7 +603,7 @@ script_objects:
   SimpleAnimScaleLineAPI:
     uiobject: LineScale
   SimpleAnimTextureCoordTranslationAPI:
-    uiobject: TextureCoordTranslation
+    uiobject: TextureCoord
   SimpleAnimTranslationAPI:
     uiobject: Translation
   SimpleAnimTranslationLineAPI:

--- a/data/products/wow_classic_era/uiobjects.yaml
+++ b/data/products/wow_classic_era/uiobjects.yaml
@@ -8828,7 +8828,7 @@ TextureBase:
       outputs:
   objectType: Texture
   virtual: true
-TextureCoordTranslation:
+TextureCoord:
   fields:
   inherits:
     TranslationBase:

--- a/data/products/wow_classic_era/uiobjects.yaml
+++ b/data/products/wow_classic_era/uiobjects.yaml
@@ -8833,6 +8833,7 @@ TextureCoord:
   inherits:
     TranslationBase:
   methods:
+  objectType: TextureCoordTranslation
 Translation:
   fields:
   inherits:

--- a/data/products/wow_classic_era/xml.yaml
+++ b/data/products/wow_classic_era/xml.yaml
@@ -1486,7 +1486,7 @@ Texture:
 TextureCoordTranslation:
   extends: Animation
   impl:
-    uiobject: TextureCoordTranslation
+    uiobject: TextureCoord
 ThumbTexture:
   extends: Texture
   impl:

--- a/data/products/wow_classic_era_ptr/docs.yaml
+++ b/data/products/wow_classic_era_ptr/docs.yaml
@@ -614,7 +614,7 @@ script_objects:
   SimpleAnimScaleLineAPI:
     uiobject: LineScale
   SimpleAnimTextureCoordTranslationAPI:
-    uiobject: TextureCoordTranslation
+    uiobject: TextureCoord
   SimpleAnimTranslationAPI:
     uiobject: Translation
   SimpleAnimTranslationLineAPI:

--- a/data/products/wow_classic_era_ptr/uiobjects.yaml
+++ b/data/products/wow_classic_era_ptr/uiobjects.yaml
@@ -8870,6 +8870,7 @@ TextureCoord:
   inherits:
     TranslationBase:
   methods:
+  objectType: TextureCoordTranslation
 Translation:
   fields:
   inherits:

--- a/data/products/wow_classic_era_ptr/uiobjects.yaml
+++ b/data/products/wow_classic_era_ptr/uiobjects.yaml
@@ -8865,7 +8865,7 @@ TextureBase:
       outputs:
   objectType: Texture
   virtual: true
-TextureCoordTranslation:
+TextureCoord:
   fields:
   inherits:
     TranslationBase:

--- a/data/products/wow_classic_era_ptr/xml.yaml
+++ b/data/products/wow_classic_era_ptr/xml.yaml
@@ -1491,7 +1491,7 @@ Texture:
 TextureCoordTranslation:
   extends: Animation
   impl:
-    uiobject: TextureCoordTranslation
+    uiobject: TextureCoord
 ThumbTexture:
   extends: Texture
   impl:

--- a/data/products/wow_classic_ptr/docs.yaml
+++ b/data/products/wow_classic_ptr/docs.yaml
@@ -496,7 +496,7 @@ script_objects:
   SimpleAnimScaleLineAPI:
     uiobject: LineScale
   SimpleAnimTextureCoordTranslationAPI:
-    uiobject: TextureCoordTranslation
+    uiobject: TextureCoord
   SimpleAnimTranslationAPI:
     uiobject: Translation
   SimpleAnimTranslationLineAPI:

--- a/data/products/wow_classic_ptr/uiobjects.yaml
+++ b/data/products/wow_classic_ptr/uiobjects.yaml
@@ -9017,6 +9017,7 @@ TextureCoord:
   inherits:
     TranslationBase:
   methods:
+  objectType: TextureCoordTranslation
 Translation:
   fields:
   inherits:

--- a/data/products/wow_classic_ptr/uiobjects.yaml
+++ b/data/products/wow_classic_ptr/uiobjects.yaml
@@ -9012,7 +9012,7 @@ TextureBase:
       outputs:
   objectType: Texture
   virtual: true
-TextureCoordTranslation:
+TextureCoord:
   fields:
   inherits:
     TranslationBase:

--- a/data/products/wow_classic_ptr/xml.yaml
+++ b/data/products/wow_classic_ptr/xml.yaml
@@ -1497,7 +1497,7 @@ Texture:
 TextureCoordTranslation:
   extends: Animation
   impl:
-    uiobject: TextureCoordTranslation
+    uiobject: TextureCoord
 ThumbTexture:
   extends: Texture
   impl:

--- a/data/products/wowt/docs.yaml
+++ b/data/products/wowt/docs.yaml
@@ -465,7 +465,7 @@ script_objects:
   SimpleAnimScaleLineAPI:
     uiobject: LineScale
   SimpleAnimTextureCoordTranslationAPI:
-    uiobject: TextureCoordTranslation
+    uiobject: TextureCoord
   SimpleAnimTranslationAPI:
     uiobject: Translation
   SimpleAnimTranslationLineAPI:

--- a/data/products/wowt/uiobjects.yaml
+++ b/data/products/wowt/uiobjects.yaml
@@ -9262,6 +9262,7 @@ TextureCoord:
   inherits:
     TranslationBase:
   methods:
+  objectType: TextureCoordTranslation
 Translation:
   fields:
   inherits:

--- a/data/products/wowt/uiobjects.yaml
+++ b/data/products/wowt/uiobjects.yaml
@@ -9257,7 +9257,7 @@ TextureBase:
       outputs:
   objectType: Texture
   virtual: true
-TextureCoordTranslation:
+TextureCoord:
   fields:
   inherits:
     TranslationBase:

--- a/data/products/wowt/xml.yaml
+++ b/data/products/wowt/xml.yaml
@@ -1520,7 +1520,7 @@ Texture:
 TextureCoordTranslation:
   extends: Animation
   impl:
-    uiobject: TextureCoordTranslation
+    uiobject: TextureCoord
 ThumbTexture:
   extends: Texture
   impl:

--- a/data/products/wowxptr/docs.yaml
+++ b/data/products/wowxptr/docs.yaml
@@ -479,7 +479,7 @@ script_objects:
   SimpleAnimScaleLineAPI:
     uiobject: LineScale
   SimpleAnimTextureCoordTranslationAPI:
-    uiobject: TextureCoordTranslation
+    uiobject: TextureCoord
   SimpleAnimTranslationAPI:
     uiobject: Translation
   SimpleAnimTranslationLineAPI:

--- a/data/products/wowxptr/uiobjects.yaml
+++ b/data/products/wowxptr/uiobjects.yaml
@@ -9091,6 +9091,7 @@ TextureCoord:
   inherits:
     TranslationBase:
   methods:
+  objectType: TextureCoordTranslation
 Translation:
   fields:
   inherits:

--- a/data/products/wowxptr/uiobjects.yaml
+++ b/data/products/wowxptr/uiobjects.yaml
@@ -9086,7 +9086,7 @@ TextureBase:
       outputs:
   objectType: Texture
   virtual: true
-TextureCoordTranslation:
+TextureCoord:
   fields:
   inherits:
     TranslationBase:

--- a/data/products/wowxptr/xml.yaml
+++ b/data/products/wowxptr/xml.yaml
@@ -1497,7 +1497,7 @@ Texture:
 TextureCoordTranslation:
   extends: Animation
   impl:
-    uiobject: TextureCoordTranslation
+    uiobject: TextureCoord
 ThumbTexture:
   extends: Texture
   impl:

--- a/data/uiobjects/AnimationGroup/CreateAnimation.lua
+++ b/data/uiobjects/AnimationGroup/CreateAnimation.lua
@@ -1,6 +1,8 @@
 local api, uiobjecttypes = ...
 return function(self, type)
   local ltype = (type or 'animation'):lower()
-  assert(uiobjecttypes.InheritsFrom(ltype, 'animation'))
+  if not (uiobjecttypes.Has(ltype) and uiobjecttypes.InheritsFrom(ltype, 'animation')) then
+    ltype = 'animation'
+  end
   return api.CreateUIObject(ltype, nil, self)
 end


### PR DESCRIPTION
## Summary
- Real WoW client creates this animation via `CreateAnimation('TextureCoord')`, not the XML tag name `TextureCoordTranslation` — rename the wowless uiobject type accordingly, keeping the XML tag `TextureCoordTranslation` pointing at the renamed type.
- `CreateAnimation` now falls back to a bare `Animation` for unrecognized type strings (matching real client behavior), so the addon test can assert that calling `CreateAnimation('TextureCoordTranslation')` directly (the wrong/XML name) yields a bare Animation, and drop the `_G.__wowless` guard now that this is exercisable in wowless.
- Converted the generated addon test's `TextureCoordTranslation` factory to use the `CreateAnimation('TextureCoord')` flow instead of a dedicated XML template, and removed the now-unused `WowlessTextureCoordTranslationFactory` template from `test.xml`.
- Regenerated `docs.yaml` (`docs-all`) and hand-updated the `SimpleAnimTextureCoordTranslationAPI` doc mapping to point at `TextureCoord`.

## Test plan
- [x] `cmake --build --preset default --target test`
- [x] `cmake --build --preset default --target docs-all`
- [x] `pre-commit run -a`

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

https://claude.ai/code/session_01WFj2g7eSbsyBykRzadQL8v