### PR TITLE
chunks: caller supplies the taint string, sourced from addon identity

### DIFF
--- a/wowless/modules/chunks.lua
+++ b/wowless/modules/chunks.lua
@@ -1,21 +1,14 @@
 local path = require('path')
 
 return function()
-  local function LoadChunk(str, filename, line)
-    local function doload()
-      local pre = line and string.rep('\n', line - 1) or ''
-      return loadstring_untainted(pre .. str, '@' .. path.normalize(filename):gsub('/', '\\'))
-    end
-    if filename:find('Wowless') then
-      debug.setstacktaint('Wowless')
-      debug.settaintmode('rw')
-      local fn = doload()
-      debug.settaintmode('disabled')
-      debug.setstacktaint(nil)
-      return assert(fn)
-    else
-      return assert(doload())
-    end
+  local function LoadChunk(str, filename, line, taint)
+    local pre = line and string.rep('\n', line - 1) or ''
+    debug.setstacktaint(taint)
+    debug.settaintmode('rw')
+    local fn = assert(loadstring_untainted(pre .. str, '@' .. path.normalize(filename):gsub('/', '\\')))
+    debug.settaintmode('disabled')
+    debug.setstacktaint(nil)
+    return fn
   end
   return {
     LoadChunk = LoadChunk,

--- a/wowless/modules/loader.lua
+++ b/wowless/modules/loader.lua
@@ -97,9 +97,13 @@ return function(
     return 0, 0, 0, 1
   end
 
-  local function loadLuaString(filename, str, line, useSecureEnv, closureTaint, ...)
+  local function addonTaint(addonName)
+    return addonName == 'Wowless' and addonName or nil
+  end
+
+  local function loadLuaString(filename, str, line, useSecureEnv, closureTaint, addonName, ...)
     local before = genv.ScrollingMessageFrameMixin
-    local fn = chunks.LoadChunk(str, filename, line)
+    local fn = chunks.LoadChunk(str, filename, line, addonTaint(addonName))
     if useSecureEnv then
       setfenv(fn, secureenv)
     end
@@ -119,7 +123,7 @@ return function(
 
   local scriptCache = {}
 
-  local function precacheScriptText(script, obj, env, filename)
+  local function precacheScriptText(script, obj, env, filename, addonName)
     if not scripts.HasScript(obj, script.type) then
       return
     end
@@ -134,7 +138,7 @@ return function(
     if script.text then
       local args = xmlimpls[string.lower(script.type)].tag.script.args or 'self, ...'
       local fnstr = 'return function(' .. args .. ') ' .. script.text .. ' end'
-      local outfn = chunks.LoadChunk(fnstr, filename, script.line)
+      local outfn = chunks.LoadChunk(fnstr, filename, script.line, addonTaint(addonName))
       local success, ret = security.CallSandbox(outfn)
       assert(success)
       fn = setfenv(ret, env)
@@ -634,7 +638,7 @@ return function(
           local fn = xmllang[e.type]
           if type(impl) == 'table' and impl.script then
             local env = ctx.useAddonEnv and addonEnv or ctx.useSecureEnv and secureenv or genv
-            precacheScriptText(e, parent, env, filename)
+            precacheScriptText(e, parent, env, filename, addonName)
           elseif type(impl) == 'table' and impl.call then
             local elt = impl.call.argument == 'lastkid' and e.kids[#e.kids]
               or mixin({}, e, { type = impl.call.argument })
@@ -653,13 +657,13 @@ return function(
             end
             loadElements(ctxmix, e.kids, parent)
             if impl == 'loadstring' and e.text then
-              loadLuaString(filename, e.text, e.line, ctx.useSecureEnv)
+              loadLuaString(filename, e.text, e.line, ctx.useSecureEnv, nil, addonName)
             end
           elseif e.type == 'binding' then -- TODO do this another way
             -- TODO interpret all binding attributes
             if not e.attr.debug then -- TODO support debug bindings
               local bfn = 'return function(keystate) ' .. e.text .. ' end'
-              bindings[e.attr.name] = chunks.LoadChunk(bfn, filename, e.line)()
+              bindings[e.attr.name] = chunks.LoadChunk(bfn, filename, e.line, addonTaint(addonName))()
             end
           elseif e.type == 'fontfamily' then -- TODO do this another way
             local font = e.kids[1].kids[1]
@@ -711,7 +715,9 @@ return function(
           success, content = pcall(readFile, secondaryFileName)
         end
         if success then
-          loadFn(filename, content, nil, useSecureEnv, closureTaint, addonName, addonEnv)
+          -- addonName appears twice: once as loadLuaString's taint arg, once as
+          -- the chunk's own first vararg (matching real addon file execution).
+          loadFn(filename, content, nil, useSecureEnv, closureTaint, addonName, addonName, addonEnv)
         else
           log(1, 'skipping missing file %s', filename)
         end


### PR DESCRIPTION
## Summary

Builds on [#736](https://github.com/wowless/wowless/pull/736) (the chunks
module extraction). This is a real behavior change — a taint-correctness
fix — kept as its own PR rather than bundled into that mechanical move, so it
gets its own scrutiny.

- `LoadChunk` no longer sniffs the filename for `"Wowless"` to decide whether
  to apply stack taint. The taint-setting dance
  (`setstacktaint`/`settaintmode`) now runs unconditionally, using a taint
  string the *caller* passes in.
- `loader.lua` computes the taint from the addon's actual name rather than a
  filename substring match: `addonTaint(addonName)` applies taint only for
  the `Wowless` test addon (same gate the old heuristic implemented, now
  checked precisely against addon identity instead of pattern-matching the
  file path), and threads `addonName` through to all three `LoadChunk` call
  sites — already an upvalue at the binding call site inside `loadElement`,
  newly threaded as an explicit parameter into `loadLuaString` and
  `precacheScriptText` (both defined outside `forAddon`'s closure, so they
  didn't have it for free). The caller still invokes the returned chunk
  itself, exactly as before.

Note: an earlier version of this fix passed `addonName` unconditionally,
which tainted *every* addon's code (not just `Wowless`) and broke 15 elune
scripttest cases that assert execution starts untainted. This version
restores the original conditional gate, just sourced from addon identity
instead of a filename pattern.

## Test plan

- [x] `cmake --build --preset default --target test` passes
- [x] `cmake --build --preset default --target outs`: all 8 products produce
      an empty `log.txt` at loglevel 5
- [x] pre-commit hooks pass on all changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q2zVCtSzRDfbZY8bXSL5Es