### PR TITLE
loader: extract Lua chunk compilation into a chunks module

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -876,6 +876,7 @@ lua2c(
   wowless.modules.bindings=${CMAKE_CURRENT_SOURCE_DIR}/wowless/modules/bindings.lua
   wowless.modules.calendar=${CMAKE_CURRENT_SOURCE_DIR}/wowless/modules/calendar.lua
   wowless.modules.cgencode=${CMAKE_CURRENT_SOURCE_DIR}/wowless/modules/cgencode.lua
+  wowless.modules.chunks=${CMAKE_CURRENT_SOURCE_DIR}/wowless/modules/chunks.lua
   wowless.modules.clog=${CMAKE_CURRENT_SOURCE_DIR}/wowless/modules/clog.lua
   wowless.modules.cstubs=${CMAKE_CURRENT_SOURCE_DIR}/wowless/modules/cstubs.lua
   wowless.modules.cvars=${CMAKE_CURRENT_SOURCE_DIR}/wowless/modules/cvars.lua

--- a/data/modules.yaml
+++ b/data/modules.yaml
@@ -32,6 +32,8 @@ cgencode:
     luaobjects:
     uiobjects:
     units:
+chunks:
+  deps:
 clog:
   deps:
     datalua:
@@ -91,6 +93,7 @@ loader:
     addons:
     api:
     bindings:
+    chunks:
     datalua:
     env:
     events:

--- a/wowless/modules/chunks.lua
+++ b/wowless/modules/chunks.lua
@@ -1,0 +1,23 @@
+local path = require('path')
+
+return function()
+  local function LoadChunk(str, filename, line)
+    local function doload()
+      local pre = line and string.rep('\n', line - 1) or ''
+      return loadstring_untainted(pre .. str, '@' .. path.normalize(filename):gsub('/', '\\'))
+    end
+    if filename:find('Wowless') then
+      debug.setstacktaint('Wowless')
+      debug.settaintmode('rw')
+      local fn = doload()
+      debug.settaintmode('disabled')
+      debug.setstacktaint(nil)
+      return assert(fn)
+    else
+      return assert(doload())
+    end
+  end
+  return {
+    LoadChunk = LoadChunk,
+  }
+end

--- a/wowless/modules/loader.lua
+++ b/wowless/modules/loader.lua
@@ -2,6 +2,7 @@ return function(
   addons,
   api,
   bindingsmodule,
+  chunks,
   datalua,
   envmodule,
   events,
@@ -83,23 +84,6 @@ return function(
     return v('left'), v('right'), v('top'), v('bottom')
   end
 
-  local function loadstr(str, filename, line)
-    local function doload()
-      local pre = line and string.rep('\n', line - 1) or ''
-      return loadstring_untainted(pre .. str, '@' .. path.normalize(filename):gsub('/', '\\'))
-    end
-    if filename:find('Wowless') then
-      debug.setstacktaint('Wowless')
-      debug.settaintmode('rw')
-      local fn = doload()
-      debug.settaintmode('disabled')
-      debug.setstacktaint(nil)
-      return assert(fn)
-    else
-      return assert(doload())
-    end
-  end
-
   local function getColor(e)
     local name = e.attr.name or e.attr.color
     if not name then
@@ -115,7 +99,7 @@ return function(
 
   local function loadLuaString(filename, str, line, useSecureEnv, closureTaint, ...)
     local before = genv.ScrollingMessageFrameMixin
-    local fn = loadstr(str, filename, line)
+    local fn = chunks.LoadChunk(str, filename, line)
     if useSecureEnv then
       setfenv(fn, secureenv)
     end
@@ -150,7 +134,7 @@ return function(
     if script.text then
       local args = xmlimpls[string.lower(script.type)].tag.script.args or 'self, ...'
       local fnstr = 'return function(' .. args .. ') ' .. script.text .. ' end'
-      local outfn = loadstr(fnstr, filename, script.line)
+      local outfn = chunks.LoadChunk(fnstr, filename, script.line)
       local success, ret = security.CallSandbox(outfn)
       assert(success)
       fn = setfenv(ret, env)
@@ -675,7 +659,7 @@ return function(
             -- TODO interpret all binding attributes
             if not e.attr.debug then -- TODO support debug bindings
               local bfn = 'return function(keystate) ' .. e.text .. ' end'
-              bindings[e.attr.name] = loadstr(bfn, filename, e.line)()
+              bindings[e.attr.name] = chunks.LoadChunk(bfn, filename, e.line)()
             end
           elseif e.type == 'fontfamily' then -- TODO do this another way
             local font = e.kids[1].kids[1]


### PR DESCRIPTION
Second piece of breaking up #731 into independently reviewable steps:
loader's loadstr helper (compiling a Lua string with the Wowless
stack-taint branch) moves wholesale into a new chunks module as
LoadChunk. loader.lua takes chunks as a dependency and calls
chunks.LoadChunk at all three former call sites; the compile semantics
are unchanged.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Q2zVCtSzRDfbZY8bXSL5Es
