### PR TITLE
enums: wrap each enum's values in a record

### DIFF
--- a/data/products/wow/enums.yaml
+++ b/data/products/wow/enums.yaml
@@ -1,7521 +1,8370 @@
 AbbreviationDataError:
-  InvalidBreakpoint: 1
-  InvalidFractionDivisor: 4
-  InvalidSignificandDivisor: 2
-  NotMultipleOfTen: 8
+  values:
+    InvalidBreakpoint: 1
+    InvalidFractionDivisor: 4
+    InvalidSignificandDivisor: 2
+    NotMultipleOfTen: 8
 AccountCurrencyTransferResult:
-  CannotUseCurrency: 8
-  CharacterLoggedIn: 2
-  CurrencyTransferDisabled: 10
-  InsufficientCurrency: 3
-  InvalidCharacter: 1
-  InvalidCurrency: 5
-  MaxQuantity: 4
-  NoValidSourceCharacter: 6
-  ServerError: 7
-  Success: 0
-  TransactionInProgress: 9
+  values:
+    CannotUseCurrency: 8
+    CharacterLoggedIn: 2
+    CurrencyTransferDisabled: 10
+    InsufficientCurrency: 3
+    InvalidCharacter: 1
+    InvalidCurrency: 5
+    MaxQuantity: 4
+    NoValidSourceCharacter: 6
+    ServerError: 7
+    Success: 0
+    TransactionInProgress: 9
 AccountData:
-  Bindings: 2
-  Bindings2: 3
-  CharacterListOrder: 16
-  ChatSettings: 7
-  ClickBindings: 12
-  Config: 0
-  Config2: 1
-  CooldownManager: 17
-  CooldownManager2: 18
-  FlaggedIDs: 10
-  FlaggedIDs2: 11
-  FrontendChatSettings: 15
-  Macros: 4
-  Macros2: 5
-  Shop2PendingOrders: 19
-  TtsSettings: 8
-  TtsSettings2: 9
-  UIEditModeAccount: 13
-  UIEditModeChar: 14
-  UILayout: 6
+  values:
+    Bindings: 2
+    Bindings2: 3
+    CharacterListOrder: 16
+    ChatSettings: 7
+    ClickBindings: 12
+    Config: 0
+    Config2: 1
+    CooldownManager: 17
+    CooldownManager2: 18
+    FlaggedIDs: 10
+    FlaggedIDs2: 11
+    FrontendChatSettings: 15
+    Macros: 4
+    Macros2: 5
+    Shop2PendingOrders: 19
+    TtsSettings: 8
+    TtsSettings2: 9
+    UIEditModeAccount: 13
+    UIEditModeChar: 14
+    UILayout: 6
 AccountDataUpdateStatus:
-  Corrupt: 2
-  Failed: 1
-  Success: 0
-  Toobig: 3
+  values:
+    Corrupt: 2
+    Failed: 1
+    Success: 0
+    Toobig: 3
 AccountExportResult:
-  AlreadyInProgress: 11
-  Cancelled: 2
-  FailedToGenerateFile: 13
-  FailedToLockAccount: 12
-  FileInvalid: 8
-  FileWriteFailed: 9
-  NoAccountFound: 5
-  RequestedInvalidCharacter: 6
-  RpcError: 7
-  ShuttingDown: 3
-  Success: 0
-  TimedOut: 4
-  Unavailable: 10
-  UnknownError: 1
+  values:
+    AlreadyInProgress: 11
+    Cancelled: 2
+    FailedToGenerateFile: 13
+    FailedToLockAccount: 12
+    FileInvalid: 8
+    FileWriteFailed: 9
+    NoAccountFound: 5
+    RequestedInvalidCharacter: 6
+    RpcError: 7
+    ShuttingDown: 3
+    Success: 0
+    TimedOut: 4
+    Unavailable: 10
+    UnknownError: 1
 AccountSequenceCacheType:
-  HouseDecor: 2
-  Invalid: 0
-  Local: 1
+  values:
+    HouseDecor: 2
+    Invalid: 0
+    Local: 1
 AccountStateFlags:
-  AccountUpgradeComplete: 4
-  InPetCombat: 2
-  LoadFailed: 1
-  None: 0
-  TokenEligCheckComplete: 8
+  values:
+    AccountUpgradeComplete: 4
+    InPetCombat: 2
+    LoadFailed: 1
+    None: 0
+    TokenEligCheckComplete: 8
 AccountStateLoadedFlags:
-  AccountCurrenciesLoaded: '0x0000000000200000'
-  AccountFactionsLoaded: '0x0000000200000000'
-  AccountItemsLoaded: '0x0000000400000000'
-  AccountMappingLoaded: '0x0000008000000000'
-  AccountNotificationsLoaded: '0x0000000008000000'
-  AccountWowlabsLoaded: '0x0000000020000000'
-  AchievementsLoaded: '0x0000000000000001'
-  ArchivedPurchasesLoaded: '0x0000000000000200'
-  AuctionableTokensLoaded: '0x0000000000002000'
-  BanktabSettingsLoaded: '0x0000004000000000'
-  BattleNetAccountLoaded: '0x0000000000100000'
-  BitVectorsLoaded: '0x0000000100000000'
-  BpayAddLicenseObjectsLoaded: '0x0000000000000800'
-  BpayDistributionObjectsLoaded: '0x0000000000000100'
-  BpayProductitemObjectsLoaded: '0x0000000000020000'
-  CharacterItemsLoaded: '0x0000010000000000'
-  CharactersLoaded: '0x0000000000000040'
-  CombinedQuestLogLoaded: '0x0000000800000000'
-  ConsumableTokensLoaded: '0x0000000000004000'
-  CriteriaLoaded: '0x0000000000000002'
-  CurrencyCapsLoaded: '0x0000000000000010'
-  CurrencyTransferLogLoaded: '0x0000020000000000'
-  DataElementsLoaded: '0x0000001000000000'
-  DynamicCriteriaLoaded: '0x0000000001000000'
-  EventRecordsLoaded: '0x0000200000000000'
-  HousingDataLoaded: '0x0000080000000000'
-  ItemCollectionsLoaded: '0x0000000000001000'
-  LgVendorPurchaseLoaded: '0x0000040000000000'
-  LoadedNone: '0x0000000000000000'
-  MountsLoaded: '0x0000000000000004'
-  PerksHeldItemLoaded: '0x0000000040000000'
-  PerksPastRewardsLoaded: '0x0000000000008000'
-  PerksPendingPurchaseLoaded: '0x0000000010000000'
-  PerksPendingRewardsLoaded: '0x0000000080000000'
-  PetjournalInitialized: '0x0000000000000008'
-  PurchasesLoaded: '0x0000000000000080'
-  QuestCriteriaLoaded: '0x0000000000080000'
-  QuestLogLoaded: '0x0000000000000020'
-  RafActivityLoaded: '0x0000000002000000'
-  RafBalanceLoaded: '0x0000000000400000'
-  RafRewardsLoaded: '0x0000000000800000'
-  RevokedRafRewardsLoaded: '0x0000000004000000'
-  SettingsLoaded: '0x0000000000000400'
-  TransmogOutfitsLoaded: '0x0000400000000000'
-  TrialBoostHistoryLoaded: '0x0000000000040000'
-  VasTransactionsLoaded: '0x0000000000010000'
-  WarbandScenesLoaded: '0x0000100000000000'
-  WarbandsLoaded: '0x0000002000000000'
+  values:
+    AccountCurrenciesLoaded: '0x0000000000200000'
+    AccountFactionsLoaded: '0x0000000200000000'
+    AccountItemsLoaded: '0x0000000400000000'
+    AccountMappingLoaded: '0x0000008000000000'
+    AccountNotificationsLoaded: '0x0000000008000000'
+    AccountWowlabsLoaded: '0x0000000020000000'
+    AchievementsLoaded: '0x0000000000000001'
+    ArchivedPurchasesLoaded: '0x0000000000000200'
+    AuctionableTokensLoaded: '0x0000000000002000'
+    BanktabSettingsLoaded: '0x0000004000000000'
+    BattleNetAccountLoaded: '0x0000000000100000'
+    BitVectorsLoaded: '0x0000000100000000'
+    BpayAddLicenseObjectsLoaded: '0x0000000000000800'
+    BpayDistributionObjectsLoaded: '0x0000000000000100'
+    BpayProductitemObjectsLoaded: '0x0000000000020000'
+    CharacterItemsLoaded: '0x0000010000000000'
+    CharactersLoaded: '0x0000000000000040'
+    CombinedQuestLogLoaded: '0x0000000800000000'
+    ConsumableTokensLoaded: '0x0000000000004000'
+    CriteriaLoaded: '0x0000000000000002'
+    CurrencyCapsLoaded: '0x0000000000000010'
+    CurrencyTransferLogLoaded: '0x0000020000000000'
+    DataElementsLoaded: '0x0000001000000000'
+    DynamicCriteriaLoaded: '0x0000000001000000'
+    EventRecordsLoaded: '0x0000200000000000'
+    HousingDataLoaded: '0x0000080000000000'
+    ItemCollectionsLoaded: '0x0000000000001000'
+    LgVendorPurchaseLoaded: '0x0000040000000000'
+    LoadedNone: '0x0000000000000000'
+    MountsLoaded: '0x0000000000000004'
+    PerksHeldItemLoaded: '0x0000000040000000'
+    PerksPastRewardsLoaded: '0x0000000000008000'
+    PerksPendingPurchaseLoaded: '0x0000000010000000'
+    PerksPendingRewardsLoaded: '0x0000000080000000'
+    PetjournalInitialized: '0x0000000000000008'
+    PurchasesLoaded: '0x0000000000000080'
+    QuestCriteriaLoaded: '0x0000000000080000'
+    QuestLogLoaded: '0x0000000000000020'
+    RafActivityLoaded: '0x0000000002000000'
+    RafBalanceLoaded: '0x0000000000400000'
+    RafRewardsLoaded: '0x0000000000800000'
+    RevokedRafRewardsLoaded: '0x0000000004000000'
+    SettingsLoaded: '0x0000000000000400'
+    TransmogOutfitsLoaded: '0x0000400000000000'
+    TrialBoostHistoryLoaded: '0x0000000000040000'
+    VasTransactionsLoaded: '0x0000000000010000'
+    WarbandScenesLoaded: '0x0000100000000000'
+    WarbandsLoaded: '0x0000002000000000'
 AccountStoreCategoryType:
-  Creature: 1
-  Icon: 4
-  Mount: 3
-  TransmogSet: 2
+  values:
+    Creature: 1
+    Icon: 4
+    Mount: 3
+    TransmogSet: 2
 AccountStoreFrontFlag:
-  Enabled: 1
-  PurchaseEnabled: 2
-  RefundEnabled: 4
+  values:
+    Enabled: 1
+    PurchaseEnabled: 2
+    RefundEnabled: 4
 AccountStoreItemFlag:
-  DisplayAsNew: 4
-  DisplayDefaultArmor: 1
-  DisplayOnly: 8
-  NotInGameReward: 2
+  values:
+    DisplayAsNew: 4
+    DisplayDefaultArmor: 1
+    DisplayOnly: 8
+    NotInGameReward: 2
 AccountStoreItemMode:
-  Hidden: 2
-  Locked: 3
-  Normal: 1
+  values:
+    Hidden: 2
+    Locked: 3
+    Normal: 1
 AccountStoreItemRewardType:
-  Illusion: 7
-  Misc: 10
-  Mount: 2
-  Pet: 3
-  Tender: 9
-  Toy: 5
-  Transmog: 1
-  TransmogSet: 8
-  WarbandScene: 11
+  values:
+    Illusion: 7
+    Misc: 10
+    Mount: 2
+    Pet: 3
+    Tender: 9
+    Toy: 5
+    Transmog: 1
+    TransmogSet: 8
+    WarbandScene: 11
 AccountStoreItemStatus:
-  Owned: 3
-  Refundable: 2
-  Unowned: 1
+  values:
+    Owned: 3
+    Refundable: 2
+    Unowned: 1
 AccountStoreSettlementAction:
-  Give: 1
-  NotSet: 0
-  Remove: 2
+  values:
+    Give: 1
+    NotSet: 0
+    Remove: 2
 AccountStoreState:
-  Available: 0
-  Unavailable: 2
-  Unknown: 1
+  values:
+    Available: 0
+    Unavailable: 2
+    Unknown: 1
 AccountStoreTransactionResult:
-  Incomplete: 1
-  InsufficientFunds: 4
-  InvalidCurrencyType: 8
-  ItemAlreadyOwned: 6
-  ItemNotOwned: 7
-  ItemUnknown: 5
-  NotSupported: 10
-  OwnedButRefundTimeExpired: 9
-  ProxyError: 12
-  Success: 0
-  TransactionInProgress: 3
-  Unavailable: 11
-  UnknownError: 2
+  values:
+    Incomplete: 1
+    InsufficientFunds: 4
+    InvalidCurrencyType: 8
+    ItemAlreadyOwned: 6
+    ItemNotOwned: 7
+    ItemUnknown: 5
+    NotSupported: 10
+    OwnedButRefundTimeExpired: 9
+    ProxyError: 12
+    Success: 0
+    TransactionInProgress: 3
+    Unavailable: 11
+    UnknownError: 2
 AccountStoreTransactionType:
-  DebugRemoveItem: 4
-  DebugResetHistory: 3
-  Purchase: 1
-  Refund: 2
-  Undefined: 0
+  values:
+    DebugRemoveItem: 4
+    DebugResetHistory: 3
+    Purchase: 1
+    Refund: 2
+    Undefined: 0
 AccountTransType:
-  AccountCurrencies: 26
-  AccountNotifications: 38
-  AccountStore: 54
-  Achievements: 4
-  AddLicense: 16
-  ArchivedPurchases: 9
-  AuctionableToken: 18
-  BankTab: 48
-  BattlenetAccount: 25
-  Battlepet: 3
-  BitVectors: 50
-  CharacterDataMerge: 53
-  CharacterItems: 57
-  Characters: 7
-  CombinedQuestLog: 51
-  ConsumableToken: 19
-  CreateOrderInfo: 32
-  Criteria: 5
-  CriteriaNotif: 13
-  CurrencyCaps: 11
-  CurrencyTransferLog: 58
-  Distribution: 2
-  Distributions: 10
-  DynamicCriteria: 30
-  EventRecords: 63
-  Factions: 49
-  FixedLicense: 15
-  GetOrderStatusByPurchaseID: 46
-  HouseInitiativeFavor: 66
-  HousingItem: 64
-  ItemCollections: 17
-  Items: 47
-  LgVendorPurchase: 59
-  LoadWowlabs: 44
-  Mapping: 56
-  Mounts: 6
-  OutstandingRpc: 43
-  PerkItemHold: 39
-  PerkPastRewards: 41
-  PerkPendingRewards: 40
-  PerkTransaction: 42
-  PlayerDataElements: 52
-  Productitem: 21
-  Profile: 61
-  ProxyCreateAccountHonor: 34
-  ProxyForwarder: 0
-  ProxyGenerateBpayID: 37
-  ProxyGmSetHonor: 36
-  ProxyHonorInitialConversion: 33
-  ProxyValidateAccountHonor: 35
-  Purchase: 1
-  Purchases: 8
-  QuestCriteria: 24
-  QuestLog: 12
-  RafActivity: 31
-  RafFriendMonth: 28
-  RafRecruiterAcceptances: 27
-  RafReward: 29
-  SaveWarbandGroups: 60
-  Settings: 14
-  TransmogOutfitCollection: 65
-  TrialBoostHistories: 23
-  TrialBoostHistory: 22
-  UpgradeAccount: 45
-  VasTransaction: 20
-  WarbandGroups: 55
-  WarbandSceneCollection: 62
+  values:
+    AccountCurrencies: 26
+    AccountNotifications: 38
+    AccountStore: 54
+    Achievements: 4
+    AddLicense: 16
+    ArchivedPurchases: 9
+    AuctionableToken: 18
+    BankTab: 48
+    BattlenetAccount: 25
+    Battlepet: 3
+    BitVectors: 50
+    CharacterDataMerge: 53
+    CharacterItems: 57
+    Characters: 7
+    CombinedQuestLog: 51
+    ConsumableToken: 19
+    CreateOrderInfo: 32
+    Criteria: 5
+    CriteriaNotif: 13
+    CurrencyCaps: 11
+    CurrencyTransferLog: 58
+    Distribution: 2
+    Distributions: 10
+    DynamicCriteria: 30
+    EventRecords: 63
+    Factions: 49
+    FixedLicense: 15
+    GetOrderStatusByPurchaseID: 46
+    HouseInitiativeFavor: 66
+    HousingItem: 64
+    ItemCollections: 17
+    Items: 47
+    LgVendorPurchase: 59
+    LoadWowlabs: 44
+    Mapping: 56
+    Mounts: 6
+    OutstandingRpc: 43
+    PerkItemHold: 39
+    PerkPastRewards: 41
+    PerkPendingRewards: 40
+    PerkTransaction: 42
+    PlayerDataElements: 52
+    Productitem: 21
+    Profile: 61
+    ProxyCreateAccountHonor: 34
+    ProxyForwarder: 0
+    ProxyGenerateBpayID: 37
+    ProxyGmSetHonor: 36
+    ProxyHonorInitialConversion: 33
+    ProxyValidateAccountHonor: 35
+    Purchase: 1
+    Purchases: 8
+    QuestCriteria: 24
+    QuestLog: 12
+    RafActivity: 31
+    RafFriendMonth: 28
+    RafRecruiterAcceptances: 27
+    RafReward: 29
+    SaveWarbandGroups: 60
+    Settings: 14
+    TransmogOutfitCollection: 65
+    TrialBoostHistories: 23
+    TrialBoostHistory: 22
+    UpgradeAccount: 45
+    VasTransaction: 20
+    WarbandGroups: 55
+    WarbandSceneCollection: 62
 ActionBarOrientation:
-  Horizontal: 0
-  Vertical: 1
+  values:
+    Horizontal: 0
+    Vertical: 1
 ActionBarVisibleSetting:
-  Always: 0
-  Hidden: 3
-  InCombat: 1
-  OutOfCombat: 2
+  values:
+    Always: 0
+    Hidden: 3
+    InCombat: 1
+    OutOfCombat: 2
 AddOnEnableState:
-  All: 2
-  None: 0
-  Some: 1
+  values:
+    All: 2
+    None: 0
+    Some: 1
 AddOnPerformanceMessageType:
-  OverallAddOnErrorDialog: 2
-  SpecificAddOnChatWarning: 0
-  SpecificAddOnErrorDialog: 1
+  values:
+    OverallAddOnErrorDialog: 2
+    SpecificAddOnChatWarning: 0
+    SpecificAddOnErrorDialog: 1
 AddOnProfilerMetric:
-  CountTimeOver1000Ms: 11
-  CountTimeOver100Ms: 9
-  CountTimeOver10Ms: 7
-  CountTimeOver1Ms: 5
-  CountTimeOver500Ms: 10
-  CountTimeOver50Ms: 8
-  CountTimeOver5Ms: 6
-  EncounterAverageTime: 2
-  LastTime: 3
-  PeakTime: 4
-  RecentAverageTime: 1
-  SessionAverageTime: 0
+  values:
+    CountTimeOver1000Ms: 11
+    CountTimeOver100Ms: 9
+    CountTimeOver10Ms: 7
+    CountTimeOver1Ms: 5
+    CountTimeOver500Ms: 10
+    CountTimeOver50Ms: 8
+    CountTimeOver5Ms: 6
+    EncounterAverageTime: 2
+    LastTime: 3
+    PeakTime: 4
+    RecentAverageTime: 1
+    SessionAverageTime: 0
 AddOnRestrictionState:
-  Activating: 1
-  Active: 2
-  Inactive: 0
+  values:
+    Activating: 1
+    Active: 2
+    Inactive: 0
 AddOnRestrictionType:
-  ChallengeMode: 2
-  Chat: 5
-  Combat: 0
-  Encounter: 1
-  Map: 4
-  PvPMatch: 3
+  values:
+    ChallengeMode: 2
+    Chat: 5
+    Combat: 0
+    Encounter: 1
+    Map: 4
+    PvPMatch: 3
 AddOnSecurityStatus:
-  Banned: 2
-  Insecure: 1
-  NotAvailable: 3
-  Secure: 0
+  values:
+    Banned: 2
+    Insecure: 1
+    NotAvailable: 3
+    Secure: 0
 AddSoulbindConduitReason:
-  Cheat: 1
-  None: 0
-  SpellEffect: 2
-  Upgrade: 3
+  values:
+    Cheat: 1
+    None: 0
+    SpellEffect: 2
+    Upgrade: 3
 AnimaDiversionNodeState:
-  Available: 1
-  Cooldown: 4
-  SelectedPermanent: 3
-  SelectedTemporary: 2
-  Unavailable: 0
+  values:
+    Available: 1
+    Cooldown: 4
+    SelectedPermanent: 3
+    SelectedTemporary: 2
+    Unavailable: 0
 ArrowCalloutDirection:
-  Down: 1
-  Left: 2
-  Right: 3
-  Up: 0
+  values:
+    Down: 1
+    Left: 2
+    Right: 3
+    Up: 0
 ArrowCalloutType:
-  Generic: 1
-  None: 0
-  Tutorial: 3
-  WidgetContainerNoBorder: 4
-  WorldLootObject: 2
+  values:
+    Generic: 1
+    None: 0
+    Tutorial: 3
+    WidgetContainerNoBorder: 4
+    WorldLootObject: 2
 AssistActionType:
-  CapturedBuff: 6
-  GraveMarker: 2
-  LoungingPlayer: 1
-  None: 0
-  PlacedVo: 3
-  PlayerGuardian: 4
-  PlayerSlayer: 5
+  values:
+    CapturedBuff: 6
+    GraveMarker: 2
+    LoungingPlayer: 1
+    None: 0
+    PlacedVo: 3
+    PlayerGuardian: 4
+    PlayerSlayer: 5
 AuctionHouseCommoditySortOrder:
-  Quantity: 1
-  UnitPrice: 0
+  values:
+    Quantity: 1
+    UnitPrice: 0
 AuctionHouseError:
-  BidIncrement: 2
-  BidOwn: 3
-  BoundItem: 16
-  ConjuredItem: 17
-  DatabaseError: 10
-  DoubleBid: 23
-  EquippedBag: 20
-  FavoritesMaxed: 24
-  HasRestriction: 6
-  HigherBid: 1
-  IsBag: 19
-  IsBusy: 7
-  ItemBoundToAccountUntilEquip: 26
-  ItemHasQuote: 9
-  ItemNotAvailable: 25
-  ItemNotFound: 4
-  LimitedDurationItem: 18
-  LootItem: 22
-  MinBid: 11
-  NotEnoughItems: 12
-  NotEnoughMoney: 0
-  QuestItem: 15
-  RepairItem: 13
-  RestrictedAccountTrial: 5
-  Unavailable: 8
-  UsedCharges: 14
-  WrappedItem: 21
+  values:
+    BidIncrement: 2
+    BidOwn: 3
+    BoundItem: 16
+    ConjuredItem: 17
+    DatabaseError: 10
+    DoubleBid: 23
+    EquippedBag: 20
+    FavoritesMaxed: 24
+    HasRestriction: 6
+    HigherBid: 1
+    IsBag: 19
+    IsBusy: 7
+    ItemBoundToAccountUntilEquip: 26
+    ItemHasQuote: 9
+    ItemNotAvailable: 25
+    ItemNotFound: 4
+    LimitedDurationItem: 18
+    LootItem: 22
+    MinBid: 11
+    NotEnoughItems: 12
+    NotEnoughMoney: 0
+    QuestItem: 15
+    RepairItem: 13
+    RestrictedAccountTrial: 5
+    Unavailable: 8
+    UsedCharges: 14
+    WrappedItem: 21
 AuctionHouseExtraColumn:
-  Ilvl: 1
-  Level: 3
-  None: 0
-  Skill: 4
-  Slots: 2
+  values:
+    Ilvl: 1
+    Level: 3
+    None: 0
+    Skill: 4
+    Slots: 2
 AuctionHouseFilter:
-  ArtifactQuality: 12
-  CommonQuality: 7
-  CurrentExpansionOnly: 3
-  EpicQuality: 10
-  ExactMatch: 5
-  LegendaryCraftedItemOnly: 13
-  LegendaryQuality: 11
-  None: 0
-  PoorQuality: 6
-  RareQuality: 9
-  UncollectedOnly: 1
-  UncommonQuality: 8
-  UpgradesOnly: 4
-  UsableOnly: 2
+  values:
+    ArtifactQuality: 12
+    CommonQuality: 7
+    CurrentExpansionOnly: 3
+    EpicQuality: 10
+    ExactMatch: 5
+    LegendaryCraftedItemOnly: 13
+    LegendaryQuality: 11
+    None: 0
+    PoorQuality: 6
+    RareQuality: 9
+    UncollectedOnly: 1
+    UncommonQuality: 8
+    UpgradesOnly: 4
+    UsableOnly: 2
 AuctionHouseFilterCategory:
-  Equipment: 1
-  Rarity: 2
-  Uncategorized: 0
+  values:
+    Equipment: 1
+    Rarity: 2
+    Uncategorized: 0
 AuctionHouseItemSortOrder:
-  Bid: 0
-  Buyout: 1
+  values:
+    Bid: 0
+    Buyout: 1
 AuctionHouseNotification:
-  AuctionExpired: 5
-  AuctionOutbid: 3
-  AuctionRemoved: 1
-  AuctionSold: 4
-  AuctionWon: 2
-  BidPlaced: 0
+  values:
+    AuctionExpired: 5
+    AuctionOutbid: 3
+    AuctionRemoved: 1
+    AuctionSold: 4
+    AuctionWon: 2
+    BidPlaced: 0
 AuctionHouseSortOrder:
-  Bid: 3
-  Buyout: 4
-  Level: 2
-  Name: 1
-  Price: 0
-  TimeRemaining: 5
+  values:
+    Bid: 3
+    Buyout: 4
+    Level: 2
+    Name: 1
+    Price: 0
+    TimeRemaining: 5
 AuctionHouseTimeLeftBand:
-  Long: 2
-  Medium: 1
-  Short: 0
-  VeryLong: 3
+  values:
+    Long: 2
+    Medium: 1
+    Short: 0
+    VeryLong: 3
 AuctionStatus:
-  Active: 0
-  Sold: 1
+  values:
+    Active: 0
+    Sold: 1
 AuraFrameIconDirection:
-  Down: 0
-  Left: 0
-  Right: 1
-  Up: 1
+  values:
+    Down: 0
+    Left: 0
+    Right: 1
+    Up: 1
 AuraFrameIconWrap:
-  Down: 0
-  Left: 0
-  Right: 1
-  Up: 1
+  values:
+    Down: 0
+    Left: 0
+    Right: 1
+    Up: 1
 AuraFrameOrientation:
-  Horizontal: 0
-  Vertical: 1
+  values:
+    Horizontal: 0
+    Vertical: 1
 AuraFrameVisibleSetting:
-  Always: 0
-  Hidden: 2
-  InCombat: 1
+  values:
+    Always: 0
+    Hidden: 2
+    InCombat: 1
 AutoCompleteEntryFlag:
-  AccountCharacter: 128
-  Bnet: 8
-  Friend: 4
-  InAOI: 64
-  InGroup: 1
-  InGuild: 2
-  InteractedWith: 16
-  Online: 32
-  RecentPlayer: 256
+  values:
+    AccountCharacter: 128
+    Bnet: 8
+    Friend: 4
+    InAOI: 64
+    InGroup: 1
+    InGuild: 2
+    InteractedWith: 16
+    Online: 32
+    RecentPlayer: 256
 AutoCompletePriority:
-  AccountCharacter: 5
-  AccountCharacterSameRealm: 6
-  Friend: 4
-  Guild: 3
-  InGroup: 2
-  Interacted: 1
-  Other: 0
+  values:
+    AccountCharacter: 5
+    AccountCharacterSameRealm: 6
+    Friend: 4
+    Guild: 3
+    InGroup: 2
+    Interacted: 1
+    Other: 0
 AvgItemLevelCategories:
-  Base: 0
-  EquippedBase: 1
-  EquippedEffective: 2
-  EquippedEffectiveWeighted: 5
-  PvP: 3
-  PvPWeighted: 4
+  values:
+    Base: 0
+    EquippedBase: 1
+    EquippedEffective: 2
+    EquippedEffectiveWeighted: 5
+    PvP: 3
+    PvPWeighted: 4
 AzeriteEssenceSlot:
-  MainSlot: 0
-  PassiveOneSlot: 1
-  PassiveThreeSlot: 3
-  PassiveTwoSlot: 2
+  values:
+    MainSlot: 0
+    PassiveOneSlot: 1
+    PassiveThreeSlot: 3
+    PassiveTwoSlot: 2
 AzeritePowerLevel:
-  Base: 0
-  Downgraded: 2
-  Upgraded: 1
+  values:
+    Base: 0
+    Downgraded: 2
+    Upgraded: 1
 BagFlag:
-  AllowBagsInNonBagSlots: 1024
-  AllowBuyback: 65536
-  AllowPartialStack: 16384
-  AllowSoulboundItemInAccountBank: 134217728
-  AlreadyBound: 4
-  AlreadyOwner: 2
-  AsymmetricSwap: 1048576
-  BagIsEmpty: 16
-  DontFindStack: 1
-  HasRefund: 33554432
-  IgnoreBankcheck: 512
-  IgnoreBoundItemCheck: 64
-  IgnoreExisting: 8192
-  IgnorePetBankcheck: 131072
-  IgnoreReagentBags: 8388608
-  IgnoreSoulbound: 4194304
-  LookInAccountBankOnly: 16777216
-  LookInCharacterBankOnly: 32768
-  LookInInventory: 32
-  PreferNeutralPriorityBags: 524288
-  PreferPriorityBags: 262144
-  PreferQuivers: 2048
-  PreferReagentBags: 2097152
-  RecurseQuivers: 256
-  SkipValidCountCheck: 67108864
-  StackOnly: 128
-  Swap: 8
-  SwapBags: 4096
+  values:
+    AllowBagsInNonBagSlots: 1024
+    AllowBuyback: 65536
+    AllowPartialStack: 16384
+    AllowSoulboundItemInAccountBank: 134217728
+    AlreadyBound: 4
+    AlreadyOwner: 2
+    AsymmetricSwap: 1048576
+    BagIsEmpty: 16
+    DontFindStack: 1
+    HasRefund: 33554432
+    IgnoreBankcheck: 512
+    IgnoreBoundItemCheck: 64
+    IgnoreExisting: 8192
+    IgnorePetBankcheck: 131072
+    IgnoreReagentBags: 8388608
+    IgnoreSoulbound: 4194304
+    LookInAccountBankOnly: 16777216
+    LookInCharacterBankOnly: 32768
+    LookInInventory: 32
+    PreferNeutralPriorityBags: 524288
+    PreferPriorityBags: 262144
+    PreferQuivers: 2048
+    PreferReagentBags: 2097152
+    RecurseQuivers: 256
+    SkipValidCountCheck: 67108864
+    StackOnly: 128
+    Swap: 8
+    SwapBags: 4096
 BagIndex:
-  Accountbanktab: -3
-  AccountBankTab_1: 12
-  AccountBankTab_2: 13
-  AccountBankTab_3: 14
-  AccountBankTab_4: 15
-  AccountBankTab_5: 16
-  Backpack: 0
-  Bag_1: 1
-  Bag_2: 2
-  Bag_3: 3
-  Bag_4: 4
-  Characterbanktab: -2
-  CharacterBankTab_1: 6
-  CharacterBankTab_2: 7
-  CharacterBankTab_3: 8
-  CharacterBankTab_4: 9
-  CharacterBankTab_5: 10
-  CharacterBankTab_6: 11
-  Keyring: -1
-  ReagentBag: 5
+  values:
+    Accountbanktab: -3
+    AccountBankTab_1: 12
+    AccountBankTab_2: 13
+    AccountBankTab_3: 14
+    AccountBankTab_4: 15
+    AccountBankTab_5: 16
+    Backpack: 0
+    Bag_1: 1
+    Bag_2: 2
+    Bag_3: 3
+    Bag_4: 4
+    Characterbanktab: -2
+    CharacterBankTab_1: 6
+    CharacterBankTab_2: 7
+    CharacterBankTab_3: 8
+    CharacterBankTab_4: 9
+    CharacterBankTab_5: 10
+    CharacterBankTab_6: 11
+    Keyring: -1
+    ReagentBag: 5
 BagsDirection:
-  Down: 1
-  Left: 0
-  Right: 1
-  Up: 0
+  values:
+    Down: 1
+    Left: 0
+    Right: 1
+    Up: 0
 BagSlotFlags:
-  ClassConsumables: 4
-  ClassEquipment: 2
-  ClassJunk: 16
-  ClassProfessionGoods: 8
-  ClassQuestItems: 32
-  ClassReagents: 128
-  DisableAutoSort: 1
-  ExcludeJunkSell: 64
-  ExpansionCurrent: 256
-  ExpansionLegacy: 512
+  values:
+    ClassConsumables: 4
+    ClassEquipment: 2
+    ClassJunk: 16
+    ClassProfessionGoods: 8
+    ClassQuestItems: 32
+    ClassReagents: 128
+    DisableAutoSort: 1
+    ExcludeJunkSell: 64
+    ExpansionCurrent: 256
+    ExpansionLegacy: 512
 BagsOrientation:
-  Horizontal: 0
-  Vertical: 1
+  values:
+    Horizontal: 0
+    Vertical: 1
 BalanceType:
-  Eclipse: 0
-  None: -1
+  values:
+    Eclipse: 0
+    None: -1
 BankLockedReason:
-  BankConversionFailed: 3
-  BankDisabled: 2
-  NoAccountInventoryLock: 1
-  None: 0
+  values:
+    BankConversionFailed: 3
+    BankDisabled: 2
+    NoAccountInventoryLock: 1
+    None: 0
 BankType:
-  Account: 2
-  Character: 0
-  Guild: 1
+  values:
+    Account: 2
+    Character: 0
+    Guild: 1
 Base64Variant:
-  Standard: 0
-  StandardUrlSafe: 1
+  values:
+    Standard: 0
+    StandardUrlSafe: 1
 BattlepayBannerType:
-  Discount: 1
-  Featured: 2
-  New: 3
-  None: 0
+  values:
+    Discount: 1
+    Featured: 2
+    New: 3
+    None: 0
 BattlepayCardType:
-  FullCardWithBuyButton: 4
-  FullCardWithNydusLinkButton: 8
-  LargeHorizontalCard: 2
-  LargeHorizontalCardWithBuyButton: 6
-  LargeVeritcalCard: 3
-  LargeVeritcalCardWithBuyButton: 7
-  LargeVeritcalPageableCardWithBuyButton: 9
-  MediumCard: 1
-  MediumCardWithBuyButton: 5
-  SmallCard: 0
+  values:
+    FullCardWithBuyButton: 4
+    FullCardWithNydusLinkButton: 8
+    LargeHorizontalCard: 2
+    LargeHorizontalCardWithBuyButton: 6
+    LargeVeritcalCard: 3
+    LargeVeritcalCardWithBuyButton: 7
+    LargeVeritcalPageableCardWithBuyButton: 9
+    MediumCard: 1
+    MediumCardWithBuyButton: 5
+    SmallCard: 0
 BattlepayDisplayFlags:
-  CardAlwaysShowsTexture: 4
-  CardDoesNotShowModel: 2
-  Deprecated1: 32
-  Deprecated2: 64
-  Expansion: 1
-  HiddenPrice: 8
-  HideWhenOwned: 256
-  RafReward: 512
-  ShowFancyToast: 1024
-  UseHorizontalLayoutForFullCard: 16
-  UseIconBorderWithOverrideTexture: 2048
-  UseSquareIconBorder: 128
+  values:
+    CardAlwaysShowsTexture: 4
+    CardDoesNotShowModel: 2
+    Deprecated1: 32
+    Deprecated2: 64
+    Expansion: 1
+    HiddenPrice: 8
+    HideWhenOwned: 256
+    RafReward: 512
+    ShowFancyToast: 1024
+    UseHorizontalLayoutForFullCard: 16
+    UseIconBorderWithOverrideTexture: 2048
+    UseSquareIconBorder: 128
 BattlepayGroupDisplayType:
-  ActiveTimeOnly: 2
-  Everyone: 0
-  TrialAndVeteranOnly: 1
+  values:
+    ActiveTimeOnly: 2
+    Everyone: 0
+    TrialAndVeteranOnly: 1
 BattlepayLicenseSynthesisFlags:
-  ForceToGameAccount: 1
+  values:
+    ForceToGameAccount: 1
 BattlepayProductChoiceType:
-  ChoiceNone: 0
-  ChoiceOne: 1
-  SpecAndFaction: 2
-  VasCharacter: 3
-  VasCharacterAndName: 4
+  values:
+    ChoiceNone: 0
+    ChoiceOne: 1
+    SpecAndFaction: 2
+    VasCharacter: 3
+    VasCharacterAndName: 4
 BattlepayProductDecorator:
-  Boost: 0
-  Expansion: 1
-  VasService: 3
-  WoWToken: 2
+  values:
+    Boost: 0
+    Expansion: 1
+    VasService: 3
+    WoWToken: 2
 BattlepayProductGroupFlags:
-  DisableOwnedProducts: 4
-  EnabledForTrial: 2
-  EnabledForVeteran: 8
-  HideOwnedProducts: 1
-  None: 0
+  values:
+    DisableOwnedProducts: 4
+    EnabledForTrial: 2
+    EnabledForVeteran: 8
+    HideOwnedProducts: 1
+    None: 0
 BattlepayShopEntryBannerType:
-  Discount: 1
-  Featured: 0
-  New: 2
+  values:
+    Discount: 1
+    Featured: 0
+    New: 2
 BattlepayShopEntryFlags:
-  None: 0
+  values:
+    None: 0
 BattlePetAction:
-  Ability: 1
-  None: 0
-  Skip: 4
-  SwitchPet: 2
-  Trap: 3
+  values:
+    Ability: 1
+    None: 0
+    Skip: 4
+    SwitchPet: 2
+    Trap: 3
 BattlePetBreedQuality:
-  Common: 1
-  Epic: 4
-  Legendary: 5
-  Poor: 0
-  Rare: 3
-  Uncommon: 2
+  values:
+    Common: 1
+    Epic: 4
+    Legendary: 5
+    Poor: 0
+    Rare: 3
+    Uncommon: 2
 BattlePetOwner:
-  Ally: 1
-  Enemy: 2
-  Weather: 0
+  values:
+    Ally: 1
+    Enemy: 2
+    Weather: 0
 BattlePetSources:
-  Achievement: 5
-  Discovery: 10
-  Drop: 0
-  PetStore: 9
-  Profession: 3
-  Promotion: 7
-  Quest: 1
-  Tcg: 8
-  TradingPost: 11
-  Vendor: 2
-  WildPet: 4
-  WorldEvent: 6
+  values:
+    Achievement: 5
+    Discovery: 10
+    Drop: 0
+    PetStore: 9
+    Profession: 3
+    Promotion: 7
+    Quest: 1
+    Tcg: 8
+    TradingPost: 11
+    Vendor: 2
+    WildPet: 4
+    WorldEvent: 6
 BindingContext:
-  HousingEditor: 1
-  HousingEditorBasicAndExpertDecorMode: 7
-  HousingEditorBasicDecorMode: 2
-  HousingEditorCleanupMode: 5
-  HousingEditorCustomizeMode: 4
-  HousingEditorExpertDecorMode: 3
-  HousingEditorExteriorCustomizationMode: 8
-  HousingEditorLayoutMode: 6
-  None: 0
-  ReservedFutureFeatureBinding01: 9
+  values:
+    HousingEditor: 1
+    HousingEditorBasicAndExpertDecorMode: 7
+    HousingEditorBasicDecorMode: 2
+    HousingEditorCleanupMode: 5
+    HousingEditorCustomizeMode: 4
+    HousingEditorExpertDecorMode: 3
+    HousingEditorExteriorCustomizationMode: 8
+    HousingEditorLayoutMode: 6
+    None: 0
+    ReservedFutureFeatureBinding01: 9
 BindingSet:
-  Account: 1
-  Character: 2
-  Current: 3
-  Default: 0
+  values:
+    Account: 1
+    Character: 2
+    Current: 3
+    Default: 0
 BnetAccountFlag:
-  AccountQuestBitFixUp: 64
-  AchievementsToBi: 128
-  BattlePetTrainer: 1
-  CanBuyAhGameTimeTokens: 32768
-  CataLegendaryMountChecked: 262144
-  CataLegendaryMountObtained: 524288
-  DarkRealmLightCopy: 2048
-  Employee: 16
-  EmployeeFlagIsManual: 32
-  GdprErased: 1024
-  InvalidTransmogsFixUp: 256
-  InvalidTransmogsFixUp2: 512
-  IsLegacy: 131072
-  LockedForExport: 16384
-  MopQuestLogFlagsFixUp: 1048576
-  None: 0
-  PetAchievementFixUp: 65536
-  QuestLogFlagsFixUp: 4096
-  RafVeteranNotified: 2
-  TwitterHasTempSecret: 8
-  TwitterLinked: 4
-  WasSecured: 8192
+  values:
+    AccountQuestBitFixUp: 64
+    AchievementsToBi: 128
+    BattlePetTrainer: 1
+    CanBuyAhGameTimeTokens: 32768
+    CataLegendaryMountChecked: 262144
+    CataLegendaryMountObtained: 524288
+    DarkRealmLightCopy: 2048
+    Employee: 16
+    EmployeeFlagIsManual: 32
+    GdprErased: 1024
+    InvalidTransmogsFixUp: 256
+    InvalidTransmogsFixUp2: 512
+    IsLegacy: 131072
+    LockedForExport: 16384
+    MopQuestLogFlagsFixUp: 1048576
+    None: 0
+    PetAchievementFixUp: 65536
+    QuestLogFlagsFixUp: 4096
+    RafVeteranNotified: 2
+    TwitterHasTempSecret: 8
+    TwitterLinked: 4
+    WasSecured: 8192
 BonusStatIndex:
-  Agility: 3
-  AgilityOrIntellect: 73
-  AgilityOrStrength: 72
-  AgilityOrStrengthOrIntellect: 71
-  ArcaneResistance: 56
-  AttackPower: 38
-  BlockRating: 15
-  BlockValueObsolete: 48
-  CombatRatingAvoidance: 63
-  CombatRatingLifesteal: 62
-  CombatRatingSpeed: 61
-  CombatRatingSturdiness: 64
-  CombatRatingUnused_0: 58
-  CombatRatingUnused_10: 68
-  CombatRatingUnused_11: 69
-  CombatRatingUnused_12: 70
-  CombatRatingUnused_2: 59
-  CombatRatingUnused_27: 66
-  CombatRatingUnused_3: 60
-  CombatRatingUnused_7: 65
-  CombatRatingUnused_9: 67
-  Corruption: 22
-  CorruptionResistance: 23
-  CritMeleeRating: 19
-  CritRangedRating: 20
-  CritRating: 32
-  CritSpellRating: 21
-  CritTakenRangedRatingObsolete: 26
-  CritTakenRatingObsolete: 34
-  CritTakenSpellRatingObsolete: 27
-  DefenseSkillRating: 12
-  DodgeRating: 13
-  Endurance: 2
-  Energy: 8
-  ExpertiseRating: 37
-  ExtraArmor: 50
-  FireResistance: 51
-  Focus: 10
-  FrostResistance: 52
-  HasteMeleeRatingObsolete: 28
-  HasteRangedRatingObsolete: 29
-  HasteRating: 36
-  HasteSpellRatingObsolete: 30
-  Health: 1
-  HealthRegen: 46
-  HitMeleeRating: 16
-  HitRangedRating: 17
-  HitRating: 31
-  HitSpellRating: 18
-  HitTakenRatingObsolete: 33
-  HolyResistance: 53
-  Intellect: 5
-  Mana: 0
-  ManaRegenerationObsolete: 43
-  MasteryRating: 49
-  ModifiedCraftingStat_1: 24
-  ModifiedCraftingStat_2: 25
-  NatureResistance: 55
-  ParryRating: 14
-  ProfessionCraftingSpeed: 80
-  ProfessionDeftness: 78
-  ProfessionFinesse: 77
-  ProfessionIngenuity: 82
-  ProfessionInspiration: 75
-  ProfessionMulticraft: 81
-  ProfessionPerception: 79
-  ProfessionResourcefulness: 76
-  PvPPower: 57
-  Rage: 9
-  RangedAttackPower: 39
-  ResilienceRating: 35
-  ShadowResistance: 54
-  SpellDamageDone: 42
-  SpellHealingDone: 41
-  SpellPenetration: 47
-  SpellPower: 45
-  Spirit: 6
-  Stamina: 7
-  Strength: 4
-  StrengthOrIntellect: 74
-  Unused: 44
-  Versatility: 40
-  WeaponSkillRatingObsolete: 11
+  values:
+    Agility: 3
+    AgilityOrIntellect: 73
+    AgilityOrStrength: 72
+    AgilityOrStrengthOrIntellect: 71
+    ArcaneResistance: 56
+    AttackPower: 38
+    BlockRating: 15
+    BlockValueObsolete: 48
+    CombatRatingAvoidance: 63
+    CombatRatingLifesteal: 62
+    CombatRatingSpeed: 61
+    CombatRatingSturdiness: 64
+    CombatRatingUnused_0: 58
+    CombatRatingUnused_10: 68
+    CombatRatingUnused_11: 69
+    CombatRatingUnused_12: 70
+    CombatRatingUnused_2: 59
+    CombatRatingUnused_27: 66
+    CombatRatingUnused_3: 60
+    CombatRatingUnused_7: 65
+    CombatRatingUnused_9: 67
+    Corruption: 22
+    CorruptionResistance: 23
+    CritMeleeRating: 19
+    CritRangedRating: 20
+    CritRating: 32
+    CritSpellRating: 21
+    CritTakenRangedRatingObsolete: 26
+    CritTakenRatingObsolete: 34
+    CritTakenSpellRatingObsolete: 27
+    DefenseSkillRating: 12
+    DodgeRating: 13
+    Endurance: 2
+    Energy: 8
+    ExpertiseRating: 37
+    ExtraArmor: 50
+    FireResistance: 51
+    Focus: 10
+    FrostResistance: 52
+    HasteMeleeRatingObsolete: 28
+    HasteRangedRatingObsolete: 29
+    HasteRating: 36
+    HasteSpellRatingObsolete: 30
+    Health: 1
+    HealthRegen: 46
+    HitMeleeRating: 16
+    HitRangedRating: 17
+    HitRating: 31
+    HitSpellRating: 18
+    HitTakenRatingObsolete: 33
+    HolyResistance: 53
+    Intellect: 5
+    Mana: 0
+    ManaRegenerationObsolete: 43
+    MasteryRating: 49
+    ModifiedCraftingStat_1: 24
+    ModifiedCraftingStat_2: 25
+    NatureResistance: 55
+    ParryRating: 14
+    ProfessionCraftingSpeed: 80
+    ProfessionDeftness: 78
+    ProfessionFinesse: 77
+    ProfessionIngenuity: 82
+    ProfessionInspiration: 75
+    ProfessionMulticraft: 81
+    ProfessionPerception: 79
+    ProfessionResourcefulness: 76
+    PvPPower: 57
+    Rage: 9
+    RangedAttackPower: 39
+    ResilienceRating: 35
+    ShadowResistance: 54
+    SpellDamageDone: 42
+    SpellHealingDone: 41
+    SpellPenetration: 47
+    SpellPower: 45
+    Spirit: 6
+    Stamina: 7
+    Strength: 4
+    StrengthOrIntellect: 74
+    Unused: 44
+    Versatility: 40
+    WeaponSkillRatingObsolete: 11
 BrawlType:
-  Arena: 2
-  Battleground: 1
-  LFG: 3
-  None: 0
-  SoloRbg: 5
-  SoloShuffle: 4
+  values:
+    Arena: 2
+    Battleground: 1
+    LFG: 3
+    None: 0
+    SoloRbg: 5
+    SoloShuffle: 4
 BulkPurchaseResult:
-  ResultFailed: 3
-  ResultInProgress: 1
-  ResultInsufficientFunds: 6
-  ResultOk: 0
-  ResultPartialSuccess: 2
-  ResultPurchaseTimeout: 7
-  ResultSystemDisabled: 5
-  ResultTooManyProducts: 4
+  values:
+    ResultFailed: 3
+    ResultInProgress: 1
+    ResultInsufficientFunds: 6
+    ResultOk: 0
+    ResultPartialSuccess: 2
+    ResultPurchaseTimeout: 7
+    ResultSystemDisabled: 5
+    ResultTooManyProducts: 4
 BulkPurchaseStatus:
-  Done: 3
-  Failed: 4
-  FetchEntitlements: 2
-  PlacingOrders: 0
-  PurchasesPending: 1
+  values:
+    Done: 3
+    Failed: 4
+    FetchEntitlements: 2
+    PlacingOrders: 0
+    PurchasesPending: 1
 BulkRefundResult:
-  ResultFailed: 1
-  ResultInvalidRequest: 2
-  ResultOk: 0
-  ResultRefundWindowExpired: 3
-  ResultSystemDisabled: 4
-  ResultTimeout: 5
+  values:
+    ResultFailed: 1
+    ResultInvalidRequest: 2
+    ResultOk: 0
+    ResultRefundWindowExpired: 3
+    ResultSystemDisabled: 4
+    ResultTimeout: 5
 CachedRewardType:
-  Currency: 2
-  Item: 1
-  None: 0
-  Quest: 3
+  values:
+    Currency: 2
+    Item: 1
+    None: 0
+    Quest: 3
 CalendarCommandType:
-  Complain: 10
-  Create: 0
-  GetCalendar: 7
-  GetEvent: 8
-  Invite: 1
-  ModeratorStatus: 6
-  Notes: 11
-  RemoveEvent: 4
-  RemoveInvite: 3
-  Rsvp: 2
-  Status: 5
-  UpdateEvent: 9
+  values:
+    Complain: 10
+    Create: 0
+    GetCalendar: 7
+    GetEvent: 8
+    Invite: 1
+    ModeratorStatus: 6
+    Notes: 11
+    RemoveEvent: 4
+    RemoveInvite: 3
+    Rsvp: 2
+    Status: 5
+    UpdateEvent: 9
 CalendarErrorType:
-  ArenaEventsExceeded: 27
-  CalendarDisabled: 25
-  CommunityEventsExceeded: 1
-  ComplaintAdded: 50
-  ComplaintDisabled: 31
-  ComplaintGm: 34
-  ComplaintLimit: 35
-  ComplaintNotFound: 36
-  ComplaintSameGuild: 33
-  ComplaintSelf: 32
-  CreatorNotFound: 46
-  DataAlreadySet: 24
-  DeleteCreatorFailed: 23
-  EventInvalid: 6
-  EventLocked: 22
-  EventPassed: 21
-  EventsExceeded: 2
-  EventThrottled: 47
-  EventWrongServer: 37
-  Ignored: 14
-  Internal: 49
-  InvalidClub: 45
-  InvalidDate: 17
-  InvalidDescription: 44
-  InvalidMaxSize: 16
-  InvalidNotes: 42
-  InvalidSignup: 39
-  InvalidTime: 18
-  InvalidTitle: 43
-  InvitesExceeded: 15
-  InviteThrottled: 48
-  ModeratorRestricted: 41
-  NameNotFound: 12
-  NeedsTitle: 20
-  NoCommunityInvites: 38
-  NoInvite: 30
-  NoInvites: 19
-  NoModerator: 40
-  NoPermission: 5
-  NotInCommunity: 10
-  NotInGuild: 9
-  NotInvited: 7
-  OtherInvitesExceeded: 4
-  RestrictedAccount: 26
-  RestrictedLevel: 28
-  SelfInvitesExceeded: 3
-  Squelched: 29
-  Success: 0
-  TargetAlreadyInvited: 11
-  UnknownError: 8
-  WrongFaction: 13
+  values:
+    ArenaEventsExceeded: 27
+    CalendarDisabled: 25
+    CommunityEventsExceeded: 1
+    ComplaintAdded: 50
+    ComplaintDisabled: 31
+    ComplaintGm: 34
+    ComplaintLimit: 35
+    ComplaintNotFound: 36
+    ComplaintSameGuild: 33
+    ComplaintSelf: 32
+    CreatorNotFound: 46
+    DataAlreadySet: 24
+    DeleteCreatorFailed: 23
+    EventInvalid: 6
+    EventLocked: 22
+    EventPassed: 21
+    EventsExceeded: 2
+    EventThrottled: 47
+    EventWrongServer: 37
+    Ignored: 14
+    Internal: 49
+    InvalidClub: 45
+    InvalidDate: 17
+    InvalidDescription: 44
+    InvalidMaxSize: 16
+    InvalidNotes: 42
+    InvalidSignup: 39
+    InvalidTime: 18
+    InvalidTitle: 43
+    InvitesExceeded: 15
+    InviteThrottled: 48
+    ModeratorRestricted: 41
+    NameNotFound: 12
+    NeedsTitle: 20
+    NoCommunityInvites: 38
+    NoInvite: 30
+    NoInvites: 19
+    NoModerator: 40
+    NoPermission: 5
+    NotInCommunity: 10
+    NotInGuild: 9
+    NotInvited: 7
+    OtherInvitesExceeded: 4
+    RestrictedAccount: 26
+    RestrictedLevel: 28
+    SelfInvitesExceeded: 3
+    Squelched: 29
+    Success: 0
+    TargetAlreadyInvited: 11
+    UnknownError: 8
+    WrongFaction: 13
 CalendarEventBits:
-  ArenaDeprecated: 256
-  AutoApprove: 32
-  CantComplain: 3788
-  CommunityAnnouncement: 64
-  CommunitySignup: 1024
-  CommunityWide: 3136
-  GuildDeprecated: 2
-  GuildSignup: 2048
-  Holiday: 8
-  Locked: 16
-  Player: 1
-  PlayerCreated: 3395
-  RaidLockout: 128
-  RaidResetDeprecated: 512
-  System: 4
+  values:
+    ArenaDeprecated: 256
+    AutoApprove: 32
+    CantComplain: 3788
+    CommunityAnnouncement: 64
+    CommunitySignup: 1024
+    CommunityWide: 3136
+    GuildDeprecated: 2
+    GuildSignup: 2048
+    Holiday: 8
+    Locked: 16
+    Player: 1
+    PlayerCreated: 3395
+    RaidLockout: 128
+    RaidResetDeprecated: 512
+    System: 4
 CalendarEventRepeatOptions:
-  Biweekly: 2
-  Monthly: 3
-  Never: 0
-  Weekly: 1
+  values:
+    Biweekly: 2
+    Monthly: 3
+    Never: 0
+    Weekly: 1
 CalendarEventType:
-  Dungeon: 1
-  HeroicDeprecated: 5
-  Meeting: 3
-  Other: 4
-  PvP: 2
-  Raid: 0
+  values:
+    Dungeon: 1
+    HeroicDeprecated: 5
+    Meeting: 3
+    Other: 4
+    PvP: 2
+    Raid: 0
 CalendarFilterFlags:
-  Battleground: 4
-  Darkmoon: 2
-  RaidLockout: 8
-  RaidReset: 16
-  WeeklyHoliday: 1
+  values:
+    Battleground: 4
+    Darkmoon: 2
+    RaidLockout: 8
+    RaidReset: 16
+    WeeklyHoliday: 1
 CalendarGetEventType:
-  Add: 1
-  Copy: 2
-  Get: 0
+  values:
+    Add: 1
+    Copy: 2
+    Get: 0
 CalendarHolidayFilterType:
-  Battleground: 2
-  Darkmoon: 1
-  Weekly: 0
+  values:
+    Battleground: 2
+    Darkmoon: 1
+    Weekly: 0
 CalendarInviteBits:
-  Creator: 4
-  Moderator: 2
-  None: 0
-  PendingInvite: 1
-  Signup: 8
+  values:
+    Creator: 4
+    Moderator: 2
+    None: 0
+    PendingInvite: 1
+    Signup: 8
 CalendarInviteSortType:
-  Class: 2
-  Level: 1
-  Name: 0
-  Notes: 5
-  Party: 4
-  Status: 3
+  values:
+    Class: 2
+    Level: 1
+    Name: 0
+    Notes: 5
+    Party: 4
+    Status: 3
 CalendarInviteType:
-  Normal: 0
-  Signup: 1
+  values:
+    Normal: 0
+    Signup: 1
 CalendarModeratorStatus:
-  Creator: 2
-  Moderator: 1
-  None: 0
+  values:
+    Creator: 2
+    Moderator: 1
+    None: 0
 CalendarStatus:
-  Available: 1
-  Confirmed: 3
-  Declined: 2
-  Invited: 0
-  NotSignedup: 7
-  Out: 4
-  Signedup: 6
-  Standby: 5
-  Tentative: 8
+  values:
+    Available: 1
+    Confirmed: 3
+    Declined: 2
+    Invited: 0
+    NotSignedup: 7
+    Out: 4
+    Signedup: 6
+    Standby: 5
+    Tentative: 8
 CalendarTexturesType:
-  Dungeons: 0
-  Raid: 1
+  values:
+    Dungeons: 0
+    Raid: 1
 CalendarType:
-  Community: 1
-  Holiday: 4
-  HolidayBattleground: 7
-  HolidayDarkmoon: 6
-  HolidayWeekly: 5
-  Player: 0
-  RaidLockout: 2
-  RaidResetDeprecated: 3
+  values:
+    Community: 1
+    Holiday: 4
+    HolidayBattleground: 7
+    HolidayDarkmoon: 6
+    HolidayWeekly: 5
+    Player: 0
+    RaidLockout: 2
+    RaidResetDeprecated: 3
 CalendarWebActionType:
-  Accept: 0
-  Decline: 1
-  Remove: 2
-  ReportSpam: 3
-  Signup: 4
-  Tentative: 5
-  TentativeSignup: 6
+  values:
+    Accept: 0
+    Decline: 1
+    Remove: 2
+    ReportSpam: 3
+    Signup: 4
+    Tentative: 5
+    TentativeSignup: 6
 CallingStates:
-  QuestActive: 1
-  QuestCompleted: 2
-  QuestOffer: 0
+  values:
+    QuestActive: 1
+    QuestCompleted: 2
+    QuestOffer: 0
 CameraModeAspectRatio:
-  Cinemascope_2_Dot_4_X_1: 3
-  Default: 0
-  HighDefinition_16_X_9: 2
-  LegacyLetterbox: 1
+  values:
+    Cinemascope_2_Dot_4_X_1: 3
+    Default: 0
+    HighDefinition_16_X_9: 2
+    LegacyLetterbox: 1
 CampaignState:
-  Complete: 1
-  InProgress: 2
-  Invalid: 0
-  Stalled: 3
+  values:
+    Complete: 1
+    InProgress: 2
+    Invalid: 0
+    Stalled: 3
 CanRedeemTokenForBalanceResult:
-  FailureCap: 1
-  Ok: 0
+  values:
+    FailureCap: 1
+    Ok: 0
 CaptureBarWidgetFillDirectionType:
-  LeftToRight: 1
-  RightToLeft: 0
+  values:
+    LeftToRight: 1
+    RightToLeft: 0
 Causeofdeath:
-  Creature: 3
-  Drowning: 5
-  Falling: 4
-  Fatigue: 6
-  Fire: 9
-  Lava: 8
-  None: 0
-  PlayerDuel: 2
-  PlayerPvP: 1
-  Slime: 7
+  values:
+    Creature: 3
+    Drowning: 5
+    Falling: 4
+    Fatigue: 6
+    Fire: 9
+    Lava: 8
+    None: 0
+    PlayerDuel: 2
+    PlayerPvP: 1
+    Slime: 7
 CauseofdeathFlags:
-  CreatureNameNeeded: 2
-  NoneNeeded: 0
-  PlayerNameNeeded: 1
-  ZoneNameNeeded: 4
+  values:
+    CreatureNameNeeded: 2
+    NoneNeeded: 0
+    PlayerNameNeeded: 1
+    ZoneNameNeeded: 4
 ChallengeModeHistoryFlags:
-  ConfirmedLeaver: 1
-  None: 0
+  values:
+    ConfirmedLeaver: 1
+    None: 0
 ChallengeModeHistoryResult:
-  Leaver: 1
-  Successful: 0
+  values:
+    Leaver: 1
+    Successful: 0
 ChallengeModeHistoryStatus:
-  Leaver: 1
-  Normal: 0
+  values:
+    Leaver: 1
+    Normal: 0
 ChannelPlayerFlags:
-  ChannelPlayerHidden: 8
-  ChannelPlayerModerator: 2
-  ChannelPlayerNone: 0
-  ChannelPlayerOwner: 1
-  ChannelPlayerTextAllow: 4
+  values:
+    ChannelPlayerHidden: 8
+    ChannelPlayerModerator: 2
+    ChannelPlayerNone: 0
+    ChannelPlayerOwner: 1
+    ChannelPlayerTextAllow: 4
 CharacterServiceInfoFlag:
-  AllowMaxLevelBoost: 2
-  RestrictToRecommendedSpecs: 1
+  values:
+    AllowMaxLevelBoost: 2
+    RestrictToRecommendedSpecs: 1
 CharCustomizationType:
-  CustomOptionFacewear: 7
-  CustomOptionHorn: 6
-  CustomOptionTattoo: 5
-  CustomOptionTattooColor: 8
-  Face: 1
-  FacialHair: 4
-  Hair: 2
-  HairColor: 3
-  Skin: 0
+  values:
+    CustomOptionFacewear: 7
+    CustomOptionHorn: 6
+    CustomOptionTattoo: 5
+    CustomOptionTattooColor: 8
+    Face: 1
+    FacialHair: 4
+    Hair: 2
+    HairColor: 3
+    Skin: 0
 ChatChannelRuleset:
-  ChromieTimeBuringCrusade: 4
-  ChromieTimeCataclysm: 3
-  ChromieTimeLegion: 8
-  ChromieTimeMists: 6
-  ChromieTimeWoD: 7
-  ChromieTimeWrath: 5
-  Disabled: 2
-  Mentor: 1
-  None: 0
+  values:
+    ChromieTimeBuringCrusade: 4
+    ChromieTimeCataclysm: 3
+    ChromieTimeLegion: 8
+    ChromieTimeMists: 6
+    ChromieTimeWoD: 7
+    ChromieTimeWrath: 5
+    Disabled: 2
+    Mentor: 1
+    None: 0
 ChatChannelType:
-  Communities: 4
-  Custom: 1
-  None: 0
-  PrivateParty: 2
-  PublicParty: 3
+  values:
+    Communities: 4
+    Custom: 1
+    None: 0
+    PrivateParty: 2
+    PublicParty: 3
 ChatToxityFilterOptOut:
-  ExcludeFilterAll: 4294967295
-  ExcludeFilterFriend: 1
-  ExcludeFilterGuild: 2
-  FilterAll: 0
+  values:
+    ExcludeFilterAll: 4294967295
+    ExcludeFilterFriend: 1
+    ExcludeFilterGuild: 2
+    FilterAll: 0
 ChatWhisperTargetStatus:
-  CanWhisper: 0
-  CanWhisperGuild: 1
-  Offline: 2
-  WrongFaction: 3
+  values:
+    CanWhisper: 0
+    CanWhisperGuild: 1
+    Offline: 2
+    WrongFaction: 3
 ChrCustomizationCategoryFlag:
-  Subcategory: 2
-  UndressModel: 1
+  values:
+    Subcategory: 2
+    UndressModel: 1
 ChrCustomizationOptionType:
-  Checkbox: 1
-  Dropdown: 0
-  Slider: 2
+  values:
+    Checkbox: 1
+    Dropdown: 0
+    Slider: 2
 ChrModelFeatureFlags:
-  Deprecated0: 8
-  Forms: 2
-  HunterPets: 32
-  Identity: 4
-  Mounts: 16
-  None: 0
-  Players: 64
-  Summons: 1
+  values:
+    Deprecated0: 8
+    Forms: 2
+    HunterPets: 32
+    Identity: 4
+    Mounts: 16
+    None: 0
+    Players: 64
+    Summons: 1
 ChrRacesAllianceType:
-  Alliance: 0
-  Horde: 1
-  NeutralOrNpc: 2
+  values:
+    Alliance: 0
+    Horde: 1
+    NeutralOrNpc: 2
 CinematicType:
-  GameCinematicSequence: 3
-  GameClientScene: 2
-  GameMovie: 1
-  GlueMovie: 0
+  values:
+    GameCinematicSequence: 3
+    GameClientScene: 2
+    GameMovie: 1
+    GlueMovie: 0
 ClickBindingInteraction:
-  OpenContextMenu: 2
-  Target: 1
+  values:
+    OpenContextMenu: 2
+    Target: 1
 ClickBindingType:
-  Interaction: 3
-  Macro: 2
-  None: 0
-  PetAction: 4
-  Spell: 1
+  values:
+    Interaction: 3
+    Macro: 2
+    None: 0
+    PetAction: 4
+    Spell: 1
 ClientPlatformType:
-  Macintosh: 1
-  Windows: 0
+  values:
+    Macintosh: 1
+    Windows: 0
 ClientSceneType:
-  DefaultSceneType: 0
-  MinigameSceneType: 1
+  values:
+    DefaultSceneType: 0
+    MinigameSceneType: 1
 ClientSettingsConfigFlag:
-  ClientSettingsConfigBeta: 64
-  ClientSettingsConfigBetaRetail: 128
-  ClientSettingsConfigDebug: 1
-  ClientSettingsConfigGm: 8
-  ClientSettingsConfigInternal: 2
-  ClientSettingsConfigPerf: 4
-  ClientSettingsConfigRetail: 256
-  ClientSettingsConfigTest: 16
-  ClientSettingsConfigTestRetail: 32
+  values:
+    ClientSettingsConfigBeta: 64
+    ClientSettingsConfigBetaRetail: 128
+    ClientSettingsConfigDebug: 1
+    ClientSettingsConfigGm: 8
+    ClientSettingsConfigInternal: 2
+    ClientSettingsConfigPerf: 4
+    ClientSettingsConfigRetail: 256
+    ClientSettingsConfigTest: 16
+    ClientSettingsConfigTestRetail: 32
 ClubActionType:
-  ErrorClubActionAcceptInvitation: 13
-  ErrorClubActionAddBan: 22
-  ErrorClubActionCreate: 1
-  ErrorClubActionCreateMessage: 24
-  ErrorClubActionCreateStream: 15
-  ErrorClubActionCreateTicket: 5
-  ErrorClubActionDeclineInvitation: 14
-  ErrorClubActionDestroy: 3
-  ErrorClubActionDestroyMessage: 26
-  ErrorClubActionDestroyStream: 17
-  ErrorClubActionDestroyTicket: 6
-  ErrorClubActionEdit: 2
-  ErrorClubActionEditMember: 19
-  ErrorClubActionEditMemberNote: 20
-  ErrorClubActionEditMessage: 25
-  ErrorClubActionEditStream: 16
-  ErrorClubActionGetBans: 10
-  ErrorClubActionGetInvitations: 11
-  ErrorClubActionGetTicket: 8
-  ErrorClubActionGetTickets: 9
-  ErrorClubActionInviteMember: 18
-  ErrorClubActionKickMember: 21
-  ErrorClubActionLeave: 4
-  ErrorClubActionRedeemTicket: 7
-  ErrorClubActionRemoveBan: 23
-  ErrorClubActionRevokeInvitation: 12
-  ErrorClubActionSubscribe: 0
+  values:
+    ErrorClubActionAcceptInvitation: 13
+    ErrorClubActionAddBan: 22
+    ErrorClubActionCreate: 1
+    ErrorClubActionCreateMessage: 24
+    ErrorClubActionCreateStream: 15
+    ErrorClubActionCreateTicket: 5
+    ErrorClubActionDeclineInvitation: 14
+    ErrorClubActionDestroy: 3
+    ErrorClubActionDestroyMessage: 26
+    ErrorClubActionDestroyStream: 17
+    ErrorClubActionDestroyTicket: 6
+    ErrorClubActionEdit: 2
+    ErrorClubActionEditMember: 19
+    ErrorClubActionEditMemberNote: 20
+    ErrorClubActionEditMessage: 25
+    ErrorClubActionEditStream: 16
+    ErrorClubActionGetBans: 10
+    ErrorClubActionGetInvitations: 11
+    ErrorClubActionGetTicket: 8
+    ErrorClubActionGetTickets: 9
+    ErrorClubActionInviteMember: 18
+    ErrorClubActionKickMember: 21
+    ErrorClubActionLeave: 4
+    ErrorClubActionRedeemTicket: 7
+    ErrorClubActionRemoveBan: 23
+    ErrorClubActionRevokeInvitation: 12
+    ErrorClubActionSubscribe: 0
 ClubErrorType:
-  ErrorClubAlreadyMember: 19
-  ErrorClubBanAlreadyExists: 35
-  ErrorClubBanCountAtMax: 36
-  ErrorClubDoesntAllowCrossFaction: 40
-  ErrorClubEditHasCrossFactionMembers: 41
-  ErrorClubFull: 16
-  ErrorClubInsufficientPrivileges: 24
-  ErrorClubInvalidRoleID: 23
-  ErrorClubInvitationAlreadyExists: 22
-  ErrorClubMemberHasRequiredRole: 31
-  ErrorClubNoClub: 17
-  ErrorClubNoSuchInvitation: 21
-  ErrorClubNoSuchMember: 20
-  ErrorClubNotMember: 18
-  ErrorClubReceivedInvitationCountAtMax: 33
-  ErrorClubSentInvitationCountAtMax: 32
-  ErrorClubStreamCountAtMax: 30
-  ErrorClubStreamCountAtMin: 29
-  ErrorClubStreamInvalidName: 28
-  ErrorClubStreamNoStream: 27
-  ErrorClubTargetIsBanned: 34
-  ErrorClubTicketCountAtMax: 37
-  ErrorClubTicketHasConsumedAllowedRedeemCount: 39
-  ErrorClubTicketNoSuchTicket: 38
-  ErrorClubTooManyClubsJoined: 25
-  ErrorClubVoiceFull: 26
-  ErrorCommunitiesBadTarget: 4
-  ErrorCommunitiesChatMute: 15
-  ErrorCommunitiesGuild: 8
-  ErrorCommunitiesIgnored: 7
-  ErrorCommunitiesMissingShortName: 11
-  ErrorCommunitiesNeutralFaction: 2
-  ErrorCommunitiesNone: 0
-  ErrorCommunitiesProfanity: 12
-  ErrorCommunitiesRestricted: 6
-  ErrorCommunitiesTrial: 13
-  ErrorCommunitiesUnknown: 1
-  ErrorCommunitiesUnknownRealm: 3
-  ErrorCommunitiesUnknownTicket: 10
-  ErrorCommunitiesVeteranTrial: 14
-  ErrorCommunitiesWrongFaction: 5
-  ErrorCommunitiesWrongRegion: 9
+  values:
+    ErrorClubAlreadyMember: 19
+    ErrorClubBanAlreadyExists: 35
+    ErrorClubBanCountAtMax: 36
+    ErrorClubDoesntAllowCrossFaction: 40
+    ErrorClubEditHasCrossFactionMembers: 41
+    ErrorClubFull: 16
+    ErrorClubInsufficientPrivileges: 24
+    ErrorClubInvalidRoleID: 23
+    ErrorClubInvitationAlreadyExists: 22
+    ErrorClubMemberHasRequiredRole: 31
+    ErrorClubNoClub: 17
+    ErrorClubNoSuchInvitation: 21
+    ErrorClubNoSuchMember: 20
+    ErrorClubNotMember: 18
+    ErrorClubReceivedInvitationCountAtMax: 33
+    ErrorClubSentInvitationCountAtMax: 32
+    ErrorClubStreamCountAtMax: 30
+    ErrorClubStreamCountAtMin: 29
+    ErrorClubStreamInvalidName: 28
+    ErrorClubStreamNoStream: 27
+    ErrorClubTargetIsBanned: 34
+    ErrorClubTicketCountAtMax: 37
+    ErrorClubTicketHasConsumedAllowedRedeemCount: 39
+    ErrorClubTicketNoSuchTicket: 38
+    ErrorClubTooManyClubsJoined: 25
+    ErrorClubVoiceFull: 26
+    ErrorCommunitiesBadTarget: 4
+    ErrorCommunitiesChatMute: 15
+    ErrorCommunitiesGuild: 8
+    ErrorCommunitiesIgnored: 7
+    ErrorCommunitiesMissingShortName: 11
+    ErrorCommunitiesNeutralFaction: 2
+    ErrorCommunitiesNone: 0
+    ErrorCommunitiesProfanity: 12
+    ErrorCommunitiesRestricted: 6
+    ErrorCommunitiesTrial: 13
+    ErrorCommunitiesUnknown: 1
+    ErrorCommunitiesUnknownRealm: 3
+    ErrorCommunitiesUnknownTicket: 10
+    ErrorCommunitiesVeteranTrial: 14
+    ErrorCommunitiesWrongFaction: 5
+    ErrorCommunitiesWrongRegion: 9
 ClubFieldType:
-  ClubBroadcast: 3
-  ClubDescription: 2
-  ClubName: 0
-  ClubShortName: 1
-  ClubStreamName: 4
-  ClubStreamSubject: 5
-  NumTypes: 6
+  values:
+    ClubBroadcast: 3
+    ClubDescription: 2
+    ClubName: 0
+    ClubShortName: 1
+    ClubStreamName: 4
+    ClubStreamSubject: 5
+    NumTypes: 6
 ClubFinderApplicationUpdateType:
-  AcceptInvite: 1
-  Cancel: 3
-  DeclineInvite: 2
-  None: 0
+  values:
+    AcceptInvite: 1
+    Cancel: 3
+    DeclineInvite: 2
+    None: 0
 ClubFinderClubPostingStatusFlags:
-  Banned: 5
-  FakePost: 6
-  ForceDescriptionChange: 2
-  ForceNameChange: 3
-  NeedsCacheUpdate: 1
-  None: 0
-  PendingDelete: 7
-  PostDelisted: 8
-  UnderReview: 4
+  values:
+    Banned: 5
+    FakePost: 6
+    ForceDescriptionChange: 2
+    ForceNameChange: 3
+    NeedsCacheUpdate: 1
+    None: 0
+    PendingDelete: 7
+    PostDelisted: 8
+    UnderReview: 4
 ClubFinderDisableReason:
-  Muted: 0
-  Silenced: 1
-  VeteranTrial: 2
+  values:
+    Muted: 0
+    Silenced: 1
+    VeteranTrial: 2
 ClubFinderPostingReportType:
-  ApplicantsName: 3
-  ClubName: 1
-  JoinNote: 4
-  PostersName: 0
-  PostingDescription: 2
+  values:
+    ApplicantsName: 3
+    ClubName: 1
+    JoinNote: 4
+    PostersName: 0
+    PostingDescription: 2
 ClubFinderRequestType:
-  All: 3
-  Community: 2
-  Guild: 1
-  None: 0
+  values:
+    All: 3
+    Community: 2
+    Guild: 1
+    None: 0
 ClubFinderSettingFlags:
-  AutoAccept: 14
-  Damage: 11
-  Dungeons: 1
-  EnableListing: 12
-  FactionAlliance: 16
-  FactionHorde: 15
-  FactionNeutral: 17
-  Healer: 10
-  LanguageReserved1: 21
-  LanguageReserved2: 22
-  LanguageReserved3: 23
-  LanguageReserved4: 24
-  LanguageReserved5: 25
-  Large: 8
-  MaxLevelOnly: 13
-  Medium: 7
-  None: 0
-  PvP: 3
-  Raids: 2
-  RP: 4
-  Small: 6
-  Social: 5
-  SortMemberCount: 19
-  SortNewest: 20
-  SortRelevance: 18
-  Tank: 9
+  values:
+    AutoAccept: 14
+    Damage: 11
+    Dungeons: 1
+    EnableListing: 12
+    FactionAlliance: 16
+    FactionHorde: 15
+    FactionNeutral: 17
+    Healer: 10
+    LanguageReserved1: 21
+    LanguageReserved2: 22
+    LanguageReserved3: 23
+    LanguageReserved4: 24
+    LanguageReserved5: 25
+    Large: 8
+    MaxLevelOnly: 13
+    Medium: 7
+    None: 0
+    PvP: 3
+    Raids: 2
+    RP: 4
+    Small: 6
+    Social: 5
+    SortMemberCount: 19
+    SortNewest: 20
+    SortRelevance: 18
+    Tank: 9
 ClubInvitationCandidateStatus:
-  AlreadyMember: 2
-  Available: 0
-  InvitePending: 1
+  values:
+    AlreadyMember: 2
+    Available: 0
+    InvitePending: 1
 ClubMemberPresence:
-  Away: 4
-  Busy: 5
-  Offline: 3
-  Online: 1
-  OnlineMobile: 2
-  Unknown: 0
+  values:
+    Away: 4
+    Busy: 5
+    Offline: 3
+    Online: 1
+    OnlineMobile: 2
+    Unknown: 0
 ClubRemovedReason:
-  Banned: 1
-  ClubDestroyed: 3
-  None: 0
-  Removed: 2
+  values:
+    Banned: 1
+    ClubDestroyed: 3
+    None: 0
+    Removed: 2
 ClubRestrictionReason:
-  None: 0
-  Unavailable: 1
+  values:
+    None: 0
+    Unavailable: 1
 ClubRoleIdentifier:
-  Leader: 2
-  Member: 4
-  Moderator: 3
-  Owner: 1
+  values:
+    Leader: 2
+    Member: 4
+    Moderator: 3
+    Owner: 1
 ClubStreamNotificationFilter:
-  All: 2
-  Mention: 1
-  None: 0
+  values:
+    All: 2
+    Mention: 1
+    None: 0
 ClubStreamType:
-  General: 0
-  Guild: 1
-  Officer: 2
-  Other: 3
+  values:
+    General: 0
+    Guild: 1
+    Officer: 2
+    Other: 3
 ClubType:
-  BattleNet: 0
-  Character: 1
-  Guild: 2
-  Other: 3
+  values:
+    BattleNet: 0
+    Character: 1
+    Guild: 2
+    Other: 3
 ColorOverride:
-  ItemQualityAccount: 7
-  ItemQualityArtifact: 6
-  ItemQualityCommon: 1
-  ItemQualityEpic: 4
-  ItemQualityLegendary: 5
-  ItemQualityPoor: 0
-  ItemQualityRare: 3
-  ItemQualityUncommon: 2
+  values:
+    ItemQualityAccount: 7
+    ItemQualityArtifact: 6
+    ItemQualityCommon: 1
+    ItemQualityEpic: 4
+    ItemQualityLegendary: 5
+    ItemQualityPoor: 0
+    ItemQualityRare: 3
+    ItemQualityUncommon: 2
 CombatAudioAlertCastState:
-  Off: 0
-  OnCastEnd: 2
-  OnCastStart: 1
+  values:
+    Off: 0
+    OnCastEnd: 2
+    OnCastStart: 1
 CombatAudioAlertCategory:
-  General: 0
-  PartyHealth: 7
-  PlayerCast: 3
-  PlayerDebuffs: 8
-  PlayerHealth: 1
-  PlayerResource1: 5
-  PlayerResource2: 6
-  TargetCast: 4
-  TargetHealth: 2
+  values:
+    General: 0
+    PartyHealth: 7
+    PlayerCast: 3
+    PlayerDebuffs: 8
+    PlayerHealth: 1
+    PlayerResource1: 5
+    PlayerResource2: 6
+    TargetCast: 4
+    TargetHealth: 2
 CombatAudioAlertDebuffSelfAlertValues:
-  DispelType: 1
-  Off: 0
+  values:
+    DispelType: 1
+    Off: 0
 CombatAudioAlertPartyPercentValues:
-  Off: 0
-  Under100Percent: 1
-  Under10Percent: 10
-  Under20Percent: 9
-  Under30Percent: 8
-  Under40Percent: 7
-  Under50Percent: 6
-  Under60Percent: 5
-  Under70Percent: 4
-  Under80Percent: 3
-  Under90Percent: 2
+  values:
+    Off: 0
+    Under100Percent: 1
+    Under10Percent: 10
+    Under20Percent: 9
+    Under30Percent: 8
+    Under40Percent: 7
+    Under50Percent: 6
+    Under60Percent: 5
+    Under70Percent: 4
+    Under80Percent: 3
+    Under90Percent: 2
 CombatAudioAlertPercentValues:
-  Every10Percent: 1
-  Every20Percent: 2
-  Every30Percent: 3
-  Every40Percent: 4
-  Every50Percent: 5
-  Off: 0
+  values:
+    Every10Percent: 1
+    Every20Percent: 2
+    Every30Percent: 3
+    Every40Percent: 4
+    Every50Percent: 5
+    Off: 0
 CombatAudioAlertPlayerCastFormatValues:
-  Cast: 3
-  Casting: 2
-  CastingSpellname: 0
-  CastSpellname: 1
-  Spellname: 4
+  values:
+    Cast: 3
+    Casting: 2
+    CastingSpellname: 0
+    CastSpellname: 1
+    Spellname: 4
 CombatAudioAlertPlayerDebuffFormatValues:
-  Full: 0
-  NoSpellname: 1
+  values:
+    Full: 0
+    NoSpellname: 1
 CombatAudioAlertPlayerHealthFormatValues:
-  HealthFull: 0
-  HealthNoPercent: 1
-  HealthNoPercentDiv10: 2
-  NoHealthFull: 3
-  NoHealthNoPercent: 4
-  NoHealthNoPercentDiv10: 5
+  values:
+    HealthFull: 0
+    HealthNoPercent: 1
+    HealthNoPercentDiv10: 2
+    NoHealthFull: 3
+    NoHealthNoPercent: 4
+    NoHealthNoPercentDiv10: 5
 CombatAudioAlertPlayerResourceFormatValues:
-  NoResourceFull: 3
-  NoResourceNoPercent: 4
-  NoResourceNoPercentDiv10: 5
-  ResourceFull: 0
-  ResourceNoPercent: 1
-  ResourceNoPercentDiv10: 2
+  values:
+    NoResourceFull: 3
+    NoResourceNoPercent: 4
+    NoResourceNoPercentDiv10: 5
+    ResourceFull: 0
+    ResourceNoPercent: 1
+    ResourceNoPercentDiv10: 2
 CombatAudioAlertSayIfTargetedType:
-  Aggro: 1
-  None: 0
-  Targeted: 2
-  TargetedBy: 3
+  values:
+    Aggro: 1
+    None: 0
+    Targeted: 2
+    TargetedBy: 3
 CombatAudioAlertSpecSetting:
-  Resource1Format: 1
-  Resource1Percent: 0
-  Resource1Voice: 2
-  Resource1Volume: 3
-  Resource2Format: 5
-  Resource2Percent: 4
-  Resource2Voice: 6
-  Resource2Volume: 7
-  SayIfTargeted: 8
+  values:
+    Resource1Format: 1
+    Resource1Percent: 0
+    Resource1Voice: 2
+    Resource1Volume: 3
+    Resource2Format: 5
+    Resource2Percent: 4
+    Resource2Voice: 6
+    Resource2Volume: 7
+    SayIfTargeted: 8
 CombatAudioAlertTargetCastFormatValues:
-  Cast: 5
-  Casting: 4
-  CastingSpellname: 2
-  CastSpellname: 3
-  Spellname: 6
-  TargetCastingSpellname: 0
-  TargetCastSpellname: 1
+  values:
+    Cast: 5
+    Casting: 4
+    CastingSpellname: 2
+    CastSpellname: 3
+    Spellname: 6
+    TargetCastingSpellname: 0
+    TargetCastSpellname: 1
 CombatAudioAlertTargetDeathBehavior:
-  Default: 0
-  SayTargetDead: 1
+  values:
+    Default: 0
+    SayTargetDead: 1
 CombatAudioAlertTargetHealthFormatValues:
-  HealthFull: 3
-  HealthNoPercent: 4
-  HealthNoPercentDiv10: 5
-  NoHealthFull: 0
-  NoHealthNoPercent: 1
-  NoHealthNoPercentDiv10: 2
-  TargetFull: 6
-  TargetNoPercent: 7
-  TargetNoPercentDiv10: 8
+  values:
+    HealthFull: 3
+    HealthNoPercent: 4
+    HealthNoPercentDiv10: 5
+    NoHealthFull: 0
+    NoHealthNoPercent: 1
+    NoHealthNoPercentDiv10: 2
+    TargetFull: 6
+    TargetNoPercent: 7
+    TargetNoPercentDiv10: 8
 CombatAudioAlertThrottle:
-  PlayerCast: 3
-  PlayerHealth: 1
-  PlayerHealthSamePercent: 7
-  PlayerResource1: 5
-  PlayerResource1SamePercent: 9
-  PlayerResource2: 6
-  PlayerResource2SamePercent: 10
-  Sample: 0
-  TargetCast: 4
-  TargetHealth: 2
-  TargetHealthSamePercent: 8
+  values:
+    PlayerCast: 3
+    PlayerHealth: 1
+    PlayerHealthSamePercent: 7
+    PlayerResource1: 5
+    PlayerResource1SamePercent: 9
+    PlayerResource2: 6
+    PlayerResource2SamePercent: 10
+    Sample: 0
+    TargetCast: 4
+    TargetHealth: 2
+    TargetHealthSamePercent: 8
 CombatAudioAlertType:
-  Cast: 1
-  Health: 0
+  values:
+    Cast: 1
+    Health: 0
 CombatAudioAlertUnit:
-  Player: 0
-  Target: 1
+  values:
+    Player: 0
+    Target: 1
 CombatLogMessageOrder:
-  Newest: 0
-  Oldest: 1
+  values:
+    Newest: 0
+    Oldest: 1
 CombatLogObject:
-  AffiliationMine: 1
-  AffiliationOutsider: 8
-  AffiliationParty: 2
-  AffiliationRaid: 4
-  ControlNpc: 512
-  ControlPlayer: 256
-  Empty: 0
-  Focus: 131072
-  Mainassist: 524288
-  Maintank: 262144
-  None: 2147483648
-  ReactionFriendly: 16
-  ReactionHostile: 64
-  ReactionNeutral: 32
-  Target: 65536
-  TypeGuardian: 8192
-  TypeNpc: 2048
-  TypeObject: 16384
-  TypePet: 4096
-  TypePlayer: 1024
+  values:
+    AffiliationMine: 1
+    AffiliationOutsider: 8
+    AffiliationParty: 2
+    AffiliationRaid: 4
+    ControlNpc: 512
+    ControlPlayer: 256
+    Empty: 0
+    Focus: 131072
+    Mainassist: 524288
+    Maintank: 262144
+    None: 2147483648
+    ReactionFriendly: 16
+    ReactionHostile: 64
+    ReactionNeutral: 32
+    Target: 65536
+    TypeGuardian: 8192
+    TypeNpc: 2048
+    TypeObject: 16384
+    TypePet: 4096
+    TypePlayer: 1024
 CombatLogObjectTarget:
-  RaidNone: 2147483648
-  Raidtarget1: 1
-  Raidtarget2: 2
-  Raidtarget3: 4
-  Raidtarget4: 8
-  Raidtarget5: 16
-  Raidtarget6: 32
-  Raidtarget7: 64
-  Raidtarget8: 128
+  values:
+    RaidNone: 2147483648
+    Raidtarget1: 1
+    Raidtarget2: 2
+    Raidtarget3: 4
+    Raidtarget4: 8
+    Raidtarget5: 16
+    Raidtarget6: 32
+    Raidtarget7: 64
+    Raidtarget8: 128
 CombinedQuestLogStatus:
-  Available: 0
-  Complete: 1
-  CompleteDaily: 2
-  CompleteGameReset: 6
-  CompleteMonthly: 4
-  CompleteWeekly: 3
-  CompleteYearly: 5
-  Reset: 7
+  values:
+    Available: 0
+    Complete: 1
+    CompleteDaily: 2
+    CompleteGameReset: 6
+    CompleteMonthly: 4
+    CompleteWeekly: 3
+    CompleteYearly: 5
+    Reset: 7
 CombinedQuestStatus:
-  Completed: 1
-  Invalid: 0
-  NotCompleted: 2
+  values:
+    Completed: 1
+    Invalid: 0
+    NotCompleted: 2
 CommunicationMode:
-  OpenMic: 1
-  PushToTalk: 0
+  values:
+    OpenMic: 1
+    PushToTalk: 0
 CompanionConfigSlotTypes:
-  Combat: 2
-  Role: 0
-  Utility: 1
+  values:
+    Combat: 2
+    Role: 0
+    Utility: 1
 CompanionRoleType:
-  Dps: 0
-  Heal: 1
-  Tank: 2
+  values:
+    Dps: 0
+    Heal: 1
+    Tank: 2
 CompressionLevel:
-  Default: 0
-  OptimizeForSize: 2
-  OptimizeForSpeed: 1
+  values:
+    Default: 0
+    OptimizeForSize: 2
+    OptimizeForSpeed: 1
 CompressionMethod:
-  Deflate: 0
-  Gzip: 2
-  Zlib: 1
+  values:
+    Deflate: 0
+    Gzip: 2
+    Zlib: 1
 ConfirmationPromptUIType:
-  BonusRoll: 1
-  SimpleWarning: 2
-  SimpleWarningAlert: 4
-  StaticText: 0
-  StaticTextAlert: 3
+  values:
+    BonusRoll: 1
+    SimpleWarning: 2
+    SimpleWarningAlert: 4
+    StaticText: 0
+    StaticTextAlert: 3
 ConquestProgressBarDisplayType:
-  AdditionalChest: 1
-  FirstChest: 0
-  Seasonal: 2
+  values:
+    AdditionalChest: 1
+    FirstChest: 0
+    Seasonal: 2
 ConsoleCategory:
-  Combat: 3
-  Console: 2
-  Debug: 0
-  Default: 5
-  Game: 4
-  Gm: 8
-  Graphics: 1
-  Net: 6
-  None: 10
-  Reveal: 9
-  Sound: 7
+  values:
+    Combat: 3
+    Console: 2
+    Debug: 0
+    Default: 5
+    Game: 4
+    Gm: 8
+    Graphics: 1
+    Net: 6
+    None: 10
+    Reveal: 9
+    Sound: 7
 ConsoleColorType:
-  AdminColor: 6
-  BackgroundColor: 8
-  ClickbufferColor: 9
-  DefaultColor: 0
-  DefaultGreen: 11
-  EchoColor: 2
-  ErrorColor: 3
-  GlobalColor: 5
-  HighlightColor: 7
-  InputColor: 1
-  PrivateColor: 10
-  WarningColor: 4
+  values:
+    AdminColor: 6
+    BackgroundColor: 8
+    ClickbufferColor: 9
+    DefaultColor: 0
+    DefaultGreen: 11
+    EchoColor: 2
+    ErrorColor: 3
+    GlobalColor: 5
+    HighlightColor: 7
+    InputColor: 1
+    PrivateColor: 10
+    WarningColor: 4
 ConsoleCommandType:
-  Command: 1
-  Cvar: 0
-  Macro: 2
-  Script: 3
+  values:
+    Command: 1
+    Cvar: 0
+    Macro: 2
+    Script: 3
 ContentTrackingError:
-  AlreadyTracked: 2
-  MaxTracked: 1
-  Untrackable: 0
+  values:
+    AlreadyTracked: 2
+    MaxTracked: 1
+    Untrackable: 0
 ContentTrackingResult:
-  DataPending: 1
-  Failure: 2
-  Success: 0
+  values:
+    DataPending: 1
+    Failure: 2
+    Success: 0
 ContentTrackingStopType:
-  Collected: 1
-  Invalidated: 0
-  Manual: 2
+  values:
+    Collected: 1
+    Invalidated: 0
+    Manual: 2
 ContentTrackingTargetType:
-  Achievement: 2
-  JournalEncounter: 0
-  Profession: 3
-  Quest: 4
-  Vendor: 1
+  values:
+    Achievement: 2
+    JournalEncounter: 0
+    Profession: 3
+    Quest: 4
+    Vendor: 1
 ContentTrackingType:
-  Achievement: 2
-  Appearance: 0
-  Decor: 3
-  Mount: 1
+  values:
+    Achievement: 2
+    Appearance: 0
+    Decor: 3
+    Mount: 1
 ContributionAppearanceFlags:
-  TooltipUseTimeRemaining: 0
+  values:
+    TooltipUseTimeRemaining: 0
 ContributionResult:
-  FailedConditionCheck: 5
-  IncorrectState: 2
-  InternalError: 7
-  InvalidID: 3
-  MustBeNearNpc: 1
-  QuestDataMissing: 4
-  Success: 0
-  UnableToCompleteTurnIn: 6
+  values:
+    FailedConditionCheck: 5
+    IncorrectState: 2
+    InternalError: 7
+    InvalidID: 3
+    MustBeNearNpc: 1
+    QuestDataMissing: 4
+    Success: 0
+    UnableToCompleteTurnIn: 6
 ContributionState:
-  Active: 2
-  Building: 1
-  Destroyed: 4
-  None: 0
-  UnderAttack: 3
+  values:
+    Active: 2
+    Building: 1
+    Destroyed: 4
+    None: 0
+    UnderAttack: 3
 CooldownSetLinkedSpellFlags:
-  UseAsTooltip: 1
+  values:
+    UseAsTooltip: 1
 CooldownSetSpellFlags:
-  HideAura: 1
-  HideByDefault: 2
+  values:
+    HideAura: 1
+    HideByDefault: 2
 CooldownViewerAddAlertStatus:
-  DuplicateAlert: 3
-  InvalidAlertType: 1
-  InvalidEventType: 2
-  Success: 0
+  values:
+    DuplicateAlert: 3
+    InvalidAlertType: 1
+    InvalidEventType: 2
+    Success: 0
 CooldownViewerAlertEventType:
-  Available: 1
-  ChargeGained: 4
-  OnAuraApplied: 5
-  OnAuraRemoved: 6
-  OnCooldown: 3
-  PandemicTime: 2
+  values:
+    Available: 1
+    ChargeGained: 4
+    OnAuraApplied: 5
+    OnAuraRemoved: 6
+    OnCooldown: 3
+    PandemicTime: 2
 CooldownViewerAlertType:
-  Sound: 1
-  Visual: 2
+  values:
+    Sound: 1
+    Visual: 2
 CooldownViewerBarContent:
-  IconAndName: 0
-  IconOnly: 1
-  NameOnly: 2
+  values:
+    IconAndName: 0
+    IconOnly: 1
+    NameOnly: 2
 CooldownViewerCategory:
-  Essential: 0
-  TrackedBar: 3
-  TrackedBuff: 2
-  Utility: 1
+  values:
+    Essential: 0
+    TrackedBar: 3
+    TrackedBuff: 2
+    Utility: 1
 CooldownViewerIconDirection:
-  Left: 0
-  Right: 1
+  values:
+    Left: 0
+    Right: 1
 CooldownViewerOrientation:
-  Horizontal: 0
-  Vertical: 1
+  values:
+    Horizontal: 0
+    Vertical: 1
 CooldownViewerVisibleSetting:
-  Always: 0
-  Hidden: 2
-  InCombat: 1
+  values:
+    Always: 0
+    Hidden: 2
+    InCombat: 1
 CornerstonePurchaseMode:
-  Basic: 0
-  Import: 1
-  Move: 2
+  values:
+    Basic: 0
+    Import: 1
+    Move: 2
 CovenantAbilityType:
-  Class: 0
-  Signature: 1
-  Soulbind: 2
+  values:
+    Class: 0
+    Signature: 1
+    Soulbind: 2
 CovenantSkill:
-  Kyrian: 2730
-  Necrolord: 2733
-  NightFae: 2732
-  Venthyr: 2731
+  values:
+    Kyrian: 2730
+    Necrolord: 2733
+    NightFae: 2732
+    Venthyr: 2731
 CovenantType:
-  Kyrian: 1
-  Necrolord: 4
-  NightFae: 3
-  None: 0
-  Venthyr: 2
+  values:
+    Kyrian: 1
+    Necrolord: 4
+    NightFae: 3
+    None: 0
+    Venthyr: 2
 CraftingOrderCustomerCategoryType:
-  Primary: 0
-  Secondary: 1
-  Tertiary: 2
+  values:
+    Primary: 0
+    Secondary: 1
+    Tertiary: 2
 CraftingOrderDuration:
-  Long: 2
-  Medium: 1
-  Short: 0
+  values:
+    Long: 2
+    Medium: 1
+    Short: 0
 CraftingOrderFlags:
-  HasAllReagents: 8
-  HasNoneReagents: 2
-  HasSomeReagents: 4
-  IsFulfillable: 16
-  IsRecraft: 1
-  None: 0
+  values:
+    HasAllReagents: 8
+    HasNoneReagents: 2
+    HasSomeReagents: 4
+    IsFulfillable: 16
+    IsRecraft: 1
+    None: 0
 CraftingOrderItemFlags:
-  HasEnchantmentData: 2
-  None: 0
-  NpcProvided: 1
+  values:
+    HasEnchantmentData: 2
+    None: 0
+    NpcProvided: 1
 CraftingOrderItemType:
-  CraftedResult: 2
-  Currency: 5
-  Deprecated: 4
-  Item: 0
-  Recraft: 1
-  RemoveReagent: 3
+  values:
+    CraftedResult: 2
+    Currency: 5
+    Deprecated: 4
+    Item: 0
+    Recraft: 1
+    RemoveReagent: 3
 CraftingOrderReagentSource:
-  Any: 0
-  Crafter: 2
-  Customer: 1
-  None: 3
+  values:
+    Any: 0
+    Crafter: 2
+    Customer: 1
+    None: 3
 CraftingOrderReagentsType:
-  All: 0
-  None: 2
-  Some: 1
+  values:
+    All: 0
+    None: 2
+    Some: 1
 CraftingOrderResult:
-  Aborted: 1
-  AlreadyClaimed: 2
-  AlreadyCrafted: 3
-  CannotBeOrdered: 4
-  CannotCancel: 5
-  CannotClaim: 6
-  CannotClaimOwnOrder: 7
-  CannotCraft: 8
-  CannotCreate: 9
-  CannotFulfill: 10
-  CannotRecraft: 11
-  CannotReject: 12
-  CannotRelease: 13
-  CrafterIsIgnored: 14
-  DatabaseError: 15
-  Expired: 16
-  InvalidDuration: 18
-  InvalidMinQuality: 19
-  InvalidNotes: 20
-  InvalidReagent: 21
-  InvalidRealm: 22
-  InvalidRecipe: 23
-  InvalidRecraftItem: 24
-  InvalidSort: 25
-  InvalidTarget: 26
-  InvalidType: 27
-  Locked: 17
-  MaxOrdersReached: 28
-  MissingCraftingTable: 29
-  MissingCurrency: 30
-  MissingItem: 31
-  MissingNpc: 32
-  MissingOrder: 33
-  MissingRecraftItem: 34
-  NoAccountItems: 35
-  NotClaimed: 36
-  NotCrafted: 37
-  NotInGuild: 38
-  NotYetImplemented: 39
-  Ok: 0
-  OutOfPublicOrderCapacity: 40
-  ServerIsNotAvailable: 41
-  TargetCannotCraft: 43
-  TargetLocked: 44
-  ThrottleViolation: 42
-  Timeout: 45
-  TooManyCurrencies: 46
-  TooManyItems: 47
-  WrongVersion: 48
+  values:
+    Aborted: 1
+    AlreadyClaimed: 2
+    AlreadyCrafted: 3
+    CannotBeOrdered: 4
+    CannotCancel: 5
+    CannotClaim: 6
+    CannotClaimOwnOrder: 7
+    CannotCraft: 8
+    CannotCreate: 9
+    CannotFulfill: 10
+    CannotRecraft: 11
+    CannotReject: 12
+    CannotRelease: 13
+    CrafterIsIgnored: 14
+    DatabaseError: 15
+    Expired: 16
+    InvalidDuration: 18
+    InvalidMinQuality: 19
+    InvalidNotes: 20
+    InvalidReagent: 21
+    InvalidRealm: 22
+    InvalidRecipe: 23
+    InvalidRecraftItem: 24
+    InvalidSort: 25
+    InvalidTarget: 26
+    InvalidType: 27
+    Locked: 17
+    MaxOrdersReached: 28
+    MissingCraftingTable: 29
+    MissingCurrency: 30
+    MissingItem: 31
+    MissingNpc: 32
+    MissingOrder: 33
+    MissingRecraftItem: 34
+    NoAccountItems: 35
+    NotClaimed: 36
+    NotCrafted: 37
+    NotInGuild: 38
+    NotYetImplemented: 39
+    Ok: 0
+    OutOfPublicOrderCapacity: 40
+    ServerIsNotAvailable: 41
+    TargetCannotCraft: 43
+    TargetLocked: 44
+    ThrottleViolation: 42
+    Timeout: 45
+    TooManyCurrencies: 46
+    TooManyItems: 47
+    WrongVersion: 48
 CraftingOrderSortType:
-  AveTip: 1
-  ItemName: 0
-  MaxTip: 2
-  Quantity: 3
-  Reagents: 4
-  Status: 7
-  TimeRemaining: 6
-  Tip: 5
+  values:
+    AveTip: 1
+    ItemName: 0
+    MaxTip: 2
+    Quantity: 3
+    Reagents: 4
+    Status: 7
+    TimeRemaining: 6
+    Tip: 5
 CraftingOrderState:
-  Canceled: 13
-  Canceling: 12
-  Claimed: 4
-  Claiming: 3
-  Crafting: 8
-  Created: 2
-  Creating: 1
-  Expired: 15
-  Expiring: 14
-  Fulfilled: 11
-  Fulfilling: 10
-  None: 0
-  Recrafting: 9
-  Rejected: 6
-  Rejecting: 5
-  Releasing: 7
+  values:
+    Canceled: 13
+    Canceling: 12
+    Claimed: 4
+    Claiming: 3
+    Crafting: 8
+    Created: 2
+    Creating: 1
+    Expired: 15
+    Expiring: 14
+    Fulfilled: 11
+    Fulfilling: 10
+    None: 0
+    Recrafting: 9
+    Rejected: 6
+    Rejecting: 5
+    Releasing: 7
 CraftingOrderType:
-  Guild: 1
-  Npc: 3
-  Personal: 2
-  Public: 0
+  values:
+    Guild: 1
+    Npc: 3
+    Personal: 2
+    Public: 0
 CraftingReagentItemFlag:
-  TooltipShowsAsStatModifications: 1
+  values:
+    TooltipShowsAsStatModifications: 1
 CraftingReagentType:
-  Automatic: 3
-  Basic: 1
-  Finishing: 2
-  Modifying: 0
+  values:
+    Automatic: 3
+    Basic: 1
+    Finishing: 2
+    Modifying: 0
 CreateAllAccountData:
-  AccountCurrenciesDone: '0x0000000000200000'
-  AccountDynamicCriteriaDone: '0x0000000001000000'
-  AccountFactionsDone: '0x0000000200000000'
-  AccountItemsDone: '0x0000000400000000'
-  AccountMappingDone: '0x0000008000000000'
-  AccountNotificationsDone: '0x0000000008000000'
-  AccountStateHousingData: '0x0000080000000000'
-  AchievementsDone: '0x0000000000000001'
-  ArchivedPurchasesDone: '0x0000000000000200'
-  AuctionableTokensDone: '0x0000000000002000'
-  BanktabSettingsDone: '0x0000004000000000'
-  BattlepetsDone: '0x0000000000000008'
-  BitVectorsDone: '0x0000000100000000'
-  BpayAddLicenseObjectsDone: '0x0000000000000800'
-  BpayDistributionObjectsDone: '0x0000000000000100'
-  BpayProductitemObjectsDone: '0x0000000000020000'
-  CharacterItemsDone: '0x0000010000000000'
-  CharactersDone: '0x0000000000000040'
-  CombinedQuestLogEntriesDone: '0x0000000800000000'
-  ConsumableTokensDone: '0x0000000000004000'
-  CriteriaDone: '0x0000000000000002'
-  CurrencycapsDone: '0x0000000000000010'
-  CurrencyTransferLogDone: '0x0000020000000000'
-  DataElementsDone: '0x0000001000000000'
-  EventRecordsDone: '0x0000200000000000'
-  ItemCollectionItemsDone: '0x0000000000001000'
-  LgVendorPurchaseDone: '0x0000040000000000'
-  MountsDone: '0x0000000000000004'
-  None: '0x0000000000000000'
-  Object: '0x0000000000100000'
-  PerkHeldItemsDone: '0x0000000040000000'
-  PerkPastRewardsDone: '0x0000000000008000'
-  PerkPendingPurchasesDone: '0x0000000010000000'
-  PerkPendingRewardsDone: '0x0000000080000000'
-  PurchasesDone: '0x0000000000000080'
-  QuestCriteriaDone: '0x0000000000080000'
-  QuestLogDone: '0x0000000000000020'
-  RafActivitiesDone: '0x0000000002000000'
-  RafBalanceDone: '0x0000000000400000'
-  RafRewardsDone: '0x0000000000800000'
-  RevokedRafRewardsDone: '0x0000000004000000'
-  SettingsDone: '0x0000000000000400'
-  TransmogOutfitsLoadedDone: '0x0000400000000000'
-  TrialBoostHistoryDone: '0x0000000000040000'
-  VasTransactionsDone: '0x0000000000010000'
-  WarbandGroupsDone: '0x0000002000000000'
-  WarbandScenesLoadedDone: '0x0000100000000000'
-  WowlabsDataDone: '0x0000000020000000'
+  values:
+    AccountCurrenciesDone: '0x0000000000200000'
+    AccountDynamicCriteriaDone: '0x0000000001000000'
+    AccountFactionsDone: '0x0000000200000000'
+    AccountItemsDone: '0x0000000400000000'
+    AccountMappingDone: '0x0000008000000000'
+    AccountNotificationsDone: '0x0000000008000000'
+    AccountStateHousingData: '0x0000080000000000'
+    AchievementsDone: '0x0000000000000001'
+    ArchivedPurchasesDone: '0x0000000000000200'
+    AuctionableTokensDone: '0x0000000000002000'
+    BanktabSettingsDone: '0x0000004000000000'
+    BattlepetsDone: '0x0000000000000008'
+    BitVectorsDone: '0x0000000100000000'
+    BpayAddLicenseObjectsDone: '0x0000000000000800'
+    BpayDistributionObjectsDone: '0x0000000000000100'
+    BpayProductitemObjectsDone: '0x0000000000020000'
+    CharacterItemsDone: '0x0000010000000000'
+    CharactersDone: '0x0000000000000040'
+    CombinedQuestLogEntriesDone: '0x0000000800000000'
+    ConsumableTokensDone: '0x0000000000004000'
+    CriteriaDone: '0x0000000000000002'
+    CurrencycapsDone: '0x0000000000000010'
+    CurrencyTransferLogDone: '0x0000020000000000'
+    DataElementsDone: '0x0000001000000000'
+    EventRecordsDone: '0x0000200000000000'
+    ItemCollectionItemsDone: '0x0000000000001000'
+    LgVendorPurchaseDone: '0x0000040000000000'
+    MountsDone: '0x0000000000000004'
+    None: '0x0000000000000000'
+    Object: '0x0000000000100000'
+    PerkHeldItemsDone: '0x0000000040000000'
+    PerkPastRewardsDone: '0x0000000000008000'
+    PerkPendingPurchasesDone: '0x0000000010000000'
+    PerkPendingRewardsDone: '0x0000000080000000'
+    PurchasesDone: '0x0000000000000080'
+    QuestCriteriaDone: '0x0000000000080000'
+    QuestLogDone: '0x0000000000000020'
+    RafActivitiesDone: '0x0000000002000000'
+    RafBalanceDone: '0x0000000000400000'
+    RafRewardsDone: '0x0000000000800000'
+    RevokedRafRewardsDone: '0x0000000004000000'
+    SettingsDone: '0x0000000000000400'
+    TransmogOutfitsLoadedDone: '0x0000400000000000'
+    TrialBoostHistoryDone: '0x0000000000040000'
+    VasTransactionsDone: '0x0000000000010000'
+    WarbandGroupsDone: '0x0000002000000000'
+    WarbandScenesLoadedDone: '0x0000100000000000'
+    WowlabsDataDone: '0x0000000020000000'
 CreateNeighborhoodErrorType:
-  None: 0
-  OversizedGuild: 3
-  Profanity: 1
-  UndersizedGuild: 2
+  values:
+    None: 0
+    OversizedGuild: 3
+    Profanity: 1
+    UndersizedGuild: 2
 CurioRarity:
-  Common: 1
-  Epic: 4
-  Rare: 3
-  Uncommon: 2
+  values:
+    Common: 1
+    Epic: 4
+    Rare: 3
+    Uncommon: 2
 CurioType:
-  Combat: 0
-  Utility: 1
+  values:
+    Combat: 0
+    Utility: 1
 CurrencyConversionResult:
-  Conversion: 1
-  NoConversion: 0
-  SkippedAccountCurrency: 2
+  values:
+    Conversion: 1
+    NoConversion: 0
+    SkippedAccountCurrency: 2
 CurrencyDestroyReason:
-  AccountServerConversion: 17
-  AccountTransfer: 14
-  BonusRoll: 9
-  Capped: 6
-  Cheat: 0
-  ConcentrationCast: 13
-  CraftingOrderReagent: 16
-  DroppedToCorpse: 8
-  FactionConversion: 10
-  FulfillCraftingOrder: 11
-  Garrison: 7
-  HonorLoss: 15
-  QuestTurnin: 3
-  Script: 12
-  Spell: 1
-  Trade: 5
-  Vendor: 4
-  VersionUpdate: 2
+  values:
+    AccountServerConversion: 17
+    AccountTransfer: 14
+    BonusRoll: 9
+    Capped: 6
+    Cheat: 0
+    ConcentrationCast: 13
+    CraftingOrderReagent: 16
+    DroppedToCorpse: 8
+    FactionConversion: 10
+    FulfillCraftingOrder: 11
+    Garrison: 7
+    HonorLoss: 15
+    QuestTurnin: 3
+    Script: 12
+    Spell: 1
+    Trade: 5
+    Vendor: 4
+    VersionUpdate: 2
 CurrencyFilterType:
-  DiscoveredAndAllAccountTransferable: 2
-  DiscoveredOnly: 1
-  None: 0
+  values:
+    DiscoveredAndAllAccountTransferable: 2
+    DiscoveredOnly: 1
+    None: 0
 CurrencyFlags:
-  Currency_100_Scaler: 8
-  CurrencyAccountWide: 16777216
-  CurrencyAllowOverflowMailer: 33554432
-  CurrencyAppearsInLootWindow: 2
-  CurrencyComputedWeeklyMaximum: 4
-  CurrencyDeprecated: 131072
-  CurrencyDestroyExtraOnLoot: 2097152
-  CurrencyDoNotCompressChat: 8192
-  CurrencyDoNotLogAcquisitionToBi: 16384
-  CurrencyDoNotToast: 1048576
-  CurrencyDontCoalesceInLootWindow: 8388608
-  CurrencyDontShowTotalInTooltip: 4194304
-  CurrencyDynamicMaximum: 262144
-  CurrencyHasWarmodeBonus: 134217728
-  CurrencyHasWeeklyCatchup: 4096
-  CurrencyHideAsReward: 67108864
-  CurrencyIgnoreMaxQtyOnLoad: 32
-  CurrencyIsAllianceOnly: 268435456
-  CurrencyIsHordeOnly: 536870912
-  CurrencyLimitWarmodeBonusOncePerTooltip: 1073741824
-  CurrencyLogOnWorldChange: 64
-  CurrencyNoLowLevelDrop: 16
-  CurrencyNoRaidDrop: 32768
-  CurrencyNotPersistent: 65536
-  CurrencyResetTrackedQuantity: 256
-  CurrencySingleDropInLoot: 2048
-  CurrencySuppressChatMessageOnVersionChange: 1024
-  CurrencySuppressChatMessages: 524288
-  CurrencyTrackQuantity: 128
-  CurrencyTradable: 1
-  CurrencyUpdateVersionIgnoreMax: 512
-  CurrencyUsesLedgerBalance: 2147483648
+  values:
+    Currency_100_Scaler: 8
+    CurrencyAccountWide: 16777216
+    CurrencyAllowOverflowMailer: 33554432
+    CurrencyAppearsInLootWindow: 2
+    CurrencyComputedWeeklyMaximum: 4
+    CurrencyDeprecated: 131072
+    CurrencyDestroyExtraOnLoot: 2097152
+    CurrencyDoNotCompressChat: 8192
+    CurrencyDoNotLogAcquisitionToBi: 16384
+    CurrencyDoNotToast: 1048576
+    CurrencyDontCoalesceInLootWindow: 8388608
+    CurrencyDontShowTotalInTooltip: 4194304
+    CurrencyDynamicMaximum: 262144
+    CurrencyHasWarmodeBonus: 134217728
+    CurrencyHasWeeklyCatchup: 4096
+    CurrencyHideAsReward: 67108864
+    CurrencyIgnoreMaxQtyOnLoad: 32
+    CurrencyIsAllianceOnly: 268435456
+    CurrencyIsHordeOnly: 536870912
+    CurrencyLimitWarmodeBonusOncePerTooltip: 1073741824
+    CurrencyLogOnWorldChange: 64
+    CurrencyNoLowLevelDrop: 16
+    CurrencyNoRaidDrop: 32768
+    CurrencyNotPersistent: 65536
+    CurrencyResetTrackedQuantity: 256
+    CurrencySingleDropInLoot: 2048
+    CurrencySuppressChatMessageOnVersionChange: 1024
+    CurrencySuppressChatMessages: 524288
+    CurrencyTrackQuantity: 128
+    CurrencyTradable: 1
+    CurrencyUpdateVersionIgnoreMax: 512
+    CurrencyUsesLedgerBalance: 2147483648
 CurrencyFlagsB:
-  CurrencyBAllowReductionByResourcefulness: 1024
-  CurrencyBBattlenetVirtualCurrency: 8
-  CurrencyBDontDisplayIfZero: 32
-  CurrencyBForceMaxQuantityOnConversion: 256
-  CurrencyBNoBonusXP: 2048
-  CurrencyBNoNotificationMailOnOfflineProgress: 4
-  CurrencyBScaleMaxQuantityBySeasonWeeks: 64
-  CurrencyBScaleMaxQuantityByWeeksSinceStart: 128
-  CurrencyBShowQuestXPGainInTooltip: 2
-  CurrencyBUnearnableBeforeMaxQuantityStart: 512
-  CurrencyBUseTotalEarnedForEarned: 1
-  FutureCurrencyFlag: 16
+  values:
+    CurrencyBAllowReductionByResourcefulness: 1024
+    CurrencyBBattlenetVirtualCurrency: 8
+    CurrencyBDontDisplayIfZero: 32
+    CurrencyBForceMaxQuantityOnConversion: 256
+    CurrencyBNoBonusXP: 2048
+    CurrencyBNoNotificationMailOnOfflineProgress: 4
+    CurrencyBScaleMaxQuantityBySeasonWeeks: 64
+    CurrencyBScaleMaxQuantityByWeeksSinceStart: 128
+    CurrencyBShowQuestXPGainInTooltip: 2
+    CurrencyBUnearnableBeforeMaxQuantityStart: 512
+    CurrencyBUseTotalEarnedForEarned: 1
+    FutureCurrencyFlag: 16
 CurrencyGainFlags:
-  Autotracking: 8
-  BonusAward: 1
-  DroppedFromDeath: 2
-  FromAccountServer: 4
-  None: 0
+  values:
+    Autotracking: 8
+    BonusAward: 1
+    DroppedFromDeath: 2
+    FromAccountServer: 4
+    None: 0
 CurrencySource:
-  AccountCopy: 42
-  AccountHwmUpdate: 61
-  AccountServerConversion: 63
-  AccountTransfer: 65
-  AddConduitToCollection: 46
-  Arena: 17
-  AuctionDeposit: 51
-  AzeriteRespec: 34
-  Barbershop: 47
-  BonusRoll: 33
-  CatalystBalancing: 57
-  CatalystCraft: 58
-  Cheat: 4
-  ConvertItemsToCurrencyAndReputation: 62
-  ConvertItemsToCurrencyValue: 48
-  ConvertOldItem: 0
-  ConvertOldPvPCurrency: 1
-  CraftingOrder: 56
-  CurrencyWalletClaim: 29
-  DailyQuestReward: 38
-  DailyQuestWarModeReward: 39
-  DailyReset: 45
-  ExceededMaxQty: 18
-  FactionConversion: 37
-  GarrisonBuilding: 23
-  GarrisonBuildingRefund: 26
-  GarrisonFollowerActivation: 25
-  GarrisonMissionReward: 27
-  GarrisonResourceOverTime: 28
-  GarrisonTalent: 30
-  GarrisonTalentTreeReset: 44
-  GarrisonWorldQuestBonus: 31
-  GuildBankWithdrawal: 21
-  InitiativeReward: 67
-  ItemDeletion: 14
-  ItemRefund: 2
-  LFGReward: 11
-  Loot: 9
-  PhBuffer_53: 53
-  PhBuffer_54: 54
-  PlayerTrait: 52
-  PlayerTraitRefund: 60
-  ProfessionInitialAward: 59
-  Pushloot: 22
-  PvPCompletionBonus: 19
-  PvPDrop: 24
-  PvPHonorReward: 32
-  PvPKillCredit: 6
-  PvPMetaCredit: 7
-  PvPScriptedAward: 8
-  PvPTeamContribution: 49
-  QuestReward: 3
-  RandomBattleground: 16
-  RatedBattleground: 15
-  RenownRepGain: 55
-  RenownRepGainInitialVisibility: 66
-  Script: 20
-  Spell: 13
-  SpellSkipLinkedCurrency: 64
-  Trade: 12
-  Transmogrify: 50
-  UpdatingVersion: 10
-  Vendor: 5
-  WeeklyQuestReward: 40
-  WeeklyQuestWarModeReward: 41
-  WeeklyRewardChest: 43
-  WorldQuestReward: 35
-  WorldQuestRewardIgnoreCapsDeprecated: 36
+  values:
+    AccountCopy: 42
+    AccountHwmUpdate: 61
+    AccountServerConversion: 63
+    AccountTransfer: 65
+    AddConduitToCollection: 46
+    Arena: 17
+    AuctionDeposit: 51
+    AzeriteRespec: 34
+    Barbershop: 47
+    BonusRoll: 33
+    CatalystBalancing: 57
+    CatalystCraft: 58
+    Cheat: 4
+    ConvertItemsToCurrencyAndReputation: 62
+    ConvertItemsToCurrencyValue: 48
+    ConvertOldItem: 0
+    ConvertOldPvPCurrency: 1
+    CraftingOrder: 56
+    CurrencyWalletClaim: 29
+    DailyQuestReward: 38
+    DailyQuestWarModeReward: 39
+    DailyReset: 45
+    ExceededMaxQty: 18
+    FactionConversion: 37
+    GarrisonBuilding: 23
+    GarrisonBuildingRefund: 26
+    GarrisonFollowerActivation: 25
+    GarrisonMissionReward: 27
+    GarrisonResourceOverTime: 28
+    GarrisonTalent: 30
+    GarrisonTalentTreeReset: 44
+    GarrisonWorldQuestBonus: 31
+    GuildBankWithdrawal: 21
+    InitiativeReward: 67
+    ItemDeletion: 14
+    ItemRefund: 2
+    LFGReward: 11
+    Loot: 9
+    PhBuffer_53: 53
+    PhBuffer_54: 54
+    PlayerTrait: 52
+    PlayerTraitRefund: 60
+    ProfessionInitialAward: 59
+    Pushloot: 22
+    PvPCompletionBonus: 19
+    PvPDrop: 24
+    PvPHonorReward: 32
+    PvPKillCredit: 6
+    PvPMetaCredit: 7
+    PvPScriptedAward: 8
+    PvPTeamContribution: 49
+    QuestReward: 3
+    RandomBattleground: 16
+    RatedBattleground: 15
+    RenownRepGain: 55
+    RenownRepGainInitialVisibility: 66
+    Script: 20
+    Spell: 13
+    SpellSkipLinkedCurrency: 64
+    Trade: 12
+    Transmogrify: 50
+    UpdatingVersion: 10
+    Vendor: 5
+    WeeklyQuestReward: 40
+    WeeklyQuestWarModeReward: 41
+    WeeklyRewardChest: 43
+    WorldQuestReward: 35
+    WorldQuestRewardIgnoreCapsDeprecated: 36
 CurrencyTokenCategoryFlags:
-  FlagPlayerItemAssignment: 2
-  FlagSortLast: 1
-  Hidden: 4
-  StartsCollapsed: 16
-  Virtual: 8
+  values:
+    FlagPlayerItemAssignment: 2
+    FlagSortLast: 1
+    Hidden: 4
+    StartsCollapsed: 16
+    Virtual: 8
 CurrencyType:
-  Copper: 0
-  Gold: 2
-  Silver: 1
+  values:
+    Copper: 0
+    Gold: 2
+    Silver: 1
 Cursormode:
-  AttackCursor: 4
-  AttackErrorCursor: 50
-  BroomCursor: 42
-  BroomErrorCursor: 88
-  BuyCursor: 3
-  BuyErrorCursor: 49
-  CampaignQuestCursor: 23
-  CampaignQuestErrorCursor: 69
-  CampaignQuestTurninCursor: 24
-  CampaignQuestTurninErrorCursor: 70
-  CastCursor: 2
-  CastErrorCursor: 48
-  CustomCursor: 91
-  EnchantCursor: 39
-  EnchantErrorCursor: 85
-  GatherCursor: 13
-  GatherErrorCursor: 59
-  GrabbingHandCursor: 44
-  GrabbingHandErrorCursor: 90
-  HoldingHandCursor: 43
-  HoldingHandErrorCursor: 89
-  InnkeeperCursor: 22
-  InnkeeperErrorCursor: 68
-  InspectCursor: 7
-  InspectErrorCursor: 53
-  InteractCursor: 5
-  InteractErrorCursor: 51
-  ItemCursor: 19
-  ItemErrorCursor: 65
-  LockCursor: 14
-  LockErrorCursor: 60
-  LootAllCursor: 16
-  LootAllErrorCursor: 62
-  MailCursor: 15
-  MailErrorCursor: 61
-  MapPinCursor: 37
-  MapPinErrorCursor: 83
-  MineCursor: 11
-  MineErrorCursor: 57
-  NoCursor: 0
-  PaletteCursor: 41
-  PaletteErrorCursor: 87
-  PickupCursor: 8
-  PickupErrorCursor: 54
-  PingCursor: 38
-  PingErrorCursor: 84
-  PointCursor: 1
-  PointErrorCursor: 47
-  QuestCursor: 25
-  QuestErrorCursor: 71
-  QuestImportantCursor: 30
-  QuestImportantErrorCursor: 76
-  QuestImportantTurninCursor: 31
-  QuestImportantTurninErrorCursor: 77
-  QuestLegendaryCursor: 28
-  QuestLegendaryErrorCursor: 74
-  QuestLegendaryTurninCursor: 29
-  QuestLegendaryTurninErrorCursor: 75
-  QuestMetaCursor: 32
-  QuestMetaErrorCursor: 78
-  QuestMetaTurninCursor: 33
-  QuestMetaTurninErrorCursor: 79
-  QuestRecurringCursor: 34
-  QuestRecurringErrorCursor: 80
-  QuestRecurringTurninCursor: 35
-  QuestRecurringTurninErrorCursor: 81
-  QuestRepeatableCursor: 26
-  QuestRepeatableErrorCursor: 72
-  QuestTurninCursor: 27
-  QuestTurninErrorCursor: 73
-  RepairCursor: 17
-  RepairErrorCursor: 63
-  RepairnpcCursor: 18
-  RepairnpcErrorCursor: 64
-  SkinAllianceCursor: 21
-  SkinAllianceErrorCursor: 67
-  SkinCursor: 12
-  SkinErrorCursor: 58
-  SkinHordeCursor: 20
-  SkinHordeErrorCursor: 66
-  SpeakCursor: 6
-  SpeakErrorCursor: 52
-  StablemasterCursor: 40
-  StablemasterErrorCursor: 86
-  TaxiCursor: 9
-  TaxiErrorCursor: 55
-  TrainerCursor: 10
-  TrainerErrorCursor: 56
-  UIMoveCursor: 45
-  UIResizeCursor: 46
-  VehicleCursor: 36
-  VehicleErrorCursor: 82
+  values:
+    AttackCursor: 4
+    AttackErrorCursor: 50
+    BroomCursor: 42
+    BroomErrorCursor: 88
+    BuyCursor: 3
+    BuyErrorCursor: 49
+    CampaignQuestCursor: 23
+    CampaignQuestErrorCursor: 69
+    CampaignQuestTurninCursor: 24
+    CampaignQuestTurninErrorCursor: 70
+    CastCursor: 2
+    CastErrorCursor: 48
+    CustomCursor: 91
+    EnchantCursor: 39
+    EnchantErrorCursor: 85
+    GatherCursor: 13
+    GatherErrorCursor: 59
+    GrabbingHandCursor: 44
+    GrabbingHandErrorCursor: 90
+    HoldingHandCursor: 43
+    HoldingHandErrorCursor: 89
+    InnkeeperCursor: 22
+    InnkeeperErrorCursor: 68
+    InspectCursor: 7
+    InspectErrorCursor: 53
+    InteractCursor: 5
+    InteractErrorCursor: 51
+    ItemCursor: 19
+    ItemErrorCursor: 65
+    LockCursor: 14
+    LockErrorCursor: 60
+    LootAllCursor: 16
+    LootAllErrorCursor: 62
+    MailCursor: 15
+    MailErrorCursor: 61
+    MapPinCursor: 37
+    MapPinErrorCursor: 83
+    MineCursor: 11
+    MineErrorCursor: 57
+    NoCursor: 0
+    PaletteCursor: 41
+    PaletteErrorCursor: 87
+    PickupCursor: 8
+    PickupErrorCursor: 54
+    PingCursor: 38
+    PingErrorCursor: 84
+    PointCursor: 1
+    PointErrorCursor: 47
+    QuestCursor: 25
+    QuestErrorCursor: 71
+    QuestImportantCursor: 30
+    QuestImportantErrorCursor: 76
+    QuestImportantTurninCursor: 31
+    QuestImportantTurninErrorCursor: 77
+    QuestLegendaryCursor: 28
+    QuestLegendaryErrorCursor: 74
+    QuestLegendaryTurninCursor: 29
+    QuestLegendaryTurninErrorCursor: 75
+    QuestMetaCursor: 32
+    QuestMetaErrorCursor: 78
+    QuestMetaTurninCursor: 33
+    QuestMetaTurninErrorCursor: 79
+    QuestRecurringCursor: 34
+    QuestRecurringErrorCursor: 80
+    QuestRecurringTurninCursor: 35
+    QuestRecurringTurninErrorCursor: 81
+    QuestRepeatableCursor: 26
+    QuestRepeatableErrorCursor: 72
+    QuestTurninCursor: 27
+    QuestTurninErrorCursor: 73
+    RepairCursor: 17
+    RepairErrorCursor: 63
+    RepairnpcCursor: 18
+    RepairnpcErrorCursor: 64
+    SkinAllianceCursor: 21
+    SkinAllianceErrorCursor: 67
+    SkinCursor: 12
+    SkinErrorCursor: 58
+    SkinHordeCursor: 20
+    SkinHordeErrorCursor: 66
+    SpeakCursor: 6
+    SpeakErrorCursor: 52
+    StablemasterCursor: 40
+    StablemasterErrorCursor: 86
+    TaxiCursor: 9
+    TaxiErrorCursor: 55
+    TrainerCursor: 10
+    TrainerErrorCursor: 56
+    UIMoveCursor: 45
+    UIResizeCursor: 46
+    VehicleCursor: 36
+    VehicleErrorCursor: 82
 CursorStyle:
-  Crosshair: 1
-  Mouse: 0
+  values:
+    Crosshair: 1
+    Mouse: 0
 CustomBindingType:
-  VoicePushToTalk: 0
+  values:
+    VoicePushToTalk: 0
 Damageclass:
-  All: 127
-  AllMagical: 126
-  AllPhysical: 1
-  Arcane: 6
-  Fire: 2
-  FirstResist: 2
-  Frost: 4
-  Holy: 1
-  LastResist: 6
-  MaskArcane: 64
-  MaskChaos: 124
-  MaskChromatic: 62
-  MaskCosmic: 106
-  MaskDivine: 66
-  MaskElemental: 28
-  MaskFire: 4
-  MaskFirestorm: 12
-  MaskFlamestrike: 5
-  MaskFrost: 16
-  MaskFrostfire: 20
-  MaskFroststorm: 24
-  MaskFroststrike: 17
-  MaskHoly: 2
-  MaskHolyfire: 6
-  MaskHolyfrost: 18
-  MaskHolystorm: 10
-  MaskHolystrike: 3
-  MaskMagical: 126
-  MaskNature: 8
-  MaskNone: 0
-  MaskPhysical: 1
-  MaskShadow: 32
-  MaskShadowflame: 36
-  MaskShadowfrost: 48
-  MaskShadowstorm: 40
-  MaskShadowstrike: 33
-  MaskSpellfire: 68
-  MaskSpellfrost: 80
-  MaskSpellshadow: 96
-  MaskSpellstorm: 72
-  MaskSpellstrike: 65
-  MaskStormstrike: 9
-  MaskTwilight: 34
-  Nature: 3
-  Physical: 0
-  Shadow: 5
+  values:
+    All: 127
+    AllMagical: 126
+    AllPhysical: 1
+    Arcane: 6
+    Fire: 2
+    FirstResist: 2
+    Frost: 4
+    Holy: 1
+    LastResist: 6
+    MaskArcane: 64
+    MaskChaos: 124
+    MaskChromatic: 62
+    MaskCosmic: 106
+    MaskDivine: 66
+    MaskElemental: 28
+    MaskFire: 4
+    MaskFirestorm: 12
+    MaskFlamestrike: 5
+    MaskFrost: 16
+    MaskFrostfire: 20
+    MaskFroststorm: 24
+    MaskFroststrike: 17
+    MaskHoly: 2
+    MaskHolyfire: 6
+    MaskHolyfrost: 18
+    MaskHolystorm: 10
+    MaskHolystrike: 3
+    MaskMagical: 126
+    MaskNature: 8
+    MaskNone: 0
+    MaskPhysical: 1
+    MaskShadow: 32
+    MaskShadowflame: 36
+    MaskShadowfrost: 48
+    MaskShadowstorm: 40
+    MaskShadowstrike: 33
+    MaskSpellfire: 68
+    MaskSpellfrost: 80
+    MaskSpellshadow: 96
+    MaskSpellstorm: 72
+    MaskSpellstrike: 65
+    MaskStormstrike: 9
+    MaskTwilight: 34
+    Nature: 3
+    Physical: 0
+    Shadow: 5
 DamageclassType:
-  Magical: 1
-  Physical: 0
+  values:
+    Magical: 1
+    Physical: 0
 DamageMeterCombineSessionType:
-  Arena: 2
-  ArenaMultiRound: 3
-  ChallengeMode: 1
-  None: 0
+  values:
+    Arena: 2
+    ArenaMultiRound: 3
+    ChallengeMode: 1
+    None: 0
 DamageMeterNumbers:
-  Compact: 1
-  Complete: 2
-  Minimal: 0
+  values:
+    Compact: 1
+    Complete: 2
+    Minimal: 0
 DamageMeterOverrideType:
-  AllowFriendlyFire: 1
-  Ignore: 0
-  IgnoreForAbsorbSpell: 4
-  RedirectSourceToAuraCaster: 3
-  RedirectSourceToOwner: 2
+  values:
+    AllowFriendlyFire: 1
+    Ignore: 0
+    IgnoreForAbsorbSpell: 4
+    RedirectSourceToAuraCaster: 3
+    RedirectSourceToOwner: 2
 DamageMeterSessionType:
-  Current: 1
-  Expired: 2
-  Overall: 0
+  values:
+    Current: 1
+    Expired: 2
+    Overall: 0
 DamageMeterSourceDisplayType:
-  Ally: 1
-  Enemy: 2
-  None: 0
+  values:
+    Ally: 1
+    Enemy: 2
+    None: 0
 DamageMeterSpellDetailsDisplayType:
-  Deaths: 3
-  EnemyDamageTaken: 4
-  SpellAffected: 2
-  SpellCasted: 0
-  UnitSpecificSpellCasted: 1
+  values:
+    Deaths: 3
+    EnemyDamageTaken: 4
+    SpellAffected: 2
+    SpellCasted: 0
+    UnitSpecificSpellCasted: 1
 DamageMeterStorageType:
-  Absorbs: 2
-  AvoidableDamageTaken: 6
-  Damage: 0
-  DamageTaken: 5
-  Deaths: 7
-  Dispels: 4
-  EnemyDamageTaken: 8
-  HealingAndAbsorbs: 1
-  Interrupts: 3
+  values:
+    Absorbs: 2
+    AvoidableDamageTaken: 6
+    Damage: 0
+    DamageTaken: 5
+    Deaths: 7
+    Dispels: 4
+    EnemyDamageTaken: 8
+    HealingAndAbsorbs: 1
+    Interrupts: 3
 DamageMeterStyle:
-  Bordered: 2
-  Default: 0
-  FullBackground: 3
-  Thin: 1
+  values:
+    Bordered: 2
+    Default: 0
+    FullBackground: 3
+    Thin: 1
 DamageMeterType:
-  Absorbs: 4
-  AvoidableDamageTaken: 8
-  DamageDone: 0
-  DamageTaken: 7
-  Deaths: 9
-  Dispels: 6
-  Dps: 1
-  EnemyDamageTaken: 10
-  HealingDone: 2
-  Hps: 3
-  Interrupts: 5
+  values:
+    Absorbs: 4
+    AvoidableDamageTaken: 8
+    DamageDone: 0
+    DamageTaken: 7
+    Deaths: 9
+    Dispels: 6
+    Dps: 1
+    EnemyDamageTaken: 10
+    HealingDone: 2
+    Hps: 3
+    Interrupts: 5
 DamageMeterVisibility:
-  Always: 0
-  Hidden: 2
-  InCombat: 1
-  InGroup: 3
+  values:
+    Always: 0
+    Hidden: 2
+    InCombat: 1
+    InGroup: 3
 DeveloperLogAssertDomain:
-  Art: 1
-  Design: 2
-  Engineering: 4
-  LiveOperations: 64
-  Performance: 32
-  Sound: 8
-  Tools: 16
+  values:
+    Art: 1
+    Design: 2
+    Engineering: 4
+    LiveOperations: 64
+    Performance: 32
+    Sound: 8
+    Tools: 16
 DeveloperLogErrorDomain:
-  Assert: 0
-  AssertData: 1
-  Frame: 2
-  TestSuite: 3
+  values:
+    Assert: 0
+    AssertData: 1
+    Frame: 2
+    TestSuite: 3
 DeveloperLogTrafficType:
-  ClientToServer: 1
-  GameEvent: 2
-  LuaToClient: 3
-  ServerToClient: 0
+  values:
+    ClientToServer: 1
+    GameEvent: 2
+    LuaToClient: 3
+    ServerToClient: 0
 DisableAccountProfilesFlags:
-  DecorsCollections: 32
-  Document: 1
-  ItemsCollections: 16
-  MountsCollections: 4
-  None: 0
-  PetsCollections: 8
-  SharedCollections: 2
+  values:
+    DecorsCollections: 32
+    Document: 1
+    ItemsCollections: 16
+    MountsCollections: 4
+    None: 0
+    PetsCollections: 8
+    SharedCollections: 2
 DurationTextBindingProperty:
-  ElapsedDuration: 2
-  ElapsedPercent: 3
-  EndTime: 6
-  RemainingDuration: 0
-  RemainingPercent: 1
-  StartTime: 5
-  TotalDuration: 4
+  values:
+    ElapsedDuration: 2
+    ElapsedPercent: 3
+    EndTime: 6
+    RemainingDuration: 0
+    RemainingPercent: 1
+    StartTime: 5
+    TotalDuration: 4
 DurationTimeModifier:
-  BaseTime: 1
-  RealTime: 0
+  values:
+    BaseTime: 1
+    RealTime: 0
 EditModeAccountSetting:
-  DeprecatedShowDebuffFrame: 11
-  EnableAdvancedOptions: 23
-  EnableSnap: 22
-  GridSpacing: 1
-  SettingsExpanded: 2
-  ShowArchaeologyBar: 27
-  ShowArenaFrames: 17
-  ShowBossFrames: 16
-  ShowBuffsAndDebuffs: 10
-  ShowCastBar: 7
-  ShowCooldownViewer: 28
-  ShowDamageMeter: 31
-  ShowDurabilityFrame: 21
-  ShowEncounterBar: 8
-  ShowEncounterEvents: 30
-  ShowExternalDefensives: 32
-  ShowExtraAbilities: 9
-  ShowGrid: 0
-  ShowHudTooltip: 19
-  ShowLootFrame: 18
-  ShowPartyFrames: 12
-  ShowPersonalResourceDisplay: 29
-  ShowPetActionBar: 5
-  ShowPetFrame: 24
-  ShowPossessActionBar: 6
-  ShowRaidFrames: 13
-  ShowStanceBar: 4
-  ShowStatusTrackingBar2: 20
-  ShowTalkingHeadFrame: 14
-  ShowTargetAndFocus: 3
-  ShowTimerBars: 25
-  ShowTotemActionBar: 33
-  ShowVehicleLeaveButton: 15
-  ShowVehicleSeatIndicator: 26
+  values:
+    DeprecatedShowDebuffFrame: 11
+    EnableAdvancedOptions: 23
+    EnableSnap: 22
+    GridSpacing: 1
+    SettingsExpanded: 2
+    ShowArchaeologyBar: 27
+    ShowArenaFrames: 17
+    ShowBossFrames: 16
+    ShowBuffsAndDebuffs: 10
+    ShowCastBar: 7
+    ShowCooldownViewer: 28
+    ShowDamageMeter: 31
+    ShowDurabilityFrame: 21
+    ShowEncounterBar: 8
+    ShowEncounterEvents: 30
+    ShowExternalDefensives: 32
+    ShowExtraAbilities: 9
+    ShowGrid: 0
+    ShowHudTooltip: 19
+    ShowLootFrame: 18
+    ShowPartyFrames: 12
+    ShowPersonalResourceDisplay: 29
+    ShowPetActionBar: 5
+    ShowPetFrame: 24
+    ShowPossessActionBar: 6
+    ShowRaidFrames: 13
+    ShowStanceBar: 4
+    ShowStatusTrackingBar2: 20
+    ShowTalkingHeadFrame: 14
+    ShowTargetAndFocus: 3
+    ShowTimerBars: 25
+    ShowTotemActionBar: 33
+    ShowVehicleLeaveButton: 15
+    ShowVehicleSeatIndicator: 26
 EditModeActionBarSetting:
-  AlwaysShowButtons: 9
-  DeprecatedSnapToSide: 7
-  HideBarArt: 6
-  HideBarScrolling: 8
-  IconPadding: 4
-  IconSize: 3
-  NumIcons: 2
-  NumRows: 1
-  Orientation: 0
-  VisibleSetting: 5
+  values:
+    AlwaysShowButtons: 9
+    DeprecatedSnapToSide: 7
+    HideBarArt: 6
+    HideBarScrolling: 8
+    IconPadding: 4
+    IconSize: 3
+    NumIcons: 2
+    NumRows: 1
+    Orientation: 0
+    VisibleSetting: 5
 EditModeActionBarSystemIndices:
-  Bar2: 2
-  Bar3: 3
-  ExtraBar1: 6
-  ExtraBar2: 7
-  ExtraBar3: 8
-  MainBar: 1
-  PetActionBar: 12
-  PossessActionBar: 13
-  RightBar1: 4
-  RightBar2: 5
-  StanceBar: 11
+  values:
+    Bar2: 2
+    Bar3: 3
+    ExtraBar1: 6
+    ExtraBar2: 7
+    ExtraBar3: 8
+    MainBar: 1
+    PetActionBar: 12
+    PossessActionBar: 13
+    RightBar1: 4
+    RightBar2: 5
+    StanceBar: 11
 EditModeArchaeologyBarSetting:
-  Size: 0
+  values:
+    Size: 0
 EditModeAuraFrameSetting:
-  DeprecatedShowFull: 7
-  IconDirection: 2
-  IconLimitBuffFrame: 3
-  IconLimitDebuffFrame: 4
-  IconPadding: 6
-  IconSize: 5
-  IconWrap: 1
-  Opacity: 9
-  Orientation: 0
-  ShowDispelType: 10
-  VisibleSetting: 8
+  values:
+    DeprecatedShowFull: 7
+    IconDirection: 2
+    IconLimitBuffFrame: 3
+    IconLimitDebuffFrame: 4
+    IconPadding: 6
+    IconSize: 5
+    IconWrap: 1
+    Opacity: 9
+    Orientation: 0
+    ShowDispelType: 10
+    VisibleSetting: 8
 EditModeAuraFrameSystemIndices:
-  BuffFrame: 1
-  DebuffFrame: 2
-  ExternalDefensivesFrame: 3
+  values:
+    BuffFrame: 1
+    DebuffFrame: 2
+    ExternalDefensivesFrame: 3
 EditModeBagsSetting:
-  BagSlotPadding: 3
-  Direction: 1
-  Orientation: 0
-  Size: 2
+  values:
+    BagSlotPadding: 3
+    Direction: 1
+    Orientation: 0
+    Size: 2
 EditModeCastBarSetting:
-  BarSize: 0
-  LockToPlayerFrame: 1
-  ShowCastTime: 2
+  values:
+    BarSize: 0
+    LockToPlayerFrame: 1
+    ShowCastTime: 2
 EditModeChatFrameSetting:
-  HeightHundreds: 2
-  HeightTensAndOnes: 3
-  WidthHundreds: 0
-  WidthTensAndOnes: 1
+  values:
+    HeightHundreds: 2
+    HeightTensAndOnes: 3
+    WidthHundreds: 0
+    WidthTensAndOnes: 1
 EditModeCooldownViewerSetting:
-  BarContent: 7
-  BarWidthScale: 11
-  HideWhenInactive: 8
-  IconDirection: 2
-  IconLimit: 1
-  IconPadding: 4
-  IconSize: 3
-  Opacity: 5
-  Orientation: 0
-  ShowTimer: 9
-  ShowTooltips: 10
-  VisibleSetting: 6
+  values:
+    BarContent: 7
+    BarWidthScale: 11
+    HideWhenInactive: 8
+    IconDirection: 2
+    IconLimit: 1
+    IconPadding: 4
+    IconSize: 3
+    Opacity: 5
+    Orientation: 0
+    ShowTimer: 9
+    ShowTooltips: 10
+    VisibleSetting: 6
 EditModeCooldownViewerSystemIndices:
-  BuffBar: 4
-  BuffIcon: 3
-  Essential: 1
-  Utility: 2
+  values:
+    BuffBar: 4
+    BuffIcon: 3
+    Essential: 1
+    Utility: 2
 EditModeDamageMeterSetting:
-  BackgroundTransparency: 12
-  BarHeight: 10
-  FrameHeight: 4
-  FrameWidth: 3
-  Numbers: 2
-  ObsoleteReuse1: 7
-  Padding: 5
-  ShowClassColor: 9
-  ShowSpecIcon: 8
-  Style: 1
-  TextSize: 11
-  Transparency: 6
-  Visibility: 0
+  values:
+    BackgroundTransparency: 12
+    BarHeight: 10
+    FrameHeight: 4
+    FrameWidth: 3
+    Numbers: 2
+    ObsoleteReuse1: 7
+    Padding: 5
+    ShowClassColor: 9
+    ShowSpecIcon: 8
+    Style: 1
+    TextSize: 11
+    Transparency: 6
+    Visibility: 0
 EditModeDurabilityFrameSetting:
-  Size: 0
+  values:
+    Size: 0
 EditModeEncounterEventsSetting:
-  BackgroundTransparency: 5
-  BarWidth: 12
-  FlipHorizontally: 11
-  IconDirection: 1
-  IconSize: 3
-  Orientation: 0
-  OverallSize: 4
-  Padding: 13
-  ShowSpellName: 2
-  ShowTimer: 9
-  TooltipAnchor: 8
-  Transparency: 6
-  ViewType: 10
-  Visibility: 7
+  values:
+    BackgroundTransparency: 5
+    BarWidth: 12
+    FlipHorizontally: 11
+    IconDirection: 1
+    IconSize: 3
+    Orientation: 0
+    OverallSize: 4
+    Padding: 13
+    ShowSpellName: 2
+    ShowTimer: 9
+    TooltipAnchor: 8
+    Transparency: 6
+    ViewType: 10
+    Visibility: 7
 EditModeEncounterEventsSystemIndices:
-  CriticalWarnings: 2
-  MediumWarnings: 3
-  NormalWarnings: 4
-  Timeline: 1
+  values:
+    CriticalWarnings: 2
+    MediumWarnings: 3
+    NormalWarnings: 4
+    Timeline: 1
 EditModeLayoutType:
-  Account: 1
-  Character: 2
-  Override: 3
-  Preset: 0
+  values:
+    Account: 1
+    Character: 2
+    Override: 3
+    Preset: 0
 EditModeMicroMenuSetting:
-  EyeSize: 3
-  Order: 1
-  Orientation: 0
-  Size: 2
+  values:
+    EyeSize: 3
+    Order: 1
+    Orientation: 0
+    Size: 2
 EditModeMinimapSetting:
-  HeaderUnderneath: 0
-  RotateMinimap: 1
-  Size: 2
+  values:
+    HeaderUnderneath: 0
+    RotateMinimap: 1
+    Size: 2
 EditModeObjectiveTrackerSetting:
-  Height: 0
-  Opacity: 1
-  TextSize: 2
+  values:
+    Height: 0
+    Opacity: 1
+    TextSize: 2
 EditModePersonalResourceDisplaySetting:
-  BarWidth: 12
-  DeprecatedOnlyShowInCombat: 1
-  HealthBarHeight: 4
-  HideAltPower: 14
-  HideClassInfo: 3
-  HideClassInfoOnPlayerFrame: 10
-  HideHealth: 0
-  HidePower: 2
-  Opacity: 7
-  Padding: 6
-  PowerBarHeight: 5
-  ShowBarText: 13
-  ShowClassColor: 11
-  Size: 9
-  VisibleSetting: 8
+  values:
+    BarWidth: 12
+    DeprecatedOnlyShowInCombat: 1
+    HealthBarHeight: 4
+    HideAltPower: 14
+    HideClassInfo: 3
+    HideClassInfoOnPlayerFrame: 10
+    HideHealth: 0
+    HidePower: 2
+    Opacity: 7
+    Padding: 6
+    PowerBarHeight: 5
+    ShowBarText: 13
+    ShowClassColor: 11
+    Size: 9
+    VisibleSetting: 8
 EditModePresetLayouts:
-  Classic: 1
-  Modern: 0
+  values:
+    Classic: 1
+    Modern: 0
 EditModeSettingDisplayType:
-  Checkbox: 1
-  Dropdown: 0
-  Slider: 2
+  values:
+    Checkbox: 1
+    Dropdown: 0
+    Slider: 2
 EditModeStatusTrackingBarSetting:
-  Height: 0
-  Size: 3
-  TextSize: 2
-  Width: 1
+  values:
+    Height: 0
+    Size: 3
+    TextSize: 2
+    Width: 1
 EditModeStatusTrackingBarSystemIndices:
-  StatusTrackingBar1: 1
-  StatusTrackingBar2: 2
+  values:
+    StatusTrackingBar1: 1
+    StatusTrackingBar2: 2
 EditModeSystem:
-  ActionBar: 0
-  ArchaeologyBar: 19
-  AuraFrame: 6
-  Bags: 14
-  CastBar: 1
-  ChatFrame: 8
-  CooldownViewer: 20
-  DamageMeter: 23
-  DurabilityFrame: 16
-  EncounterBar: 4
-  EncounterEvents: 22
-  ExtraAbilities: 5
-  HudTooltip: 11
-  LootFrame: 10
-  MicroMenu: 13
-  Minimap: 2
-  ObjectiveTracker: 12
-  PersonalResourceDisplay: 21
-  StatusTrackingBar: 15
-  TalkingHeadFrame: 7
-  TimerBars: 17
-  TotemActionBar: 24
-  UnitFrame: 3
-  VehicleLeaveButton: 9
-  VehicleSeatIndicator: 18
+  values:
+    ActionBar: 0
+    ArchaeologyBar: 19
+    AuraFrame: 6
+    Bags: 14
+    CastBar: 1
+    ChatFrame: 8
+    CooldownViewer: 20
+    DamageMeter: 23
+    DurabilityFrame: 16
+    EncounterBar: 4
+    EncounterEvents: 22
+    ExtraAbilities: 5
+    HudTooltip: 11
+    LootFrame: 10
+    MicroMenu: 13
+    Minimap: 2
+    ObjectiveTracker: 12
+    PersonalResourceDisplay: 21
+    StatusTrackingBar: 15
+    TalkingHeadFrame: 7
+    TimerBars: 17
+    TotemActionBar: 24
+    UnitFrame: 3
+    VehicleLeaveButton: 9
+    VehicleSeatIndicator: 18
 EditModeTimerBarsSetting:
-  Size: 0
+  values:
+    Size: 0
 EditModeUnitFrameSetting:
-  AuraOrganizationType: 18
-  BigDefensiveIconSize: 21
-  BuffsOnTop: 2
-  CastBarOnSide: 7
-  CastBarUnderneath: 1
-  DisplayBorder: 12
-  FrameHeight: 11
-  FrameSize: 16
-  FrameWidth: 10
-  HidePortrait: 0
-  IconSize: 19
-  Opacity: 20
-  RaidGroupDisplayType: 13
-  RowSize: 15
-  ShowCastTime: 8
-  ShowPartyFrameBackground: 5
-  SortPlayersBy: 14
-  UseHorizontalGroups: 6
-  UseLargerFrame: 3
-  UseRaidStylePartyFrames: 4
-  ViewArenaSize: 17
-  ViewRaidSize: 9
+  values:
+    AuraOrganizationType: 18
+    BigDefensiveIconSize: 21
+    BuffsOnTop: 2
+    CastBarOnSide: 7
+    CastBarUnderneath: 1
+    DisplayBorder: 12
+    FrameHeight: 11
+    FrameSize: 16
+    FrameWidth: 10
+    HidePortrait: 0
+    IconSize: 19
+    Opacity: 20
+    RaidGroupDisplayType: 13
+    RowSize: 15
+    ShowCastTime: 8
+    ShowPartyFrameBackground: 5
+    SortPlayersBy: 14
+    UseHorizontalGroups: 6
+    UseLargerFrame: 3
+    UseRaidStylePartyFrames: 4
+    ViewArenaSize: 17
+    ViewRaidSize: 9
 EditModeUnitFrameSystemIndices:
-  Arena: 7
-  Boss: 6
-  Focus: 3
-  Party: 4
-  Pet: 8
-  Player: 1
-  Raid: 5
-  Target: 2
+  values:
+    Arena: 7
+    Boss: 6
+    Focus: 3
+    Party: 4
+    Pet: 8
+    Player: 1
+    Raid: 5
+    Target: 2
 EditModeVehicleSeatIndicatorSetting:
-  Size: 0
+  values:
+    Size: 0
 EncounterEventCastState:
-  Casting: 1
-  Expired: 3
-  NotCasting: 2
+  values:
+    Casting: 1
+    Expired: 3
+    NotCasting: 2
 EncounterEventColorTrigger:
-  TextWarning: 0
-  TimelineEvent: 1
-  TimelineEventHighlight: 2
+  values:
+    TextWarning: 0
+    TimelineEvent: 1
+    TimelineEventHighlight: 2
 EncounterEventIconmask:
-  BleedEffect: 4
-  CurseEffect: 32
-  DeadlyEffect: 1
-  DiseaseEffect: 16
-  DpsRole: 512
-  EnrageEffect: 2
-  HealerRole: 256
-  MagicEffect: 8
-  PoisonEffect: 64
-  TankRole: 128
+  values:
+    BleedEffect: 4
+    CurseEffect: 32
+    DeadlyEffect: 1
+    DiseaseEffect: 16
+    DpsRole: 512
+    EnrageEffect: 2
+    HealerRole: 256
+    MagicEffect: 8
+    PoisonEffect: 64
+    TankRole: 128
 EncounterEventSeverity:
-  High: 2
-  Low: 0
-  Medium: 1
+  values:
+    High: 2
+    Low: 0
+    Medium: 1
 EncounterEventsIconDirection:
-  Bottom: 1
-  Left: 0
-  Right: 1
-  Top: 0
+  values:
+    Bottom: 1
+    Left: 0
+    Right: 1
+    Top: 0
 EncounterEventsOrientation:
-  Horizontal: 0
-  Vertical: 1
+  values:
+    Horizontal: 0
+    Vertical: 1
 EncounterEventSoundTrigger:
-  OnTextWarningShown: 0
-  OnTimelineEventFinished: 1
-  OnTimelineEventHighlight: 2
+  values:
+    OnTextWarningShown: 0
+    OnTimelineEventFinished: 1
+    OnTimelineEventHighlight: 2
 EncounterEventsTooltipAnchor:
-  Cursor: 2
-  Default: 1
-  Hidden: 0
+  values:
+    Cursor: 2
+    Default: 1
+    Hidden: 0
 EncounterEventsViewType:
-  Bars: 1
-  Timeline: 0
+  values:
+    Bars: 1
+    Timeline: 0
 EncounterEventsVisibility:
-  Always: 0
-  DeprecatedHidden: 2
-  InEncounter: 1
+  values:
+    Always: 0
+    DeprecatedHidden: 2
+    InEncounter: 1
 EncounterLootDropRollState:
-  Greed: 3
-  NeedMainSpec: 0
-  NeedOffSpec: 1
-  NoRoll: 4
-  Pass: 5
-  Transmog: 2
+  values:
+    Greed: 3
+    NeedMainSpec: 0
+    NeedOffSpec: 1
+    NoRoll: 4
+    Pass: 5
+    Transmog: 2
 EncounterTimelineEventSortDirection:
-  Ascending: 1
-  Descending: 0
+  values:
+    Ascending: 1
+    Descending: 0
 EncounterTimelineEventSource:
-  EditMode: 2
-  Encounter: 0
-  Script: 1
+  values:
+    EditMode: 2
+    Encounter: 0
+    Script: 1
 EncounterTimelineEventState:
-  Active: 0
-  Canceled: 3
-  Finished: 2
-  Paused: 1
+  values:
+    Active: 0
+    Canceled: 3
+    Finished: 2
+    Paused: 1
 EncounterTimelineIconSet:
-  DamageAlert: 3
-  Deadly: 4
-  Dispel: 5
-  Enrage: 6
-  HealerAlert: 2
-  TankAlert: 1
+  values:
+    DamageAlert: 3
+    Deadly: 4
+    Dispel: 5
+    Enrage: 6
+    HealerAlert: 2
+    TankAlert: 1
 EncounterTimelineTrack:
-  Indeterminate: 4
-  Long: 3
-  Medium: 2
-  Queued: 0
-  Short: 1
+  values:
+    Indeterminate: 4
+    Long: 3
+    Medium: 2
+    Queued: 0
+    Short: 1
 EncounterTimelineTrackType:
-  Hidden: 0
-  Linear: 2
-  Sorted: 1
+  values:
+    Hidden: 0
+    Linear: 2
+    Sorted: 1
 EncounterTimelineViewType:
-  Bars: 2
-  None: 0
-  Timeline: 1
+  values:
+    Bars: 2
+    None: 0
+    Timeline: 1
 EndOfMatchType:
-  None: 0
-  Plunderstorm: 1
+  values:
+    None: 0
+    Plunderstorm: 1
 EnvironmentalDamageFlags:
-  DmgIsPct: 2
-  OneTime: 1
+  values:
+    DmgIsPct: 2
+    OneTime: 1
 Environmentaldamagetype:
-  Drowning: 1
-  Falling: 2
-  Fatigue: 0
-  Fire: 5
-  Lava: 3
-  Slime: 4
+  values:
+    Drowning: 1
+    Falling: 2
+    Fatigue: 0
+    Fire: 5
+    Lava: 3
+    Slime: 4
 EventRealmQueues:
-  None: 0
-  PlunderstormDuo: 2
-  PlunderstormSolo: 1
-  PlunderstormTraining: 8
-  PlunderstormTrio: 4
+  values:
+    None: 0
+    PlunderstormDuo: 2
+    PlunderstormSolo: 1
+    PlunderstormTraining: 8
+    PlunderstormTrio: 4
 EventToastDisplayType:
-  CapstoneUnlocked: 12
-  ChallengeMode: 7
-  FlightpointDiscovered: 11
-  HouseUpgradeAvailable: 15
-  LargeTextWithIcon: 4
-  NormalBlockText: 1
-  NormalSingleLine: 0
-  NormalTextWithIcon: 3
-  NormalTextWithIconAndRarity: 5
-  NormalTitleAndSubTitle: 2
-  Scenario: 6
-  ScenarioClickExpand: 8
-  Scoreboard: 14
-  SingleLineWithIcon: 13
-  WeeklyRewardUnlock: 9
-  WeeklyRewardUpgrade: 10
+  values:
+    CapstoneUnlocked: 12
+    ChallengeMode: 7
+    FlightpointDiscovered: 11
+    HouseUpgradeAvailable: 15
+    LargeTextWithIcon: 4
+    NormalBlockText: 1
+    NormalSingleLine: 0
+    NormalTextWithIcon: 3
+    NormalTextWithIconAndRarity: 5
+    NormalTitleAndSubTitle: 2
+    Scenario: 6
+    ScenarioClickExpand: 8
+    Scoreboard: 14
+    SingleLineWithIcon: 13
+    WeeklyRewardUnlock: 9
+    WeeklyRewardUpgrade: 10
 EventToastEventType:
-  BattlePetLevelChanged: 8
-  BattlePetLevelUpAbility: 9
-  CriteriaUpdated: 19
-  FlightpointDiscovered: 25
-  HouseUpgradeAvailable: 26
-  LevelUp: 0
-  LevelUpDungeon: 2
-  LevelUpOther: 15
-  LevelUpPvP: 4
-  LevelUpRaid: 3
-  LevelUpSpell: 1
-  MythicPlusWeeklyRecord: 11
-  PetBattleCapture: 7
-  PetBattleFinalRound: 6
-  PetBattleNewAbility: 5
-  PlayerAuraAdded: 16
-  PlayerAuraRemoved: 17
-  PvPTierUpdate: 20
-  QuestBossEmote: 10
-  QuestTurnedIn: 12
-  Scenario: 14
-  SpellLearned: 21
-  SpellScript: 18
-  TreasureItem: 22
-  WeeklyRewardUnlock: 23
-  WeeklyRewardUpgrade: 24
-  WorldStateChange: 13
+  values:
+    BattlePetLevelChanged: 8
+    BattlePetLevelUpAbility: 9
+    CriteriaUpdated: 19
+    FlightpointDiscovered: 25
+    HouseUpgradeAvailable: 26
+    LevelUp: 0
+    LevelUpDungeon: 2
+    LevelUpOther: 15
+    LevelUpPvP: 4
+    LevelUpRaid: 3
+    LevelUpSpell: 1
+    MythicPlusWeeklyRecord: 11
+    PetBattleCapture: 7
+    PetBattleFinalRound: 6
+    PetBattleNewAbility: 5
+    PlayerAuraAdded: 16
+    PlayerAuraRemoved: 17
+    PvPTierUpdate: 20
+    QuestBossEmote: 10
+    QuestTurnedIn: 12
+    Scenario: 14
+    SpellLearned: 21
+    SpellScript: 18
+    TreasureItem: 22
+    WeeklyRewardUnlock: 23
+    WeeklyRewardUpgrade: 24
+    WorldStateChange: 13
 EventToastFlags:
-  DisableRightClickDismiss: 1
+  values:
+    DisableRightClickDismiss: 1
 ExcludedCensorSources:
-  All: 255
-  Friends: 1
-  Guild: 2
-  None: 0
-  Reserve1: 4
-  Reserve2: 8
-  Reserve3: 16
-  Reserve4: 32
-  Reserve5: 64
-  Reserve6: 128
+  values:
+    All: 255
+    Friends: 1
+    Guild: 2
+    None: 0
+    Reserve1: 4
+    Reserve2: 8
+    Reserve3: 16
+    Reserve4: 32
+    Reserve5: 64
+    Reserve6: 128
 ExpansionLandingPageType:
-  Midnight: 1
-  None: 0
+  values:
+    Midnight: 1
+    None: 0
 ExpansionLevel:
-  BattleForAzeroth: 7
-  BurningCrusade: 1
-  Cataclysm: 3
-  Draenor: 5
-  Dragonflight: 9
-  LastTitan: 12
-  Legion: 6
-  Midnight: 11
-  MistsOfPandaria: 4
-  None: 0
-  Northrend: 2
-  Shadowlands: 8
-  WarWithin: 10
+  values:
+    BattleForAzeroth: 7
+    BurningCrusade: 1
+    Cataclysm: 3
+    Draenor: 5
+    Dragonflight: 9
+    LastTitan: 12
+    Legion: 6
+    Midnight: 11
+    MistsOfPandaria: 4
+    None: 0
+    Northrend: 2
+    Shadowlands: 8
+    WarWithin: 10
 FlightPathFaction:
-  Alliance: 2
-  Horde: 1
-  Neutral: 0
+  values:
+    Alliance: 2
+    Horde: 1
+    Neutral: 0
 FlightPathState:
-  Current: 0
-  Reachable: 1
-  Unreachable: 2
+  values:
+    Current: 0
+    Reachable: 1
+    Unreachable: 2
 FollowerAbilityCastResult:
-  AlreadyAtMaxDurability: 13
-  CannotTargetLimitedUseFollower: 11
-  CannotTargetNonAutoMissionFollower: 14
-  Failure: 1
-  InvalidFollowerSpell: 4
-  InvalidFollowerType: 9
-  InvalidTarget: 3
-  MustBeUnique: 10
-  MustTargetFollower: 7
-  MustTargetLimitedUseFollower: 12
-  MustTargetTrait: 8
-  NoPendingCast: 2
-  RerollNotAllowed: 5
-  SingleMissionDuration: 6
-  Success: 0
+  values:
+    AlreadyAtMaxDurability: 13
+    CannotTargetLimitedUseFollower: 11
+    CannotTargetNonAutoMissionFollower: 14
+    Failure: 1
+    InvalidFollowerSpell: 4
+    InvalidFollowerType: 9
+    InvalidTarget: 3
+    MustBeUnique: 10
+    MustTargetFollower: 7
+    MustTargetLimitedUseFollower: 12
+    MustTargetTrait: 8
+    NoPendingCast: 2
+    RerollNotAllowed: 5
+    SingleMissionDuration: 6
+    Success: 0
 FontStringScaleAnimationMode:
-  FontSize: 0
-  Vertex: 1
+  values:
+    FontSize: 0
+    Vertex: 1
 FragmentID:
-  Actor: 15
-  CgObject: 2
-  ClientObservablesData: 6
-  DeferredMessages: 9
-  EntityPosition: 1
-  FHousingDecor: 20
-  FHousingDecorActor: 28
-  FHousingDecorProxy: 26
-  FHousingFixture: 34
-  FHousingHouseDecorSet: 24
-  FHousingHouseFixtureSet: 35
-  FHousingHouseRoomSet: 25
-  FHousingPlayerHouse: 23
-  FHousingPlotAreaTrigger: 29
-  FHousingRoom: 21
-  FHousingRoomComponentMesh: 22
-  FHousingStorageMirrorData: 33
-  FJamHousingCornerstone: 27
-  FLootObjectList: 12
-  FMeshObjectData: 19
-  FMirroredPositionData: 31
-  FNeighborhoodMirrorData: 30
-  FNeighborhoodStateData: 38
-  FPathingDoor: 41
-  FPathingDynamicLinks: 40
-  FPersistableJamServers: 10
-  FPhaseShiftData: 16
-  FPlayerHouseInfo: 32
-  FPlayerInitiativeInfo: 37
-  FPlayerJamServers: 11
-  FPlayerOwnershipLink: 13
-  FTransportLink: 5
-  FUnitAIGroupLink: 39
-  FUnitAreaTriggerLink: 14
-  FVendor: 17
-  HeartbeatData: 4
-  JamDispatcher: 3
-  MirroredObjectC: 18
-  MirrorState: 0
-  ReservedArchetypeSeparator: 255
-  TagActiveClientS: 216
-  TagActiveObjectC: 217
-  TagActivePlayer: 215
-  TagAIGroup: 212
-  TagAreaTrigger: 209
-  TagAzeriteEmpoweredItem: 202
-  TagAzeriteItem: 203
-  TagContainer: 201
-  TagConversation: 211
-  TagCorpse: 208
-  TagDynamicObject: 207
-  TagGameObject: 206
-  TagHouseExteriorPiece: 224
-  TagHouseExteriorRoot: 225
-  TagHousingDecorProxyGameObject: 226
-  TagHousingPoolObject: 223
-  TagHousingRoom: 220
-  TagHousingSubdivisionObject: 222
-  TagItem: 200
-  TagLootObject: 214
-  TagMeshObject: 221
-  TagPlayer: 205
-  TagScenario: 213
-  TagSceneObject: 210
-  TagUnit: 204
-  TagUnitVehicle: 219
-  TagVisibleObjectC: 218
-  TestFragment_1: 250
-  TestFragment_2: 251
-  TestFragment_3: 252
-  TestFragment_4: 253
-  TestFragment_5: 254
-  Timer: 36
-  TimerQueues: 7
-  TransferSuspensionData: 8
+  values:
+    Actor: 15
+    CgObject: 2
+    ClientObservablesData: 6
+    DeferredMessages: 9
+    EntityPosition: 1
+    FHousingDecor: 20
+    FHousingDecorActor: 28
+    FHousingDecorProxy: 26
+    FHousingFixture: 34
+    FHousingHouseDecorSet: 24
+    FHousingHouseFixtureSet: 35
+    FHousingHouseRoomSet: 25
+    FHousingPlayerHouse: 23
+    FHousingPlotAreaTrigger: 29
+    FHousingRoom: 21
+    FHousingRoomComponentMesh: 22
+    FHousingStorageMirrorData: 33
+    FJamHousingCornerstone: 27
+    FLootObjectList: 12
+    FMeshObjectData: 19
+    FMirroredPositionData: 31
+    FNeighborhoodMirrorData: 30
+    FNeighborhoodStateData: 38
+    FPathingDoor: 41
+    FPathingDynamicLinks: 40
+    FPersistableJamServers: 10
+    FPhaseShiftData: 16
+    FPlayerHouseInfo: 32
+    FPlayerInitiativeInfo: 37
+    FPlayerJamServers: 11
+    FPlayerOwnershipLink: 13
+    FTransportLink: 5
+    FUnitAIGroupLink: 39
+    FUnitAreaTriggerLink: 14
+    FVendor: 17
+    HeartbeatData: 4
+    JamDispatcher: 3
+    MirroredObjectC: 18
+    MirrorState: 0
+    ReservedArchetypeSeparator: 255
+    TagActiveClientS: 216
+    TagActiveObjectC: 217
+    TagActivePlayer: 215
+    TagAIGroup: 212
+    TagAreaTrigger: 209
+    TagAzeriteEmpoweredItem: 202
+    TagAzeriteItem: 203
+    TagContainer: 201
+    TagConversation: 211
+    TagCorpse: 208
+    TagDynamicObject: 207
+    TagGameObject: 206
+    TagHouseExteriorPiece: 224
+    TagHouseExteriorRoot: 225
+    TagHousingDecorProxyGameObject: 226
+    TagHousingPoolObject: 223
+    TagHousingRoom: 220
+    TagHousingSubdivisionObject: 222
+    TagItem: 200
+    TagLootObject: 214
+    TagMeshObject: 221
+    TagPlayer: 205
+    TagScenario: 213
+    TagSceneObject: 210
+    TagUnit: 204
+    TagUnitVehicle: 219
+    TagVisibleObjectC: 218
+    TestFragment_1: 250
+    TestFragment_2: 251
+    TestFragment_3: 252
+    TestFragment_4: 253
+    TestFragment_5: 254
+    Timer: 36
+    TimerQueues: 7
+    TransferSuspensionData: 8
 FrameTutorialAccount:
-  AccountWideReputation: 9
-  AssistedCombatRotationActionButton: 22
-  AssistedCombatRotationDragSpell: 21
-  BindToAccountUntilEquip: 11
-  CompletedQuestsFilter: 12
-  CompletedQuestsFilterSeen: 13
-  ConcentrationCurrency: 14
-  EditModeManager: 3
-  EnconterJournalTutorialsTabSeen: 33
-  EventSchedulerTabSeen: 20
-  HeirloomJournalLevel: 7
-  HousingCleanupMode: 40
-  HousingDecorCleanup: 23
-  HousingDecorClippingGrid: 25
-  HousingDecorCustomization: 26
-  HousingDecorLayout: 27
-  HousingDecorPlace: 24
-  HousingEndeavorsTabSeen: 48
-  HousingExpertMode: 39
-  HousingHouseFinderMap: 28
-  HousingHouseFinderVisitHouse: 29
-  HousingInvalidCollision: 37
-  HousingItemAcquisition: 30
-  HousingMarketTab: 34
-  HousingModesUnlocked: 38
-  HousingNewPip: 31
-  HousingTeleportButton: 35
-  HudRevampBagChanges: 1
-  LFGList: 6
-  LocalStoriesFilterSeen: 19
-  MapLegendOpened: 15
-  MountCollectionDragonriding: 5
-  NpcCraftingOrderCreateButton: 17
-  NpcCraftingOrders: 16
-  NpcCraftingOrderTabNew: 18
-  PerksProgramActivitiesIntro: 2
-  PerksProgramActivitiesOpen: 32
-  RPETalentStarterBuild: 36
-  RunesOfPower: 49
-  TimerunnersAdvantage: 8
-  TransferableCurrencies: 10
-  TransmogCustomSets: 43
-  TransmogCustomSetsMigration: 47
-  TransmogOutfits: 41
-  TransmogSets: 42
-  TransmogSetsTab: 4
-  TransmogSituations: 44
-  TransmogTrialOfStyle: 46
-  TransmogWeaponOptions: 45
+  values:
+    AccountWideReputation: 9
+    AssistedCombatRotationActionButton: 22
+    AssistedCombatRotationDragSpell: 21
+    BindToAccountUntilEquip: 11
+    CompletedQuestsFilter: 12
+    CompletedQuestsFilterSeen: 13
+    ConcentrationCurrency: 14
+    EditModeManager: 3
+    EnconterJournalTutorialsTabSeen: 33
+    EventSchedulerTabSeen: 20
+    HeirloomJournalLevel: 7
+    HousingCleanupMode: 40
+    HousingDecorCleanup: 23
+    HousingDecorClippingGrid: 25
+    HousingDecorCustomization: 26
+    HousingDecorLayout: 27
+    HousingDecorPlace: 24
+    HousingEndeavorsTabSeen: 48
+    HousingExpertMode: 39
+    HousingHouseFinderMap: 28
+    HousingHouseFinderVisitHouse: 29
+    HousingInvalidCollision: 37
+    HousingItemAcquisition: 30
+    HousingMarketTab: 34
+    HousingModesUnlocked: 38
+    HousingNewPip: 31
+    HousingTeleportButton: 35
+    HudRevampBagChanges: 1
+    LFGList: 6
+    LocalStoriesFilterSeen: 19
+    MapLegendOpened: 15
+    MountCollectionDragonriding: 5
+    NpcCraftingOrderCreateButton: 17
+    NpcCraftingOrders: 16
+    NpcCraftingOrderTabNew: 18
+    PerksProgramActivitiesIntro: 2
+    PerksProgramActivitiesOpen: 32
+    RPETalentStarterBuild: 36
+    RunesOfPower: 49
+    TimerunnersAdvantage: 8
+    TransferableCurrencies: 10
+    TransmogCustomSets: 43
+    TransmogCustomSetsMigration: 47
+    TransmogOutfits: 41
+    TransmogSets: 42
+    TransmogSetsTab: 4
+    TransmogSituations: 44
+    TransmogTrialOfStyle: 46
+    TransmogWeaponOptions: 45
 GameMode:
-  Plunderstorm: 2
-  Standard: 1
-  WoWHack: 3
+  values:
+    Plunderstorm: 2
+    Standard: 1
+    WoWHack: 3
 GamePadPowerLevel:
-  Critical: 0
-  High: 3
-  Low: 1
-  Medium: 2
-  Unknown: 5
-  Wired: 4
+  values:
+    Critical: 0
+    High: 3
+    Low: 1
+    Medium: 2
+    Unknown: 5
+    Wired: 4
 GameRule:
-  AchievementsPanelDisabled: 40
-  ActionbarIconIntroDisabled: 60
-  ActionButtonTypeOverlayStrategy: 165
-  ActionCombatTargetLockEnabled: 87
-  AfterDeathSpectatingUI: 49
-  AllPlayersAreFastMovers: 53
-  AlwaysAllowAlliedRaces: 59
-  AutoAttacksDisabled: 103
-  BagSpaceOverride: 172
-  BagsUIDisabled: 64
-  BlockWhileSheathedAllowed: 88
-  CharacterCreateUseFixedBackgroundModel: 55
-  CharacterlessLogin: 14
-  CharacterPanelDisabled: 37
-  CharNameReservationEnabled: 2
-  CharReservationsPerRealmReopenThreshold: 8
-  ChatLinkLevelToastsDisabled: 63
-  ClearMailOnRealmTransfer: 92
-  CollectionsPanelDisabled: 36
-  CommunitiesPanelDisabled: 41
-  CompactRaidFrameManagerDisabled: 81
-  CustomActionbarOverlayHeightOffset: 33
-  DeleteItemConfirmationDisabled: 62
-  DisableCampsites: 114
-  DisableHonorDecay: 23
-  DisablePct: 9
-  DisableQuickJoin: 162
-  DisableRaidGroups: 163
-  DisableRealmSelection: 113
-  DisableVas: 119
-  DoesNotCountTowardAccountCharacterMax: 142
-  EditModeDisabled: 82
-  EjDungeonsDisabled: 149
-  EjItemSetsDisabled: 151
-  EjJourneysDisabled: 156
-  EjRaidsDisabled: 150
-  EjSuggestedContentDisabled: 148
-  EncounterJournalDisabled: 42
-  EtaRealmLaunchTime: 5
-  ExperienceBarDisabled: 159
-  FastAreaTriggerTick: 52
-  FinderPanelDisabled: 43
-  ForceAlteredFormsOn: 56
-  ForcedChatLanguage: 34
-  ForcedMultiActionBarSetting: 133
-  ForcedPartyFrameScale: 32
-  FrontEndChat: 50
-  FullCharacterCreateDisabled: 84
-  GameMode: 13
-  GdapiCharacterProfileDisabled: 153
-  GroupFinderCapabilities: 98
-  GuildsDisabled: 46
-  HardcoreRuleset: 10
-  HelpPanelDisabled: 45
-  HideAllMultiActionBars: 135
-  HideFaction: 116
-  HideTransmogZeroCost: 161
-  HideUnavailableTransmogSlots: 160
-  HousingDashboardDisabled: 102
-  HousingEnabled: 154
-  IgnoreChrclassDisabledFlag: 54
-  IngameCalendarDisabled: 75
-  IngameFriendsListDisabled: 79
-  IngameMailNotificationDisabled: 74
-  IngameTrackingDisabled: 76
-  IngameWhoListDisabled: 77
-  InstanceDifficultyBannerDisabled: 83
-  LandingPageFactionID: 35
-  LootMethodStyle: 157
-  MacrosDisabled: 80
-  MailGameRule: 132
-  MapPlunderstormCircle: 48
-  MaxAccountCharReservationsPerContentset: 4
-  MaxCharactersPerContentSet: 139
-  MaxCharReservationsPerRealm: 3
-  MaximizeWorldMapDisabled: 67
-  MaxLootDropLevel: 25
-  MaxNameplateDistance: 28
-  MaxUnitNameDistance: 27
-  MerchantFilterDisabled: 101
-  MicrobarScale: 26
-  MinimapDisabled: 146
-  MinUndeleteLevelRequired: 140
-  NameplateCastBarDisabled: 107
-  NoDebuffLimit: 1
-  NonPlayerNameplateScale: 31
-  ObjectiveTrackerDisabled: 104
-  PerksProgramActivityTrackingDisabled: 66
-  PersonalResourceDisplayDisabled: 129
-  PetBattlesDisabled: 65
-  PlayerCastBarDisabled: 105
-  PlayerFrameDisabled: 131
-  PlayerNameplateAlternateHealthColor: 58
-  PlayerNameplateDifficultyIcon: 57
-  PlunderstormAreaSelection: 94
-  PremadeGroupFinderStyle: 93
-  PvPInitialRatingOverride: 190
-  QuestLogMicrobuttonDisabled: 47
-  QuestLogPanelDisabled: 71
-  QuestLogSuperTrackingDisabled: 72
-  RaceAlteredFormsDisabled: 78
-  RecommendLeastPopulatedRealm: 169
-  ReleaseSpiritGhostDisabled: 61
-  RepairArmorDisabled: 147
-  ReplaceAbsentGmSeconds: 11
-  ReplaceGmRankLastOnlineSeconds: 12
-  RestrictedAchievementCategoryID: 155
-  Runecarving: 17
-  SelfFoundAllowed: 22
-  SpellbookPanelDisabled: 38
-  StoreDisabled: 44
-  SummoningStones: 108
-  TalentRespecCostMax: 19
-  TalentRespecCostMin: 18
-  TalentRespecCostStep: 20
-  TalentsPanelDisabled: 39
-  TargetCastBarDisabled: 106
-  TargetFrameBuffsDisabled: 85
-  TargetFrameDisabled: 130
-  TimerunningAllowed: 137
-  TransmogEnabled: 109
-  TrivialGroupXPPercent: 7
-  TutorialFrameDisabled: 73
-  UnflaggedPlayersCanAttackPvPFlaggedPlayers: 173
-  UnitFramePvPContextualDisabled: 86
-  UniversalNameplateOcclusion: 51
-  UseGameTableVariation: 164
-  UserAddonsDisabled: 29
-  UserScriptsDisabled: 30
-  UseSimpleCharacterSelectList: 115
-  VanillaAccountMailInstant: 91
-  VanillaNpcKnockback: 16
-  VanillaRageGenerationModifier: 21
-  WorldMapDisabled: 145
-  WorldMapFrameStrata: 100
-  WorldMapHelpPlateDisabled: 70
-  WorldMapLegendDisabled: 99
-  WorldMapTrackingOptionsDisabled: 68
-  WorldMapTrackingPinDisabled: 69
+  values:
+    AchievementsPanelDisabled: 40
+    ActionbarIconIntroDisabled: 60
+    ActionButtonTypeOverlayStrategy: 165
+    ActionCombatTargetLockEnabled: 87
+    AfterDeathSpectatingUI: 49
+    AllPlayersAreFastMovers: 53
+    AlwaysAllowAlliedRaces: 59
+    AutoAttacksDisabled: 103
+    BagSpaceOverride: 172
+    BagsUIDisabled: 64
+    BlockWhileSheathedAllowed: 88
+    CharacterCreateUseFixedBackgroundModel: 55
+    CharacterlessLogin: 14
+    CharacterPanelDisabled: 37
+    CharNameReservationEnabled: 2
+    CharReservationsPerRealmReopenThreshold: 8
+    ChatLinkLevelToastsDisabled: 63
+    ClearMailOnRealmTransfer: 92
+    CollectionsPanelDisabled: 36
+    CommunitiesPanelDisabled: 41
+    CompactRaidFrameManagerDisabled: 81
+    CustomActionbarOverlayHeightOffset: 33
+    DeleteItemConfirmationDisabled: 62
+    DisableCampsites: 114
+    DisableHonorDecay: 23
+    DisablePct: 9
+    DisableQuickJoin: 162
+    DisableRaidGroups: 163
+    DisableRealmSelection: 113
+    DisableVas: 119
+    DoesNotCountTowardAccountCharacterMax: 142
+    EditModeDisabled: 82
+    EjDungeonsDisabled: 149
+    EjItemSetsDisabled: 151
+    EjJourneysDisabled: 156
+    EjRaidsDisabled: 150
+    EjSuggestedContentDisabled: 148
+    EncounterJournalDisabled: 42
+    EtaRealmLaunchTime: 5
+    ExperienceBarDisabled: 159
+    FastAreaTriggerTick: 52
+    FinderPanelDisabled: 43
+    ForceAlteredFormsOn: 56
+    ForcedChatLanguage: 34
+    ForcedMultiActionBarSetting: 133
+    ForcedPartyFrameScale: 32
+    FrontEndChat: 50
+    FullCharacterCreateDisabled: 84
+    GameMode: 13
+    GdapiCharacterProfileDisabled: 153
+    GroupFinderCapabilities: 98
+    GuildsDisabled: 46
+    HardcoreRuleset: 10
+    HelpPanelDisabled: 45
+    HideAllMultiActionBars: 135
+    HideFaction: 116
+    HideTransmogZeroCost: 161
+    HideUnavailableTransmogSlots: 160
+    HousingDashboardDisabled: 102
+    HousingEnabled: 154
+    IgnoreChrclassDisabledFlag: 54
+    IngameCalendarDisabled: 75
+    IngameFriendsListDisabled: 79
+    IngameMailNotificationDisabled: 74
+    IngameTrackingDisabled: 76
+    IngameWhoListDisabled: 77
+    InstanceDifficultyBannerDisabled: 83
+    LandingPageFactionID: 35
+    LootMethodStyle: 157
+    MacrosDisabled: 80
+    MailGameRule: 132
+    MapPlunderstormCircle: 48
+    MaxAccountCharReservationsPerContentset: 4
+    MaxCharactersPerContentSet: 139
+    MaxCharReservationsPerRealm: 3
+    MaximizeWorldMapDisabled: 67
+    MaxLootDropLevel: 25
+    MaxNameplateDistance: 28
+    MaxUnitNameDistance: 27
+    MerchantFilterDisabled: 101
+    MicrobarScale: 26
+    MinimapDisabled: 146
+    MinUndeleteLevelRequired: 140
+    NameplateCastBarDisabled: 107
+    NoDebuffLimit: 1
+    NonPlayerNameplateScale: 31
+    ObjectiveTrackerDisabled: 104
+    PerksProgramActivityTrackingDisabled: 66
+    PersonalResourceDisplayDisabled: 129
+    PetBattlesDisabled: 65
+    PlayerCastBarDisabled: 105
+    PlayerFrameDisabled: 131
+    PlayerNameplateAlternateHealthColor: 58
+    PlayerNameplateDifficultyIcon: 57
+    PlunderstormAreaSelection: 94
+    PremadeGroupFinderStyle: 93
+    PvPInitialRatingOverride: 190
+    QuestLogMicrobuttonDisabled: 47
+    QuestLogPanelDisabled: 71
+    QuestLogSuperTrackingDisabled: 72
+    RaceAlteredFormsDisabled: 78
+    RecommendLeastPopulatedRealm: 169
+    ReleaseSpiritGhostDisabled: 61
+    RepairArmorDisabled: 147
+    ReplaceAbsentGmSeconds: 11
+    ReplaceGmRankLastOnlineSeconds: 12
+    RestrictedAchievementCategoryID: 155
+    Runecarving: 17
+    SelfFoundAllowed: 22
+    SpellbookPanelDisabled: 38
+    StoreDisabled: 44
+    SummoningStones: 108
+    TalentRespecCostMax: 19
+    TalentRespecCostMin: 18
+    TalentRespecCostStep: 20
+    TalentsPanelDisabled: 39
+    TargetCastBarDisabled: 106
+    TargetFrameBuffsDisabled: 85
+    TargetFrameDisabled: 130
+    TimerunningAllowed: 137
+    TransmogEnabled: 109
+    TrivialGroupXPPercent: 7
+    TutorialFrameDisabled: 73
+    UnflaggedPlayersCanAttackPvPFlaggedPlayers: 173
+    UnitFramePvPContextualDisabled: 86
+    UniversalNameplateOcclusion: 51
+    UseGameTableVariation: 164
+    UserAddonsDisabled: 29
+    UserScriptsDisabled: 30
+    UseSimpleCharacterSelectList: 115
+    VanillaAccountMailInstant: 91
+    VanillaNpcKnockback: 16
+    VanillaRageGenerationModifier: 21
+    WorldMapDisabled: 145
+    WorldMapFrameStrata: 100
+    WorldMapHelpPlateDisabled: 70
+    WorldMapLegendDisabled: 99
+    WorldMapTrackingOptionsDisabled: 68
+    WorldMapTrackingPinDisabled: 69
 GameRuleFlags:
-  AllowClient: 1
-  None: 0
-  RequiresDefault: 2
+  values:
+    AllowClient: 1
+    None: 0
+    RequiresDefault: 2
 GameRuleType:
-  Bool: 2
-  Float: 1
-  Int: 0
+  values:
+    Bool: 2
+    Float: 1
+    Int: 0
 GarrAutoBoardIndex:
-  AllyCenterFront: 3
-  AllyLeftBack: 0
-  AllyLeftFront: 2
-  AllyRightBack: 1
-  AllyRightFront: 4
-  EnemyCenterLeftBack: 10
-  EnemyCenterLeftFront: 6
-  EnemyCenterRightBack: 11
-  EnemyCenterRightFront: 7
-  EnemyLeftBack: 9
-  EnemyLeftFront: 5
-  EnemyRightBack: 12
-  EnemyRightFront: 8
-  None: -1
+  values:
+    AllyCenterFront: 3
+    AllyLeftBack: 0
+    AllyLeftFront: 2
+    AllyRightBack: 1
+    AllyRightFront: 4
+    EnemyCenterLeftBack: 10
+    EnemyCenterLeftFront: 6
+    EnemyCenterRightBack: 11
+    EnemyCenterRightFront: 7
+    EnemyLeftBack: 9
+    EnemyLeftFront: 5
+    EnemyRightBack: 12
+    EnemyRightFront: 8
+    None: -1
 GarrAutoCombatantRole:
-  HealSupport: 4
-  Melee: 1
-  None: 0
-  RangedMagic: 3
-  RangedPhysical: 2
-  Tank: 5
+  values:
+    HealSupport: 4
+    Melee: 1
+    None: 0
+    RangedMagic: 3
+    RangedPhysical: 2
+    Tank: 5
 GarrAutoCombatSpellTutorialFlag:
-  All: 4
-  Column: 2
-  None: 0
-  Row: 3
-  Single: 1
+  values:
+    All: 4
+    Column: 2
+    None: 0
+    Row: 3
+    Single: 1
 GarrAutoCombatTutorial:
-  AttackAll: 256
-  AttackColumn: 64
-  AttackRow: 128
-  AttackSingle: 32
-  BeneficialEffect: 16
-  EnvironmentalEffect: 1024
-  HealCompanion: 4
-  LevelHeal: 8
-  PlaceCompanion: 2
-  SelectMission: 1
-  TroopTutorial: 512
+  values:
+    AttackAll: 256
+    AttackColumn: 64
+    AttackRow: 128
+    AttackSingle: 32
+    BeneficialEffect: 16
+    EnvironmentalEffect: 1024
+    HealCompanion: 4
+    LevelHeal: 8
+    PlaceCompanion: 2
+    SelectMission: 1
+    TroopTutorial: 512
 GarrAutoEventFlags:
-  AutoAttack: 1
-  Environment: 4
-  None: 0
-  Passive: 2
+  values:
+    AutoAttack: 1
+    Environment: 4
+    None: 0
+    Passive: 2
 GarrAutoMissionEventType:
-  ApplyAura: 7
-  Died: 9
-  Heal: 4
-  MeleeDamage: 0
-  PeriodicDamage: 5
-  PeriodicHeal: 6
-  RangeDamage: 1
-  RemoveAura: 8
-  SpellMeleeDamage: 2
-  SpellRangeDamage: 3
+  values:
+    ApplyAura: 7
+    Died: 9
+    Heal: 4
+    MeleeDamage: 0
+    PeriodicDamage: 5
+    PeriodicHeal: 6
+    RangeDamage: 1
+    RemoveAura: 8
+    SpellMeleeDamage: 2
+    SpellRangeDamage: 3
 GarrAutoPreviewTargetType:
-  Buff: 4
-  Damage: 1
-  Debuff: 8
-  Heal: 2
-  None: 0
+  values:
+    Buff: 4
+    Damage: 1
+    Debuff: 8
+    Heal: 2
+    None: 0
 GarrFollowerMissionCompleteState:
-  Alive: 0
-  KilledByMissionFailure: 1
-  OutOfDurability: 3
-  SavedByPreventDeath: 2
+  values:
+    Alive: 0
+    KilledByMissionFailure: 1
+    OutOfDurability: 3
+    SavedByPreventDeath: 2
 GarrFollowerQuality:
-  Common: 1
-  Epic: 4
-  Legendary: 5
-  None: 0
-  Rare: 3
-  Title: 6
-  Uncommon: 2
+  values:
+    Common: 1
+    Epic: 4
+    Legendary: 5
+    None: 0
+    Rare: 3
+    Title: 6
+    Uncommon: 2
 GarrisonFollowerType:
-  FollowerType_6_0_Boat: 2
-  FollowerType_6_0_GarrisonFollower: 1
-  FollowerType_7_0_GarrisonFollower: 4
-  FollowerType_8_0_GarrisonFollower: 22
-  FollowerType_9_0_GarrisonFollower: 123
+  values:
+    FollowerType_6_0_Boat: 2
+    FollowerType_6_0_GarrisonFollower: 1
+    FollowerType_7_0_GarrisonFollower: 4
+    FollowerType_8_0_GarrisonFollower: 22
+    FollowerType_9_0_GarrisonFollower: 123
 GarrisonTalentAvailability:
-  Available: 0
-  Unavailable: 1
-  UnavailableAlreadyHave: 7
-  UnavailableAnotherIsResearching: 2
-  UnavailableNotEnoughGold: 4
-  UnavailableNotEnoughResources: 3
-  UnavailablePlayerCondition: 6
-  UnavailableRequiresPrerequisiteTalent: 8
-  UnavailableTierUnavailable: 5
+  values:
+    Available: 0
+    Unavailable: 1
+    UnavailableAlreadyHave: 7
+    UnavailableAnotherIsResearching: 2
+    UnavailableNotEnoughGold: 4
+    UnavailableNotEnoughResources: 3
+    UnavailablePlayerCondition: 6
+    UnavailableRequiresPrerequisiteTalent: 8
+    UnavailableTierUnavailable: 5
 GarrisonType:
-  Type_6_0_Garrison: 2
-  Type_7_0_Garrison: 3
-  Type_8_0_Garrison: 9
-  Type_9_0_Garrison: 111
+  values:
+    Type_6_0_Garrison: 2
+    Type_7_0_Garrison: 3
+    Type_8_0_Garrison: 9
+    Type_9_0_Garrison: 111
 GarrTalentCostType:
-  Initial: 0
-  MakePermanent: 2
-  Respec: 1
-  TreeReset: 3
+  values:
+    Initial: 0
+    MakePermanent: 2
+    Respec: 1
+    TreeReset: 3
 GarrTalentFeatureSubtype:
-  Ardenweald: 3
-  Bastion: 1
-  Generic: 0
-  Maldraxxus: 4
-  Revendreth: 2
+  values:
+    Ardenweald: 3
+    Bastion: 1
+    Generic: 0
+    Maldraxxus: 4
+    Revendreth: 2
 GarrTalentFeatureType:
-  Adventures: 3
-  AnimaDiversion: 1
-  AnimaDiversionMap: 7
-  Cyphers: 8
-  Generic: 0
-  ReservoirUpgrades: 4
-  SanctumUnique: 5
-  SoulBinds: 6
-  TravelPortals: 2
+  values:
+    Adventures: 3
+    AnimaDiversion: 1
+    AnimaDiversionMap: 7
+    Cyphers: 8
+    Generic: 0
+    ReservoirUpgrades: 4
+    SanctumUnique: 5
+    SoulBinds: 6
+    TravelPortals: 2
 GarrTalentResearchCostSource:
-  Talent: 0
-  Tree: 1
+  values:
+    Talent: 0
+    Tree: 1
 GarrTalentSocketType:
-  Conduit: 2
-  None: 0
-  Spell: 1
+  values:
+    Conduit: 2
+    None: 0
+    Spell: 1
 GarrTalentTreeType:
-  Classic: 1
-  Tiers: 0
+  values:
+    Classic: 1
+    Tiers: 0
 GarrTalentType:
-  Major: 2
-  Minor: 1
-  Socket: 3
-  Standard: 0
+  values:
+    Major: 2
+    Minor: 1
+    Socket: 3
+    Standard: 0
 GarrTalentUI:
-  AnimaDiversionMap: 3
-  CovenantSanctum: 1
-  Generic: 0
-  SoulBinds: 2
+  values:
+    AnimaDiversionMap: 3
+    CovenantSanctum: 1
+    Generic: 0
+    SoulBinds: 2
 GossipNpcOption:
-  AccountBanker: 57
-  AdventureMap: 31
-  ArtifactRespec: 21
-  Auctioneer: 10
-  AzeriteRespec: 35
-  Banker: 6
-  BarbersChoice: 52
-  Battlemaster: 9
-  Binder: 5
-  BlackMarketAuctionHouse: 46
-  CemeterySelect: 22
-  CharacterBanker: 56
-  ChromieTimeNpc: 40
-  ContributionCollector: 33
-  CovenantPreviewNpc: 41
-  CovenantRenownNpc: 45
-  DisableXPGain: 16
-  EnableXPGain: 17
-  ForgeMaster: 55
-  GarrisonArchitect: 26
-  GarrisonMissionNpc: 27
-  GarrisonRecruitment: 30
-  GarrisonTalent: 32
-  GarrisonTradeskillNpc: 29
-  GlyphMaster: 24
-  GuildBanker: 14
-  GuildRename: 62
-  GuildTabardVendor: 8
-  HouseFinder: 65
-  HousingCreateGuildNeighborhood: 60
-  HousingGetNeighborhoodCharter: 61
-  HousingOpenCharterConfirmation: 63
-  IslandsMissionNpc: 36
-  ItemUpgrade: 64
-  LFGDungeon: 20
-  Mailbox: 18
-  MajorFactionRenown: 53
-  NewPlayerGuide: 43
-  None: 0
-  PerksProgramVendor: 47
-  PersonalTabardVendor: 54
-  PetitionVendor: 7
-  PetSpecializationMaster: 13
-  ProfessionRespec: 58
-  ProfessionsCraftingOrder: 48
-  ProfessionsCustomerOrder: 50
-  ProfessionsOpen: 49
-  QueueScenario: 25
-  RenameNeighborhood: 59
-  RuneforgeLegendaryCrafting: 42
-  RuneforgeLegendaryUpgrade: 44
-  ShipmentCrafter: 28
-  Soulbind: 39
-  SpecializationMaster: 23
-  Spellclick: 15
-  SpiritHealer: 4
-  Stablemaster: 12
-  TalentMaster: 11
-  Taxinode: 2
-  TieredEntrance: 66
-  Trainer: 3
-  TraitSystem: 51
-  Transmogrify: 34
-  UIItemInteraction: 37
-  Vendor: 1
-  WorldMap: 38
-  WorldPvPQueue: 19
+  values:
+    AccountBanker: 57
+    AdventureMap: 31
+    ArtifactRespec: 21
+    Auctioneer: 10
+    AzeriteRespec: 35
+    Banker: 6
+    BarbersChoice: 52
+    Battlemaster: 9
+    Binder: 5
+    BlackMarketAuctionHouse: 46
+    CemeterySelect: 22
+    CharacterBanker: 56
+    ChromieTimeNpc: 40
+    ContributionCollector: 33
+    CovenantPreviewNpc: 41
+    CovenantRenownNpc: 45
+    DisableXPGain: 16
+    EnableXPGain: 17
+    ForgeMaster: 55
+    GarrisonArchitect: 26
+    GarrisonMissionNpc: 27
+    GarrisonRecruitment: 30
+    GarrisonTalent: 32
+    GarrisonTradeskillNpc: 29
+    GlyphMaster: 24
+    GuildBanker: 14
+    GuildRename: 62
+    GuildTabardVendor: 8
+    HouseFinder: 65
+    HousingCreateGuildNeighborhood: 60
+    HousingGetNeighborhoodCharter: 61
+    HousingOpenCharterConfirmation: 63
+    IslandsMissionNpc: 36
+    ItemUpgrade: 64
+    LFGDungeon: 20
+    Mailbox: 18
+    MajorFactionRenown: 53
+    NewPlayerGuide: 43
+    None: 0
+    PerksProgramVendor: 47
+    PersonalTabardVendor: 54
+    PetitionVendor: 7
+    PetSpecializationMaster: 13
+    ProfessionRespec: 58
+    ProfessionsCraftingOrder: 48
+    ProfessionsCustomerOrder: 50
+    ProfessionsOpen: 49
+    QueueScenario: 25
+    RenameNeighborhood: 59
+    RuneforgeLegendaryCrafting: 42
+    RuneforgeLegendaryUpgrade: 44
+    ShipmentCrafter: 28
+    Soulbind: 39
+    SpecializationMaster: 23
+    Spellclick: 15
+    SpiritHealer: 4
+    Stablemaster: 12
+    TalentMaster: 11
+    Taxinode: 2
+    TieredEntrance: 66
+    Trainer: 3
+    TraitSystem: 51
+    Transmogrify: 34
+    UIItemInteraction: 37
+    Vendor: 1
+    WorldMap: 38
+    WorldPvPQueue: 19
 GossipNpcOptionDisplayFlags:
-  ForceInteractionOnSingleChoice: 1
+  values:
+    ForceInteractionOnSingleChoice: 1
 GossipOptionRecFlags:
-  HideOptionIDFromClient: 2
-  PlayMovieLabelPrepend: 4
-  QuestLabelPrepend: 1
+  values:
+    HideOptionIDFromClient: 2
+    PlayMovieLabelPrepend: 4
+    QuestLabelPrepend: 1
 GossipOptionRewardType:
-  Currency: 1
-  Item: 0
+  values:
+    Currency: 1
+    Item: 0
 GossipOptionStatus:
-  AlreadyComplete: 3
-  Available: 0
-  Locked: 2
-  Unavailable: 1
+  values:
+    AlreadyComplete: 3
+    Available: 0
+    Locked: 2
+    Unavailable: 1
 GossipOptionUIWidgetSetTypes:
-  Background: 1
-  Modifiers: 0
+  values:
+    Background: 1
+    Modifiers: 0
 GraphicsValidationResult:
-  AmdGpuUnsupported: 36
-  AppleGpuUnsupported: 35
-  CompatMode: 41
-  CpuMem_2: 6
-  CpuMem_4: 7
-  CpuMem_8: 8
-  DualCore: 4
-  Dx11Unsupported: 30
-  Dx12Win7Unsupported: 31
-  GpuDriver: 40
-  Graphics: 3
-  Illegal: 1
-  IntelGpuUnsupported: 37
-  LegacyUnsupported: 29
-  MacOsUnsupported: 27
-  Needs_5_0: 9
-  Needs_6_0: 10
-  NeedsAmdGpu: 15
-  NeedsAppleGpu: 14
-  NeedsDx12: 12
-  NeedsDx12Vrs2: 13
-  NeedsIntelGpu: 16
-  NeedsMacOs_10_13: 19
-  NeedsMacOs_10_14: 20
-  NeedsMacOs_10_15: 21
-  NeedsMacOs_11_0: 22
-  NeedsMacOs_12_0: 23
-  NeedsMacOs_13_0: 24
-  NeedsNvidiaGpu: 17
-  NeedsQualcommGpu: 18
-  NeedsRt: 11
-  NeedsWindows_10: 25
-  NeedsWindows_11: 26
-  NvapiWineUnsupported: 34
-  NvidiaGpuUnsupported: 38
-  QuadCore: 5
-  QualcommGpuUnsupported: 39
-  RemoteDesktopUnsupported: 32
-  Supported: 0
-  Unknown: 42
-  Unsupported: 2
-  WindowsUnsupported: 28
-  WineUnsupported: 33
+  values:
+    AmdGpuUnsupported: 36
+    AppleGpuUnsupported: 35
+    CompatMode: 41
+    CpuMem_2: 6
+    CpuMem_4: 7
+    CpuMem_8: 8
+    DualCore: 4
+    Dx11Unsupported: 30
+    Dx12Win7Unsupported: 31
+    GpuDriver: 40
+    Graphics: 3
+    Illegal: 1
+    IntelGpuUnsupported: 37
+    LegacyUnsupported: 29
+    MacOsUnsupported: 27
+    Needs_5_0: 9
+    Needs_6_0: 10
+    NeedsAmdGpu: 15
+    NeedsAppleGpu: 14
+    NeedsDx12: 12
+    NeedsDx12Vrs2: 13
+    NeedsIntelGpu: 16
+    NeedsMacOs_10_13: 19
+    NeedsMacOs_10_14: 20
+    NeedsMacOs_10_15: 21
+    NeedsMacOs_11_0: 22
+    NeedsMacOs_12_0: 23
+    NeedsMacOs_13_0: 24
+    NeedsNvidiaGpu: 17
+    NeedsQualcommGpu: 18
+    NeedsRt: 11
+    NeedsWindows_10: 25
+    NeedsWindows_11: 26
+    NvapiWineUnsupported: 34
+    NvidiaGpuUnsupported: 38
+    QuadCore: 5
+    QualcommGpuUnsupported: 39
+    RemoteDesktopUnsupported: 32
+    Supported: 0
+    Unknown: 42
+    Unsupported: 2
+    WindowsUnsupported: 28
+    WineUnsupported: 33
 GuildErrorType:
-  AlreadyInGuild: 2
-  BadItem: 29
-  BankNotFound: 43
-  BankTabFull: 28
-  BankTabLocked: 35
-  Busy: 20
-  CantInviteSelf: 41
-  DeleteNoAppropriateLeader: 47
-  GuildBankNotAvailable: 45
-  GuildRepTooLow: 40
-  HasRestriction: 42
-  HousingEvictError: 51
-  Ignored: 19
-  InCooldown: 49
-  InvalidBankTab: 24
-  InvitedToGuild: 4
-  LockedForMove: 39
-  NameAlreadyExists: 7
-  NameInvalid: 6
-  NewLeaderWrongFaction: 44
-  NewLeaderWrongRealm: 46
-  NoPermisson: 8
-  NotEnoughMoney: 26
-  NotInGuild: 9
-  PlayerNotFound: 11
-  RankInUse: 18
-  RankRequiresAuthenticator: 34
-  RanksLocked: 17
-  RealmMismatch: 48
-  ReservationExpired: 50
-  Success: 0
-  TargetAlreadyInGuild: 3
-  TargetInvitedToGuild: 5
-  TargetLevelTooHigh: 22
-  TargetLevelTooLow: 21
-  TargetNotInGuild: 10
-  TargetTooHigh: 13
-  TargetTooLow: 14
-  TeamNotFound: 27
-  TeamsLocked: 30
-  Throttled: 52
-  TooFewRanks: 16
-  TooManyCreate: 33
-  TooManyMembers: 23
-  TooManyRanks: 15
-  TooMuchMoney: 31
-  TrialAccount: 36
-  UndeletableDueToLevel: 38
-  UnknownError: 1
-  VeteranAccount: 37
-  WithdrawLimit: 25
-  WrongBankTab: 32
-  WrongFaction: 12
+  values:
+    AlreadyInGuild: 2
+    BadItem: 29
+    BankNotFound: 43
+    BankTabFull: 28
+    BankTabLocked: 35
+    Busy: 20
+    CantInviteSelf: 41
+    DeleteNoAppropriateLeader: 47
+    GuildBankNotAvailable: 45
+    GuildRepTooLow: 40
+    HasRestriction: 42
+    HousingEvictError: 51
+    Ignored: 19
+    InCooldown: 49
+    InvalidBankTab: 24
+    InvitedToGuild: 4
+    LockedForMove: 39
+    NameAlreadyExists: 7
+    NameInvalid: 6
+    NewLeaderWrongFaction: 44
+    NewLeaderWrongRealm: 46
+    NoPermisson: 8
+    NotEnoughMoney: 26
+    NotInGuild: 9
+    PlayerNotFound: 11
+    RankInUse: 18
+    RankRequiresAuthenticator: 34
+    RanksLocked: 17
+    RealmMismatch: 48
+    ReservationExpired: 50
+    Success: 0
+    TargetAlreadyInGuild: 3
+    TargetInvitedToGuild: 5
+    TargetLevelTooHigh: 22
+    TargetLevelTooLow: 21
+    TargetNotInGuild: 10
+    TargetTooHigh: 13
+    TargetTooLow: 14
+    TeamNotFound: 27
+    TeamsLocked: 30
+    Throttled: 52
+    TooFewRanks: 16
+    TooManyCreate: 33
+    TooManyMembers: 23
+    TooManyRanks: 15
+    TooMuchMoney: 31
+    TrialAccount: 36
+    UndeletableDueToLevel: 38
+    UnknownError: 1
+    VeteranAccount: 37
+    WithdrawLimit: 25
+    WrongBankTab: 32
+    WrongFaction: 12
 HolidayCalendarFlags:
-  Alliance: 1
-  Horde: 2
+  values:
+    Alliance: 1
+    Horde: 2
 HolidayFlags:
-  BeginEventOnlyOnStageChange: 64
-  DontDisplayBanner: 8
-  DontDisplayEnd: 4
-  DontShowInCalendar: 2
-  DurationUseMinutes: 32
-  IsRegionwide: 1
-  NotAvailableClientSide: 16
+  values:
+    BeginEventOnlyOnStageChange: 64
+    DontDisplayBanner: 8
+    DontDisplayEnd: 4
+    DontShowInCalendar: 2
+    DurationUseMinutes: 32
+    IsRegionwide: 1
+    NotAvailableClientSide: 16
 HouseEditingContext:
-  Decor: 1
-  Fixture: 3
-  None: 0
-  Room: 2
+  values:
+    Decor: 1
+    Fixture: 3
+    None: 0
+    Room: 2
 HouseEditorMode:
-  BasicDecor: 1
-  Cleanup: 5
-  Customize: 4
-  ExpertDecor: 2
-  ExteriorCustomization: 6
-  Layout: 3
-  None: 0
+  values:
+    BasicDecor: 1
+    Cleanup: 5
+    Customize: 4
+    ExpertDecor: 2
+    ExteriorCustomization: 6
+    Layout: 3
+    None: 0
 HouseExteriorWMODataFlags:
-  AllowedInAllianceNeighborhoods: 4
-  AllowedInHordeNeighborhoods: 2
-  HiddenUnlessOwned: 8
-  None: 0
-  UnlockedByDefault: 1
+  values:
+    AllowedInAllianceNeighborhoods: 4
+    AllowedInHordeNeighborhoods: 2
+    HiddenUnlessOwned: 8
+    None: 0
+    UnlockedByDefault: 1
 HouseFinderSuggestionReason:
-  BNetFriends: 8
-  CharterInvite: 2
-  Guild: 4
-  HomeOwner: 64
-  None: 0
-  Owner: 1
-  PartySync: 16
-  Random: 32
+  values:
+    BNetFriends: 8
+    CharterInvite: 2
+    Guild: 4
+    HomeOwner: 64
+    None: 0
+    Owner: 1
+    PartySync: 16
+    Random: 32
 HouseLevelRewardType:
-  Object: 1
-  Value: 0
+  values:
+    Object: 1
+    Value: 0
 HouseLevelRewardValueType:
-  ExteriorDecor: 0
-  Fixtures: 3
-  InteriorDecor: 1
-  Rooms: 2
+  values:
+    ExteriorDecor: 0
+    Fixtures: 3
+    InteriorDecor: 1
+    Rooms: 2
 HouseOwnerError:
-  Faction: 1
-  GenericPermission: 3
-  Guild: 2
-  None: 0
+  values:
+    Faction: 1
+    GenericPermission: 3
+    Guild: 2
+    None: 0
 HouseSettingFlags:
-  HouseAccessAnyone: 1
-  HouseAccessFriends: 8
-  HouseAccessGuild: 4
-  HouseAccessNeighbors: 2
-  HouseAccessParty: 16
-  None: 0
-  PlotAccessAnyone: 32
-  PlotAccessFriends: 256
-  PlotAccessGuild: 128
-  PlotAccessNeighbors: 64
-  PlotAccessParty: 512
+  values:
+    HouseAccessAnyone: 1
+    HouseAccessFriends: 8
+    HouseAccessGuild: 4
+    HouseAccessNeighbors: 2
+    HouseAccessParty: 16
+    None: 0
+    PlotAccessAnyone: 32
+    PlotAccessFriends: 256
+    PlotAccessGuild: 128
+    PlotAccessNeighbors: 64
+    PlotAccessParty: 512
 HouseVisitType:
-  Friend: 1
-  Guild: 2
-  Party: 3
-  Unknown: 0
+  values:
+    Friend: 1
+    Guild: 2
+    Party: 3
+    Unknown: 0
 HousingBasicModeTargetType:
-  Decor: 1
-  House: 2
-  None: 0
+  values:
+    Decor: 1
+    House: 2
+    None: 0
 HousingCatalogEntryModelScenePresets:
-  DecorCeiling: 1338
-  DecorDefault: 1317
-  DecorFlat: 1318
-  DecorHorizontalSurface: 1452
-  DecorHuge: 1337
-  DecorLarge: 1336
-  DecorMedium: 1335
-  DecorSmall: 1334
-  DecorTiny: 1333
-  DecorWall: 1339
+  values:
+    DecorCeiling: 1338
+    DecorDefault: 1317
+    DecorFlat: 1318
+    DecorHorizontalSurface: 1452
+    DecorHuge: 1337
+    DecorLarge: 1336
+    DecorMedium: 1335
+    DecorSmall: 1334
+    DecorTiny: 1333
+    DecorWall: 1339
 HousingCatalogEntrySize:
-  Huge: 69
-  Large: 68
-  Medium: 67
-  None: 0
-  Small: 66
-  Tiny: 65
+  values:
+    Huge: 69
+    Large: 68
+    Medium: 67
+    None: 0
+    Small: 66
+    Tiny: 65
 HousingCatalogEntryType:
-  Decor: 1
-  Invalid: 0
-  Room: 2
+  values:
+    Decor: 1
+    Invalid: 0
+    Room: 2
 HousingCatalogSortType:
-  Alphabetical: 1
-  DateAdded: 0
+  values:
+    Alphabetical: 1
+    DateAdded: 0
 HousingCleanupModeTargetType:
-  Decor: 1
-  HouseExterior: 2
-  None: 0
+  values:
+    Decor: 1
+    HouseExterior: 2
+    None: 0
 HousingCustomizeModeTargetType:
-  Decor: 1
-  ExteriorHouse: 3
-  None: 0
-  RoomComponent: 2
+  values:
+    Decor: 1
+    ExteriorHouse: 3
+    None: 0
+    RoomComponent: 2
 HousingDecorActionFlags:
-  Add: 1
-  ClickTarget: 16
-  DragMove: 4
-  HoverTarget: 32
-  IncludeTargetChildren: 512
-  MaintainLastTarget: 256
-  None: 0
-  PrecisionMove: 8
-  PreviewDecor: 2048
-  Remove: 2
-  TargetHouseExterior: 128
-  TargetRoomComponents: 64
-  UsePlacedDecorList: 1024
+  values:
+    Add: 1
+    ClickTarget: 16
+    DragMove: 4
+    HoverTarget: 32
+    IncludeTargetChildren: 512
+    MaintainLastTarget: 256
+    None: 0
+    PrecisionMove: 8
+    PreviewDecor: 2048
+    Remove: 2
+    TargetHouseExterior: 128
+    TargetRoomComponents: 64
+    UsePlacedDecorList: 1024
 HousingDecorModelType:
-  M2: 1
-  None: 0
-  WMO: 2
+  values:
+    M2: 1
+    None: 0
+    WMO: 2
 HousingDecorPlacementRestriction:
-  ChildOutsideBounds: 8
-  InvalidCollision: 32
-  InvalidLightOverlap: 64
-  InvalidTarget: 16
-  OutsidePlotBounds: 4
-  OutsideRoomBounds: 2
-  TooFarAway: 1
+  values:
+    ChildOutsideBounds: 8
+    InvalidCollision: 32
+    InvalidLightOverlap: 64
+    InvalidTarget: 16
+    OutsidePlotBounds: 4
+    OutsideRoomBounds: 2
+    TooFarAway: 1
 HousingDecorTheme:
-  BloodElf: 5
-  Folk: 1
-  Generic: 3
-  NightElf: 4
-  None: 0
-  Rugged: 2
+  values:
+    BloodElf: 5
+    Folk: 1
+    Generic: 3
+    NightElf: 4
+    None: 0
+    Rugged: 2
 HousingDecorType:
-  Ceiling: 3
-  Floor: 1
-  Flooring: 4
-  None: 0
-  Wall: 2
+  values:
+    Ceiling: 3
+    Floor: 1
+    Flooring: 4
+    None: 0
+    Wall: 2
 HousingExpertModeTargetType:
-  Decor: 1
-  House: 2
-  None: 0
+  values:
+    Decor: 1
+    House: 2
+    None: 0
 HousingExpertSubmodeRestriction:
-  NoHouseExteriorScale: 2
-  None: 0
-  NotInExpertMode: 1
-  NoWMOScale: 3
+  values:
+    NoHouseExteriorScale: 2
+    None: 0
+    NotInExpertMode: 1
+    NoWMOScale: 3
 HousingFavorUpdateSource:
-  DecorCollection: 1
-  DeferredRewards: 2
-  InitiativeChest: 6
-  InitiativeTask: 5
-  NewHouseDecorFavor: 4
-  Quest: 7
-  RetroactiveDecor: 3
-  Unknown: 0
+  values:
+    DecorCollection: 1
+    DeferredRewards: 2
+    InitiativeChest: 6
+    InitiativeTask: 5
+    NewHouseDecorFavor: 4
+    Quest: 7
+    RetroactiveDecor: 3
+    Unknown: 0
 HousingFavorUpdateType:
-  Add: 0
-  InitiativeAdd: 1
-  Set: 2
+  values:
+    Add: 0
+    InitiativeAdd: 1
+    Set: 2
 HousingFixtureDecorAction:
-  Detach: 1
-  Store: 0
+  values:
+    Detach: 1
+    Store: 0
 HousingFixtureFlags:
-  IsDefaultFixture: 1
-  None: 0
-  UnlockedByDefault: 2
+  values:
+    IsDefaultFixture: 1
+    None: 0
+    UnlockedByDefault: 2
 HousingFixtureSize:
-  Any: 1
-  Large: 4
-  Medium: 3
-  None: 0
-  Small: 2
+  values:
+    Any: 1
+    Large: 4
+    Medium: 3
+    None: 0
+    Small: 2
 HousingFixtureType:
-  Base: 9
-  Chimney: 16
-  Door: 11
-  None: 0
-  Roof: 10
-  RoofDetail: 13
-  RoofWindow: 14
-  Tower: 15
-  Window: 12
+  values:
+    Base: 9
+    Chimney: 16
+    Door: 11
+    None: 0
+    Roof: 10
+    RoofDetail: 13
+    RoofWindow: 14
+    Tower: 15
+    Window: 12
 HousingIncrementType:
-  Back: 8
-  Down: 32
-  Forward: 4
-  Left: 1
-  Right: 2
-  RotateLeft: 64
-  RotateRight: 128
-  ScaleDown: 512
-  ScaleUp: 256
-  Up: 16
+  values:
+    Back: 8
+    Down: 32
+    Forward: 4
+    Left: 1
+    Right: 2
+    RotateLeft: 64
+    RotateRight: 128
+    ScaleDown: 512
+    ScaleUp: 256
+    Up: 16
 HousingItemToastType:
-  Customization: 2
-  Decor: 3
-  Fixture: 1
-  HouseType: 4
-  Room: 0
+  values:
+    Customization: 2
+    Decor: 3
+    Fixture: 1
+    HouseType: 4
+    Room: 0
 HousingLayoutCameraDirection:
-  Down: 2
-  Left: 4
-  None: 0
-  Right: 8
-  Up: 1
+  values:
+    Down: 2
+    Left: 4
+    None: 0
+    Right: 8
+    Up: 1
 HousingLayoutPinType:
-  Door: 0
-  Room: 1
+  values:
+    Door: 0
+    Room: 1
 HousingLayoutRestriction:
-  IsBaseRoom: 4
-  LastRoom: 7
-  None: 0
-  NotHouseOwner: 3
-  NotInsideHouse: 2
-  RoomNotFound: 1
-  RoomNotLeaf: 5
-  SingleDoor: 9
-  StairwellConnection: 6
-  UnreachableRoom: 8
+  values:
+    IsBaseRoom: 4
+    LastRoom: 7
+    None: 0
+    NotHouseOwner: 3
+    NotInsideHouse: 2
+    RoomNotFound: 1
+    RoomNotLeaf: 5
+    SingleDoor: 9
+    StairwellConnection: 6
+    UnreachableRoom: 8
 HousingLayoutStairDirection:
-  Down: 1
-  Up: 0
+  values:
+    Down: 1
+    Up: 0
 HousingPlotOwnerType:
-  Friend: 2
-  None: 0
-  Self: 3
-  Stranger: 1
+  values:
+    Friend: 2
+    None: 0
+    Self: 3
+    Stranger: 1
 HousingPrecisionSubmode:
-  Rotate: 1
-  Scale: 2
-  Translate: 0
+  values:
+    Rotate: 1
+    Scale: 2
+    Translate: 0
 HousingResult:
-  ActionLockedByCombat: 1
-  BoundsFailureChildren: 2
-  BoundsFailurePlot: 3
-  BoundsFailureRoom: 4
-  BoundToStartingArea: 5
-  CannotAfford: 6
-  CharterComplete: 7
-  CollisionInvalid: 8
-  DbError: 9
-  DecorCannotBeRedeemed: 10
-  DecorItemNotDestroyable: 11
-  DecorNotFound: 12
-  DecorNotFoundInStorage: 13
-  DuplicateCharterSignature: 14
-  FilterRejected: 15
-  FixtureCantDeleteDoor: 16
-  FixtureHookEmpty: 17
-  FixtureHookOccupied: 18
-  FixtureHouseTypeMismatch: 19
-  FixtureNotFound: 20
-  FixtureSizeMismatch: 21
-  FixtureTypeMismatch: 22
-  GenericFailure: 23
-  GuildMoreAccountsNeeded: 24
-  GuildMoreActivePlayersNeeded: 25
-  GuildNotLoaded: 26
-  HookNotChildOfFixture: 35
-  HouseEditLockFailed: 27
-  HouseExteriorAlreadyThatSize: 28
-  HouseExteriorAlreadyThatType: 29
-  HouseExteriorRootNotFound: 30
-  HouseExteriorSizeNotAvailable: 34
-  HouseExteriorTypeNeighborhoodMismatch: 31
-  HouseExteriorTypeNotFound: 32
-  HouseExteriorTypeSizeMismatch: 33
-  HouseNotFound: 36
-  IncorrectFaction: 37
-  InvalidDecorItem: 38
-  InvalidDistance: 39
-  InvalidGuild: 40
-  InvalidHouse: 41
-  InvalidInstance: 42
-  InvalidInteraction: 43
-  InvalidLightOverlap: 44
-  InvalidMap: 45
-  InvalidNeighborhoodName: 46
-  InvalidRoomLayout: 47
-  LockedByOtherPlayer: 48
-  LockOperationFailed: 49
-  MaxDecorReached: 50
-  MaxPreviewDecorReached: 51
-  MissingCoreFixture: 52
-  MissingDye: 53
-  MissingExpansionAccess: 54
-  MissingFactionMap: 55
-  MissingPrivateNeighborhoodInvite: 56
-  MoreHouseSlotsNeeded: 57
-  MoreSignaturesNeeded: 58
-  NeighborhoodNotFound: 59
-  NoNeighborhoodOwnershipRequests: 60
-  NotInDecorEditMode: 61
-  NotInFixtureEditMode: 62
-  NotInLayoutEditMode: 63
-  NotInsideHouse: 64
-  NotOnOwnedPlot: 65
-  OperationAborted: 66
-  OwnerNotInGuild: 67
-  PermissionDenied: 68
-  PlacementTargetInvalid: 69
-  PlayerNotFound: 70
-  PlayerNotInInstance: 71
-  PlotNotFound: 72
-  PlotNotVacant: 73
-  PlotReservationCooldown: 74
-  PlotReserved: 75
-  RoomNotFound: 76
-  RoomUpdateFailed: 77
-  RpcFailure: 78
-  ServiceNotAvailable: 79
-  StaticDataNotFound: 80
-  Success: 0
-  TimeoutLimit: 81
-  TimerunningNotAllowed: 82
-  TokenRequired: 83
-  TooManyRequests: 84
-  TransactionFailure: 85
-  UncollectedExteriorFixture: 86
-  UncollectedHouseType: 87
-  UncollectedRoom: 88
-  UncollectedRoomMaterial: 89
-  UncollectedRoomTheme: 90
-  UnlockOperationFailed: 91
+  values:
+    ActionLockedByCombat: 1
+    BoundsFailureChildren: 2
+    BoundsFailurePlot: 3
+    BoundsFailureRoom: 4
+    BoundToStartingArea: 5
+    CannotAfford: 6
+    CharterComplete: 7
+    CollisionInvalid: 8
+    DbError: 9
+    DecorCannotBeRedeemed: 10
+    DecorItemNotDestroyable: 11
+    DecorNotFound: 12
+    DecorNotFoundInStorage: 13
+    DuplicateCharterSignature: 14
+    FilterRejected: 15
+    FixtureCantDeleteDoor: 16
+    FixtureHookEmpty: 17
+    FixtureHookOccupied: 18
+    FixtureHouseTypeMismatch: 19
+    FixtureNotFound: 20
+    FixtureSizeMismatch: 21
+    FixtureTypeMismatch: 22
+    GenericFailure: 23
+    GuildMoreAccountsNeeded: 24
+    GuildMoreActivePlayersNeeded: 25
+    GuildNotLoaded: 26
+    HookNotChildOfFixture: 35
+    HouseEditLockFailed: 27
+    HouseExteriorAlreadyThatSize: 28
+    HouseExteriorAlreadyThatType: 29
+    HouseExteriorRootNotFound: 30
+    HouseExteriorSizeNotAvailable: 34
+    HouseExteriorTypeNeighborhoodMismatch: 31
+    HouseExteriorTypeNotFound: 32
+    HouseExteriorTypeSizeMismatch: 33
+    HouseNotFound: 36
+    IncorrectFaction: 37
+    InvalidDecorItem: 38
+    InvalidDistance: 39
+    InvalidGuild: 40
+    InvalidHouse: 41
+    InvalidInstance: 42
+    InvalidInteraction: 43
+    InvalidLightOverlap: 44
+    InvalidMap: 45
+    InvalidNeighborhoodName: 46
+    InvalidRoomLayout: 47
+    LockedByOtherPlayer: 48
+    LockOperationFailed: 49
+    MaxDecorReached: 50
+    MaxPreviewDecorReached: 51
+    MissingCoreFixture: 52
+    MissingDye: 53
+    MissingExpansionAccess: 54
+    MissingFactionMap: 55
+    MissingPrivateNeighborhoodInvite: 56
+    MoreHouseSlotsNeeded: 57
+    MoreSignaturesNeeded: 58
+    NeighborhoodNotFound: 59
+    NoNeighborhoodOwnershipRequests: 60
+    NotInDecorEditMode: 61
+    NotInFixtureEditMode: 62
+    NotInLayoutEditMode: 63
+    NotInsideHouse: 64
+    NotOnOwnedPlot: 65
+    OperationAborted: 66
+    OwnerNotInGuild: 67
+    PermissionDenied: 68
+    PlacementTargetInvalid: 69
+    PlayerNotFound: 70
+    PlayerNotInInstance: 71
+    PlotNotFound: 72
+    PlotNotVacant: 73
+    PlotReservationCooldown: 74
+    PlotReserved: 75
+    RoomNotFound: 76
+    RoomUpdateFailed: 77
+    RpcFailure: 78
+    ServiceNotAvailable: 79
+    StaticDataNotFound: 80
+    Success: 0
+    TimeoutLimit: 81
+    TimerunningNotAllowed: 82
+    TokenRequired: 83
+    TooManyRequests: 84
+    TransactionFailure: 85
+    UncollectedExteriorFixture: 86
+    UncollectedHouseType: 87
+    UncollectedRoom: 88
+    UncollectedRoomMaterial: 89
+    UncollectedRoomTheme: 90
+    UnlockOperationFailed: 91
 HousingRoomComponentCeilingType:
-  Flat: 0
-  Vaulted: 1
+  values:
+    Flat: 0
+    Vaulted: 1
 HousingRoomComponentDoorType:
-  Doorway: 1
-  None: 0
-  Threshold: 2
+  values:
+    Doorway: 1
+    None: 0
+    Threshold: 2
 HousingRoomComponentFlags:
-  HiddenInLayoutMode: 1
-  None: 0
+  values:
+    HiddenInLayoutMode: 1
+    None: 0
 HousingRoomComponentFloorType:
-  Floor: 0
+  values:
+    Floor: 0
 HousingRoomComponentOptionFlags:
-  IsDefault: 1
-  None: 0
+  values:
+    IsDefault: 1
+    None: 0
 HousingRoomComponentOptionType:
-  Cosmetic: 0
-  Doorway: 2
-  DoorwayWall: 1
+  values:
+    Cosmetic: 0
+    Doorway: 2
+    DoorwayWall: 1
 HousingRoomComponentStairType:
-  MiddleToEnd: 4
-  MiddleToMiddle: 3
-  None: 0
-  StartToEnd: 1
-  StartToMiddle: 2
+  values:
+    MiddleToEnd: 4
+    MiddleToMiddle: 3
+    None: 0
+    StartToEnd: 1
+    StartToMiddle: 2
 HousingRoomComponentTextureFlags:
-  None: 0
-  UnlockedByDefault: 1
+  values:
+    None: 0
+    UnlockedByDefault: 1
 HousingRoomComponentType:
-  Ceiling: 3
-  Doorway: 7
-  DoorwayWall: 6
-  Floor: 2
-  None: 0
-  Pillar: 5
-  Stairs: 4
-  Wall: 1
+  values:
+    Ceiling: 3
+    Doorway: 7
+    DoorwayWall: 6
+    Floor: 2
+    None: 0
+    Pillar: 5
+    Stairs: 4
+    Wall: 1
 HousingRoomFlags:
-  BaseRoom: 1
-  HasCustomGeometry: 8
-  HasStairs: 2
-  None: 0
-  UnlockedByDefault: 4
+  values:
+    BaseRoom: 1
+    HasCustomGeometry: 8
+    HasStairs: 2
+    None: 0
+    UnlockedByDefault: 4
 HousingTeleportReason:
-  Booted: 3
-  Cheat: 1
-  ExitingHouse: 9
-  Friend: 6
-  GuildMember: 7
-  Homestone: 4
-  None: 0
-  PartyMember: 8
-  Portal: 10
-  Tutorial: 11
-  UnspecifiedSpellcast: 2
-  Visit: 5
+  values:
+    Booted: 3
+    Cheat: 1
+    ExitingHouse: 9
+    Friend: 6
+    GuildMember: 7
+    Homestone: 4
+    None: 0
+    PartyMember: 8
+    Portal: 10
+    Tutorial: 11
+    UnspecifiedSpellcast: 2
+    Visit: 5
 HousingThemeFlags:
-  None: 0
-  ShowInStyleSelector: 2
-  UnlockedByDefault: 1
+  values:
+    None: 0
+    ShowInStyleSelector: 2
+    UnlockedByDefault: 1
 HousingThrottleType:
-  Decoration: 1
-  General: 0
+  values:
+    Decoration: 1
+    General: 0
 IconAndTextShiftTextType:
-  None: 0
-  ShiftText: 1
+  values:
+    None: 0
+    ShiftText: 1
 IconAndTextWidgetState:
-  Hidden: 0
-  Shown: 1
-  ShownWithDynamicIconFlashing: 2
-  ShownWithDynamicIconNotFlashing: 3
+  values:
+    Hidden: 0
+    Shown: 1
+    ShownWithDynamicIconFlashing: 2
+    ShownWithDynamicIconNotFlashing: 3
 IconState:
-  Hidden: 0
-  ShowState1: 1
-  ShowState2: 2
+  values:
+    Hidden: 0
+    ShowState1: 1
+    ShowState2: 2
 ImageSharingResult:
-  AccountDataRequestFailure: 6
-  EncryptionFailure: 11
-  EncryptionSecretNotSet: 14
-  FailedToCreateHeader: 10
-  Failure: 0
-  GetAccountDataRequestFailure: 7
-  InvalidOAuthExpiration: 12
-  InvalidRefreshExpiration: 13
-  MissingFieldApiError: 5
-  NotConfigured: 2
-  PlatformApiError: 4
-  RefreshTokenExpired: 9
-  RetrievedExisting: 3
-  SetAccountDataRequestFailure: 8
-  Success: 1
+  values:
+    AccountDataRequestFailure: 6
+    EncryptionFailure: 11
+    EncryptionSecretNotSet: 14
+    FailedToCreateHeader: 10
+    Failure: 0
+    GetAccountDataRequestFailure: 7
+    InvalidOAuthExpiration: 12
+    InvalidRefreshExpiration: 13
+    MissingFieldApiError: 5
+    NotConfigured: 2
+    PlatformApiError: 4
+    RefreshTokenExpired: 9
+    RetrievedExisting: 3
+    SetAccountDataRequestFailure: 8
+    Success: 1
 InitiativeMilestoneFlags:
-  FinalMilestone: 1
+  values:
+    FinalMilestone: 1
 InitiativeRewardFlags:
-  PermanentWorldState: 1
+  values:
+    PermanentWorldState: 1
 InputContext:
-  GamePad: 3
-  Keyboard: 1
-  Mouse: 2
-  None: 0
+  values:
+    GamePad: 3
+    Keyboard: 1
+    Mouse: 2
+    None: 0
 InvalidPlotScreenshotReason:
-  Facing: 2
-  NoActivePlayer: 4
-  None: 0
-  NoNeighborhoodFound: 3
-  OutOfBounds: 1
+  values:
+    Facing: 2
+    NoActivePlayer: 4
+    None: 0
+    NoNeighborhoodFound: 3
+    OutOfBounds: 1
 InventoryType:
-  Index2HweaponType: 17
-  IndexAmmoType: 24
-  IndexBagType: 18
-  IndexBodyType: 4
-  IndexChestType: 5
-  IndexCloakType: 16
-  IndexEquipablespellDefensiveType: 33
-  IndexEquipablespellOffensiveType: 31
-  IndexEquipablespellUtilityType: 32
-  IndexEquipablespellWeaponType: 34
-  IndexFeetType: 8
-  IndexFingerType: 11
-  IndexHandType: 10
-  IndexHeadType: 1
-  IndexHoldableType: 23
-  IndexLegsType: 7
-  IndexNeckType: 2
-  IndexNonEquipType: 0
-  IndexProfessionGearType: 30
-  IndexProfessionToolType: 29
-  IndexQuiverType: 27
-  IndexRangedrightType: 26
-  IndexRangedType: 15
-  IndexRelicType: 28
-  IndexRobeType: 20
-  IndexShieldType: 14
-  IndexShoulderType: 3
-  IndexTabardType: 19
-  IndexThrownType: 25
-  IndexTrinketType: 12
-  IndexWaistType: 6
-  IndexWeaponmainhandType: 21
-  IndexWeaponoffhandType: 22
-  IndexWeaponType: 13
-  IndexWristType: 9
+  values:
+    Index2HweaponType: 17
+    IndexAmmoType: 24
+    IndexBagType: 18
+    IndexBodyType: 4
+    IndexChestType: 5
+    IndexCloakType: 16
+    IndexEquipablespellDefensiveType: 33
+    IndexEquipablespellOffensiveType: 31
+    IndexEquipablespellUtilityType: 32
+    IndexEquipablespellWeaponType: 34
+    IndexFeetType: 8
+    IndexFingerType: 11
+    IndexHandType: 10
+    IndexHeadType: 1
+    IndexHoldableType: 23
+    IndexLegsType: 7
+    IndexNeckType: 2
+    IndexNonEquipType: 0
+    IndexProfessionGearType: 30
+    IndexProfessionToolType: 29
+    IndexQuiverType: 27
+    IndexRangedrightType: 26
+    IndexRangedType: 15
+    IndexRelicType: 28
+    IndexRobeType: 20
+    IndexShieldType: 14
+    IndexShoulderType: 3
+    IndexTabardType: 19
+    IndexThrownType: 25
+    IndexTrinketType: 12
+    IndexWaistType: 6
+    IndexWeaponmainhandType: 21
+    IndexWeaponoffhandType: 22
+    IndexWeaponType: 13
+    IndexWristType: 9
 ItemArmorSubclass:
-  Cloth: 1
-  Cosmetic: 5
-  Generic: 0
-  Idol: 8
-  Leather: 2
-  Libram: 7
-  Mail: 3
-  Plate: 4
-  Relic: 11
-  Shield: 6
-  Sigil: 10
-  Totem: 9
+  values:
+    Cloth: 1
+    Cosmetic: 5
+    Generic: 0
+    Idol: 8
+    Leather: 2
+    Libram: 7
+    Mail: 3
+    Plate: 4
+    Relic: 11
+    Shield: 6
+    Sigil: 10
+    Totem: 9
 ItemBind:
-  None: 0
-  OnAcquire: 1
-  OnEquip: 2
-  OnUse: 3
-  Quest: 4
-  ToBnetAccount: 8
-  ToBnetAccountUntilEquipped: 9
-  ToWoWAccount: 7
-  Unused1: 5
-  Unused2: 6
+  values:
+    None: 0
+    OnAcquire: 1
+    OnEquip: 2
+    OnUse: 3
+    Quest: 4
+    ToBnetAccount: 8
+    ToBnetAccountUntilEquipped: 9
+    ToWoWAccount: 7
+    Unused1: 5
+    Unused2: 6
 ItemClass:
-  Armor: 4
-  Battlepet: 17
-  Consumable: 0
-  Container: 1
-  CurrencyTokenObsolete: 10
-  Gem: 3
-  Glyph: 16
-  Housing: 20
-  ItemEnhancement: 8
-  Key: 13
-  Miscellaneous: 15
-  PermanentObsolete: 14
-  Profession: 19
-  Projectile: 6
-  Questitem: 12
-  Quiver: 11
-  Reagent: 5
-  Recipe: 9
-  Tradegoods: 7
-  Weapon: 2
-  WoWToken: 18
+  values:
+    Armor: 4
+    Battlepet: 17
+    Consumable: 0
+    Container: 1
+    CurrencyTokenObsolete: 10
+    Gem: 3
+    Glyph: 16
+    Housing: 20
+    ItemEnhancement: 8
+    Key: 13
+    Miscellaneous: 15
+    PermanentObsolete: 14
+    Profession: 19
+    Projectile: 6
+    Questitem: 12
+    Quiver: 11
+    Reagent: 5
+    Recipe: 9
+    Tradegoods: 7
+    Weapon: 2
+    WoWToken: 18
 Itemclassfilterflags:
-  Armor: 16
-  Battlepet: 131072
-  Consumable: 1
-  Container: 2
-  CurrencyTokenObsolete: 1024
-  Gem: 8
-  Glyph: 65536
-  ItemEnhancement: 256
-  Key: 8192
-  Miscellaneous: 32768
-  PermanentObsolete: 16384
-  Projectile: 64
-  Questitemclassfilterflags: 4096
-  Quiver: 2048
-  Reagent: 32
-  Recipe: 512
-  Tradegoods: 128
-  Weapon: 4
+  values:
+    Armor: 16
+    Battlepet: 131072
+    Consumable: 1
+    Container: 2
+    CurrencyTokenObsolete: 1024
+    Gem: 8
+    Glyph: 65536
+    ItemEnhancement: 256
+    Key: 8192
+    Miscellaneous: 32768
+    PermanentObsolete: 16384
+    Projectile: 64
+    Questitemclassfilterflags: 4096
+    Quiver: 2048
+    Reagent: 32
+    Recipe: 512
+    Tradegoods: 128
+    Weapon: 4
 ItemCollectionType:
-  ExteriorFixture: 9
-  Heirloom: 2
-  HouseType: 13
-  None: 0
-  Room: 8
-  RoomMaterial: 11
-  RoomTheme: 10
-  RuneforgeLegendaryAbility: 5
-  Toy: 1
-  Transmog: 3
-  TransmogIllusion: 6
-  TransmogOutfit: 12
-  TransmogSetFavorite: 4
-  WarbandScene: 7
+  values:
+    ExteriorFixture: 9
+    Heirloom: 2
+    HouseType: 13
+    None: 0
+    Room: 8
+    RoomMaterial: 11
+    RoomTheme: 10
+    RuneforgeLegendaryAbility: 5
+    Toy: 1
+    Transmog: 3
+    TransmogIllusion: 6
+    TransmogOutfit: 12
+    TransmogSetFavorite: 4
+    WarbandScene: 7
 ItemCommodityStatus:
-  Commodity: 2
-  Item: 1
-  Unknown: 0
+  values:
+    Commodity: 2
+    Item: 1
+    Unknown: 0
 ItemConsumableSubclass:
-  Bandage: 7
-  CombatCurio: 11
-  Elixir: 2
-  Flasksphials: 3
-  Fooddrink: 5
-  Generic: 0
-  Itemenhancement: 6
-  Other: 8
-  Potion: 1
-  Relic: 12
-  Scroll: 4
-  UtilityCurio: 10
-  VantusRune: 9
+  values:
+    Bandage: 7
+    CombatCurio: 11
+    Elixir: 2
+    Flasksphials: 3
+    Fooddrink: 5
+    Generic: 0
+    Itemenhancement: 6
+    Other: 8
+    Potion: 1
+    Relic: 12
+    Scroll: 4
+    UtilityCurio: 10
+    VantusRune: 9
 ItemCreationContext:
-  BlackMarket: 15
-  ChallengeMode_1: 16
-  ChallengeMode_2: 33
-  ChallengeMode_3: 34
-  ChallengeMode_4: 87
-  ChallengeModeJackpot: 35
-  CharacterBoost_1: 61
-  CharacterBoost_2: 62
-  CharacterBoost_3: 86
-  CorpseRecovery: 80
-  Delves_1: 104
-  Delves_2: 106
-  Delves_3: 107
-  DelvesBonus_1: 129
-  DelvesBonus_10: 138
-  DelvesBonus_2: 130
-  DelvesBonus_3: 131
-  DelvesBonus_4: 132
-  DelvesBonus_5: 133
-  DelvesBonus_6: 134
-  DelvesBonus_7: 135
-  DelvesBonus_8: 136
-  DelvesBonus_9: 137
-  DelvesBounty_1: 117
-  DelvesBounty_2: 118
-  DelvesBounty_3: 119
-  DelvesBounty_4: 120
-  DelvesBounty_5: 121
-  DelvesBounty_6: 122
-  DelvesBounty_7: 123
-  DelvesBounty_8: 124
-  DelvesJackpot: 108
-  DelvesKey_1: 109
-  DelvesKey_2: 110
-  DelvesKey_3: 111
-  DelvesKey_4: 112
-  DelvesKey_5: 113
-  DelvesKey_6: 114
-  DelvesKey_7: 115
-  DelvesKey_8: 116
-  DelvesLevelUp_1: 125
-  DelvesLevelUp_2: 126
-  DelvesLevelUp_3: 127
-  DelvesLevelUp_4: 128
-  DungeonBonus_1: 139
-  DungeonBonus_10: 148
-  DungeonBonus_2: 140
-  DungeonBonus_3: 141
-  DungeonBonus_4: 142
-  DungeonBonus_5: 143
-  DungeonBonus_6: 144
-  DungeonBonus_7: 145
-  DungeonBonus_8: 146
-  DungeonBonus_9: 147
-  DungeonHardMode_1: 159
-  DungeonHardMode_2: 160
-  DungeonHardMode_3: 161
-  DungeonHeroic: 2
-  DungeonHeroicJackpot: 102
-  DungeonLevelUp_1: 17
-  DungeonLevelUp_2: 18
-  DungeonLevelUp_3: 19
-  DungeonLevelUp_4: 20
-  DungeonMythic: 23
-  DungeonMythicJackpot: 103
-  DungeonNormal: 1
-  DungeonNormalJackpot: 101
-  Endeavors: 185
-  ForceNone: 21
-  LegendaryCrafting_1: 63
-  LegendaryCrafting_2: 64
-  LegendaryCrafting_3: 65
-  LegendaryCrafting_4: 66
-  LegendaryCrafting_5: 67
-  LegendaryCrafting_6: 68
-  LegendaryCrafting_7: 69
-  LegendaryCrafting_8: 70
-  LegendaryCrafting_9: 71
-  LegendaryForge: 59
-  MissionReward_1: 31
-  MissionReward_2: 32
-  NewCharacter: 75
-  None: 0
-  PvPBrawl_1: 77
-  PvPBrawl_2: 78
-  PvPHonorReward: 24
-  PvPRanked_1: 8
-  PvPRanked_2: 38
-  PvPRanked_3: 39
-  PvPRanked_4: 40
-  PvPRanked_5: 44
-  PvPRanked_6: 45
-  PvPRanked_7: 46
-  PvPRanked_8: 52
-  PvPRanked_9: 88
-  PvPRankedJackpot: 56
-  PvPUnranked_1: 7
-  PvPUnranked_2: 41
-  PvPUnranked_3: 47
-  PvPUnranked_4: 48
-  PvPUnranked_5: 49
-  PvPUnranked_6: 50
-  PvPUnranked_7: 51
-  QuestBonusLoot: 60
-  QuestReward: 11
-  RaidBonus_1: 149
-  RaidBonus_10: 158
-  RaidBonus_2: 150
-  RaidBonus_3: 151
-  RaidBonus_4: 152
-  RaidBonus_5: 153
-  RaidBonus_6: 154
-  RaidBonus_7: 155
-  RaidBonus_8: 156
-  RaidBonus_9: 157
-  RaidFinder: 4
-  RaidFinderExtended: 83
-  RaidFinderExtended_2: 90
-  RaidFinderExtended_3: 94
-  RaidHeroic: 5
-  RaidHeroicExtended: 84
-  RaidHeroicExtended_2: 91
-  RaidHeroicExtended_3: 95
-  RaidMythic: 6
-  RaidMythicExtended: 85
-  RaidMythicExtended_2: 92
-  RaidMythicExtended_3: 96
-  RaidNormal: 3
-  RaidNormalExtended: 82
-  RaidNormalExtended_2: 89
-  RaidNormalExtended_3: 93
-  Relinquished: 58
-  ScenarioHeroic: 10
-  ScenarioNormal: 9
-  Store: 12
-  TemplateCharacter_1: 97
-  TemplateCharacter_2: 98
-  TemplateCharacter_3: 99
-  TemplateCharacter_4: 100
-  Timerunning: 105
-  TimewalkerLevelUp: 22
-  TimewalkerMaxLevel: 186
-  Torghast: 79
-  TournamentRealm_1: 57
-  TournamentRealm_2: 162
-  TournamentRealm_3: 163
-  TournamentRealm_4: 164
-  TradeSkill: 13
-  Vendor: 14
-  Warbound_1: 165
-  Warbound_10: 174
-  Warbound_11: 175
-  Warbound_12: 176
-  Warbound_13: 177
-  Warbound_14: 178
-  Warbound_15: 179
-  Warbound_16: 180
-  Warbound_17: 181
-  Warbound_18: 182
-  Warbound_19: 183
-  Warbound_2: 166
-  Warbound_20: 184
-  Warbound_3: 167
-  Warbound_4: 168
-  Warbound_5: 169
-  Warbound_6: 170
-  Warbound_7: 171
-  Warbound_8: 172
-  Warbound_9: 173
-  WarMode: 76
-  WeeklyRewardsAdditional: 72
-  WeeklyRewardsConcession: 73
-  WorldBoss: 81
-  WorldQuest_1: 25
-  WorldQuest_10: 43
-  WorldQuest_11: 53
-  WorldQuest_12: 54
-  WorldQuest_13: 55
-  WorldQuest_2: 26
-  WorldQuest_3: 27
-  WorldQuest_4: 28
-  WorldQuest_5: 29
-  WorldQuest_6: 30
-  WorldQuest_7: 36
-  WorldQuest_8: 37
-  WorldQuest_9: 42
-  WorldQuestJackpot: 74
+  values:
+    BlackMarket: 15
+    ChallengeMode_1: 16
+    ChallengeMode_2: 33
+    ChallengeMode_3: 34
+    ChallengeMode_4: 87
+    ChallengeModeJackpot: 35
+    CharacterBoost_1: 61
+    CharacterBoost_2: 62
+    CharacterBoost_3: 86
+    CorpseRecovery: 80
+    Delves_1: 104
+    Delves_2: 106
+    Delves_3: 107
+    DelvesBonus_1: 129
+    DelvesBonus_10: 138
+    DelvesBonus_2: 130
+    DelvesBonus_3: 131
+    DelvesBonus_4: 132
+    DelvesBonus_5: 133
+    DelvesBonus_6: 134
+    DelvesBonus_7: 135
+    DelvesBonus_8: 136
+    DelvesBonus_9: 137
+    DelvesBounty_1: 117
+    DelvesBounty_2: 118
+    DelvesBounty_3: 119
+    DelvesBounty_4: 120
+    DelvesBounty_5: 121
+    DelvesBounty_6: 122
+    DelvesBounty_7: 123
+    DelvesBounty_8: 124
+    DelvesJackpot: 108
+    DelvesKey_1: 109
+    DelvesKey_2: 110
+    DelvesKey_3: 111
+    DelvesKey_4: 112
+    DelvesKey_5: 113
+    DelvesKey_6: 114
+    DelvesKey_7: 115
+    DelvesKey_8: 116
+    DelvesLevelUp_1: 125
+    DelvesLevelUp_2: 126
+    DelvesLevelUp_3: 127
+    DelvesLevelUp_4: 128
+    DungeonBonus_1: 139
+    DungeonBonus_10: 148
+    DungeonBonus_2: 140
+    DungeonBonus_3: 141
+    DungeonBonus_4: 142
+    DungeonBonus_5: 143
+    DungeonBonus_6: 144
+    DungeonBonus_7: 145
+    DungeonBonus_8: 146
+    DungeonBonus_9: 147
+    DungeonHardMode_1: 159
+    DungeonHardMode_2: 160
+    DungeonHardMode_3: 161
+    DungeonHeroic: 2
+    DungeonHeroicJackpot: 102
+    DungeonLevelUp_1: 17
+    DungeonLevelUp_2: 18
+    DungeonLevelUp_3: 19
+    DungeonLevelUp_4: 20
+    DungeonMythic: 23
+    DungeonMythicJackpot: 103
+    DungeonNormal: 1
+    DungeonNormalJackpot: 101
+    Endeavors: 185
+    ForceNone: 21
+    LegendaryCrafting_1: 63
+    LegendaryCrafting_2: 64
+    LegendaryCrafting_3: 65
+    LegendaryCrafting_4: 66
+    LegendaryCrafting_5: 67
+    LegendaryCrafting_6: 68
+    LegendaryCrafting_7: 69
+    LegendaryCrafting_8: 70
+    LegendaryCrafting_9: 71
+    LegendaryForge: 59
+    MissionReward_1: 31
+    MissionReward_2: 32
+    NewCharacter: 75
+    None: 0
+    PvPBrawl_1: 77
+    PvPBrawl_2: 78
+    PvPHonorReward: 24
+    PvPRanked_1: 8
+    PvPRanked_2: 38
+    PvPRanked_3: 39
+    PvPRanked_4: 40
+    PvPRanked_5: 44
+    PvPRanked_6: 45
+    PvPRanked_7: 46
+    PvPRanked_8: 52
+    PvPRanked_9: 88
+    PvPRankedJackpot: 56
+    PvPUnranked_1: 7
+    PvPUnranked_2: 41
+    PvPUnranked_3: 47
+    PvPUnranked_4: 48
+    PvPUnranked_5: 49
+    PvPUnranked_6: 50
+    PvPUnranked_7: 51
+    QuestBonusLoot: 60
+    QuestReward: 11
+    RaidBonus_1: 149
+    RaidBonus_10: 158
+    RaidBonus_2: 150
+    RaidBonus_3: 151
+    RaidBonus_4: 152
+    RaidBonus_5: 153
+    RaidBonus_6: 154
+    RaidBonus_7: 155
+    RaidBonus_8: 156
+    RaidBonus_9: 157
+    RaidFinder: 4
+    RaidFinderExtended: 83
+    RaidFinderExtended_2: 90
+    RaidFinderExtended_3: 94
+    RaidHeroic: 5
+    RaidHeroicExtended: 84
+    RaidHeroicExtended_2: 91
+    RaidHeroicExtended_3: 95
+    RaidMythic: 6
+    RaidMythicExtended: 85
+    RaidMythicExtended_2: 92
+    RaidMythicExtended_3: 96
+    RaidNormal: 3
+    RaidNormalExtended: 82
+    RaidNormalExtended_2: 89
+    RaidNormalExtended_3: 93
+    Relinquished: 58
+    ScenarioHeroic: 10
+    ScenarioNormal: 9
+    Store: 12
+    TemplateCharacter_1: 97
+    TemplateCharacter_2: 98
+    TemplateCharacter_3: 99
+    TemplateCharacter_4: 100
+    Timerunning: 105
+    TimewalkerLevelUp: 22
+    TimewalkerMaxLevel: 186
+    Torghast: 79
+    TournamentRealm_1: 57
+    TournamentRealm_2: 162
+    TournamentRealm_3: 163
+    TournamentRealm_4: 164
+    TradeSkill: 13
+    Vendor: 14
+    Warbound_1: 165
+    Warbound_10: 174
+    Warbound_11: 175
+    Warbound_12: 176
+    Warbound_13: 177
+    Warbound_14: 178
+    Warbound_15: 179
+    Warbound_16: 180
+    Warbound_17: 181
+    Warbound_18: 182
+    Warbound_19: 183
+    Warbound_2: 166
+    Warbound_20: 184
+    Warbound_3: 167
+    Warbound_4: 168
+    Warbound_5: 169
+    Warbound_6: 170
+    Warbound_7: 171
+    Warbound_8: 172
+    Warbound_9: 173
+    WarMode: 76
+    WeeklyRewardsAdditional: 72
+    WeeklyRewardsConcession: 73
+    WorldBoss: 81
+    WorldQuest_1: 25
+    WorldQuest_10: 43
+    WorldQuest_11: 53
+    WorldQuest_12: 54
+    WorldQuest_13: 55
+    WorldQuest_2: 26
+    WorldQuest_3: 27
+    WorldQuest_4: 28
+    WorldQuest_5: 29
+    WorldQuest_6: 30
+    WorldQuest_7: 36
+    WorldQuest_8: 37
+    WorldQuest_9: 42
+    WorldQuestJackpot: 74
 ItemDisplayTextDisplayStyle:
-  ItemNameAndInfoText: 1
-  ItemNameOnlyCentered: 2
-  PlayerChoiceReward: 3
-  WorldQuestReward: 0
+  values:
+    ItemNameAndInfoText: 1
+    ItemNameOnlyCentered: 2
+    PlayerChoiceReward: 3
+    WorldQuestReward: 0
 ItemDisplayTooltipEnabledType:
-  Disabled: 1
-  Enabled: 0
+  values:
+    Disabled: 1
+    Enabled: 0
 ItemGemColor:
-  Arcane: 1024
-  Blood: 128
-  Blue: 8
-  Cogwheel: 32
-  Cypher: 8388608
-  DominationBlood: 1048576
-  DominationFrost: 2097152
-  DominationUnholy: 4194304
-  Fel: 512
-  Fiber: 1073741824
-  Fire: 4096
-  Fragrance: 67108864
-  Frost: 2048
-  Holy: 65536
-  Hydraulic: 16
-  Iron: 64
-  Life: 16384
-  Meta: 1
-  Primordial: 33554432
-  PunchcardBlue: 524288
-  PunchcardRed: 131072
-  PunchcardYellow: 262144
-  Red: 2
-  Shadow: 256
-  SingingSea: 268435456
-  SingingThunder: 134217728
-  SingingWind: 536870912
-  Tinker: 16777216
-  Water: 8192
-  Wind: 32768
-  Yellow: 4
+  values:
+    Arcane: 1024
+    Blood: 128
+    Blue: 8
+    Cogwheel: 32
+    Cypher: 8388608
+    DominationBlood: 1048576
+    DominationFrost: 2097152
+    DominationUnholy: 4194304
+    Fel: 512
+    Fiber: 1073741824
+    Fire: 4096
+    Fragrance: 67108864
+    Frost: 2048
+    Holy: 65536
+    Hydraulic: 16
+    Iron: 64
+    Life: 16384
+    Meta: 1
+    Primordial: 33554432
+    PunchcardBlue: 524288
+    PunchcardRed: 131072
+    PunchcardYellow: 262144
+    Red: 2
+    Shadow: 256
+    SingingSea: 268435456
+    SingingThunder: 134217728
+    SingingWind: 536870912
+    Tinker: 16777216
+    Water: 8192
+    Wind: 32768
+    Yellow: 4
 ItemGemSubclass:
-  Agility: 1
-  Artifactrelic: 11
-  Criticalstrike: 5
-  Haste: 7
-  Intellect: 0
-  Mastery: 6
-  Multiplestats: 10
-  Other: 9
-  Spirit: 4
-  Stamina: 3
-  Strength: 2
-  Versatility: 8
+  values:
+    Agility: 1
+    Artifactrelic: 11
+    Criticalstrike: 5
+    Haste: 7
+    Intellect: 0
+    Mastery: 6
+    Multiplestats: 10
+    Other: 9
+    Spirit: 4
+    Stamina: 3
+    Strength: 2
+    Versatility: 8
 ItemHousingSubclass:
-  Decor: 0
-  Dye: 1
-  ExteriorCustomization: 4
-  Room: 2
-  RoomCustomization: 3
-  ServiceItem: 5
+  values:
+    Decor: 0
+    Dye: 1
+    ExteriorCustomization: 4
+    Room: 2
+    RoomCustomization: 3
+    ServiceItem: 5
 ItemMiscellaneousSubclass:
-  CompanionPet: 2
-  Holiday: 3
-  Junk: 0
-  Mount: 5
-  MountEquipment: 6
-  Other: 4
-  Reagent: 1
+  values:
+    CompanionPet: 2
+    Holiday: 3
+    Junk: 0
+    Mount: 5
+    MountEquipment: 6
+    Other: 4
+    Reagent: 1
 ItemModification:
-  ArtifactAppearanceID: 8
-  ArtifactTier: 24
-  BattlePetBreed: 4
-  BattlePetCreaturedisplayid: 6
-  BattlePetLevel: 5
-  BattlePetSpecies: 3
-  ChangeModifiedCraftingStat_1: 29
-  ChangeModifiedCraftingStat_2: 30
-  ContentTuningID: 28
-  CraftingDataID: 40
-  CraftingQualityID: 38
-  CraftingReagentSlot_0: 43
-  CraftingReagentSlot_1: 44
-  CraftingReagentSlot_10: 53
-  CraftingReagentSlot_11: 54
-  CraftingReagentSlot_12: 55
-  CraftingReagentSlot_13: 56
-  CraftingReagentSlot_14: 57
-  CraftingReagentSlot_2: 45
-  CraftingReagentSlot_3: 46
-  CraftingReagentSlot_4: 47
-  CraftingReagentSlot_5: 48
-  CraftingReagentSlot_6: 49
-  CraftingReagentSlot_7: 50
-  CraftingReagentSlot_8: 51
-  CraftingReagentSlot_9: 52
-  CraftingSkillLineAbilityID: 39
-  CraftingSkillReagents: 41
-  CraftingSkillWatermark: 42
-  CurrencyWalletID: 61
-  CurrencyWalletQuantity: 62
-  CurrencyWalletVersion: 63
-  DbidHigh: 59
-  DbidLow: 60
-  IncrementLevelObsolete: 2
-  KeystoneAffix0: 19
-  KeystoneAffix01: 20
-  KeystoneAffix02: 21
-  KeystoneAffix03: 22
-  KeystoneMapChallengeModeID: 17
-  KeystonePowerLevel: 18
-  LegionArtifactKnowledgeObsolete: 23
-  PvPRating: 26
-  RedirectedBaseStats: 64
-  Reforge: 58
-  SoulbindConduitRank: 37
-  TimewalkerLevel: 9
-  TransmogrifyItemModifiedAppearanceIDSpec_0: 1
-  TransmogrifyItemModifiedAppearanceIDSpec_1: 11
-  TransmogrifyItemModifiedAppearanceIDSpec_2: 13
-  TransmogrifyItemModifiedAppearanceIDSpec_3: 15
-  TransmogrifyItemModifiedAppearanceIDSpec_4: 25
-  TransmogrifyItemModifiedAppearanceIDSpecAll: 0
-  TransmogrifyOverrideEnchantVisualIDSpec_0: 10
-  TransmogrifyOverrideEnchantVisualIDSpec_1: 12
-  TransmogrifyOverrideEnchantVisualIDSpec_2: 14
-  TransmogrifyOverrideEnchantVisualIDSpec_3: 16
-  TransmogrifyOverrideEnchantVisualIDSpec_4: 27
-  TransmogrifyOverrideEnchantVisualIDSpecAll: 7
-  TransmogrifySecondaryItemModifiedAppearanceIDSpec_0: 32
-  TransmogrifySecondaryItemModifiedAppearanceIDSpec_1: 33
-  TransmogrifySecondaryItemModifiedAppearanceIDSpec_2: 34
-  TransmogrifySecondaryItemModifiedAppearanceIDSpec_3: 35
-  TransmogrifySecondaryItemModifiedAppearanceIDSpec_4: 36
-  TransmogrifySecondaryItemModifiedAppearanceIDSpecAll: 31
+  values:
+    ArtifactAppearanceID: 8
+    ArtifactTier: 24
+    BattlePetBreed: 4
+    BattlePetCreaturedisplayid: 6
+    BattlePetLevel: 5
+    BattlePetSpecies: 3
+    ChangeModifiedCraftingStat_1: 29
+    ChangeModifiedCraftingStat_2: 30
+    ContentTuningID: 28
+    CraftingDataID: 40
+    CraftingQualityID: 38
+    CraftingReagentSlot_0: 43
+    CraftingReagentSlot_1: 44
+    CraftingReagentSlot_10: 53
+    CraftingReagentSlot_11: 54
+    CraftingReagentSlot_12: 55
+    CraftingReagentSlot_13: 56
+    CraftingReagentSlot_14: 57
+    CraftingReagentSlot_2: 45
+    CraftingReagentSlot_3: 46
+    CraftingReagentSlot_4: 47
+    CraftingReagentSlot_5: 48
+    CraftingReagentSlot_6: 49
+    CraftingReagentSlot_7: 50
+    CraftingReagentSlot_8: 51
+    CraftingReagentSlot_9: 52
+    CraftingSkillLineAbilityID: 39
+    CraftingSkillReagents: 41
+    CraftingSkillWatermark: 42
+    CurrencyWalletID: 61
+    CurrencyWalletQuantity: 62
+    CurrencyWalletVersion: 63
+    DbidHigh: 59
+    DbidLow: 60
+    IncrementLevelObsolete: 2
+    KeystoneAffix0: 19
+    KeystoneAffix01: 20
+    KeystoneAffix02: 21
+    KeystoneAffix03: 22
+    KeystoneMapChallengeModeID: 17
+    KeystonePowerLevel: 18
+    LegionArtifactKnowledgeObsolete: 23
+    PvPRating: 26
+    RedirectedBaseStats: 64
+    Reforge: 58
+    SoulbindConduitRank: 37
+    TimewalkerLevel: 9
+    TransmogrifyItemModifiedAppearanceIDSpec_0: 1
+    TransmogrifyItemModifiedAppearanceIDSpec_1: 11
+    TransmogrifyItemModifiedAppearanceIDSpec_2: 13
+    TransmogrifyItemModifiedAppearanceIDSpec_3: 15
+    TransmogrifyItemModifiedAppearanceIDSpec_4: 25
+    TransmogrifyItemModifiedAppearanceIDSpecAll: 0
+    TransmogrifyOverrideEnchantVisualIDSpec_0: 10
+    TransmogrifyOverrideEnchantVisualIDSpec_1: 12
+    TransmogrifyOverrideEnchantVisualIDSpec_2: 14
+    TransmogrifyOverrideEnchantVisualIDSpec_3: 16
+    TransmogrifyOverrideEnchantVisualIDSpec_4: 27
+    TransmogrifyOverrideEnchantVisualIDSpecAll: 7
+    TransmogrifySecondaryItemModifiedAppearanceIDSpec_0: 32
+    TransmogrifySecondaryItemModifiedAppearanceIDSpec_1: 33
+    TransmogrifySecondaryItemModifiedAppearanceIDSpec_2: 34
+    TransmogrifySecondaryItemModifiedAppearanceIDSpec_3: 35
+    TransmogrifySecondaryItemModifiedAppearanceIDSpec_4: 36
+    TransmogrifySecondaryItemModifiedAppearanceIDSpecAll: 31
 ItemProfessionSubclass:
-  Alchemy: 2
-  Archaeology: 13
-  Blacksmithing: 0
-  Cooking: 4
-  Enchanting: 8
-  Engineering: 7
-  Fishing: 9
-  Herbalism: 3
-  Inscription: 12
-  Jewelcrafting: 11
-  Leatherworking: 1
-  Mining: 5
-  Skinning: 10
-  Tailoring: 6
+  values:
+    Alchemy: 2
+    Archaeology: 13
+    Blacksmithing: 0
+    Cooking: 4
+    Enchanting: 8
+    Engineering: 7
+    Fishing: 9
+    Herbalism: 3
+    Inscription: 12
+    Jewelcrafting: 11
+    Leatherworking: 1
+    Mining: 5
+    Skinning: 10
+    Tailoring: 6
 ItemQuality:
-  Artifact: 6
-  Common: 1
-  Epic: 4
-  Heirloom: 7
-  Legendary: 5
-  Poor: 0
-  Rare: 3
-  Uncommon: 2
-  WoWToken: 8
+  values:
+    Artifact: 6
+    Common: 1
+    Epic: 4
+    Heirloom: 7
+    Legendary: 5
+    Poor: 0
+    Rare: 3
+    Uncommon: 2
+    WoWToken: 8
 ItemReagentSubclass:
-  ContextToken: 2
-  Keystone: 1
-  Reagent: 0
+  values:
+    ContextToken: 2
+    Keystone: 1
+    Reagent: 0
 ItemRecipeSubclass:
-  Alchemy: 6
-  Blacksmithing: 4
-  Book: 0
-  Cooking: 5
-  Enchanting: 8
-  Engineering: 3
-  FirstAid: 7
-  Fishing: 9
-  Inscription: 11
-  Jewelcrafting: 10
-  Leatherworking: 1
-  Tailoring: 2
+  values:
+    Alchemy: 6
+    Blacksmithing: 4
+    Book: 0
+    Cooking: 5
+    Enchanting: 8
+    Engineering: 3
+    FirstAid: 7
+    Fishing: 9
+    Inscription: 11
+    Jewelcrafting: 10
+    Leatherworking: 1
+    Tailoring: 2
 ItemRecraftFlags:
-  Invalid: 1
+  values:
+    Invalid: 1
 ItemRedundancySlot:
-  Chest: 3
-  Cloak: 11
-  Feet: 6
-  Finger: 9
-  Hand: 8
-  Head: 0
-  Legs: 5
-  MainhandWeapon: 13
-  Neck: 1
-  Offhand: 16
-  OnehandWeapon: 14
-  OnehandWeaponSecond: 15
-  Shoulder: 2
-  Trinket: 10
-  Twohand: 12
-  Waist: 4
-  Wrist: 7
+  values:
+    Chest: 3
+    Cloak: 11
+    Feet: 6
+    Finger: 9
+    Hand: 8
+    Head: 0
+    Legs: 5
+    MainhandWeapon: 13
+    Neck: 1
+    Offhand: 16
+    OnehandWeapon: 14
+    OnehandWeaponSecond: 15
+    Shoulder: 2
+    Trinket: 10
+    Twohand: 12
+    Waist: 4
+    Wrist: 7
 Itemsetflags:
-  Legacy: 1
-  RequiresPvPTalentsActive: 4
-  UseItemHistorySetSlots: 2
+  values:
+    Legacy: 1
+    RequiresPvPTalentsActive: 4
+    UseItemHistorySetSlots: 2
 ItemSlotFilterType:
-  Chest: 4
-  Cloak: 3
-  Feet: 9
-  Finger: 12
-  Hand: 6
-  Head: 0
-  Legs: 8
-  MainHand: 10
-  Neck: 1
-  NoFilter: 15
-  OffHand: 11
-  Other: 14
-  Shoulder: 2
-  Trinket: 13
-  Waist: 7
-  Wrist: 5
+  values:
+    Chest: 4
+    Cloak: 3
+    Feet: 9
+    Finger: 12
+    Hand: 6
+    Head: 0
+    Legs: 8
+    MainHand: 10
+    Neck: 1
+    NoFilter: 15
+    OffHand: 11
+    Other: 14
+    Shoulder: 2
+    Trinket: 13
+    Waist: 7
+    Wrist: 5
 ItemSocketInfoUIType:
-  Default: 0
+  values:
+    Default: 0
 ItemSocketType:
-  Arcane: 12
-  Blood: 9
-  Blue: 4
-  Cogwheel: 6
-  Cypher: 23
-  Domination: 22
-  Fel: 11
-  Fiber: 30
-  Fire: 14
-  Fragrance: 26
-  Frost: 13
-  Holy: 18
-  Hydraulic: 5
-  Iron: 8
-  Life: 16
-  Meta: 1
-  None: 0
-  Primordial: 25
-  Prismatic: 7
-  PunchcardBlue: 21
-  PunchcardRed: 19
-  PunchcardYellow: 20
-  Red: 2
-  Shadow: 10
-  SingingSea: 28
-  SingingThunder: 27
-  SingingWind: 29
-  Tinker: 24
-  Water: 15
-  Wind: 17
-  Yellow: 3
+  values:
+    Arcane: 12
+    Blood: 9
+    Blue: 4
+    Cogwheel: 6
+    Cypher: 23
+    Domination: 22
+    Fel: 11
+    Fiber: 30
+    Fire: 14
+    Fragrance: 26
+    Frost: 13
+    Holy: 18
+    Hydraulic: 5
+    Iron: 8
+    Life: 16
+    Meta: 1
+    None: 0
+    Primordial: 25
+    Prismatic: 7
+    PunchcardBlue: 21
+    PunchcardRed: 19
+    PunchcardYellow: 20
+    Red: 2
+    Shadow: 10
+    SingingSea: 28
+    SingingThunder: 27
+    SingingWind: 29
+    Tinker: 24
+    Water: 15
+    Wind: 17
+    Yellow: 3
 ItemSoundType:
-  Close: 3
-  Drop: 1
-  Pickup: 0
-  Use: 2
+  values:
+    Close: 3
+    Drop: 1
+    Pickup: 0
+    Use: 2
 ItemSubclassDisplay:
-  HideSubclassInAuction: 2
-  HideSubclassInTooltips: 1
-  ShowItemCount: 4
+  values:
+    HideSubclassInAuction: 2
+    HideSubclassInTooltips: 1
+    ShowItemCount: 4
 ItemSubclassFlag:
-  ArmorsubclassLfgscalingarmor: 1024
-  ItemsubclassQuivernotrequired: 64
-  ItemsubclassUsesInvtype: 512
-  WeaponsubclassCanparry: 1
-  WeaponsubclassDeprecatedReuseMe: 256
-  WeaponsubclassIsrifle: 8
-  WeaponsubclassIsthrown: 16
-  WeaponsubclassIsunarmed: 4
-  WeaponsubclassRanged: 128
-  WeaponsubclassRighthandRanged: 32
-  WeaponsubclassSetfingerseq: 2
+  values:
+    ArmorsubclassLfgscalingarmor: 1024
+    ItemsubclassQuivernotrequired: 64
+    ItemsubclassUsesInvtype: 512
+    WeaponsubclassCanparry: 1
+    WeaponsubclassDeprecatedReuseMe: 256
+    WeaponsubclassIsrifle: 8
+    WeaponsubclassIsthrown: 16
+    WeaponsubclassIsunarmed: 4
+    WeaponsubclassRanged: 128
+    WeaponsubclassRighthandRanged: 32
+    WeaponsubclassSetfingerseq: 2
 ItemTryOnReason:
-  DataPending: 3
-  NotEquippable: 2
-  Success: 0
-  WrongRace: 1
+  values:
+    DataPending: 3
+    NotEquippable: 2
+    Success: 0
+    WrongRace: 1
 ItemWeaponSubclass:
-  Axe1H: 0
-  Axe2H: 1
-  Bearclaw: 11
-  Bows: 2
-  Catclaw: 12
-  Crossbow: 18
-  Dagger: 15
-  Fishingpole: 20
-  Generic: 14
-  Guns: 3
-  Mace1H: 4
-  Mace2H: 5
-  Obsolete3: 17
-  Polearm: 6
-  Staff: 10
-  Sword1H: 7
-  Sword2H: 8
-  Thrown: 16
-  Unarmed: 13
-  Wand: 19
-  Warglaive: 9
+  values:
+    Axe1H: 0
+    Axe2H: 1
+    Bearclaw: 11
+    Bows: 2
+    Catclaw: 12
+    Crossbow: 18
+    Dagger: 15
+    Fishingpole: 20
+    Generic: 14
+    Guns: 3
+    Mace1H: 4
+    Mace2H: 5
+    Obsolete3: 17
+    Polearm: 6
+    Staff: 10
+    Sword1H: 7
+    Sword2H: 8
+    Thrown: 16
+    Unarmed: 13
+    Wand: 19
+    Warglaive: 9
 JailersTowerType:
-  AdamantVaults: 11
-  ArkobanHall: 7
-  BossRush: 14
-  Coldheart: 4
-  ForgottenCatacombs: 12
-  FractureChambers: 2
-  Mortregar: 5
-  Ossuary: 13
-  SkoldusHalls: 1
-  Soulforges: 3
-  TormentChamberAnduin: 10
-  TormentChamberJaina: 8
-  TormentChamberThrall: 9
-  TwistingCorridors: 0
-  UpperReaches: 6
+  values:
+    AdamantVaults: 11
+    ArkobanHall: 7
+    BossRush: 14
+    Coldheart: 4
+    ForgottenCatacombs: 12
+    FractureChambers: 2
+    Mortregar: 5
+    Ossuary: 13
+    SkoldusHalls: 1
+    Soulforges: 3
+    TormentChamberAnduin: 10
+    TormentChamberJaina: 8
+    TormentChamberThrall: 9
+    TwistingCorridors: 0
+    UpperReaches: 6
 JournalEncounterFlags:
-  AllianceOnly: 4
-  DoNotDisplayEncounter: 64
-  HordeOnly: 8
-  InternalOnly: 32
-  LimitDifficulties: 2
-  NoMap: 16
-  Obsolete: 1
+  values:
+    AllianceOnly: 4
+    DoNotDisplayEncounter: 64
+    HordeOnly: 8
+    InternalOnly: 32
+    LimitDifficulties: 2
+    NoMap: 16
+    Obsolete: 1
 JournalEncounterIconFlags:
-  Bleed: 8192
-  Curse: 256
-  Deadly: 16
-  Disease: 1024
-  Dps: 2
-  Enrage: 2048
-  Healer: 4
-  Heroic: 8
-  Important: 32
-  Interruptible: 64
-  Magic: 128
-  Mythic: 4096
-  Poison: 512
-  Tank: 1
+  values:
+    Bleed: 8192
+    Curse: 256
+    Deadly: 16
+    Disease: 1024
+    Dps: 2
+    Enrage: 2048
+    Healer: 4
+    Heroic: 8
+    Important: 32
+    Interruptible: 64
+    Magic: 128
+    Mythic: 4096
+    Poison: 512
+    Tank: 1
 JournalEncounterItemFlags:
-  DisplayAsExtremelyRare: 16
-  DisplayAsPerPlayerLoot: 4
-  DisplayAsVeryRare: 8
-  LimitDifficulties: 2
-  Obsolete: 1
+  values:
+    DisplayAsExtremelyRare: 16
+    DisplayAsPerPlayerLoot: 4
+    DisplayAsVeryRare: 8
+    LimitDifficulties: 2
+    Obsolete: 1
 JournalEncounterLocFlags:
-  Primary: 1
+  values:
+    Primary: 1
 JournalEncounterSectionFlags:
-  LimitDifficulties: 2
-  StartExpanded: 1
+  values:
+    LimitDifficulties: 2
+    StartExpanded: 1
 JournalEncounterSecTypes:
-  Ability: 2
-  Creature: 1
-  Generic: 0
-  Overview: 3
+  values:
+    Ability: 2
+    Creature: 1
+    Generic: 0
+    Overview: 3
 JournalInstanceFlags:
-  DoNotDisplayInstance: 4
-  HideUserSelectableDifficulty: 2
-  Timewalker: 1
+  values:
+    DoNotDisplayInstance: 4
+    HideUserSelectableDifficulty: 2
+    Timewalker: 1
 JournalLinkTypes:
-  Encounter: 1
-  Instance: 0
-  Section: 2
-  Tier: 3
+  values:
+    Encounter: 1
+    Instance: 0
+    Section: 2
+    Tier: 3
 LanguageFlag:
-  HiddenFromPlayer: 2
-  HideLanguageNameInChat: 4
-  IsExotic: 1
+  values:
+    HiddenFromPlayer: 2
+    HideLanguageNameInChat: 4
+    IsExotic: 1
 LeavePartyConfirmReason:
-  QuestSync: 0
-  RestrictedChallengeMode: 1
+  values:
+    QuestSync: 0
+    RestrictedChallengeMode: 1
 LFGEntryGeneralPlaystyle:
-  Expert: 4
-  FunRelaxed: 2
-  FunSerious: 3
-  Learning: 1
-  None: 0
+  values:
+    Expert: 4
+    FunRelaxed: 2
+    FunSerious: 3
+    Learning: 1
+    None: 0
 LFGEntryPlaystyle:
-  Casual: 2
-  Hardcore: 3
-  None: 0
-  Standard: 1
+  values:
+    Casual: 2
+    Hardcore: 3
+    None: 0
+    Standard: 1
 LFGListDisplayType:
-  ClassEnumerate: 2
-  Comment: 5
-  HideAll: 3
-  PlayerCount: 4
-  RoleCount: 0
-  RoleEnumerate: 1
+  values:
+    ClassEnumerate: 2
+    Comment: 5
+    HideAll: 3
+    PlayerCount: 4
+    RoleCount: 0
+    RoleEnumerate: 1
 LFGListFilter:
-  CurrentExpansion: 32
-  CurrentSeason: 64
-  NotCurrentSeason: 128
-  NotRecommended: 2
-  PvE: 4
-  PvP: 8
-  Recommended: 1
-  Timerunning: 16
+  values:
+    CurrentExpansion: 32
+    CurrentSeason: 64
+    NotCurrentSeason: 128
+    NotRecommended: 2
+    PvE: 4
+    PvP: 8
+    Recommended: 1
+    Timerunning: 16
 LFGRole:
-  Damage: 2
-  Healer: 1
-  Tank: 0
+  values:
+    Damage: 2
+    Healer: 1
+    Tank: 0
 LFGSlotInvalidReason:
-  AreaNotExplored: 9
-  CannotRunAnyChildDungeon: 14
-  ChromieTime: 16
-  EngagedInPvP: 12
-  ExpansionTooLow: 1
-  GearTooHigh: 5
-  GearTooLow: 4
-  LevelTargetTooHigh: 8
-  LevelTargetTooLow: 7
-  LevelTooHigh: 3
-  LevelTooLow: 2
-  None: 0
-  NoSpec: 13
-  NoValidRoles: 11
-  Npe: 17
-  PlayerConditionFailed: 19
-  RaidLocked: 6
-  Restricted: 15
-  Timerunning: 18
-  WrongFaction: 10
+  values:
+    AreaNotExplored: 9
+    CannotRunAnyChildDungeon: 14
+    ChromieTime: 16
+    EngagedInPvP: 12
+    ExpansionTooLow: 1
+    GearTooHigh: 5
+    GearTooLow: 4
+    LevelTargetTooHigh: 8
+    LevelTargetTooLow: 7
+    LevelTooHigh: 3
+    LevelTooLow: 2
+    None: 0
+    NoSpec: 13
+    NoValidRoles: 11
+    Npe: 17
+    PlayerConditionFailed: 19
+    RaidLocked: 6
+    Restricted: 15
+    Timerunning: 18
+    WrongFaction: 10
 LgVendorPurchaseSettlementState:
-  NotSettled: 1
-  Settled: 0
+  values:
+    NotSettled: 1
+    Settled: 0
 LgVendorPurchaseSqlResults:
-  AlreadyOwned: 102
-  Failed: 0
-  InsufficientFunds: 101
-  InsufficientSpent: 103
-  InvalidState: 107
-  NoRecord: 106
-  NotOwned: 104
-  RefundExpired: 105
-  Success: 100
+  values:
+    AlreadyOwned: 102
+    Failed: 0
+    InsufficientFunds: 101
+    InsufficientSpent: 103
+    InvalidState: 107
+    NoRecord: 106
+    NotOwned: 104
+    RefundExpired: 105
+    Success: 100
 LgVendorPurchaseState:
-  NotOwned: 0
-  Owned: 1
+  values:
+    NotOwned: 0
+    Owned: 1
 LightRadiusIndicatorType:
-  Always: 0
-  Never: 2
-  Overlap: 1
+  values:
+    Always: 0
+    Never: 2
+    Overlap: 1
 LimitedInputType:
-  MouseDown: 1
-  MouseMove: 0
-  MouseUp: 2
-  MouseWheel: 3
+  values:
+    MouseDown: 1
+    MouseMove: 0
+    MouseUp: 2
+    MouseWheel: 3
 LinkedCurrencyFlags:
-  AddIgnoresMax: 8
-  IgnoreAdd: 1
-  IgnoreSubtract: 2
-  SuppressChatLog: 4
+  values:
+    AddIgnoresMax: 8
+    IgnoreAdd: 1
+    IgnoreSubtract: 2
+    SuppressChatLog: 4
 LoadConfigResult:
-  Error: 0
-  LoadInProgress: 2
-  NoChangesNecessary: 1
-  Ready: 3
+  values:
+    Error: 0
+    LoadInProgress: 2
+    NoChangesNecessary: 1
+    Ready: 3
 LogicLogicop:
-  And: 1
-  None: 0
-  Or: 2
-  Xor: 3
+  values:
+    And: 1
+    None: 0
+    Or: 2
+    Xor: 3
 LogicMathop:
-  Div: 4
-  Minus: 2
-  Mod: 5
-  None: 0
-  Plus: 1
-  Times: 3
+  values:
+    Div: 4
+    Minus: 2
+    Mod: 5
+    None: 0
+    Plus: 1
+    Times: 3
 LogicRelop:
-  Equal: 1
-  Gt: 5
-  Gteq: 6
-  Lt: 3
-  Lteq: 4
-  None: 0
-  Notequal: 2
+  values:
+    Equal: 1
+    Gt: 5
+    Gteq: 6
+    Lt: 3
+    Lteq: 4
+    None: 0
+    Notequal: 2
 LogPriority:
-  Debug: 30
-  Error: 2
-  Fatal: 1
-  Normal: 10
-  Spam: 40
-  Warning: 3
+  values:
+    Debug: 30
+    Error: 2
+    Fatal: 1
+    Normal: 10
+    Spam: 40
+    Warning: 3
 LootMethod:
-  Freeforall: 0
-  Group: 3
-  Masterlooter: 2
-  Needbeforegreed: 4
-  Personal: 5
-  Roundrobin: 1
+  values:
+    Freeforall: 0
+    Group: 3
+    Masterlooter: 2
+    Needbeforegreed: 4
+    Personal: 5
+    Roundrobin: 1
 LootMethodStyles:
-  Mainline: 0
-  Vanilla: 1
+  values:
+    Mainline: 0
+    Vanilla: 1
 LootSlotType:
-  Currency: 3
-  Item: 1
-  Money: 2
-  None: 0
+  values:
+    Currency: 3
+    Item: 1
+    Money: 2
+    None: 0
 LuaCurveType:
-  Cosine: 2
-  Cubic: 3
-  Linear: 0
-  Step: 1
+  values:
+    Cosine: 2
+    Cubic: 3
+    Linear: 0
+    Step: 1
 MajorFactionFeatureAbility:
-  Fishing: 1
-  Generic: 0
-  Hunts: 2
+  values:
+    Fishing: 1
+    Generic: 0
+    Hunts: 2
 MajorFactionType:
-  DragonscaleExpedition: 1
-  IskaaraTuskarr: 3
-  MaruukCentaur: 2
-  None: 0
-  ValdrakkenAccord: 4
+  values:
+    DragonscaleExpedition: 1
+    IskaaraTuskarr: 3
+    MaruukCentaur: 2
+    None: 0
+    ValdrakkenAccord: 4
 ManipulatorEventType:
-  Complete: 2
-  Delete: 3
-  Move: 1
-  Start: 0
+  values:
+    Complete: 2
+    Delete: 3
+    Move: 1
+    Start: 0
 MapCanvasPosition:
-  BottomLeft: 1
-  BottomRight: 2
-  None: 0
-  TopLeft: 3
-  TopRight: 4
+  values:
+    BottomLeft: 1
+    BottomRight: 2
+    None: 0
+    TopLeft: 3
+    TopRight: 4
 MapIconUIWidgetSetType:
-  AdventureMapDetails: 2
-  BehindIcon: 1
-  Tooltip: 0
+  values:
+    AdventureMapDetails: 2
+    BehindIcon: 1
+    Tooltip: 0
 MapobjEventTypes:
-  PlayAnim: 0
-  SetAnimSpeed: 1
+  values:
+    PlayAnim: 0
+    SetAnimSpeed: 1
 MapOverlayDisplayLocation:
-  BottomLeft: 1
-  BottomRight: 3
-  Default: 0
-  Hidden: 5
-  TopLeft: 2
-  TopRight: 4
+  values:
+    BottomLeft: 1
+    BottomRight: 3
+    Default: 0
+    Hidden: 5
+    TopLeft: 2
+    TopRight: 4
 MapPinAnimationType:
-  None: 0
-  Pulse: 1
+  values:
+    None: 0
+    Pulse: 1
 MatchDetailType:
-  Kills: 1
-  Placement: 0
-  PlunderAcquired: 2
+  values:
+    Kills: 1
+    Placement: 0
+    PlunderAcquired: 2
 MicroMenuOrder:
-  Default: 0
-  Reverse: 1
+  values:
+    Default: 0
+    Reverse: 1
 MicroMenuOrientation:
-  Horizontal: 0
-  Vertical: 1
+  values:
+    Horizontal: 0
+    Vertical: 1
 MinimapTrackingFilter:
-  AccountBanker: 4194304
-  AccountCompletedQuests: 2097152
-  Auctioneer: 1
-  Banker: 2
-  Barber: 262144
-  Battlemaster: 4
-  Digsites: 131072
-  Focus: 32768
-  Innkeeper: 32
-  ItemUpgrade: 524288
-  Mailbox: 64
-  POI: 8192
-  QuestPOIs: 65536
-  Repair: 512
-  Stablemaster: 2048
-  Target: 16384
-  TaxiNode: 8
-  TrainerProfession: 128
-  Transmogrifier: 4096
-  TrivialQuests: 1024
-  Unfiltered: 0
-  VenderFood: 16
-  VendorPoison: 1048576
-  VendorReagent: 256
+  values:
+    AccountBanker: 4194304
+    AccountCompletedQuests: 2097152
+    Auctioneer: 1
+    Banker: 2
+    Barber: 262144
+    Battlemaster: 4
+    Digsites: 131072
+    Focus: 32768
+    Innkeeper: 32
+    ItemUpgrade: 524288
+    Mailbox: 64
+    POI: 8192
+    QuestPOIs: 65536
+    Repair: 512
+    Stablemaster: 2048
+    Target: 16384
+    TaxiNode: 8
+    TrainerProfession: 128
+    Transmogrifier: 4096
+    TrivialQuests: 1024
+    Unfiltered: 0
+    VenderFood: 16
+    VendorPoison: 1048576
+    VendorReagent: 256
 ModelBlendOperation:
-  Anim: 1
-  None: 0
+  values:
+    Anim: 1
+    None: 0
 ModelLightType:
-  Directional: 0
-  Point: 1
+  values:
+    Directional: 0
+    Point: 1
 ModelSceneSetting:
-  AlignLightToOrbitDelta: 1
+  values:
+    AlignLightToOrbitDelta: 1
 ModelSceneType:
-  ArtifactRelicTalentEffect: 9
-  ArtifactTier2: 5
-  ArtifactTier2ForgingScene: 6
-  ArtifactTier2SlamEffect: 7
-  AzeriteItemLevelUpToast: 13
-  AzeritePowers: 14
-  AzeriteRewardGlow: 15
-  CommentatorVictoryFanfare: 8
-  EncounterJournal: 3
-  HeartOfAzeroth: 16
-  JailersTowerAnimaGlow: 19
-  MountJournal: 0
-  PartyPose: 12
-  PetJournalCard: 1
-  PetJournalLoadout: 4
-  PvPWarModeFire: 11
-  PvPWarModeOrb: 10
-  ShopCard: 2
-  Soulbinds: 18
-  WorldMapThreat: 17
+  values:
+    ArtifactRelicTalentEffect: 9
+    ArtifactTier2: 5
+    ArtifactTier2ForgingScene: 6
+    ArtifactTier2SlamEffect: 7
+    AzeriteItemLevelUpToast: 13
+    AzeritePowers: 14
+    AzeriteRewardGlow: 15
+    CommentatorVictoryFanfare: 8
+    EncounterJournal: 3
+    HeartOfAzeroth: 16
+    JailersTowerAnimaGlow: 19
+    MountJournal: 0
+    PartyPose: 12
+    PetJournalCard: 1
+    PetJournalLoadout: 4
+    PvPWarModeFire: 11
+    PvPWarModeOrb: 10
+    ShopCard: 2
+    Soulbinds: 18
+    WorldMapThreat: 17
 ModelSoundOverrideType:
-  Mute: 2
-  UseOverride: 1
-  UseParent: 0
+  values:
+    Mute: 2
+    UseOverride: 1
+    UseParent: 0
 ModelSoundTagType:
-  Looping: 2
-  Oneshot: 1
+  values:
+    Looping: 2
+    Oneshot: 1
 MountType:
-  Aquatic: 2
-  Dragonriding: 3
-  Flying: 1
-  Ground: 0
-  RideAlong: 4
+  values:
+    Aquatic: 2
+    Dragonriding: 3
+    Flying: 1
+    Ground: 0
+    RideAlong: 4
 MountTypeFlag:
-  IsAquaticMount: 2
-  IsDragonRidingMount: 4
-  IsFlyingMount: 1
-  IsRideAlongMount: 8
+  values:
+    IsAquaticMount: 2
+    IsDragonRidingMount: 4
+    IsFlyingMount: 1
+    IsRideAlongMount: 8
 NamePlateCastBarDisplay:
-  HighlightImportantCasts: 4
-  HighlightWhenCastTarget: 5
-  None: 0
-  SpellIcon: 2
-  SpellName: 1
-  SpellTarget: 3
+  values:
+    HighlightImportantCasts: 4
+    HighlightWhenCastTarget: 5
+    None: 0
+    SpellIcon: 2
+    SpellName: 1
+    SpellTarget: 3
 NamePlateEnemyNpcAuraDisplay:
-  Buffs: 1
-  CrowdControl: 3
-  Debuffs: 2
-  None: 0
+  values:
+    Buffs: 1
+    CrowdControl: 3
+    Debuffs: 2
+    None: 0
 NamePlateEnemyPlayerAuraDisplay:
-  Buffs: 1
-  Debuffs: 2
-  LossOfControl: 3
-  None: 0
+  values:
+    Buffs: 1
+    Debuffs: 2
+    LossOfControl: 3
+    None: 0
 NamePlateFriendlyPlayerAuraDisplay:
-  Buffs: 1
-  Debuffs: 2
-  LossOfControl: 3
-  None: 0
+  values:
+    Buffs: 1
+    Debuffs: 2
+    LossOfControl: 3
+    None: 0
 NamePlateInfoDisplay:
-  CurrentHealthPercent: 1
-  CurrentHealthValue: 2
-  None: 0
-  RarityIcon: 3
+  values:
+    CurrentHealthPercent: 1
+    CurrentHealthValue: 2
+    None: 0
+    RarityIcon: 3
 NamePlateSimplifiedType:
-  FriendlyNpc: 4
-  FriendlyPlayer: 3
-  Minion: 1
-  MinusMob: 2
-  None: 0
+  values:
+    FriendlyNpc: 4
+    FriendlyPlayer: 3
+    Minion: 1
+    MinusMob: 2
+    None: 0
 NamePlateSize:
-  ExtraLarge: 4
-  Huge: 5
-  Large: 3
-  Medium: 2
-  Small: 1
+  values:
+    ExtraLarge: 4
+    Huge: 5
+    Large: 3
+    Medium: 2
+    Small: 1
 NamePlateStackType:
-  Enemy: 1
-  Friendly: 2
-  None: 0
+  values:
+    Enemy: 1
+    Friendly: 2
+    None: 0
 NamePlateStyle:
-  Block: 2
-  CastFocus: 4
-  HealthFocus: 3
-  Legacy: 5
-  Modern: 0
-  Thin: 1
+  values:
+    Block: 2
+    CastFocus: 4
+    HealthFocus: 3
+    Legacy: 5
+    Modern: 0
+    Thin: 1
 NamePlateThreatDisplay:
-  Flash: 2
-  HealthBarColor: 3
-  None: 0
-  Progressive: 1
+  values:
+    Flash: 2
+    HealthBarColor: 3
+    None: 0
+    Progressive: 1
 NamePlateType:
-  Enemy: 1
-  Friendly: 0
+  values:
+    Enemy: 1
+    Friendly: 0
 NavigationState:
-  Disabled: 3
-  InRange: 2
-  Invalid: 0
-  Occluded: 1
+  values:
+    Disabled: 3
+    InRange: 2
+    Invalid: 0
+    Occluded: 1
 NeighborhoodFlags:
-  None: 0
-  OpenToPublic: 2
-  PoolParent: 1
+  values:
+    None: 0
+    OpenToPublic: 2
+    PoolParent: 1
 NeighborhoodInitiativeChestResult:
-  NiNoHouseFound: 2
-  NiNoRewards: 3
-  NiServiceDisabled: 5
-  NiSuccess: 0
-  NiThrottled: 4
-  NiUnspecifiedFailure: 1
+  values:
+    NiNoHouseFound: 2
+    NiNoRewards: 3
+    NiServiceDisabled: 5
+    NiSuccess: 0
+    NiThrottled: 4
+    NiUnspecifiedFailure: 1
 NeighborhoodInitiativeFlags:
-  Disabled: 1
-  NoAbandon: 2
-  NoRepeat: 4
+  values:
+    Disabled: 1
+    NoAbandon: 2
+    NoRepeat: 4
 NeighborhoodInitiativeNeighborhoodTypes:
-  NiNeighborhoodTypePool: 1
-  NiNeighborhoodTypeSingleton: 0
+  values:
+    NiNeighborhoodTypePool: 1
+    NiNeighborhoodTypeSingleton: 0
 NeighborhoodInitiativesCompletionStates:
-  NiCompletionStateNotCompleted: 0
-  NiCompletionStatePlayerCompleted: 1
-  NiCompletionStateSystemAbandoned: 2
+  values:
+    NiCompletionStateNotCompleted: 0
+    NiCompletionStatePlayerCompleted: 1
+    NiCompletionStateSystemAbandoned: 2
 NeighborhoodInitiativeTaskType:
-  RepeatableFinite: 1
-  RepeatableInfinite: 2
-  Single: 0
+  values:
+    RepeatableFinite: 1
+    RepeatableInfinite: 2
+    Single: 0
 NeighborhoodInitiativeUpdateStatus:
-  Completed: 2
-  Failed: 3
-  MilestoneCompleted: 1
-  Started: 0
+  values:
+    Completed: 2
+    Failed: 3
+    MilestoneCompleted: 1
+    Started: 0
 NeighborhoodInviteResult:
-  AlreadyInNeighborhood: 11
-  DbError: 1
-  Faction: 5
-  GenericFailure: 3
-  InviteLimit: 7
-  NotEnoughPlots: 8
-  NotFound: 9
-  PendingInvitation: 6
-  Permission: 4
-  RpcFailure: 2
-  Success: 0
-  TooManyRequests: 10
+  values:
+    AlreadyInNeighborhood: 11
+    DbError: 1
+    Faction: 5
+    GenericFailure: 3
+    InviteLimit: 7
+    NotEnoughPlots: 8
+    NotFound: 9
+    PendingInvitation: 6
+    Permission: 4
+    RpcFailure: 2
+    Success: 0
+    TooManyRequests: 10
 NeighborhoodMapFlags:
-  AlliancePurchasable: 1
-  CanSystemGenerate: 4
-  HordePurchasable: 2
-  None: 0
+  values:
+    AlliancePurchasable: 1
+    CanSystemGenerate: 4
+    HordePurchasable: 2
+    None: 0
 NeighborhoodOwnerType:
-  Charter: 2
-  Guild: 1
-  None: 0
+  values:
+    Charter: 2
+    Guild: 1
+    None: 0
 NeighborhoodType:
-  Open: 0
-  Private: 1
-  Public: 2
+  values:
+    Open: 0
+    Private: 1
+    Public: 2
 NewCharGear:
-  Preview: 1
-  Start: 0
+  values:
+    Preview: 1
+    Start: 0
 NodeOpFailureReason:
-  AccountDataNoMatch: 25
-  DataError: 13
-  EntryNotFound: 19
-  HasMutuallyExclusiveEdge: 4
-  LevelTooLow: 22
-  MaxRank: 12
-  MissingAchievement: 8
-  MissingEdgeConnection: 1
-  MissingQuest: 9
-  MissingRequiredEdge: 3
-  NodeNeverPurchasable: 24
-  NodeNotFound: 18
-  None: 0
-  NotEnoughCurrency: 15
-  NotEnoughCurrencySpent: 6
-  NotEnoughGold: 16
-  NotEnoughGoldSpent: 7
-  NotEnoughRanksInEntry: 26
-  NotEnoughSourcedCurrency: 14
-  NotEnoughSourcedCurrencySpent: 5
-  RequiredForCondition: 20
-  RequiredForEdge: 2
-  SameSelection: 17
-  TreeFlaggedNoRefund: 23
-  WrongSelection: 11
-  WrongSpec: 10
-  WrongTreeID: 21
+  values:
+    AccountDataNoMatch: 25
+    DataError: 13
+    EntryNotFound: 19
+    HasMutuallyExclusiveEdge: 4
+    LevelTooLow: 22
+    MaxRank: 12
+    MissingAchievement: 8
+    MissingEdgeConnection: 1
+    MissingQuest: 9
+    MissingRequiredEdge: 3
+    NodeNeverPurchasable: 24
+    NodeNotFound: 18
+    None: 0
+    NotEnoughCurrency: 15
+    NotEnoughCurrencySpent: 6
+    NotEnoughGold: 16
+    NotEnoughGoldSpent: 7
+    NotEnoughRanksInEntry: 26
+    NotEnoughSourcedCurrency: 14
+    NotEnoughSourcedCurrencySpent: 5
+    RequiredForCondition: 20
+    RequiredForEdge: 2
+    SameSelection: 17
+    TreeFlaggedNoRefund: 23
+    WrongSelection: 11
+    WrongSpec: 10
+    WrongTreeID: 21
 NoRPEReason:
-  BNetToken: 8
-  FactionOrRaceChange: 7
-  HasRPE: 0
-  IneligibleMap: 3
-  LowLevel: 1
-  PlayerLocked: 9
-  RecentlyActive: 4
-  RecentlyBoosted: 5
-  Timerunner: 2
-  UpgradeInProgress: 6
+  values:
+    BNetToken: 8
+    FactionOrRaceChange: 7
+    HasRPE: 0
+    IneligibleMap: 3
+    LowLevel: 1
+    PlayerLocked: 9
+    RecentlyActive: 4
+    RecentlyBoosted: 5
+    Timerunner: 2
+    UpgradeInProgress: 6
 NpcCraftingOrderSetFlags:
-  AllowDuplicate: 2
-  AllowMultiple: 1
+  values:
+    AllowDuplicate: 2
+    AllowMultiple: 1
 NumericRuleFormatRounding:
-  Down: 2
-  Nearest: 0
-  Up: 1
+  values:
+    Down: 2
+    Nearest: 0
+    Up: 1
 PartyPlaylistEntry:
-  DuoGameMode: 1
-  SoloGameMode: 0
-  TrainingGameMode: 3
-  TrioGameMode: 2
+  values:
+    DuoGameMode: 1
+    SoloGameMode: 0
+    TrainingGameMode: 3
+    TrioGameMode: 2
 PartyPoseFlags:
-  HideLeaveInstanceButton: 1
+  values:
+    HideLeaveInstanceButton: 1
 PartyRequestJoinRelation:
-  Club: 3
-  Friend: 1
-  Guild: 2
-  None: 0
-  RecentAllies: 4
+  values:
+    Club: 3
+    Friend: 1
+    Guild: 2
+    None: 0
+    RecentAllies: 4
 PerksVendorCategoryType:
-  Achievement: 23
-  Activity: 21
-  GmAdjustment: 22
-  Illusion: 7
-  Mount: 2
-  Pet: 3
-  RefundUnused: 24
-  Stipend: 20
-  Toy: 5
-  Transmog: 1
-  Transmogset: 8
-  WarbandScene: 9
+  values:
+    Achievement: 23
+    Activity: 21
+    GmAdjustment: 22
+    Illusion: 7
+    Mount: 2
+    Pet: 3
+    RefundUnused: 24
+    Stipend: 20
+    Toy: 5
+    Transmog: 1
+    Transmogset: 8
+    WarbandScene: 9
 PermanentChatChannelType:
-  Communities: 2
-  Custom: 3
-  None: 0
-  Zone: 1
+  values:
+    Communities: 2
+    Custom: 3
+    None: 0
+    Zone: 1
 PersonalResourceDisplayVisibleSetting:
-  Always: 0
-  Hidden: 2
-  InCombat: 1
+  values:
+    Always: 0
+    Hidden: 2
+    InCombat: 1
 PetActionbuttonType:
-  Max: 18
-  Mode: 6
-  None: 0
-  Orders: 7
-  Slot1: 8
-  Slot10: 17
-  Slot1Obsolete: 2
-  Slot2: 9
-  Slot2Obsolete: 3
-  Slot3: 10
-  Slot3Obsolete: 4
-  Slot4: 11
-  Slot4Obsolete: 5
-  Slot5: 12
-  Slot6: 13
-  Slot7: 14
-  Slot8: 15
-  Slot9: 16
-  Spell: 1
-  VehicleAction: 19
+  values:
+    Max: 18
+    Mode: 6
+    None: 0
+    Orders: 7
+    Slot1: 8
+    Slot10: 17
+    Slot1Obsolete: 2
+    Slot2: 9
+    Slot2Obsolete: 3
+    Slot3: 10
+    Slot3Obsolete: 4
+    Slot4: 11
+    Slot4Obsolete: 5
+    Slot5: 12
+    Slot6: 13
+    Slot7: 14
+    Slot8: 15
+    Slot9: 16
+    Spell: 1
+    VehicleAction: 19
 PetActionFeedback:
-  Dead: 1
-  FriendlyTarget: 3
-  InvalidTarget: 2
-  NoPath: 4
-  Success: 0
+  values:
+    Dead: 1
+    FriendlyTarget: 3
+    InvalidTarget: 2
+    NoPath: 4
+    Success: 0
 PetBattleQueueStatus:
-  AlreadyQueued: 3
-  InBattle: 20
-  JoinFailed: 4
-  JoinFailedJournalLock: 6
-  JoinFailedNeutral: 7
-  JoinFailedSlots: 5
-  LostConnection: 16
-  MatchAccepted: 8
-  MatchDeclined: 9
-  Matchmaking: 15
-  MatchOpponentDeclined: 10
-  NoBattlingHere: 21
-  None: 0
-  ProposalTimedOut: 11
-  Queued: 1
-  QueuedUpdate: 2
-  Removed: 12
-  RequeuedAfterInternalError: 13
-  RequeuedAfterOpponentRemoved: 14
-  Shutdown: 17
-  Suspended: 18
-  Unsuspended: 19
+  values:
+    AlreadyQueued: 3
+    InBattle: 20
+    JoinFailed: 4
+    JoinFailedJournalLock: 6
+    JoinFailedNeutral: 7
+    JoinFailedSlots: 5
+    LostConnection: 16
+    MatchAccepted: 8
+    MatchDeclined: 9
+    Matchmaking: 15
+    MatchOpponentDeclined: 10
+    NoBattlingHere: 21
+    None: 0
+    ProposalTimedOut: 11
+    Queued: 1
+    QueuedUpdate: 2
+    Removed: 12
+    RequeuedAfterInternalError: 13
+    RequeuedAfterOpponentRemoved: 14
+    Shutdown: 17
+    Suspended: 18
+    Unsuspended: 19
 PetbattleSlot:
-  Slot_0: 0
-  Slot_1: 1
-  Slot_2: 2
+  values:
+    Slot_0: 0
+    Slot_1: 1
+    Slot_2: 2
 PetbattleState:
-  Created: 0
-  CreatedFailed: 4
-  FinalRound: 5
-  Finished: 6
-  RoundInProgress: 2
-  WaitingForFrontPets: 3
-  WaitingPreBattle: 1
+  values:
+    Created: 0
+    CreatedFailed: 4
+    FinalRound: 5
+    Finished: 6
+    RoundInProgress: 2
+    WaitingForFrontPets: 3
+    WaitingPreBattle: 1
 PetJournalError:
-  InvalidFaction: 3
-  JournalIsLocked: 2
-  NoFavoritesToSummon: 4
-  None: 0
-  NoValidRandomSummon: 5
-  PetIsDead: 1
+  values:
+    InvalidFaction: 3
+    JournalIsLocked: 2
+    NoFavoritesToSummon: 4
+    None: 0
+    NoValidRandomSummon: 5
+    PetIsDead: 1
 PetMode:
-  Aggressive: 2
-  Assist: 3
-  Defensive: 1
-  Passive: 0
+  values:
+    Aggressive: 2
+    Assist: 3
+    Defensive: 1
+    Passive: 0
 PetOrders:
-  Attack: 2
-  Dismiss: 3
-  Follow: 1
-  MoveTo: 4
-  Wait: 0
+  values:
+    Attack: 2
+    Dismiss: 3
+    Follow: 1
+    MoveTo: 4
+    Wait: 0
 PetOverride:
-  AICombatControl: 1
-  AICombatPassive: 2
-  None: 0
-  OwnerMounted: 4
+  values:
+    AICombatControl: 1
+    AICombatPassive: 2
+    None: 0
+    OwnerMounted: 4
 Pettameresult:
-  Anothersummonactive: 5
-  Cantcontrolexotic: 12
-  Creaturealreadyowned: 3
-  Dead: 10
-  EliteToohighlevel: 14
-  Internalerror: 8
-  Invalidcreature: 1
-  Invalidslot: 13
-  Nopetavailable: 7
-  Notdead: 11
-  Nottameable: 4
-  Numresults: 15
-  Ok: 0
-  Toohighlevel: 9
-  Toomany: 2
-  Unitscanttame: 6
+  values:
+    Anothersummonactive: 5
+    Cantcontrolexotic: 12
+    Creaturealreadyowned: 3
+    Dead: 10
+    EliteToohighlevel: 14
+    Internalerror: 8
+    Invalidcreature: 1
+    Invalidslot: 13
+    Nopetavailable: 7
+    Notdead: 11
+    Nottameable: 4
+    Numresults: 15
+    Ok: 0
+    Toohighlevel: 9
+    Toomany: 2
+    Unitscanttame: 6
 PhaseReason:
-  ChromieTime: 3
-  Phasing: 0
-  Sharding: 1
-  TimerunningHwt: 4
-  WarMode: 2
+  values:
+    ChromieTime: 3
+    Phasing: 0
+    Sharding: 1
+    TimerunningHwt: 4
+    WarMode: 2
 PhotoSharingStatus:
-  AADCRestricted: 6
-  Configured: 2
-  Disabled: 0
-  Error: 7
-  Expired: 3
-  FailedToClear: 8
-  NotConfigured: 1
-  ParentalControl: 4
-  TrialOrVeteran: 5
+  values:
+    AADCRestricted: 6
+    Configured: 2
+    Disabled: 0
+    Error: 7
+    Expired: 3
+    FailedToClear: 8
+    NotConfigured: 1
+    ParentalControl: 4
+    TrialOrVeteran: 5
 PhotoSharingUploadStatus:
-  CreatePageApiCallFailed: 13
-  CreatePageBadRequest: 14
-  CreatePageForbidden: 16
-  CreatePageGenericFailure: 19
-  CreatePageNoBoardIDFound: 20
-  CreatePageNotFound: 17
-  CreatePageTooManyRequests: 18
-  CreatePageUnauthorized: 15
-  CreatePostApiCallFailed: 21
-  CreatePostBadRequest: 22
-  CreatePostForbidden: 24
-  CreatePostGenericFailure: 27
-  CreatePostNoIDFound: 28
-  CreatePostNotFound: 25
-  CreatePostThrottled: 29
-  CreatePostTooManyRequests: 26
-  CreatePostUnauthorized: 23
-  Disabled: 0
-  Failed: 1
-  ListPagesApiCallFailed: 4
-  ListPagesBadRequest: 5
-  ListPagesEmptyBoardID: 11
-  ListPagesForbidden: 7
-  ListPagesGenericFailure: 10
-  ListPagesInvalidBookmark: 12
-  ListPagesNotFound: 8
-  ListPagesTooManyRequests: 9
-  ListPagesUnauthorized: 6
-  Locked: 3
-  Success: 2
+  values:
+    CreatePageApiCallFailed: 13
+    CreatePageBadRequest: 14
+    CreatePageForbidden: 16
+    CreatePageGenericFailure: 19
+    CreatePageNoBoardIDFound: 20
+    CreatePageNotFound: 17
+    CreatePageTooManyRequests: 18
+    CreatePageUnauthorized: 15
+    CreatePostApiCallFailed: 21
+    CreatePostBadRequest: 22
+    CreatePostForbidden: 24
+    CreatePostGenericFailure: 27
+    CreatePostNoIDFound: 28
+    CreatePostNotFound: 25
+    CreatePostThrottled: 29
+    CreatePostTooManyRequests: 26
+    CreatePostUnauthorized: 23
+    Disabled: 0
+    Failed: 1
+    ListPagesApiCallFailed: 4
+    ListPagesBadRequest: 5
+    ListPagesEmptyBoardID: 11
+    ListPagesForbidden: 7
+    ListPagesGenericFailure: 10
+    ListPagesInvalidBookmark: 12
+    ListPagesNotFound: 8
+    ListPagesTooManyRequests: 9
+    ListPagesUnauthorized: 6
+    Locked: 3
+    Success: 2
 PingMode:
-  ClickDrag: 1
-  KeyDown: 0
+  values:
+    ClickDrag: 1
+    KeyDown: 0
 PingResult:
-  FailedDisabledByLeader: 3
-  FailedDisabledBySettings: 4
-  FailedGeneric: 1
-  FailedOutOfPingArea: 5
-  FailedSpamming: 2
-  FailedSquelched: 6
-  FailedUnspecified: 7
-  Success: 0
+  values:
+    FailedDisabledByLeader: 3
+    FailedDisabledBySettings: 4
+    FailedGeneric: 1
+    FailedOutOfPingArea: 5
+    FailedSpamming: 2
+    FailedSquelched: 6
+    FailedUnspecified: 7
+    Success: 0
 PingSubjectType:
-  AlertNotThreat: 5
-  AlertThreat: 4
-  Assist: 2
-  Attack: 0
-  OnMyWay: 3
-  Warning: 1
+  values:
+    AlertNotThreat: 5
+    AlertThreat: 4
+    Assist: 2
+    Attack: 0
+    OnMyWay: 3
+    Warning: 1
 PingTextureType:
-  Center: 0
-  Expand: 1
-  Rotation: 2
+  values:
+    Center: 0
+    Expand: 1
+    Rotation: 2
 PingTypeFlags:
-  DefaultPing: 1
+  values:
+    DefaultPing: 1
 PlayerChoiceRarity:
-  Common: 0
-  Epic: 3
-  Rare: 2
-  Uncommon: 1
+  values:
+    Common: 0
+    Epic: 3
+    Rare: 2
+    Uncommon: 1
 PlayerClubRequestStatus:
-  Approved: 4
-  AutoApproved: 2
-  Canceled: 7
-  Declined: 3
-  Joined: 5
-  JoinedAnother: 6
-  None: 0
-  Pending: 1
+  values:
+    Approved: 4
+    AutoApproved: 2
+    Canceled: 7
+    Declined: 3
+    Joined: 5
+    JoinedAnother: 6
+    None: 0
+    Pending: 1
 PlayerCompanionInfoFlags:
-  IgnoreSeasonInScenarios: 1
+  values:
+    IgnoreSeasonInScenarios: 1
 PlayerCurrencyFlags:
-  Incremented: 1
-  Loading: 2
+  values:
+    Incremented: 1
+    Loading: 2
 PlayerCurrencyFlagsDbFlags:
-  IgnoreMaxQtyOnload: 1
-  InBackpack: 4
-  Reuse1: 2
-  Reuse2: 16
-  UnusedInUI: 8
+  values:
+    IgnoreMaxQtyOnload: 1
+    InBackpack: 4
+    Reuse1: 2
+    Reuse2: 16
+    UnusedInUI: 8
 PlayerDataElementType:
-  Float: 1
-  Int: 0
+  values:
+    Float: 1
+    Int: 0
 PlayerInteractionType:
-  AccountBanker: 68
-  AdventureJournal: 54
-  AdventureMap: 28
-  AlliedRaceDetailsGiver: 9
-  AnimaDiversion: 47
-  AreaSpiritHealer: 19
-  ArtifactForge: 38
-  Auctioneer: 21
-  AzeriteForge: 56
-  AzeriteRespec: 42
-  Banker: 8
-  BarbersChoice: 62
-  BattleMaster: 23
-  Binder: 20
-  BlackMarketAuctioneer: 27
-  CharacterBanker: 67
-  ChromieTime: 45
-  ContributionCollector: 41
-  CornerstoneInteraction: 70
-  CovenantPreview: 46
-  CovenantSanctum: 51
-  CreateGuildNeighborhood: 74
-  ForgeMaster: 66
-  GarrArchitect: 30
-  GarrMission: 32
-  GarrRecruitment: 34
-  GarrTalent: 35
-  GarrTradeskill: 31
-  Gossip: 3
-  GuildBanker: 10
-  GuildRename: 76
-  GuildTabardVendor: 14
-  HousingBulletinBoard: 72
-  HousingPedestal: 73
-  IslandQueue: 43
-  Item: 2
-  ItemInteraction: 44
-  ItemUpgrade: 53
-  JailersTowerBuffs: 63
-  LegendaryCrafting: 48
-  LFGDungeon: 25
-  MailInfo: 17
-  MajorFactionRenown: 64
-  Merchant: 5
-  NeighborhoodCharter: 75
-  NewPlayerGuide: 52
-  None: 0
-  ObliterumForge: 39
-  OpenHouseFinder: 78
-  OpenNeighborhoodCharterConfirmation: 77
-  PerksProgramVendor: 57
-  PersonalTabardVendor: 65
-  PetitionVendor: 13
-  PlayerChoice: 37
-  ProfessionRespec: 69
-  Professions: 59
-  ProfessionsCraftingOrder: 58
-  ProfessionsCustomerOrder: 60
-  QuestGiver: 4
-  Registrar: 11
-  RenameNeighborhood: 71
-  Renown: 55
-  ScrappingMachine: 40
-  ShipmentCrafter: 33
-  Soulbind: 50
-  SpecializationMaster: 16
-  SpiritHealer: 18
-  StableMaster: 22
-  TalentMaster: 15
-  TaxiNode: 6
-  TieredEntrance: 79
-  TradePartner: 1
-  Trainer: 7
-  TraitSystem: 61
-  Transmogrifier: 24
-  Trophy: 36
-  Vendor: 12
-  VoidStorageBanker: 26
-  WeeklyRewards: 49
-  WorldMap: 29
+  values:
+    AccountBanker: 68
+    AdventureJournal: 54
+    AdventureMap: 28
+    AlliedRaceDetailsGiver: 9
+    AnimaDiversion: 47
+    AreaSpiritHealer: 19
+    ArtifactForge: 38
+    Auctioneer: 21
+    AzeriteForge: 56
+    AzeriteRespec: 42
+    Banker: 8
+    BarbersChoice: 62
+    BattleMaster: 23
+    Binder: 20
+    BlackMarketAuctioneer: 27
+    CharacterBanker: 67
+    ChromieTime: 45
+    ContributionCollector: 41
+    CornerstoneInteraction: 70
+    CovenantPreview: 46
+    CovenantSanctum: 51
+    CreateGuildNeighborhood: 74
+    ForgeMaster: 66
+    GarrArchitect: 30
+    GarrMission: 32
+    GarrRecruitment: 34
+    GarrTalent: 35
+    GarrTradeskill: 31
+    Gossip: 3
+    GuildBanker: 10
+    GuildRename: 76
+    GuildTabardVendor: 14
+    HousingBulletinBoard: 72
+    HousingPedestal: 73
+    IslandQueue: 43
+    Item: 2
+    ItemInteraction: 44
+    ItemUpgrade: 53
+    JailersTowerBuffs: 63
+    LegendaryCrafting: 48
+    LFGDungeon: 25
+    MailInfo: 17
+    MajorFactionRenown: 64
+    Merchant: 5
+    NeighborhoodCharter: 75
+    NewPlayerGuide: 52
+    None: 0
+    ObliterumForge: 39
+    OpenHouseFinder: 78
+    OpenNeighborhoodCharterConfirmation: 77
+    PerksProgramVendor: 57
+    PersonalTabardVendor: 65
+    PetitionVendor: 13
+    PlayerChoice: 37
+    ProfessionRespec: 69
+    Professions: 59
+    ProfessionsCraftingOrder: 58
+    ProfessionsCustomerOrder: 60
+    QuestGiver: 4
+    Registrar: 11
+    RenameNeighborhood: 71
+    Renown: 55
+    ScrappingMachine: 40
+    ShipmentCrafter: 33
+    Soulbind: 50
+    SpecializationMaster: 16
+    SpiritHealer: 18
+    StableMaster: 22
+    TalentMaster: 15
+    TaxiNode: 6
+    TieredEntrance: 79
+    TradePartner: 1
+    Trainer: 7
+    TraitSystem: 61
+    Transmogrifier: 24
+    Trophy: 36
+    Vendor: 12
+    VoidStorageBanker: 26
+    WeeklyRewards: 49
+    WorldMap: 29
 PlayerMentorshipApplicationResult:
-  AlreadyMentor: 1
-  Ineligible: 2
-  Success: 0
+  values:
+    AlreadyMentor: 1
+    Ineligible: 2
+    Success: 0
 PlayerMentorshipStatus:
-  Mentor: 2
-  Newcomer: 1
-  None: 0
+  values:
+    Mentor: 2
+    Newcomer: 1
+    None: 0
 PlunderstormQueueState:
-  None: 0
-  Proposed: 2
-  Queued: 1
-  Suspended: 3
+  values:
+    None: 0
+    Proposed: 2
+    Queued: 1
+    Suspended: 3
 PowerType:
-  Alternate: 10
-  AlternateEncounter: 24
-  AlternateMount: 25
-  AlternateQuest: 23
-  ArcaneCharges: 16
-  Balance: 26
-  BurningEmbers: 14
-  Chi: 12
-  ComboPoints: 4
-  DemonicFury: 15
-  Energy: 3
-  Essence: 19
-  Focus: 2
-  Fury: 17
-  Happiness: 27
-  HolyPower: 9
-  Insanity: 13
-  LunarPower: 8
-  Maelstrom: 11
-  Mana: 0
-  Pain: 18
-  Rage: 1
-  RuneBlood: 20
-  RuneChromatic: 29
-  RuneFrost: 21
-  Runes: 5
-  RuneUnholy: 22
-  RunicPower: 6
-  ShadowOrbs: 28
-  SoulShards: 7
+  values:
+    Alternate: 10
+    AlternateEncounter: 24
+    AlternateMount: 25
+    AlternateQuest: 23
+    ArcaneCharges: 16
+    Balance: 26
+    BurningEmbers: 14
+    Chi: 12
+    ComboPoints: 4
+    DemonicFury: 15
+    Energy: 3
+    Essence: 19
+    Focus: 2
+    Fury: 17
+    Happiness: 27
+    HolyPower: 9
+    Insanity: 13
+    LunarPower: 8
+    Maelstrom: 11
+    Mana: 0
+    Pain: 18
+    Rage: 1
+    RuneBlood: 20
+    RuneChromatic: 29
+    RuneFrost: 21
+    Runes: 5
+    RuneUnholy: 22
+    RunicPower: 6
+    ShadowOrbs: 28
+    SoulShards: 7
 PowerTypeSign:
-  Negative: 1
-  None: -1
-  Positive: 0
+  values:
+    Negative: 1
+    None: -1
+    Positive: 0
 PowerTypeSlot:
-  Slot_0: 0
-  Slot_1: 1
-  Slot_2: 2
-  Slot_3: 3
-  Slot_4: 4
-  Slot_5: 5
-  Slot_6: 6
-  Slot_7: 7
-  Slot_8: 8
-  Slot_9: 9
+  values:
+    Slot_0: 0
+    Slot_1: 1
+    Slot_2: 2
+    Slot_3: 3
+    Slot_4: 4
+    Slot_5: 5
+    Slot_6: 6
+    Slot_7: 7
+    Slot_8: 8
+    Slot_9: 9
 PremadeGroupFinderStyle:
-  Disabled: 0
-  Mainline: 1
-  Vanilla: 2
+  values:
+    Disabled: 0
+    Mainline: 1
+    Vanilla: 2
 PreyHuntProgressState:
-  Cold: 0
-  Final: 3
-  Hot: 2
-  Warm: 1
+  values:
+    Cold: 0
+    Final: 3
+    Hot: 2
+    Warm: 1
 ProceduralSpawnInteractionMode:
-  Manipulate: 2
-  None: 0
-  Paint: 1
+  values:
+    Manipulate: 2
+    None: 0
+    Paint: 1
 ProceduralSpawnVolumeChunkFlags:
-  AllSubChunksSet: 1
-  None: 0
+  values:
+    AllSubChunksSet: 1
+    None: 0
 Profession:
-  Alchemy: 3
-  Archaeology: 14
-  Blacksmithing: 1
-  Cooking: 5
-  Enchanting: 9
-  Engineering: 8
-  FirstAid: 0
-  Fishing: 10
-  Herbalism: 4
-  Inscription: 13
-  Jewelcrafting: 12
-  Leatherworking: 2
-  Mining: 6
-  Skinning: 11
-  Tailoring: 7
+  values:
+    Alchemy: 3
+    Archaeology: 14
+    Blacksmithing: 1
+    Cooking: 5
+    Enchanting: 9
+    Engineering: 8
+    FirstAid: 0
+    Fishing: 10
+    Herbalism: 4
+    Inscription: 13
+    Jewelcrafting: 12
+    Leatherworking: 2
+    Mining: 6
+    Skinning: 11
+    Tailoring: 7
 ProfessionActionType:
-  Craft: 0
-  Gather: 1
+  values:
+    Craft: 0
+    Gather: 1
 ProfessionEffect:
-  AccumulateRanksByLabel: 25
-  ConcentrationRefund: 30
-  DecreaseDifficulty: 22
-  IncreaseDifficulty: 23
-  ModConcentration: 27
-  ModCraftCritSize: 20
-  ModCraftExtraQuantity: 18
-  ModCraftingSpeed: 14
-  ModCraftReductionQuantity: 21
-  ModDeftness: 12
-  ModFinesse: 11
-  ModGatherExtraQuantity: 19
-  ModIngenuity: 29
-  ModInspiration: 9
-  ModMulticraft: 15
-  ModPerception: 13
-  ModResourcefulness: 10
-  ModSkillGain: 24
-  ModUnused_1: 16
-  ModUnused_2: 17
-  Skill: 0
-  StatCraftingSpeed: 6
-  StatDeftness: 4
-  StatFinesse: 3
-  StatIngenuity: 26
-  StatInspiration: 1
-  StatMulticraft: 7
-  StatPerception: 5
-  StatResourcefulness: 2
-  Tokenizer: 28
-  UnlockReagentSlot: 8
+  values:
+    AccumulateRanksByLabel: 25
+    ConcentrationRefund: 30
+    DecreaseDifficulty: 22
+    IncreaseDifficulty: 23
+    ModConcentration: 27
+    ModCraftCritSize: 20
+    ModCraftExtraQuantity: 18
+    ModCraftingSpeed: 14
+    ModCraftReductionQuantity: 21
+    ModDeftness: 12
+    ModFinesse: 11
+    ModGatherExtraQuantity: 19
+    ModIngenuity: 29
+    ModInspiration: 9
+    ModMulticraft: 15
+    ModPerception: 13
+    ModResourcefulness: 10
+    ModSkillGain: 24
+    ModUnused_1: 16
+    ModUnused_2: 17
+    Skill: 0
+    StatCraftingSpeed: 6
+    StatDeftness: 4
+    StatFinesse: 3
+    StatIngenuity: 26
+    StatInspiration: 1
+    StatMulticraft: 7
+    StatPerception: 5
+    StatResourcefulness: 2
+    Tokenizer: 28
+    UnlockReagentSlot: 8
 ProfessionRating:
-  CraftingSpeed: 5
-  Deftness: 3
-  Finesse: 2
-  Ingenuity: 7
-  Inspiration: 0
-  Multicraft: 6
-  Perception: 4
-  Resourcefulness: 1
-  Unused_2: 8
+  values:
+    CraftingSpeed: 5
+    Deftness: 3
+    Finesse: 2
+    Ingenuity: 7
+    Inspiration: 0
+    Multicraft: 6
+    Perception: 4
+    Resourcefulness: 1
+    Unused_2: 8
 ProfessionRatingType:
-  Craft: 0
-  Gather: 1
+  values:
+    Craft: 0
+    Gather: 1
 ProfessionsSpecPathState:
-  Completed: 2
-  Locked: 0
-  Progressing: 1
+  values:
+    Completed: 2
+    Locked: 0
+    Progressing: 1
 ProfessionsSpecPerkState:
-  Earned: 2
-  Pending: 1
-  Unearned: 0
+  values:
+    Earned: 2
+    Pending: 1
+    Unearned: 0
 ProfessionsSpecTabState:
-  Locked: 0
-  Unlockable: 2
-  Unlocked: 1
+  values:
+    Locked: 0
+    Unlockable: 2
+    Unlocked: 1
 ProfTraitPerkNodeFlags:
-  IsMajorBonus: 2
-  UnlocksSubpath: 1
+  values:
+    IsMajorBonus: 2
+    UnlocksSubpath: 1
 PurchaseEligibility:
-  ExpansionTooHigh: 4
-  ExpansionTooLow: 3
-  MissingRequiredDeliverable: 5
-  Ok: 0
-  Owned: 2
-  PartiallyOwned: 1
+  values:
+    ExpansionTooHigh: 4
+    ExpansionTooLow: 3
+    MissingRequiredDeliverable: 5
+    Ok: 0
+    Owned: 2
+    PartiallyOwned: 1
 PurchaseHouseDisabledReason:
-  CharterLockout: 7
-  GuildLockout: 6
-  MaxHouses: 8
-  NoExpansion: 4
-  NoGameTimeRemaining: 9
-  None: 0
-  NotInvited: 3
-  Reserved: 5
-  WrongFaction: 1
-  WrongGuild: 2
+  values:
+    CharterLockout: 7
+    GuildLockout: 6
+    MaxHouses: 8
+    NoExpansion: 4
+    NoGameTimeRemaining: 9
+    None: 0
+    NotInvited: 3
+    Reserved: 5
+    WrongFaction: 1
+    WrongGuild: 2
 PurchaseResult:
-  ErrorAuthorizingPayment: 37
-  ErrorBattlepayDisabled: 14
-  ErrorBattlepayTemporarilyUnavailable: 13
-  ErrorBattlepayTimeoutMopAndRisk: 11
-  ErrorBattlepayTimeoutValidatePurchase: 56
-  ErrorBattlepayTimeoutValidationHash: 62
-  ErrorBlockedByParentalControls: 33
-  ErrorBuyingProductNotAllowedInGlueScreen: 27
-  ErrorBuyingProductNotAllowedInWorld: 32
-  ErrorCharacterUpgradeOperationInProgress: 51
-  ErrorClientCheckoutCanceledOrFailed: 63
-  ErrorClientCheckoutTimeout: 60
-  ErrorClientDeclined: 4
-  ErrorClientDeclinedChallenge: 41
-  ErrorClientGone: 9
-  ErrorClientRestricted: 66
-  ErrorClientTimeout: 3
-  ErrorClientTimeoutChallenge: 40
-  ErrorCommerceServerDisabled: 48
-  ErrorCouldNotGetValidationHash: 64
-  ErrorCurrencyInvalidInRegion: 12
-  ErrorDistributionObjectAlreadyAssigned: 20
-  ErrorDistributionObjectExpansionBlocked: 45
-  ErrorDistributionObjectInvalidChoice: 35
-  ErrorDistributionObjectInvalidTarget: 42
-  ErrorDistributionObjectNotFound: 19
-  ErrorDistributionObjectTrialBlocked: 44
-  ErrorDistributionObjectWrongGameAccount: 65
-  ErrorFailedOldPurchaseFlow: 59
-  ErrorFailedToCreatePurchaseRecord: 5
-  ErrorFailedToGetPurchaseID: 6
-  ErrorFailedToSaveClientCheckoutStatus: 58
-  ErrorFailedToSaveMopAndRiskResponse: 8
-  ErrorFailedToSaveMopAndRiskStatus: 7
-  ErrorFailedToSavePlaceOrderStatus: 10
-  ErrorFailedToSaveRedeemTokenStatus: 67
-  ErrorFailedToSaveValidatePurchaseResponse: 55
-  ErrorFailedToSaveValidatePurchaseStatus: 54
-  ErrorFailedToSaveValidationHashStatus: 61
-  ErrorFailedToWriteVasLicenseID: 50
-  ErrorFailedToWriteVasPurchaseID: 49
-  ErrorFixedLicenseProductAlreadyExists: 43
-  ErrorInManualReview: 71
-  ErrorInvalidCreditCardExpiryDate: 36
-  ErrorInvalidDeviceID: 53
-  ErrorInvalidPlatform: 52
-  ErrorInvalidProduct: 16
-  ErrorInvalidPurchaseID: 68
-  ErrorInvalidRegionGroupMask: 17
-  ErrorMopAndRiskAmqpRpcFailed: 22
-  ErrorMopAndRiskNotEnoughBalance: 28
-  ErrorMopAndRiskNoValidPaymentMethods: 25
-  ErrorMopAndRiskRpcErrorFromBattlepay: 23
-  ErrorMopAndRiskUnexpectedResponseFromBattlepay: 24
-  ErrorNoStorePurchaseFlagIsSet: 34
-  ErrorOrderCanceledPriceChange: 26
-  ErrorOrderFailed: 2
-  ErrorOverSpendingLimit: 39
-  ErrorOwnsConsumableToken: 46
-  ErrorPaymentProviderDeniedPayment: 38
-  ErrorPlaceOrderNotEnoughBalance: 29
-  ErrorProductInvalidInRegion: 18
-  ErrorProductNotPurchasable: 57
-  ErrorProgrammerManualFail: 30
-  ErrorRiskDenied: 1
-  ErrorRiskResponseMissingScore: 21
-  ErrorServerRestarted: 15
-  ErrorThrottledByUserServer: 31
-  ErrorTokenRedemptionOrderFailed: 69
-  ErrorTooManyTokens: 47
-  ErrorVasTransactionCreateFailed: 70
-  Ok: 0
+  values:
+    ErrorAuthorizingPayment: 37
+    ErrorBattlepayDisabled: 14
+    ErrorBattlepayTemporarilyUnavailable: 13
+    ErrorBattlepayTimeoutMopAndRisk: 11
+    ErrorBattlepayTimeoutValidatePurchase: 56
+    ErrorBattlepayTimeoutValidationHash: 62
+    ErrorBlockedByParentalControls: 33
+    ErrorBuyingProductNotAllowedInGlueScreen: 27
+    ErrorBuyingProductNotAllowedInWorld: 32
+    ErrorCharacterUpgradeOperationInProgress: 51
+    ErrorClientCheckoutCanceledOrFailed: 63
+    ErrorClientCheckoutTimeout: 60
+    ErrorClientDeclined: 4
+    ErrorClientDeclinedChallenge: 41
+    ErrorClientGone: 9
+    ErrorClientRestricted: 66
+    ErrorClientTimeout: 3
+    ErrorClientTimeoutChallenge: 40
+    ErrorCommerceServerDisabled: 48
+    ErrorCouldNotGetValidationHash: 64
+    ErrorCurrencyInvalidInRegion: 12
+    ErrorDistributionObjectAlreadyAssigned: 20
+    ErrorDistributionObjectExpansionBlocked: 45
+    ErrorDistributionObjectInvalidChoice: 35
+    ErrorDistributionObjectInvalidTarget: 42
+    ErrorDistributionObjectNotFound: 19
+    ErrorDistributionObjectTrialBlocked: 44
+    ErrorDistributionObjectWrongGameAccount: 65
+    ErrorFailedOldPurchaseFlow: 59
+    ErrorFailedToCreatePurchaseRecord: 5
+    ErrorFailedToGetPurchaseID: 6
+    ErrorFailedToSaveClientCheckoutStatus: 58
+    ErrorFailedToSaveMopAndRiskResponse: 8
+    ErrorFailedToSaveMopAndRiskStatus: 7
+    ErrorFailedToSavePlaceOrderStatus: 10
+    ErrorFailedToSaveRedeemTokenStatus: 67
+    ErrorFailedToSaveValidatePurchaseResponse: 55
+    ErrorFailedToSaveValidatePurchaseStatus: 54
+    ErrorFailedToSaveValidationHashStatus: 61
+    ErrorFailedToWriteVasLicenseID: 50
+    ErrorFailedToWriteVasPurchaseID: 49
+    ErrorFixedLicenseProductAlreadyExists: 43
+    ErrorInManualReview: 71
+    ErrorInvalidCreditCardExpiryDate: 36
+    ErrorInvalidDeviceID: 53
+    ErrorInvalidPlatform: 52
+    ErrorInvalidProduct: 16
+    ErrorInvalidPurchaseID: 68
+    ErrorInvalidRegionGroupMask: 17
+    ErrorMopAndRiskAmqpRpcFailed: 22
+    ErrorMopAndRiskNotEnoughBalance: 28
+    ErrorMopAndRiskNoValidPaymentMethods: 25
+    ErrorMopAndRiskRpcErrorFromBattlepay: 23
+    ErrorMopAndRiskUnexpectedResponseFromBattlepay: 24
+    ErrorNoStorePurchaseFlagIsSet: 34
+    ErrorOrderCanceledPriceChange: 26
+    ErrorOrderFailed: 2
+    ErrorOverSpendingLimit: 39
+    ErrorOwnsConsumableToken: 46
+    ErrorPaymentProviderDeniedPayment: 38
+    ErrorPlaceOrderNotEnoughBalance: 29
+    ErrorProductInvalidInRegion: 18
+    ErrorProductNotPurchasable: 57
+    ErrorProgrammerManualFail: 30
+    ErrorRiskDenied: 1
+    ErrorRiskResponseMissingScore: 21
+    ErrorServerRestarted: 15
+    ErrorThrottledByUserServer: 31
+    ErrorTokenRedemptionOrderFailed: 69
+    ErrorTooManyTokens: 47
+    ErrorVasTransactionCreateFailed: 70
+    Ok: 0
 PvPFaction:
-  Alliance: 1
-  Horde: 0
+  values:
+    Alliance: 1
+    Horde: 0
 PvPMatchmakingType:
-  Arena: 1
-  Battleground: 0
+  values:
+    Arena: 1
+    Battleground: 0
 PvPMatchState:
-  Complete: 5
-  Engaged: 3
-  Inactive: 0
-  PostRound: 4
-  StartUp: 2
-  Waiting: 1
+  values:
+    Complete: 5
+    Engaged: 3
+    Inactive: 0
+    PostRound: 4
+    StartUp: 2
+    Waiting: 1
 PvPRanks:
-  Rank_1: 5
-  Rank_10: 14
-  Rank_11: 15
-  Rank_12: 16
-  Rank_13: 17
-  Rank_14: 18
-  Rank_2: 6
-  Rank_3: 7
-  Rank_4: 8
-  Rank_5: 9
-  Rank_6: 10
-  Rank_7: 11
-  Rank_8: 12
-  Rank_9: 13
-  RankDishonored: 4
-  RankExiled: 3
-  RankNone: 0
-  RankOutlaw: 2
-  RankPariah: 1
+  values:
+    Rank_1: 5
+    Rank_10: 14
+    Rank_11: 15
+    Rank_12: 16
+    Rank_13: 17
+    Rank_14: 18
+    Rank_2: 6
+    Rank_3: 7
+    Rank_4: 8
+    Rank_5: 9
+    Rank_6: 10
+    Rank_7: 11
+    Rank_8: 12
+    Rank_9: 13
+    RankDishonored: 4
+    RankExiled: 3
+    RankNone: 0
+    RankOutlaw: 2
+    RankPariah: 1
 PvPUnitClassification:
-  AssassinAlliance: 6
-  AssassinHorde: 5
-  CartRunnerAlliance: 4
-  CartRunnerHorde: 3
-  FlagCarrierAlliance: 1
-  FlagCarrierHorde: 0
-  FlagCarrierNeutral: 2
-  OrbCarrierBlue: 7
-  OrbCarrierGreen: 8
-  OrbCarrierOrange: 9
-  OrbCarrierPurple: 10
+  values:
+    AssassinAlliance: 6
+    AssassinHorde: 5
+    CartRunnerAlliance: 4
+    CartRunnerHorde: 3
+    FlagCarrierAlliance: 1
+    FlagCarrierHorde: 0
+    FlagCarrierNeutral: 2
+    OrbCarrierBlue: 7
+    OrbCarrierGreen: 8
+    OrbCarrierOrange: 9
+    OrbCarrierPurple: 10
 QuestClassification:
-  BonusObjective: 8
-  Calling: 3
-  Campaign: 2
-  Important: 0
-  Legendary: 1
-  Meta: 4
-  Normal: 7
-  Questline: 6
-  Recurring: 5
-  Threat: 9
-  WorldQuest: 10
+  values:
+    BonusObjective: 8
+    Calling: 3
+    Campaign: 2
+    Important: 0
+    Legendary: 1
+    Meta: 4
+    Normal: 7
+    Questline: 6
+    Recurring: 5
+    Threat: 9
+    WorldQuest: 10
 QuestCompleteSpellType:
-  Ability: 3
-  Aura: 4
-  Companion: 7
-  Follower: 1
-  LegacyBehavior: 0
-  PossibleReward: 11
-  QuestlineReward: 9
-  QuestlineUnlock: 8
-  QuestlineUnlockPart: 10
-  Spell: 5
-  Tradeskill: 2
-  Unlock: 6
+  values:
+    Ability: 3
+    Aura: 4
+    Companion: 7
+    Follower: 1
+    LegacyBehavior: 0
+    PossibleReward: 11
+    QuestlineReward: 9
+    QuestlineUnlock: 8
+    QuestlineUnlockPart: 10
+    Spell: 5
+    Tradeskill: 2
+    Unlock: 6
 QuestFrequency:
-  Daily: 1
-  Default: 0
-  ResetByScheduler: 3
-  Weekly: 2
+  values:
+    Daily: 1
+    Default: 0
+    ResetByScheduler: 3
+    Weekly: 2
 QuestLineFloorLocation:
-  Above: 0
-  Below: 1
-  Same: 2
+  values:
+    Above: 0
+    Below: 1
+    Same: 2
 QuestRepeatability:
-  Daily: 1
-  None: 0
-  Turnin: 3
-  Weekly: 2
-  World: 4
+  values:
+    Daily: 1
+    None: 0
+    Turnin: 3
+    Weekly: 2
+    World: 4
 QuestRewardContextFlags:
-  FirstCompletionBonus: 1
-  None: 0
-  RepeatCompletionBonus: 2
+  values:
+    FirstCompletionBonus: 1
+    None: 0
+    RepeatCompletionBonus: 2
 QuestSessionCommand:
-  None: 0
-  SessionActiveNoCommand: 3
-  Start: 1
-  Stop: 2
+  values:
+    None: 0
+    SessionActiveNoCommand: 3
+    Start: 1
+    Stop: 2
 QuestSessionResult:
-  AlreadyActive: 3
-  AlreadyJoined: 20
-  AlreadyMember: 17
-  AlreadyOwner: 19
-  Busy: 22
-  Disabled: 8
-  Empty: 25
-  InCombat: 32
-  InPetBattle: 29
-  InRaid: 5
-  InvalidOwner: 2
-  InvalidPublicParty: 30
-  Joined: 11
-  JoinRejected: 23
-  Left: 12
-  Logout: 24
-  MemberInCombat: 33
-  MemberTimeout: 16
-  NotActive: 4
-  NotInParty: 1
-  NotMember: 21
-  NotOwner: 18
-  Ok: 0
-  OwnerLeft: 13
-  OwnerRefused: 6
-  PartyDestroyed: 15
-  QuestNotCompleted: 26
-  ReadyCheckFailed: 14
-  Restricted: 28
-  RestrictedCrossFaction: 34
-  Resync: 27
-  Started: 9
-  Stopped: 10
-  Timeout: 7
-  Unknown: 31
+  values:
+    AlreadyActive: 3
+    AlreadyJoined: 20
+    AlreadyMember: 17
+    AlreadyOwner: 19
+    Busy: 22
+    Disabled: 8
+    Empty: 25
+    InCombat: 32
+    InPetBattle: 29
+    InRaid: 5
+    InvalidOwner: 2
+    InvalidPublicParty: 30
+    Joined: 11
+    JoinRejected: 23
+    Left: 12
+    Logout: 24
+    MemberInCombat: 33
+    MemberTimeout: 16
+    NotActive: 4
+    NotInParty: 1
+    NotMember: 21
+    NotOwner: 18
+    Ok: 0
+    OwnerLeft: 13
+    OwnerRefused: 6
+    PartyDestroyed: 15
+    QuestNotCompleted: 26
+    ReadyCheckFailed: 14
+    Restricted: 28
+    RestrictedCrossFaction: 34
+    Resync: 27
+    Started: 9
+    Stopped: 10
+    Timeout: 7
+    Unknown: 31
 QuestTag:
-  Account: 102
-  CombatAlly: 266
-  Delve: 288
-  Dungeon: 81
-  Group: 1
-  Heroic: 85
-  Legendary: 83
-  PvP: 41
-  Raid: 62
-  Raid10: 88
-  Raid25: 89
-  Scenario: 98
+  values:
+    Account: 102
+    CombatAlly: 266
+    Delve: 288
+    Dungeon: 81
+    Group: 1
+    Heroic: 85
+    Legendary: 83
+    PvP: 41
+    Raid: 62
+    Raid10: 88
+    Raid25: 89
+    Scenario: 98
 QuestTagType:
-  Bounty: 5
-  Capstone: 17
-  Contribution: 9
-  CovenantCalling: 15
-  DragonRiderRacing: 16
-  Dungeon: 6
-  FactionAssault: 12
-  Invasion: 7
-  InvasionWrapper: 11
-  Islands: 13
-  Normal: 2
-  PetBattle: 4
-  Prey: 19
-  Profession: 1
-  PvP: 3
-  Raid: 8
-  RatedReward: 10
-  Tag: 0
-  Threat: 14
-  WorldBoss: 18
+  values:
+    Bounty: 5
+    Capstone: 17
+    Contribution: 9
+    CovenantCalling: 15
+    DragonRiderRacing: 16
+    Dungeon: 6
+    FactionAssault: 12
+    Invasion: 7
+    InvasionWrapper: 11
+    Islands: 13
+    Normal: 2
+    PetBattle: 4
+    Prey: 19
+    Profession: 1
+    PvP: 3
+    Raid: 8
+    RatedReward: 10
+    Tag: 0
+    Threat: 14
+    WorldBoss: 18
 QuestTreasurePickerType:
-  Hidden: 1
-  Select: 2
-  Visible: 0
+  values:
+    Hidden: 1
+    Select: 2
+    Visible: 0
 QuestWatchType:
-  Automatic: 0
-  Manual: 1
+  values:
+    Automatic: 0
+    Manual: 1
 RafLinkType:
-  Both: 3
-  Friend: 2
-  None: 0
-  Recruit: 1
+  values:
+    Both: 3
+    Friend: 2
+    None: 0
+    Recruit: 1
 RafRecruitActivityState:
-  Complete: 1
-  Incomplete: 0
-  RewardClaimed: 2
+  values:
+    Complete: 1
+    Incomplete: 0
+    RewardClaimed: 2
 RafRecruitSubStatus:
-  Active: 1
-  Inactive: 2
-  Trial: 0
+  values:
+    Active: 1
+    Inactive: 2
+    Trial: 0
 RafRewardType:
-  Appearance: 2
-  AppearanceSet: 5
-  GameTime: 4
-  Illusion: 6
-  Invalid: 7
-  Mount: 1
-  Pet: 0
-  Title: 3
+  values:
+    Appearance: 2
+    AppearanceSet: 5
+    GameTime: 4
+    Illusion: 6
+    Invalid: 7
+    Mount: 1
+    Pet: 0
+    Title: 3
 RaidAuraOrganizationType:
-  BuffsRightDebuffsLeft: 2
-  BuffsTopDebuffsBottom: 1
-  Legacy: 0
+  values:
+    BuffsRightDebuffsLeft: 2
+    BuffsTopDebuffsBottom: 1
+    Legacy: 0
 RaidDispelDisplayType:
-  Disabled: 0
-  DispellableByMe: 1
-  DisplayAll: 2
+  values:
+    Disabled: 0
+    DispellableByMe: 1
+    DisplayAll: 2
 RaidGroupDisplayType:
-  CombineGroupsHorizontal: 3
-  CombineGroupsVertical: 2
-  SeparateGroupsHorizontal: 1
-  SeparateGroupsVertical: 0
+  values:
+    CombineGroupsHorizontal: 3
+    CombineGroupsVertical: 2
+    SeparateGroupsHorizontal: 1
+    SeparateGroupsVertical: 0
 RcoCloseReason:
-  Cancel: 2
-  CrafterFulfill: 5
-  Expire: 1
-  Fulfill: 0
-  GmCancel: 4
-  Invalid: 6
-  Reject: 3
+  values:
+    Cancel: 2
+    CrafterFulfill: 5
+    Expire: 1
+    Fulfill: 0
+    GmCancel: 4
+    Invalid: 6
+    Reject: 3
 RecentAllyPinResult:
-  ServerError: 1
-  Success: 0
+  values:
+    ServerError: 1
+    Success: 0
 RecipeRequirementType:
-  Area: 2
-  SpellFocus: 0
-  Totem: 1
+  values:
+    Area: 2
+    SpellFocus: 0
+    Totem: 1
 RecruitAFriendRewardsVersion:
-  InvalidVersion: 0
-  UnusedVersionOne: 1
-  VersionThree: 3
-  VersionTwo: 2
+  values:
+    InvalidVersion: 0
+    UnusedVersionOne: 1
+    VersionThree: 3
+    VersionTwo: 2
 RegisterAddonMessagePrefixResult:
-  DuplicatePrefix: 1
-  InvalidPrefix: 2
-  MaxPrefixes: 3
-  Success: 0
+  values:
+    DuplicatePrefix: 1
+    InvalidPrefix: 2
+    MaxPrefixes: 3
+    Success: 0
 RelativeContentDifficulty:
-  Difficult: 3
-  Easy: 1
-  Fair: 2
-  Impossible: 4
-  Trivial: 0
+  values:
+    Difficult: 3
+    Easy: 1
+    Fair: 2
+    Impossible: 4
+    Trivial: 0
 ReleaseType:
-  Classic: 2
-  Original: 1
+  values:
+    Classic: 2
+    Original: 1
 RenownRewardDisplayType:
-  Currency: 9
-  GarrFollower: 8
-  Item: 1
-  Mount: 3
-  None: 0
-  Spell: 2
-  Title: 7
-  Transmog: 4
-  TransmogIllusion: 6
-  TransmogSet: 5
+  values:
+    Currency: 9
+    GarrFollower: 8
+    Item: 1
+    Mount: 3
+    None: 0
+    Spell: 2
+    Title: 7
+    Transmog: 4
+    TransmogIllusion: 6
+    TransmogSet: 5
 RenownRewardsFlags:
-  AccountUnlock: 8
-  Capstone: 2
-  Hidden: 4
-  Milestone: 1
+  values:
+    AccountUnlock: 8
+    Capstone: 2
+    Hidden: 4
+    Milestone: 1
 ReportEvidenceType:
-  HouseLayoutJson: 2
-  HouseScreenshot: 1
-  Invalid: 0
+  values:
+    HouseLayoutJson: 2
+    HouseScreenshot: 1
+    Invalid: 0
 ReportMajorCategory:
-  Cheating: 2
-  GameplaySabotage: 1
-  InappropriateCommunication: 0
-  InappropriateDecor: 4
-  InappropriateName: 3
+  values:
+    Cheating: 2
+    GameplaySabotage: 1
+    InappropriateCommunication: 0
+    InappropriateDecor: 4
+    InappropriateName: 3
 ReportMinorCategory:
-  Advertisement: 256
-  Afk: 8
-  BlockingProgress: 32
-  Boosting: 2
-  Botting: 128
-  BTag: 512
-  CharacterName: 2048
-  ChildSexualExploitationAndAbuse: 262144
-  Description: 8192
-  Disruption: 65536
-  GroupName: 1024
-  GuildName: 4096
-  Hacking: 64
-  HarmfulToMinors: 32768
-  IntentionallyFeeding: 16
-  Name: 16384
-  NeighborhoodName: 524288
-  Spam: 4
-  TerroristAndViolentExtremistContent: 131072
-  TextChat: 1
+  values:
+    Advertisement: 256
+    Afk: 8
+    BlockingProgress: 32
+    Boosting: 2
+    Botting: 128
+    BTag: 512
+    CharacterName: 2048
+    ChildSexualExploitationAndAbuse: 262144
+    Description: 8192
+    Disruption: 65536
+    GroupName: 1024
+    GuildName: 4096
+    Hacking: 64
+    HarmfulToMinors: 32768
+    IntentionallyFeeding: 16
+    Name: 16384
+    NeighborhoodName: 524288
+    Spam: 4
+    TerroristAndViolentExtremistContent: 131072
+    TextChat: 1
 ReportSubComplaintTypes:
-  Advertising: 1
-  Inappropriate: 0
+  values:
+    Advertising: 1
+    Inappropriate: 0
 ReportThrottleType:
-  Expensive: 2
-  General: 1
-  Invalid: 0
+  values:
+    Expensive: 2
+    General: 1
+    Invalid: 0
 ReportType:
-  BattlePet: 10
-  Calendar: 11
-  Chat: 0
-  ClubFinderApplicant: 3
-  ClubFinderPosting: 2
-  ClubMember: 6
-  CraftingOrder: 16
-  Friend: 8
-  GroupFinderApplicant: 5
-  GroupFinderPosting: 4
-  GroupMember: 7
-  HousingDecor: 18
-  InWorld: 1
-  Mail: 12
-  Neighborhood: 19
-  NeighborhoodRoster: 20
-  Pet: 9
-  PvP: 13
-  PvPGroupMember: 15
-  PvPScoreboard: 14
-  RecentAlly: 17
+  values:
+    BattlePet: 10
+    Calendar: 11
+    Chat: 0
+    ClubFinderApplicant: 3
+    ClubFinderPosting: 2
+    ClubMember: 6
+    CraftingOrder: 16
+    Friend: 8
+    GroupFinderApplicant: 5
+    GroupFinderPosting: 4
+    GroupMember: 7
+    HousingDecor: 18
+    InWorld: 1
+    Mail: 12
+    Neighborhood: 19
+    NeighborhoodRoster: 20
+    Pet: 9
+    PvP: 13
+    PvPGroupMember: 15
+    PvPScoreboard: 14
+    RecentAlly: 17
 ReputationSortType:
-  Account: 1
-  Character: 2
-  None: 0
+  values:
+    Account: 1
+    Character: 2
+    None: 0
 ReservationFlags:
-  Canceled: 2
-  None: 0
-  Plotless: 4
-  Relinquish: 1
+  values:
+    Canceled: 2
+    None: 0
+    Plotless: 4
+    Relinquish: 1
 ResidentType:
-  Manager: 1
-  Owner: 2
-  Resident: 0
+  values:
+    Manager: 1
+    Owner: 2
+    Resident: 0
 RestrictPingsTo:
-  Assist: 2
-  Lead: 1
-  None: 0
-  TankHealer: 3
+  values:
+    Assist: 2
+    Lead: 1
+    None: 0
+    TankHealer: 3
 RetroactiveDecorRewardFlags:
-  AllCriteriaRequired: 1
-  None: 0
+  values:
+    AllCriteriaRequired: 1
+    None: 0
 RolodexContextLevelType:
-  DelveTier: 3
-  Difficulty: 1
-  KeystoneLevel: 2
-  None: 0
+  values:
+    DelveTier: 3
+    Difficulty: 1
+    KeystoneLevel: 2
+    None: 0
 RolodexType:
-  CompleteArena: 16
-  CompleteBg: 17
-  CompleteDelve: 15
-  CompleteDungeon: 12
-  CreatureKill: 11
-  Duel: 18
-  GuildOrderFilledByOther: 9
-  GuildOrderFilledByYou: 10
-  KillLfrBoss: 14
-  KillRaidBoss: 13
-  None: 0
-  PartyMember: 1
-  PersonalOrderFilledByOther: 7
-  PersonalOrderFilledByYou: 8
-  PetBattle: 19
-  PublicOrderFilledByOther: 5
-  PublicOrderFilledByYou: 6
-  PvPKill: 20
-  RaidMember: 2
-  Trade: 3
-  Whisper: 4
+  values:
+    CompleteArena: 16
+    CompleteBg: 17
+    CompleteDelve: 15
+    CompleteDungeon: 12
+    CreatureKill: 11
+    Duel: 18
+    GuildOrderFilledByOther: 9
+    GuildOrderFilledByYou: 10
+    KillLfrBoss: 14
+    KillRaidBoss: 13
+    None: 0
+    PartyMember: 1
+    PersonalOrderFilledByOther: 7
+    PersonalOrderFilledByYou: 8
+    PetBattle: 19
+    PublicOrderFilledByOther: 5
+    PublicOrderFilledByYou: 6
+    PvPKill: 20
+    RaidMember: 2
+    Trade: 3
+    Whisper: 4
 RolodexTypeFlags:
-  HiddenFromHistory: 1
-  None: 0
+  values:
+    HiddenFromHistory: 1
+    None: 0
 RoomConnectionType:
-  All: 1
-  None: 0
+  values:
+    All: 1
+    None: 0
 RuneforgePowerFilter:
-  All: 0
-  Available: 2
-  Relevant: 1
-  Unavailable: 3
+  values:
+    All: 0
+    Available: 2
+    Relevant: 1
+    Unavailable: 3
 RuneforgePowerState:
-  Available: 0
-  Invalid: 2
-  Unavailable: 1
+  values:
+    Available: 0
+    Invalid: 2
+    Unavailable: 1
 ScreenLocationType:
-  Bottom: 4
-  Center: 0
-  Left: 1
-  LeftOutside: 7
-  LeftRight: 9
-  LeftRightOutside: 11
-  Right: 2
-  RightOutside: 8
-  Top: 3
-  TopBottom: 10
-  TopLeft: 5
-  TopRight: 6
+  values:
+    Bottom: 4
+    Center: 0
+    Left: 1
+    LeftOutside: 7
+    LeftRight: 9
+    LeftRightOutside: 11
+    Right: 2
+    RightOutside: 8
+    Top: 3
+    TopBottom: 10
+    TopLeft: 5
+    TopRight: 6
 ScreenshotSource:
-  Automatic: 0
-  Cheat: 2
-  PlayerReport: 1
+  values:
+    Automatic: 0
+    Cheat: 2
+    PlayerReport: 1
 ScriptedAnimationBehavior:
-  None: 0
-  SourceCollideWithTarget: 4
-  SourceRecoil: 3
-  TargetKnockBack: 2
-  TargetShake: 1
-  UIParentShake: 5
+  values:
+    None: 0
+    SourceCollideWithTarget: 4
+    SourceRecoil: 3
+    TargetKnockBack: 2
+    TargetShake: 1
+    UIParentShake: 5
 ScriptedAnimationFlags:
-  UseTargetAsSource: 1
+  values:
+    UseTargetAsSource: 1
 ScriptedAnimationTrajectory:
-  AtSource: 0
-  AtTarget: 1
-  CurveLeft: 3
-  CurveRandom: 5
-  CurveRight: 4
-  HalfwayBetween: 6
-  Straight: 2
+  values:
+    AtSource: 0
+    AtTarget: 1
+    CurveLeft: 3
+    CurveRandom: 5
+    CurveRight: 4
+    HalfwayBetween: 6
+    Straight: 2
 ScrubStringFlags:
-  AllowBarCodes: 2
-  None: 0
-  StripControlCodes: 4
-  TruncateNewLines: 1
+  values:
+    AllowBarCodes: 2
+    None: 0
+    StripControlCodes: 4
+    TruncateNewLines: 1
 SeasonID:
-  Fresh: 11
-  FreshHardcore: 12
-  Hardcore: 3
-  NoSeason: 0
-  SeasonOfDiscovery: 2
-  SeasonOfMastery: 1
+  values:
+    Fresh: 11
+    FreshHardcore: 12
+    Hardcore: 3
+    NoSeason: 0
+    SeasonOfDiscovery: 2
+    SeasonOfMastery: 1
 SecondsFormatterAbbreviation:
-  None: 0
-  OneLetter: 2
-  Truncate: 1
+  values:
+    None: 0
+    OneLetter: 2
+    Truncate: 1
 SecondsFormatterInterval:
-  Days: 3
-  Hours: 2
-  Minutes: 1
-  Seconds: 0
+  values:
+    Days: 3
+    Hours: 2
+    Minutes: 1
+    Seconds: 0
 SecondsFormatterIntervalWhitespace:
-  Preserve: 0
-  Strip: 1
-  StripIgnoreLocale: 2
+  values:
+    Preserve: 0
+    Strip: 1
+    StripIgnoreLocale: 2
 SecrecyLevel:
-  AlwaysSecret: 1
-  ContextuallySecret: 2
-  NeverSecret: 0
+  values:
+    AlwaysSecret: 1
+    ContextuallySecret: 2
+    NeverSecret: 0
 SecretAspect:
-  Alpha: 128
-  Attributes: 1
-  BarValue: 16384
-  ButtonState: 2097152
-  Cooldown: 32768
-  CooldownStyle: 524288
-  Cursor: 1024
-  Desaturation: 4096
-  FrameLevel: 256
-  Hierarchy: 1
-  ID: 2
-  MinimumWidth: 131072
-  ObjectDebug: 1
-  ObjectName: 1
-  ObjectSecrets: 1
-  ObjectSecurity: 1
-  ObjectType: 1
-  Padding: 262144
-  Rotation: 65536
-  Scale: 64
-  ScrollOffset: 4194304
-  ScrollRange: 512
-  SecureText: 16
-  Shown: 32
-  TexCoords: 8192
-  Text: 8
-  TooltipTexture: 1048576
-  Toplevel: 4
-  VertexColor: 2048
+  values:
+    Alpha: 128
+    Attributes: 1
+    BarValue: 16384
+    ButtonState: 2097152
+    Cooldown: 32768
+    CooldownStyle: 524288
+    Cursor: 1024
+    Desaturation: 4096
+    FrameLevel: 256
+    Hierarchy: 1
+    ID: 2
+    MinimumWidth: 131072
+    ObjectDebug: 1
+    ObjectName: 1
+    ObjectSecrets: 1
+    ObjectSecurity: 1
+    ObjectType: 1
+    Padding: 262144
+    Rotation: 65536
+    Scale: 64
+    ScrollOffset: 4194304
+    ScrollRange: 512
+    SecureText: 16
+    Shown: 32
+    TexCoords: 8192
+    Text: 8
+    TooltipTexture: 1048576
+    Toplevel: 4
+    VertexColor: 2048
 SelfResurrectOptionType:
-  Item: 1
-  Spell: 0
+  values:
+    Item: 1
+    Spell: 0
 SendAddonMessageResult:
-  AddOnMessageLockdown: 11
-  AddonMessageThrottle: 3
-  ChannelThrottle: 8
-  GeneralError: 9
-  InvalidChannel: 7
-  InvalidChatType: 4
-  InvalidMessage: 2
-  InvalidPrefix: 1
-  NotInGroup: 5
-  NotInGuild: 10
-  Success: 0
-  TargetOffline: 12
-  TargetRequired: 6
+  values:
+    AddOnMessageLockdown: 11
+    AddonMessageThrottle: 3
+    ChannelThrottle: 8
+    GeneralError: 9
+    InvalidChannel: 7
+    InvalidChatType: 4
+    InvalidMessage: 2
+    InvalidPrefix: 1
+    NotInGroup: 5
+    NotInGuild: 10
+    Success: 0
+    TargetOffline: 12
+    TargetRequired: 6
 SendReportResult:
-  GeneralError: 1
-  RequiresChatLine: 3
-  RequiresChatLineOrVoice: 4
-  RequiresScreenshot: 5
-  Success: 0
-  TooManyReports: 2
+  values:
+    GeneralError: 1
+    RequiresChatLine: 3
+    RequiresChatLineOrVoice: 4
+    RequiresScreenshot: 5
+    Success: 0
+    TooManyReports: 2
 SharedStringFlag:
-  InternalOnly: 1
+  values:
+    InternalOnly: 1
 ShutdownSessionReason:
-  AccountLoginCommand: 4
-  Error: 6
-  ForceLogoutCommand: 2
-  LuaScript: 5
-  RealmSelectCommand: 3
-  RestartSessionCommand: 1
-  SessionEnded: 0
+  values:
+    AccountLoginCommand: 4
+    Error: 6
+    ForceLogoutCommand: 2
+    LuaScript: 5
+    RealmSelectCommand: 3
+    RestartSessionCommand: 1
+    SessionEnded: 0
 Siflag:
-  Affectedbyaltitude: 16
-  Affectedbysanity: 2048
-  AutocreatedByBroadcastText: 4
-  CasterOwnsTargetSound: 128
-  Disablepositionallpf: 1
-  Dontplayindoors: 256
-  Dontplayunderwater: 1024
-  Dontstopondeath: 4096
-  Ignoresuppressors: 64
-  Ignorevopriority: 16384
-  Looping: 512
-  Noduplicates: 32
-  None: 0
-  Onlyplayindoors: 32768
-  Onlyplayunderwater: 65536
-  Playonlyforowner: 8192
-  Playsequential: 8
-  UseModCastSpeed: 2
+  values:
+    Affectedbyaltitude: 16
+    Affectedbysanity: 2048
+    AutocreatedByBroadcastText: 4
+    CasterOwnsTargetSound: 128
+    Disablepositionallpf: 1
+    Dontplayindoors: 256
+    Dontplayunderwater: 1024
+    Dontstopondeath: 4096
+    Ignoresuppressors: 64
+    Ignorevopriority: 16384
+    Looping: 512
+    Noduplicates: 32
+    None: 0
+    Onlyplayindoors: 32768
+    Onlyplayunderwater: 65536
+    Playonlyforowner: 8192
+    Playsequential: 8
+    UseModCastSpeed: 2
 SimpleOrderStatus:
-  Creating: 1
-  Failed: 4
-  InProgress: 2
-  Invalid: 0
-  Success: 3
+  values:
+    Creating: 1
+    Failed: 4
+    InProgress: 2
+    Invalid: 0
+    Success: 3
 SkinningState:
-  Looting: 3
-  None: 0
-  Reserved: 1
-  Skinned: 4
-  Skinning: 2
+  values:
+    Looting: 3
+    None: 0
+    Reserved: 1
+    Skinned: 4
+    Skinning: 2
 SleevesGeoRange:
-  Default: 1
-  Flared: 2
-  None: 0
-  PandaCollar: 4
-  Puffy: 3
+  values:
+    Default: 1
+    Flared: 2
+    None: 0
+    PandaCollar: 4
+    Puffy: 3
 SlotRegion:
-  AccountBank: 5
-  CharacterBank: 4
-  Invalid: 0
-  PlayerBags: 2
-  PlayerEquip: 1
-  PlayerInv: 3
+  values:
+    AccountBank: 5
+    CharacterBank: 4
+    Invalid: 0
+    PlayerBags: 2
+    PlayerEquip: 1
+    PlayerInv: 3
 SlotRegionMask:
-  AccountBank: 64
-  CharacterBank: 16
-  Invalid: 1
-  PlayerBags: 4
-  PlayerEquip: 2
-  PlayerInv: 8
+  values:
+    AccountBank: 64
+    CharacterBank: 16
+    Invalid: 1
+    PlayerBags: 4
+    PlayerEquip: 2
+    PlayerInv: 8
 SocialWhoOrigin:
-  Chat: 2
-  Item: 3
-  Social: 1
-  Unknown: 0
+  values:
+    Chat: 2
+    Item: 3
+    Social: 1
+    Unknown: 0
 SoftTargetEnableFlags:
-  Any: 3
-  Gamepad: 1
-  Kbm: 2
-  None: 0
+  values:
+    Any: 3
+    Gamepad: 1
+    Kbm: 2
+    None: 0
 SortPlayersBy:
-  Alphabetical: 2
-  Group: 1
-  Role: 0
+  values:
+    Alphabetical: 2
+    Group: 1
+    Role: 0
 SoulbindConduitFlags:
-  VisibleToGetallsoulbindconduitScript: 1
+  values:
+    VisibleToGetallsoulbindconduitScript: 1
 SoulbindConduitInstallResult:
-  DuplicateConduit: 4
-  ForgeNotInProximity: 5
-  InvalidConduit: 2
-  InvalidItem: 1
-  InvalidTalent: 3
-  SocketNotEmpty: 6
-  Success: 0
+  values:
+    DuplicateConduit: 4
+    ForgeNotInProximity: 5
+    InvalidConduit: 2
+    InvalidItem: 1
+    InvalidTalent: 3
+    SocketNotEmpty: 6
+    Success: 0
 SoulbindConduitTransactionType:
-  Install: 0
-  Uninstall: 1
+  values:
+    Install: 0
+    Uninstall: 1
 SoulbindConduitType:
-  Endurance: 2
-  Finesse: 0
-  Flex: 3
-  Potency: 1
+  values:
+    Endurance: 2
+    Finesse: 0
+    Flex: 3
+    Potency: 1
 SoulbindNodeState:
-  Selectable: 2
-  Selected: 3
-  Unavailable: 0
-  Unselected: 1
+  values:
+    Selectable: 2
+    Selected: 3
+    Unavailable: 0
+    Unselected: 1
 SoundBusFlag:
-  Disablepositionallpf: 1
+  values:
+    Disablepositionallpf: 1
 SpecializationSystem:
-  ChrSpecialization: 1
-  TalentTab: 0
+  values:
+    ChrSpecialization: 1
+    TalentTab: 0
 SpellAuraVisibilityType:
-  EnemyTarget: 2
-  RaidInCombat: 0
-  RaidOutOfCombat: 1
+  values:
+    EnemyTarget: 2
+    RaidInCombat: 0
+    RaidOutOfCombat: 1
 SpellBookItemType:
-  Flyout: 4
-  FutureSpell: 2
-  None: 0
-  PetAction: 3
-  Spell: 1
+  values:
+    Flyout: 4
+    FutureSpell: 2
+    None: 0
+    PetAction: 3
+    Spell: 1
 SpellBookSkillLineIndex:
-  Class: 2
-  General: 1
-  MainSpec: 3
-  OffSpecStart: 4
+  values:
+    Class: 2
+    General: 1
+    MainSpec: 3
+    OffSpecStart: 4
 SpellBookSpellBank:
-  Pet: 1
-  Player: 0
+  values:
+    Pet: 1
+    Player: 0
 SpellDiminishCategory:
-  AoEKnockback: 3
-  Disarm: 7
-  Disorient: 5
-  Incapacitate: 4
-  Root: 0
-  Silence: 6
-  Stun: 2
-  Taunt: 1
+  values:
+    AoEKnockback: 3
+    Disarm: 7
+    Disorient: 5
+    Incapacitate: 4
+    Root: 0
+    Silence: 6
+    Stun: 2
+    Taunt: 1
 SpellDiminishRuleset:
-  None: 0
-  PvE: 1
-  PvP: 2
+  values:
+    None: 0
+    PvE: 1
+    PvP: 2
 SpellDisplayBorderColor:
-  Black: 1
-  Blue: 8
-  Green: 7
-  None: 0
-  Orange: 5
-  Purple: 6
-  Red: 3
-  White: 2
-  Yellow: 4
+  values:
+    Black: 1
+    Blue: 8
+    Green: 7
+    None: 0
+    Orange: 5
+    Purple: 6
+    Red: 3
+    White: 2
+    Yellow: 4
 SpellDisplayIconDisplayType:
-  Buff: 0
-  Circular: 2
-  Debuff: 1
-  NoBorder: 3
+  values:
+    Buff: 0
+    Circular: 2
+    Debuff: 1
+    NoBorder: 3
 SpellDisplayTextShownStateType:
-  Hidden: 1
-  Shown: 0
+  values:
+    Hidden: 1
+    Shown: 0
 SpellDisplayTint:
-  None: 0
-  Red: 1
+  values:
+    None: 0
+    Red: 1
 SplashScreenType:
-  SeasonRollOver: 1
-  WhatsNew: 0
+  values:
+    SeasonRollOver: 1
+    WhatsNew: 0
 StableResult:
-  AlreadyStabled: 5
-  AlreadySummoned: 6
-  BuySlotSuccess: 14
-  CantControlExotic: 11
-  CheckForLuaHack: 13
-  FavoriteToggle: 15
-  InsufficientFunds: 1
-  InternalError: 12
-  InvalidSlot: 3
-  MaxSlots: 0
-  NoPet: 4
-  NotFound: 7
-  NotStableMaster: 2
-  PetRenamed: 16
-  ReviveSuccess: 10
-  StableSuccess: 8
-  UnstableSuccess: 9
+  values:
+    AlreadyStabled: 5
+    AlreadySummoned: 6
+    BuySlotSuccess: 14
+    CantControlExotic: 11
+    CheckForLuaHack: 13
+    FavoriteToggle: 15
+    InsufficientFunds: 1
+    InternalError: 12
+    InvalidSlot: 3
+    MaxSlots: 0
+    NoPet: 4
+    NotFound: 7
+    NotStableMaster: 2
+    PetRenamed: 16
+    ReviveSuccess: 10
+    StableSuccess: 8
+    UnstableSuccess: 9
 StartTimerType:
-  ChallengeModeCountdown: 1
-  PlayerCountdown: 2
-  PlunderstormCountdown: 3
-  PvPBeginTimer: 0
+  values:
+    ChallengeModeCountdown: 1
+    PlayerCountdown: 2
+    PlunderstormCountdown: 3
+    PvPBeginTimer: 0
 StatusBarColorTintValue:
-  Black: 1
-  Blue: 8
-  Green: 7
-  None: 0
-  Orange: 5
-  Purple: 6
-  Red: 3
-  White: 2
-  Yellow: 4
+  values:
+    Black: 1
+    Blue: 8
+    Green: 7
+    None: 0
+    Orange: 5
+    Purple: 6
+    Red: 3
+    White: 2
+    Yellow: 4
 StatusBarFillStyle:
-  Center: 2
-  Reverse: 3
-  Standard: 0
-  StandardNoRangeFill: 1
+  values:
+    Center: 2
+    Reverse: 3
+    Standard: 0
+    StandardNoRangeFill: 1
 StatusBarInterpolation:
-  ExponentialEaseOut: 1
-  Immediate: 0
+  values:
+    ExponentialEaseOut: 1
+    Immediate: 0
 StatusBarOverrideBarTextShownType:
-  Always: 1
-  Never: 0
-  OnlyNotOnMouseover: 3
-  OnlyOnMouseover: 2
+  values:
+    Always: 1
+    Never: 0
+    OnlyNotOnMouseover: 3
+    OnlyOnMouseover: 2
 StatusBarTimerDirection:
-  ElapsedTime: 0
-  RemainingTime: 1
+  values:
+    ElapsedTime: 0
+    RemainingTime: 1
 StatusBarValueTextType:
-  Hidden: 0
-  Percentage: 1
-  Time: 3
-  TimeShowOneLevelOnly: 4
-  Value: 2
-  ValueOverMax: 5
-  ValueOverMaxNormalized: 6
+  values:
+    Hidden: 0
+    Percentage: 1
+    Time: 3
+    TimeShowOneLevelOnly: 4
+    Value: 2
+    ValueOverMax: 5
+    ValueOverMaxNormalized: 6
 StoreError:
-  AlreadyOwned: 7
-  BattlepayDisabled: 4
-  ClientRestricted: 13
-  ConsumableTokenOwned: 10
-  InsufficientBalance: 5
-  InvalidPaymentMethod: 1
-  ItemUnavailable: 12
-  Other: 6
-  ParentalControlsNoPurchase: 8
-  PaymentFailed: 2
-  PurchaseDenied: 9
-  Success: 0
-  TooManyTokens: 11
-  WrongCurrency: 3
+  values:
+    AlreadyOwned: 7
+    BattlepayDisabled: 4
+    ClientRestricted: 13
+    ConsumableTokenOwned: 10
+    InsufficientBalance: 5
+    InvalidPaymentMethod: 1
+    ItemUnavailable: 12
+    Other: 6
+    ParentalControlsNoPurchase: 8
+    PaymentFailed: 2
+    PurchaseDenied: 9
+    Success: 0
+    TooManyTokens: 11
+    WrongCurrency: 3
 SubcontainerType:
-  AccountBankTabs: 36
-  Auction: 5
-  Bag: 0
-  Bankbag: 3
-  Bankgeneric: 2
-  BuybackSlots: 26
-  CachedReward: 27
-  CharacterBankTabs: 38
-  Childequipmentstorage: 23
-  CraftingOrder: 34
-  CraftingOrderReagents: 35
-  CreatedImmediately: 25
-  CurrencytokenOboslete: 15
-  CurrencyTransfer: 37
-  Equipablespells: 14
-  Equipped: 1
-  EquippedBags: 28
-  EquippedCooking: 31
-  EquippedFishing: 32
-  EquippedProfession1: 29
-  EquippedProfession2: 30
-  EquippedReagentbag: 33
-  GuildBank0: 7
-  GuildBank1: 8
-  GuildBank10: 20
-  GuildBank11: 21
-  GuildBank2: 9
-  GuildBank3: 10
-  GuildBank4: 11
-  GuildBank5: 12
-  GuildBank6: 16
-  GuildBank7: 17
-  GuildBank8: 18
-  GuildBank9: 19
-  GuildOverflow: 13
-  HousingDecorConversion: 39
-  Keyring: 6
-  Mail: 4
-  Quarantine: 24
-  Reagentbank: 22
+  values:
+    AccountBankTabs: 36
+    Auction: 5
+    Bag: 0
+    Bankbag: 3
+    Bankgeneric: 2
+    BuybackSlots: 26
+    CachedReward: 27
+    CharacterBankTabs: 38
+    Childequipmentstorage: 23
+    CraftingOrder: 34
+    CraftingOrderReagents: 35
+    CreatedImmediately: 25
+    CurrencytokenOboslete: 15
+    CurrencyTransfer: 37
+    Equipablespells: 14
+    Equipped: 1
+    EquippedBags: 28
+    EquippedCooking: 31
+    EquippedFishing: 32
+    EquippedProfession1: 29
+    EquippedProfession2: 30
+    EquippedReagentbag: 33
+    GuildBank0: 7
+    GuildBank1: 8
+    GuildBank10: 20
+    GuildBank11: 21
+    GuildBank2: 9
+    GuildBank3: 10
+    GuildBank4: 11
+    GuildBank5: 12
+    GuildBank6: 16
+    GuildBank7: 17
+    GuildBank8: 18
+    GuildBank9: 19
+    GuildOverflow: 13
+    HousingDecorConversion: 39
+    Keyring: 6
+    Mail: 4
+    Quarantine: 24
+    Reagentbank: 22
 SubscriptionInterstitialResponseType:
-  Clicked: 0
-  Closed: 1
-  WebRedirect: 2
+  values:
+    Clicked: 0
+    Closed: 1
+    WebRedirect: 2
 SubscriptionInterstitialType:
-  LeftNpeArea: 1
-  MaxLevel: 2
-  Standard: 0
+  values:
+    LeftNpeArea: 1
+    MaxLevel: 2
+    Standard: 0
 SummonReason:
-  Scenario: 1
-  Spell: 0
+  values:
+    Scenario: 1
+    Spell: 0
 SummonStatus:
-  Accepted: 2
-  Declined: 3
-  None: 0
-  Pending: 1
+  values:
+    Accepted: 2
+    Declined: 3
+    None: 0
+    Pending: 1
 SuperTrackingMapPinType:
-  AreaPOI: 0
-  DigSite: 3
-  HousingPlot: 4
-  QuestOffer: 1
-  TaxiNode: 2
+  values:
+    AreaPOI: 0
+    DigSite: 3
+    HousingPlot: 4
+    QuestOffer: 1
+    TaxiNode: 2
 SuperTrackingType:
-  Content: 4
-  Corpse: 2
-  MapPin: 6
-  PartyMember: 5
-  Quest: 0
-  Scenario: 3
-  UserWaypoint: 1
-  Vignette: 7
+  values:
+    Content: 4
+    Corpse: 2
+    MapPin: 6
+    PartyMember: 5
+    Quest: 0
+    Scenario: 3
+    UserWaypoint: 1
+    Vignette: 7
 SurveyDeliveryFlags:
-  EncounterSucccessOnly: 1
-  None: 0
+  values:
+    EncounterSucccessOnly: 1
+    None: 0
 SurveyDeliveryMoment:
-  ChestLooted: 3
-  EncounterEnd: 5
-  Login: 0
-  MythicPlusCompleted: 4
-  ProfessionTable: 1
-  QuestTurnIn: 2
+  values:
+    ChestLooted: 3
+    EncounterEnd: 5
+    Login: 0
+    MythicPlusCompleted: 4
+    ProfessionTable: 1
+    QuestTurnIn: 2
 TableSecurityOption:
-  DisallowSecretKeys: 1
-  DisallowTaintedAccess: 0
-  SecretWrapContents: 2
+  values:
+    DisallowSecretKeys: 1
+    DisallowTaintedAccess: 0
+    SecretWrapContents: 2
 TieredEntranceRewardType:
-  Currency: 1
-  Item: 0
+  values:
+    Currency: 1
+    Item: 0
 TieredEntranceType:
-  Delve: 1
-  Invalid: 0
-  Sites: 2
-  WorldTier: 3
+  values:
+    Delve: 1
+    Invalid: 0
+    Sites: 2
+    WorldTier: 3
 TimeEventFlag:
-  GlobalLaunch: 4
-  GlueScreenShortcut: 1
-  WeeklyReset: 2
+  values:
+    GlobalLaunch: 4
+    GlueScreenShortcut: 1
+    WeeklyReset: 2
 TitleIconVersion:
-  Large: 2
-  Medium: 1
-  Small: 0
+  values:
+    Large: 2
+    Medium: 1
+    Small: 0
 TooltipComparisonMethod:
-  Single: 0
-  WithBagMainHandItem: 2
-  WithBagOffHandItem: 3
-  WithBothHands: 1
+  values:
+    Single: 0
+    WithBagMainHandItem: 2
+    WithBagOffHandItem: 3
+    WithBothHands: 1
 TooltipDataItemBinding:
-  Account: 1
-  AccountUntilEquipped: 9
-  BindOnEquip: 7
-  BindOnPickup: 6
-  BindOnUse: 8
-  BindToAccount: 4
-  BindToAccountUntilEquipped: 10
-  BindToBnetAccount: 5
-  BnetAccount: 2
-  Quest: 0
-  Soulbound: 3
+  values:
+    Account: 1
+    AccountUntilEquipped: 9
+    BindOnEquip: 7
+    BindOnPickup: 6
+    BindOnUse: 8
+    BindToAccount: 4
+    BindToAccountUntilEquipped: 10
+    BindToBnetAccount: 5
+    BnetAccount: 2
+    Quest: 0
+    Soulbound: 3
 TooltipDataLineType:
-  AzeriteEssencePower: 5
-  AzeriteEssenceSlot: 4
-  AzeriteItemPowerDescription: 9
-  Blank: 1
-  CurrencyTotal: 14
-  DisabledLine: 42
-  EquipSlot: 21
-  ErrorLine: 41
-  FlavorText: 37
-  GemSocket: 3
-  GemSocketEnchantment: 30
-  ItemBinding: 20
-  ItemEnchantmentPermanent: 15
-  ItemLevel: 31
-  ItemName: 22
-  ItemQuality: 35
-  ItemSpellTriggerLearn: 38
-  ItemUpgradeLevel: 32
-  LearnableSpell: 6
-  LearnTransmogIllusion: 40
-  LearnTransmogSet: 39
-  NestedBlock: 19
-  None: 0
-  ProfessionCraftingQuality: 12
-  QuestObjective: 8
-  QuestPlayer: 18
-  QuestTitle: 17
-  RuneforgeLegendaryPowerDescription: 10
-  SellPrice: 11
-  Separator: 23
-  SpellDescription: 34
-  SpellName: 13
-  SpellPassive: 33
-  ToyDescription: 28
-  ToyDuration: 27
-  ToyEffect: 26
-  ToyName: 24
-  ToySource: 29
-  ToyText: 25
-  TradeTimeRemaining: 36
-  UnitName: 2
-  UnitOwner: 16
-  UnitThreat: 7
-  UsageRequirement: 43
+  values:
+    AzeriteEssencePower: 5
+    AzeriteEssenceSlot: 4
+    AzeriteItemPowerDescription: 9
+    Blank: 1
+    CurrencyTotal: 14
+    DisabledLine: 42
+    EquipSlot: 21
+    ErrorLine: 41
+    FlavorText: 37
+    GemSocket: 3
+    GemSocketEnchantment: 30
+    ItemBinding: 20
+    ItemEnchantmentPermanent: 15
+    ItemLevel: 31
+    ItemName: 22
+    ItemQuality: 35
+    ItemSpellTriggerLearn: 38
+    ItemUpgradeLevel: 32
+    LearnableSpell: 6
+    LearnTransmogIllusion: 40
+    LearnTransmogSet: 39
+    NestedBlock: 19
+    None: 0
+    ProfessionCraftingQuality: 12
+    QuestObjective: 8
+    QuestPlayer: 18
+    QuestTitle: 17
+    RuneforgeLegendaryPowerDescription: 10
+    SellPrice: 11
+    Separator: 23
+    SpellDescription: 34
+    SpellName: 13
+    SpellPassive: 33
+    ToyDescription: 28
+    ToyDuration: 27
+    ToyEffect: 26
+    ToyName: 24
+    ToySource: 29
+    ToyText: 25
+    TradeTimeRemaining: 36
+    UnitName: 2
+    UnitOwner: 16
+    UnitThreat: 7
+    UsageRequirement: 43
 TooltipDataType:
-  Achievement: 12
-  AzeriteEssence: 8
-  BattlePet: 6
-  CompanionPet: 9
-  Corpse: 3
-  CorruptionCleanser: 20
-  Currency: 5
-  Debug: 26
-  EnhancedConduit: 13
-  EquipmentSet: 14
-  Flyout: 22
-  InstanceLock: 15
-  Item: 0
-  Macro: 25
-  MinimapMouseover: 21
-  Mount: 10
-  Object: 4
-  Outfit: 27
-  PetAction: 11
-  PvPBrawl: 16
-  Quest: 23
-  QuestPartyProgress: 24
-  RecipeRankInfo: 17
-  Spell: 1
-  Totem: 18
-  Toy: 19
-  Unit: 2
-  UnitAura: 7
+  values:
+    Achievement: 12
+    AzeriteEssence: 8
+    BattlePet: 6
+    CompanionPet: 9
+    Corpse: 3
+    CorruptionCleanser: 20
+    Currency: 5
+    Debug: 26
+    EnhancedConduit: 13
+    EquipmentSet: 14
+    Flyout: 22
+    InstanceLock: 15
+    Item: 0
+    Macro: 25
+    MinimapMouseover: 21
+    Mount: 10
+    Object: 4
+    Outfit: 27
+    PetAction: 11
+    PvPBrawl: 16
+    Quest: 23
+    QuestPartyProgress: 24
+    RecipeRankInfo: 17
+    Spell: 1
+    Totem: 18
+    Toy: 19
+    Unit: 2
+    UnitAura: 7
 TooltipDataUsageRequirementType:
-  Achievement: 7
-  ArenaRating: 11
-  EarnCurrency: 12
-  EquippedItem: 9
-  Faction: 1
-  Guild: 6
-  Level: 5
-  NotAlreadyKnown: 14
-  NotInArena: 15
-  NotInRatedBg: 16
-  PvPMedal: 3
-  PvPRank: 8
-  RaceClass: 0
-  Reputation: 4
-  ShapeshiftForm: 10
-  Skill: 2
-  Specialization: 13
+  values:
+    Achievement: 7
+    ArenaRating: 11
+    EarnCurrency: 12
+    EquippedItem: 9
+    Faction: 1
+    Guild: 6
+    Level: 5
+    NotAlreadyKnown: 14
+    NotInArena: 15
+    NotInRatedBg: 16
+    PvPMedal: 3
+    PvPRank: 8
+    RaceClass: 0
+    Reputation: 4
+    ShapeshiftForm: 10
+    Skill: 2
+    Specialization: 13
 TooltipSide:
-  Bottom: 3
-  Left: 0
-  Right: 1
-  Top: 2
+  values:
+    Bottom: 3
+    Left: 0
+    Right: 1
+    Top: 2
 TooltipTextureAnchor:
-  All: 6
-  LeftBottom: 2
-  LeftCenter: 1
-  LeftTop: 0
-  RightBottom: 5
-  RightCenter: 4
-  RightTop: 3
+  values:
+    All: 6
+    LeftBottom: 2
+    LeftCenter: 1
+    LeftTop: 0
+    RightBottom: 5
+    RightCenter: 4
+    RightTop: 3
 TooltipTextureRelativeRegion:
-  LeftLine: 0
-  RightLine: 1
+  values:
+    LeftLine: 0
+    RightLine: 1
 TrackedSpellCategory:
-  Debuff: 3
-  Defensive: 2
-  None: 0
-  Offensive: 1
-  RacialAbility: 4
+  values:
+    Debuff: 3
+    Defensive: 2
+    None: 0
+    Offensive: 1
+    RacialAbility: 4
 TrackedSpellsResult:
-  MismatchedCooldownInfo: 3
-  NoCooldownInfo: 2
-  PlayerNotFound: 1
-  Success: 0
+  values:
+    MismatchedCooldownInfo: 3
+    NoCooldownInfo: 2
+    PlayerNotFound: 1
+    Success: 0
 TradeskillOrderDuration:
-  Long: 3
-  Medium: 2
-  Short: 1
+  values:
+    Long: 3
+    Medium: 2
+    Short: 1
 TradeskillOrderRecipient:
-  Guild: 2
-  Private: 3
-  Public: 1
+  values:
+    Guild: 2
+    Private: 3
+    Public: 1
 TradeskillOrderStatus:
-  Completed: 3
-  Expired: 4
-  Started: 2
-  Unclaimed: 1
+  values:
+    Completed: 3
+    Expired: 4
+    Started: 2
+    Unclaimed: 1
 TradeskillRecipeType:
-  Enchant: 3
-  Gathering: 4
-  Item: 1
-  Salvage: 2
+  values:
+    Enchant: 3
+    Gathering: 4
+    Item: 1
+    Salvage: 2
 TradeskillRelativeDifficulty:
-  Easy: 2
-  Medium: 1
-  Optimal: 0
-  Trivial: 3
+  values:
+    Easy: 2
+    Medium: 1
+    Optimal: 0
+    Trivial: 3
 TradeskillSlotDataType:
-  Currency: 3
-  ModifiedReagent: 2
-  Reagent: 1
+  values:
+    Currency: 3
+    ModifiedReagent: 2
+    Reagent: 1
 TraitCombatConfigFlags:
-  ActiveForSpec: 1
-  SharedActionBars: 4
-  StarterBuild: 2
+  values:
+    ActiveForSpec: 1
+    SharedActionBars: 4
+    StarterBuild: 2
 TraitCondFlag:
-  IsAlwaysMet: 2
-  IsGate: 1
-  IsSufficient: 4
+  values:
+    IsAlwaysMet: 2
+    IsGate: 1
+    IsSufficient: 4
 TraitConditionType:
-  Available: 0
-  DisplayError: 4
-  Granted: 2
-  Increased: 3
-  RanksAllowed: 5
-  Visible: 1
+  values:
+    Available: 0
+    DisplayError: 4
+    Granted: 2
+    Increased: 3
+    RanksAllowed: 5
+    Visible: 1
 TraitConfigDbState:
-  Created: 1
-  Deleted: 3
-  Ready: 0
-  Removed: 2
+  values:
+    Created: 1
+    Deleted: 3
+    Ready: 0
+    Removed: 2
 TraitConfigType:
-  Combat: 1
-  Generic: 3
-  Invalid: 0
-  Profession: 2
+  values:
+    Combat: 1
+    Generic: 3
+    Invalid: 0
+    Profession: 2
 TraitCurrencyFlag:
-  ShowQuantityAsSpent: 1
-  TraitSourcedShowMax: 2
-  UseClassIcon: 4
-  UseSpecIcon: 8
+  values:
+    ShowQuantityAsSpent: 1
+    TraitSourcedShowMax: 2
+    UseClassIcon: 4
+    UseSpecIcon: 8
 TraitCurrencyType:
-  CurrencyTypesBased: 1
-  Gold: 0
-  TraitSourced: 2
-  TraitSourcedPlayerDataElement: 3
+  values:
+    CurrencyTypesBased: 1
+    Gold: 0
+    TraitSourced: 2
+    TraitSourcedPlayerDataElement: 3
 TraitDefinitionSubType:
-  DragonflightBlack: 4
-  DragonflightBlue: 1
-  DragonflightBronze: 3
-  DragonflightGreen: 2
-  DragonflightRed: 0
+  values:
+    DragonflightBlack: 4
+    DragonflightBlue: 1
+    DragonflightBronze: 3
+    DragonflightGreen: 2
+    DragonflightRed: 0
 TraitEdgeType:
-  DeprecatedRankConnection: 1
-  DeprecatedSelectionOption: 5
-  MutuallyExclusive: 4
-  RequiredForAvailability: 3
-  SufficientForAvailability: 2
-  VisualOnly: 0
+  values:
+    DeprecatedRankConnection: 1
+    DeprecatedSelectionOption: 5
+    MutuallyExclusive: 4
+    RequiredForAvailability: 3
+    SufficientForAvailability: 2
+    VisualOnly: 0
 TraitEdgeVisualStyle:
-  None: 0
-  Straight: 1
+  values:
+    None: 0
+    Straight: 1
 TraitNodeEntryType:
-  ArmorSet: 11
-  DeprecatedSelect: 4
-  DragAndDrop: 5
-  ProfPath: 7
-  ProfPathUnlock: 9
-  ProfPerk: 8
-  RedButton: 10
-  SpendCapstoneCircle: 13
-  SpendCapstoneSquare: 14
-  SpendCircle: 2
-  SpendDiamond: 6
-  SpendHex: 0
-  SpendInfinite: 12
-  SpendSmallCircle: 3
-  SpendSquare: 1
+  values:
+    ArmorSet: 11
+    DeprecatedSelect: 4
+    DragAndDrop: 5
+    ProfPath: 7
+    ProfPathUnlock: 9
+    ProfPerk: 8
+    RedButton: 10
+    SpendCapstoneCircle: 13
+    SpendCapstoneSquare: 14
+    SpendCircle: 2
+    SpendDiamond: 6
+    SpendHex: 0
+    SpendInfinite: 12
+    SpendSmallCircle: 3
+    SpendSquare: 1
 TraitNodeFlag:
-  ActiveAtFirstRank: 16
-  HideMaxRank: 64
-  HighestChosenRank: 128
-  NeverPurchasable: 2
-  ShowExpandedSelection: 32
-  ShowMultipleIcons: 1
-  ShowTierTrack: 256
-  TestGridPositioned: 8
-  TestPositionLocked: 4
+  values:
+    ActiveAtFirstRank: 16
+    HideMaxRank: 64
+    HighestChosenRank: 128
+    NeverPurchasable: 2
+    ShowExpandedSelection: 32
+    ShowMultipleIcons: 1
+    ShowTierTrack: 256
+    TestGridPositioned: 8
+    TestPositionLocked: 4
 TraitNodeGroupFlag:
-  AvailableByDefault: 1
+  values:
+    AvailableByDefault: 1
 TraitNodeType:
-  Selection: 2
-  Single: 0
-  SubTreeSelection: 3
-  Tiered: 1
+  values:
+    Selection: 2
+    Single: 0
+    SubTreeSelection: 3
+    Tiered: 1
 TraitPointsOperationType:
-  Multiply: 1
-  None: -1
-  Set: 0
+  values:
+    Multiply: 1
+    None: -1
+    Set: 0
 TraitSystemFlag:
-  AllowEditInChallengeMode: 8
-  AllowEditInCombat: 4
-  AllowMultipleLoadoutsPerTree: 1
-  ShowSpendConfirmation: 2
+  values:
+    AllowEditInChallengeMode: 8
+    AllowEditInCombat: 4
+    AllowMultipleLoadoutsPerTree: 1
+    ShowSpendConfirmation: 2
 TraitSystemVariationType:
-  None: 0
-  Spec: 1
+  values:
+    None: 0
+    Spec: 1
 TraitTreeFlag:
-  CannotRefund: 1
-  HideSingleRankNumbers: 2
+  values:
+    CannotRefund: 1
+    HideSingleRankNumbers: 2
 TransformManipulatorAxis:
-  X: 1
-  Y: 2
-  Z: 4
+  values:
+    X: 1
+    Y: 2
+    Z: 4
 TransformManipulatorControlState:
-  Default: 0
-  Dimmed: 2
-  ExternallyHighlighted: 3
-  Hidden: 1
-  Hovered: 4
-  Moving: 6
-  Selected: 5
+  values:
+    Default: 0
+    Dimmed: 2
+    ExternallyHighlighted: 3
+    Hidden: 1
+    Hovered: 4
+    Moving: 6
+    Selected: 5
 TransformManipulatorDirection:
-  Negative: 1
-  Positive: 0
+  values:
+    Negative: 1
+    Positive: 0
 TransformManipulatorEvent:
-  Cancel: 3
-  Change: 1
-  Complete: 2
-  Hover: 4
-  MouseDown: 5
-  MouseUp: 6
-  Start: 0
+  values:
+    Cancel: 3
+    Change: 1
+    Complete: 2
+    Hover: 4
+    MouseDown: 5
+    MouseUp: 6
+    Start: 0
 TransformManipulatorMode:
-  Rotate: 1
-  Scale: 2
-  Translate: 0
+  values:
+    Rotate: 1
+    Scale: 2
+    Translate: 0
 TransmogCameraVariation:
-  CloakBackpack: 1
-  None: 0
-  RightShoulder: 1
+  values:
+    CloakBackpack: 1
+    None: 0
+    RightShoulder: 1
 TransmogCollectionType:
-  Back: 3
-  Bow: 25
-  Chest: 4
-  Crossbow: 27
-  Dagger: 16
-  Feet: 11
-  Fist: 17
-  Gun: 26
-  Hands: 8
-  Head: 1
-  Holdable: 19
-  Legs: 10
-  None: 0
-  OneHAxe: 13
-  OneHMace: 15
-  OneHSword: 14
-  Paired: 29
-  Polearm: 24
-  Shield: 18
-  Shirt: 5
-  Shoulder: 2
-  Staff: 23
-  Tabard: 6
-  TwoHAxe: 20
-  TwoHMace: 22
-  TwoHSword: 21
-  Waist: 9
-  Wand: 12
-  Warglaives: 28
-  Wrist: 7
+  values:
+    Back: 3
+    Bow: 25
+    Chest: 4
+    Crossbow: 27
+    Dagger: 16
+    Feet: 11
+    Fist: 17
+    Gun: 26
+    Hands: 8
+    Head: 1
+    Holdable: 19
+    Legs: 10
+    None: 0
+    OneHAxe: 13
+    OneHMace: 15
+    OneHSword: 14
+    Paired: 29
+    Polearm: 24
+    Shield: 18
+    Shirt: 5
+    Shoulder: 2
+    Staff: 23
+    Tabard: 6
+    TwoHAxe: 20
+    TwoHMace: 22
+    TwoHSword: 21
+    Waist: 9
+    Wand: 12
+    Warglaives: 28
+    Wrist: 7
 TransmogIllusionFlags:
-  AllowedRangedShieldsHoldables: 4
-  HideUntilCollected: 1
-  PlayerConditionGrantsOnLogin: 2
+  values:
+    AllowedRangedShieldsHoldables: 4
+    HideUntilCollected: 1
+    PlayerConditionGrantsOnLogin: 2
 TransmogModification:
-  Main: 0
-  Secondary: 1
+  values:
+    Main: 0
+    Secondary: 1
 TransmogOutfitCostModifiersApplied:
-  AuraDiscountApplied: 8
-  DebugOnlyFreeDiscountApplied: 1
-  OutfitCostModifierApplied: 4
-  VoidRacialDiscountApplied: 2
+  values:
+    AuraDiscountApplied: 8
+    DebugOnlyFreeDiscountApplied: 1
+    OutfitCostModifierApplied: 4
+    VoidRacialDiscountApplied: 2
 TransmogOutfitDataFlags:
-  IsCachedLocally: 1
+  values:
+    IsCachedLocally: 1
 TransmogOutfitDisplayType:
-  Assigned: 1
-  Disabled: 4
-  Equipped: 2
-  Hidden: 3
-  Unassigned: 0
+  values:
+    Assigned: 1
+    Disabled: 4
+    Equipped: 2
+    Hidden: 3
+    Unassigned: 0
 TransmogOutfitEntryFlags:
-  AutomaticallyAwardedOnLogin: 1
-  IsDefaultEquipped: 32
-  OnlyAvailableDuringEvent: 4
-  SortedToTopOfList: 8
-  UseOverrideCostModifier: 16
-  UseOverrideName: 2
+  values:
+    AutomaticallyAwardedOnLogin: 1
+    IsDefaultEquipped: 32
+    OnlyAvailableDuringEvent: 4
+    SortedToTopOfList: 8
+    UseOverrideCostModifier: 16
+    UseOverrideName: 2
 TransmogOutfitEntrySource:
-  AutomaticallyAwarded: 1
-  PlayerPurchased: 2
-  StampedSource: 0
+  values:
+    AutomaticallyAwarded: 1
+    PlayerPurchased: 2
+    StampedSource: 0
 TransmogOutfitEquipAction:
-  Equip: 0
-  EquipAndLock: 1
-  Lock: 5
-  Remove: 2
-  RemoveAndLock: 3
-  Unlock: 4
+  values:
+    Equip: 0
+    EquipAndLock: 1
+    Lock: 5
+    Remove: 2
+    RemoveAndLock: 3
+    Unlock: 4
 TransmogOutfitSetType:
-  CustomSet: 2
-  Equipped: 0
-  Outfit: 1
+  values:
+    CustomSet: 2
+    Equipped: 0
+    Outfit: 1
 TransmogOutfitSlot:
-  Back: 3
-  Body: 6
-  Chest: 4
-  Feet: 11
-  Hand: 8
-  Head: 0
-  Legs: 10
-  ShoulderLeft: 2
-  ShoulderRight: 1
-  Tabard: 5
-  Waist: 9
-  WeaponMainHand: 12
-  WeaponOffHand: 13
-  WeaponRanged: 14
-  Wrist: 7
+  values:
+    Back: 3
+    Body: 6
+    Chest: 4
+    Feet: 11
+    Hand: 8
+    Head: 0
+    Legs: 10
+    ShoulderLeft: 2
+    ShoulderRight: 1
+    Tabard: 5
+    Waist: 9
+    WeaponMainHand: 12
+    WeaponOffHand: 13
+    WeaponRanged: 14
+    Wrist: 7
 TransmogOutfitSlotError:
-  CannotUseItem: 10
-  IncompatibleWithMainHand: 14
-  InvalidDestination: 5
-  InvalidItemType: 4
-  InvalidSlotForForm: 13
-  InvalidSlotForRace: 11
-  InvalidSource: 8
-  InvalidSourceQuality: 9
-  Legendary: 3
-  Mismatch: 6
-  NoIllusion: 12
-  NoItem: 1
-  NotSoulbound: 2
-  Ok: 0
-  SameItem: 7
+  values:
+    CannotUseItem: 10
+    IncompatibleWithMainHand: 14
+    InvalidDestination: 5
+    InvalidItemType: 4
+    InvalidSlotForForm: 13
+    InvalidSlotForRace: 11
+    InvalidSource: 8
+    InvalidSourceQuality: 9
+    Legendary: 3
+    Mismatch: 6
+    NoIllusion: 12
+    NoItem: 1
+    NotSoulbound: 2
+    Ok: 0
+    SameItem: 7
 TransmogOutfitSlotFlags:
-  CanHaveIllusions: 2
-  CannotBeHidden: 1
-  IsSecondarySlot: 4
+  values:
+    CanHaveIllusions: 2
+    CannotBeHidden: 1
+    IsSecondarySlot: 4
 TransmogOutfitSlotOption:
-  ArtifactSpecFour: 11
-  ArtifactSpecOne: 8
-  ArtifactSpecThree: 10
-  ArtifactSpecTwo: 9
-  DeprecatedReuseMe: 6
-  FuryTwoHandedWeapon: 7
-  None: 0
-  OffHand: 4
-  OneHandedWeapon: 1
-  RangedWeapon: 3
-  Shield: 5
-  TwoHandedWeapon: 2
+  values:
+    ArtifactSpecFour: 11
+    ArtifactSpecOne: 8
+    ArtifactSpecThree: 10
+    ArtifactSpecTwo: 9
+    DeprecatedReuseMe: 6
+    FuryTwoHandedWeapon: 7
+    None: 0
+    OffHand: 4
+    OneHandedWeapon: 1
+    RangedWeapon: 3
+    Shield: 5
+    TwoHandedWeapon: 2
 TransmogOutfitSlotOptionFlags:
-  DisablesOffhandSlot: 4
-  DynamicOptionName: 2
-  IllusionNotAllowed: 1
+  values:
+    DisablesOffhandSlot: 4
+    DynamicOptionName: 2
+    IllusionNotAllowed: 1
 TransmogOutfitSlotOptionSheatheCategory:
-  Back: 1
-  Default: 0
-  Hide: 3
-  Side: 2
+  values:
+    Back: 1
+    Default: 0
+    Hide: 3
+    Side: 2
 TransmogOutfitSlotPosition:
-  Bottom: 2
-  Left: 0
-  Right: 1
+  values:
+    Bottom: 2
+    Left: 0
+    Right: 1
 TransmogOutfitSlotSaveFlags:
-  AppearanceIsNotValid: 1
+  values:
+    AppearanceIsNotValid: 1
 TransmogOutfitSlotWarning:
-  InvalidEquippedDestinationItem: 1
-  NothingEquipped: 5
-  Ok: 0
-  PendingWeaponChanges: 3
-  WeaponDoesNotSupportIllusions: 4
-  WrongWeaponCategoryEquipped: 2
+  values:
+    InvalidEquippedDestinationItem: 1
+    NothingEquipped: 5
+    Ok: 0
+    PendingWeaponChanges: 3
+    WeaponDoesNotSupportIllusions: 4
+    WrongWeaponCategoryEquipped: 2
 TransmogOutfitTransactionFlags:
-  AddNewOutfitMask: 20
-  AddOutfitAndUpdateSlots: 28
-  CreateAndUpdateOutfitInfoMask: 6
-  CreateOutfitInfo: 4
-  FullOutfitUpdateMask: 27
-  UpdateMetadata: 1
-  UpdateOutfitInfo: 2
-  UpdateSituations: 16
-  UpdateSituationsMask: 18
-  UpdateSlots: 8
+  values:
+    AddNewOutfitMask: 20
+    AddOutfitAndUpdateSlots: 28
+    CreateAndUpdateOutfitInfoMask: 6
+    CreateOutfitInfo: 4
+    FullOutfitUpdateMask: 27
+    UpdateMetadata: 1
+    UpdateOutfitInfo: 2
+    UpdateSituations: 16
+    UpdateSituationsMask: 18
+    UpdateSlots: 8
 TransmogOutfitTransactionType:
-  CreateOutfitInfo: 2
-  UpdateMetadata: 0
-  UpdateOutfitInfo: 1
-  UpdateSituations: 4
-  UpdateSlots: 3
+  values:
+    CreateOutfitInfo: 2
+    UpdateMetadata: 0
+    UpdateOutfitInfo: 1
+    UpdateSituations: 4
+    UpdateSlots: 3
 TransmogPendingType:
-  Apply: 0
-  Revert: 1
-  ToggleOff: 3
-  ToggleOn: 2
+  values:
+    Apply: 0
+    Revert: 1
+    ToggleOff: 3
+    ToggleOn: 2
 TransmogSearchType:
-  BaseSets: 2
-  Items: 1
-  UsableSets: 3
+  values:
+    BaseSets: 2
+    Items: 1
+    UsableSets: 3
 TransmogSituation:
-  AllEquipmentSets: 17
-  AllLocations: 2
-  AllMovement: 12
-  AllRacialForms: 19
-  AllSpecs: 0
-  AllTime: 27
-  AllWeather: 22
-  EquipmentSets: 18
-  FormNative: 20
-  FormNonNative: 21
-  LocationArenas: 10
-  LocationBattlegrounds: 11
-  LocationCharacterSelect: 5
-  LocationDelves: 7
-  LocationDungeons: 8
-  LocationHouse: 4
-  LocationRaids: 9
-  LocationRested: 3
-  LocationWorld: 6
-  MovementFlyingMount: 16
-  MovementGroundMount: 15
-  MovementSwimming: 14
-  MovementUnmounted: 13
-  Spec: 1
-  TimeDay: 29
-  TimeEvening: 30
-  TimeMorning: 28
-  TimeNight: 31
-  WeatherClear: 23
-  WeatherRain: 24
-  WeatherSand: 26
-  WeatherSnow: 25
+  values:
+    AllEquipmentSets: 17
+    AllLocations: 2
+    AllMovement: 12
+    AllRacialForms: 19
+    AllSpecs: 0
+    AllTime: 27
+    AllWeather: 22
+    EquipmentSets: 18
+    FormNative: 20
+    FormNonNative: 21
+    LocationArenas: 10
+    LocationBattlegrounds: 11
+    LocationCharacterSelect: 5
+    LocationDelves: 7
+    LocationDungeons: 8
+    LocationHouse: 4
+    LocationRaids: 9
+    LocationRested: 3
+    LocationWorld: 6
+    MovementFlyingMount: 16
+    MovementGroundMount: 15
+    MovementSwimming: 14
+    MovementUnmounted: 13
+    Spec: 1
+    TimeDay: 29
+    TimeEvening: 30
+    TimeMorning: 28
+    TimeNight: 31
+    WeatherClear: 23
+    WeatherRain: 24
+    WeatherSand: 26
+    WeatherSnow: 25
 TransmogSituationFlags:
-  AllSituation: 4
-  DefaultsToOn: 8
-  DisabledSituation: 64
-  DynamicallyNamed: 16
-  IsPlayerFacing: 1
-  NoneSituation: 32
-  SpecUseTalentLoadout: 2
+  values:
+    AllSituation: 4
+    DefaultsToOn: 8
+    DisabledSituation: 64
+    DynamicallyNamed: 16
+    IsPlayerFacing: 1
+    NoneSituation: 32
+    SpecUseTalentLoadout: 2
 TransmogSituationGroupFlags:
-  DynamicallyCreatesGroups: 1
+  values:
+    DynamicallyCreatesGroups: 1
 TransmogSituationTrigger:
-  EquipmentSet: 6
-  EventOutfit: 8
-  Forms: 7
-  Location: 3
-  Manual: 1
-  Movement: 4
-  None: 0
-  Specialization: 5
-  TimeOfDay: 10
-  TransmogUpdate: 2
-  Weather: 9
+  values:
+    EquipmentSet: 6
+    EventOutfit: 8
+    Forms: 7
+    Location: 3
+    Manual: 1
+    Movement: 4
+    None: 0
+    Specialization: 5
+    TimeOfDay: 10
+    TransmogUpdate: 2
+    Weather: 9
 TransmogSituationTriggerFlags:
-  CanChangeLockedOutfit: 2
-  CanLockOutfit: 1
-  DisabledTrigger: 16
-  IsPlayerFacing: 4
-  SituationsAreExclusive: 8
+  values:
+    CanChangeLockedOutfit: 2
+    CanLockOutfit: 1
+    DisabledTrigger: 16
+    IsPlayerFacing: 4
+    SituationsAreExclusive: 8
 TransmogSituationTriggerType:
-  Automatic: 2
-  Manual: 1
-  None: 0
-  TransmogUpdate: 3
+  values:
+    Automatic: 2
+    Manual: 1
+    None: 0
+    TransmogUpdate: 3
 TransmogSlot:
-  Back: 2
-  Body: 4
-  Chest: 3
-  Feet: 10
-  Hand: 7
-  Head: 0
-  Legs: 9
-  Mainhand: 11
-  Offhand: 12
-  Shoulder: 1
-  Tabard: 5
-  Waist: 8
-  Wrist: 6
+  values:
+    Back: 2
+    Body: 4
+    Chest: 3
+    Feet: 10
+    Hand: 7
+    Head: 0
+    Legs: 9
+    Mainhand: 11
+    Offhand: 12
+    Shoulder: 1
+    Tabard: 5
+    Waist: 8
+    Wrist: 6
 TransmogSource:
-  Achievement: 7
-  CantCollect: 6
-  HiddenUntilCollected: 5
-  JournalEncounter: 1
-  None: 0
-  NotValidForTransmog: 9
-  Profession: 8
-  Quest: 2
-  TradingPost: 10
-  Vendor: 3
-  WorldDrop: 4
+  values:
+    Achievement: 7
+    CantCollect: 6
+    HiddenUntilCollected: 5
+    JournalEncounter: 1
+    None: 0
+    NotValidForTransmog: 9
+    Profession: 8
+    Quest: 2
+    TradingPost: 10
+    Vendor: 3
+    WorldDrop: 4
 TransmogTimeOfDayCategory:
-  Evening: 2
-  Midday: 1
-  Morning: 0
-  Night: 3
+  values:
+    Evening: 2
+    Midday: 1
+    Morning: 0
+    Night: 3
 TransmogType:
-  Appearance: 0
-  Illusion: 1
+  values:
+    Appearance: 0
+    Illusion: 1
 TransmogUseErrorType:
-  Ability: 3
-  Class: 7
-  Faction: 9
-  Holiday: 5
-  HotRecheckFailed: 6
-  ItemProficiency: 10
-  None: 0
-  PlayerCondition: 1
-  Race: 8
-  Reputation: 4
-  Skill: 2
+  values:
+    Ability: 3
+    Class: 7
+    Faction: 9
+    Holiday: 5
+    HotRecheckFailed: 6
+    ItemProficiency: 10
+    None: 0
+    PlayerCondition: 1
+    Race: 8
+    Reputation: 4
+    Skill: 2
 TtsBoolSetting:
-  AddCharacterNameToSpeech: 1
-  AlternateSystemVoice: 3
-  NarrateMyMessages: 4
-  PlayActivitySoundWhenNotFocused: 2
-  PlaySoundSeparatingChatLineBreaks: 0
+  values:
+    AddCharacterNameToSpeech: 1
+    AlternateSystemVoice: 3
+    NarrateMyMessages: 4
+    PlayActivitySoundWhenNotFocused: 2
+    PlaySoundSeparatingChatLineBreaks: 0
 TtsVoiceType:
-  Alternate: 1
-  Standard: 0
+  values:
+    Alternate: 1
+    Standard: 0
 TugOfWarMarkerArrowShownState:
-  Always: 1
-  FlashOnMove: 2
-  Never: 0
+  values:
+    Always: 1
+    FlashOnMove: 2
+    Never: 0
 TugOfWarStyleValue:
-  ArchaeologyBrown: 1
-  DefaultYellow: 0
+  values:
+    ArchaeologyBrown: 1
+    DefaultYellow: 0
 TurnStrafeStyle:
-  Custom: 2
-  Legacy: 1
-  Modern: 0
+  values:
+    Custom: 2
+    Legacy: 1
+    Modern: 0
 UIActionType:
-  DefaultAction: 0
-  Reserved1: 2
-  UpdateMapSystem: 1
+  values:
+    DefaultAction: 0
+    Reserved1: 2
+    UpdateMapSystem: 1
 UICovenantDisplayInfoFlags:
-  DisplayCovenantAsJourney: 1
-  UseJourneyRewardTrack: 2
-  UseJourneyUnlockToastText: 3
+  values:
+    DisplayCovenantAsJourney: 1
+    UseJourneyRewardTrack: 2
+    UseJourneyUnlockToastText: 3
 UICursorType:
-  ActionBar: 6
-  AmmoObsolete: 8
-  BattlePet: 16
-  ConduitCollectionItem: 19
-  Currency: 13
-  Default: 0
-  EquipmentSet: 12
-  Flyout: 14
-  GuildBank: 10
-  GuildBankMoney: 11
-  Item: 1
-  Macro: 7
-  Merchant: 5
-  Money: 2
-  Mount: 17
-  Outfit: 21
-  PerksProgramVendorItem: 20
-  Pet: 9
-  PetAction: 4
-  Spell: 3
-  Toy: 18
-  VoidItem: 15
+  values:
+    ActionBar: 6
+    AmmoObsolete: 8
+    BattlePet: 16
+    ConduitCollectionItem: 19
+    Currency: 13
+    Default: 0
+    EquipmentSet: 12
+    Flyout: 14
+    GuildBank: 10
+    GuildBankMoney: 11
+    Item: 1
+    Macro: 7
+    Merchant: 5
+    Money: 2
+    Mount: 17
+    Outfit: 21
+    PerksProgramVendorItem: 20
+    Pet: 9
+    PetAction: 4
+    Spell: 3
+    Toy: 18
+    VoidItem: 15
 UIFrameType:
-  InterruptTutorial: 1
-  JailersTowerBuffs: 0
+  values:
+    InterruptTutorial: 1
+    JailersTowerBuffs: 0
 UIItemInteractionFlags:
-  AddCurrency: 16
-  ClickShowsFlyout: 8
-  ConfirmationHasDelay: 2
-  ConversionMode: 4
-  DisplayWithInset: 1
-  UsesCharges: 32
+  values:
+    AddCurrency: 16
+    ClickShowsFlyout: 8
+    ConfirmationHasDelay: 2
+    ConversionMode: 4
+    DisplayWithInset: 1
+    UsesCharges: 32
 UIItemInteractionType:
-  CastSpell: 1
-  CleanseCorruption: 2
-  ItemConversion: 4
-  None: 0
-  RunecarverScrapping: 3
+  values:
+    CastSpell: 1
+    CleanseCorruption: 2
+    ItemConversion: 4
+    None: 0
+    RunecarverScrapping: 3
 UIMapFlag:
-  AlwaysAllowTaxiPathing: 131072
-  AlwaysAllowUserWaypoints: 65536
-  DoNotShowOnNavbar: 524288
-  DoNotTranslateBranches: 512
-  FallbackToParentMap: 16
-  FlightMapAutoZoom: 16384
-  FlightMapShowZoomOut: 8192
-  ForceAllOverlayExplored: 4096
-  ForceAllowMapLinks: 262144
-  ForceOnNavbar: 32768
-  GarrisonMap: 8
-  HideArchaeologyDigs: 256
-  HideIcons: 1024
-  HideVignettes: 2048
-  IgnoreInTranslationsToParent: 2097152
-  IsCityMap: 1048576
-  NoHighlight: 1
-  NoHighlightTexture: 32
-  NoWorldPositions: 128
-  ShowOverlays: 2
-  ShowTaskObjectives: 64
-  ShowTaxiNodes: 4
+  values:
+    AlwaysAllowTaxiPathing: 131072
+    AlwaysAllowUserWaypoints: 65536
+    DoNotShowOnNavbar: 524288
+    DoNotTranslateBranches: 512
+    FallbackToParentMap: 16
+    FlightMapAutoZoom: 16384
+    FlightMapShowZoomOut: 8192
+    ForceAllOverlayExplored: 4096
+    ForceAllowMapLinks: 262144
+    ForceOnNavbar: 32768
+    GarrisonMap: 8
+    HideArchaeologyDigs: 256
+    HideIcons: 1024
+    HideVignettes: 2048
+    IgnoreInTranslationsToParent: 2097152
+    IsCityMap: 1048576
+    NoHighlight: 1
+    NoHighlightTexture: 32
+    NoWorldPositions: 128
+    ShowOverlays: 2
+    ShowTaskObjectives: 64
+    ShowTaxiNodes: 4
 UIMapGroupFlag:
-  ShowIconsAcrossFloors: 1
+  values:
+    ShowIconsAcrossFloors: 1
 UIMapSystem:
-  Adventure: 2
-  Minimap: 3
-  Taxi: 1
-  World: 0
+  values:
+    Adventure: 2
+    Minimap: 3
+    Taxi: 1
+    World: 0
 UIMapType:
-  Continent: 2
-  Cosmic: 0
-  Dungeon: 4
-  Micro: 5
-  Orphan: 6
-  World: 1
-  Zone: 3
+  values:
+    Continent: 2
+    Cosmic: 0
+    Dungeon: 4
+    Micro: 5
+    Orphan: 6
+    World: 1
+    Zone: 3
 UIModelSceneActorFlag:
-  Deprecated1: 1
-  UseCenterForOriginX: 2
-  UseCenterForOriginY: 4
-  UseCenterForOriginZ: 8
+  values:
+    Deprecated1: 1
+    UseCenterForOriginX: 2
+    UseCenterForOriginY: 4
+    UseCenterForOriginZ: 8
 UIModelSceneContext:
-  None: -1
-  PerksProgram: 0
+  values:
+    None: -1
+    PerksProgram: 0
 UIModelSceneFlags:
-  Autodress: 4
-  HideWeapon: 2
-  NoCameraSpin: 8
-  SheatheWeapon: 1
+  values:
+    Autodress: 4
+    HideWeapon: 2
+    NoCameraSpin: 8
+    SheatheWeapon: 1
 UISystemType:
-  InGameNavigation: 0
+  values:
+    InGameNavigation: 0
 UITextureSliceMode:
-  Stretched: 0
-  Tiled: 1
+  values:
+    Stretched: 0
+    Tiled: 1
 UIWidgetBlendModeType:
-  Additive: 1
-  Opaque: 0
+  values:
+    Additive: 1
+    Opaque: 0
 UIWidgetButtonEnabledState:
-  Disabled: 0
-  Enabled: 1
+  values:
+    Disabled: 0
+    Enabled: 1
 UIWidgetButtonIconType:
-  Checkmark: 3
-  Exit: 0
-  RedX: 4
-  Speak: 1
-  Undo: 2
+  values:
+    Checkmark: 3
+    Exit: 0
+    RedX: 4
+    Speak: 1
+    Undo: 2
 UIWidgetFlag:
-  UniversalWidget: 1
+  values:
+    UniversalWidget: 1
 UIWidgetFontType:
-  Normal: 0
-  Outline: 2
-  Shadow: 1
+  values:
+    Normal: 0
+    Outline: 2
+    Shadow: 1
 UIWidgetHorizontalDirection:
-  LeftToRight: 0
-  RightToLeft: 1
+  values:
+    LeftToRight: 0
+    RightToLeft: 1
 UIWidgetLayoutDirection:
-  Default: 0
-  Horizontal: 2
-  HorizontalForceNewRow: 4
-  Overlap: 3
-  Vertical: 1
+  values:
+    Default: 0
+    Horizontal: 2
+    HorizontalForceNewRow: 4
+    Overlap: 3
+    Vertical: 1
 UIWidgetModelSceneLayer:
-  Back: 2
-  Front: 1
-  None: 0
+  values:
+    Back: 2
+    Front: 1
+    None: 0
 UIWidgetMotionType:
-  Instant: 0
-  Smooth: 1
+  values:
+    Instant: 0
+    Smooth: 1
 UIWidgetOverrideState:
-  Active: 1
-  Inactive: 0
+  values:
+    Active: 1
+    Inactive: 0
 UIWidgetRewardShownState:
-  Hidden: 0
-  ShownEarned: 1
-  ShownUnearned: 2
+  values:
+    Hidden: 0
+    ShownEarned: 1
+    ShownUnearned: 2
 UIWidgetScale:
-  Eighty: 2
-  Fifty: 5
-  Ninty: 1
-  OneHundred: 0
-  OneHundredEighty: 13
-  OneHundredFifty: 10
-  OneHundredForty: 9
-  OneHundredNinety: 14
-  OneHundredSeventy: 12
-  OneHundredSixty: 11
-  OneHundredTen: 6
-  OneHundredThirty: 8
-  OneHundredTwenty: 7
-  Seventy: 3
-  Sixty: 4
-  TwoHundred: 15
+  values:
+    Eighty: 2
+    Fifty: 5
+    Ninty: 1
+    OneHundred: 0
+    OneHundredEighty: 13
+    OneHundredFifty: 10
+    OneHundredForty: 9
+    OneHundredNinety: 14
+    OneHundredSeventy: 12
+    OneHundredSixty: 11
+    OneHundredTen: 6
+    OneHundredThirty: 8
+    OneHundredTwenty: 7
+    Seventy: 3
+    Sixty: 4
+    TwoHundred: 15
 UIWidgetSetLayoutDirection:
-  Horizontal: 1
-  Overlap: 2
-  Vertical: 0
+  values:
+    Horizontal: 1
+    Overlap: 2
+    Vertical: 0
 UIWidgetSpellButtonCooldownType:
-  HideCooldown: 0
-  ShowCooldown: 1
-  ShowCooldownAndDisableOnCooldown: 2
+  values:
+    HideCooldown: 0
+    ShowCooldown: 1
+    ShowCooldownAndDisableOnCooldown: 2
 UIWidgetTextFormatType:
-  LeadingZeroesWithSixDigits: 3
-  None: 0
-  TimeOneLevel: 1
-  TimeTwoLevel: 2
+  values:
+    LeadingZeroesWithSixDigits: 3
+    None: 0
+    TimeOneLevel: 1
+    TimeTwoLevel: 2
 UIWidgetTextSizeType:
-  Huge27Pt: 3
-  Large20Pt: 8
-  Large24Pt: 2
-  Medium16Pt: 1
-  Medium18Pt: 7
-  Small10Pt: 5
-  Small11Pt: 6
-  Small12Pt: 0
-  Standard14Pt: 4
+  values:
+    Huge27Pt: 3
+    Large20Pt: 8
+    Large24Pt: 2
+    Medium16Pt: 1
+    Medium18Pt: 7
+    Small10Pt: 5
+    Small11Pt: 6
+    Small12Pt: 0
+    Standard14Pt: 4
 UIWidgetTextureAndTextSizeType:
-  Huge: 3
-  Large: 2
-  Medium: 1
-  Medium2: 5
-  Small: 0
-  Standard: 4
+  values:
+    Huge: 3
+    Large: 2
+    Medium: 1
+    Medium2: 5
+    Small: 0
+    Standard: 4
 UIWidgetTooltipLocation:
-  Bottom: 8
-  BottomLeft: 1
-  BottomRight: 7
-  Default: 0
-  Left: 2
-  Right: 6
-  Top: 4
-  TopLeft: 3
-  TopRight: 5
+  values:
+    Bottom: 8
+    BottomLeft: 1
+    BottomRight: 7
+    Default: 0
+    Left: 2
+    Right: 6
+    Top: 4
+    TopLeft: 3
+    TopRight: 5
 UIWidgetUpdateAnimType:
-  Flash: 1
-  FlashAndAnimateNumber: 2
-  None: 0
+  values:
+    Flash: 1
+    FlashAndAnimateNumber: 2
+    None: 0
 UIWidgetVisualizationType:
-  BulletTextList: 10
-  ButtonHeader: 30
-  CaptureBar: 1
-  CaptureZone: 17
-  DiscreteProgressSteps: 19
-  DoubleIconAndText: 5
-  DoubleStateIconRow: 14
-  DoubleStatusBar: 3
-  FillUpFrames: 24
-  HorizontalCurrencies: 9
-  IconAndText: 0
-  IconTextAndBackground: 4
-  IconTextAndCurrencies: 7
-  ItemDisplay: 27
-  MapPinAnimation: 26
-  PreyHuntProgress: 31
-  ScenarioHeaderCurrenciesAndBackground: 11
-  ScenarioHeaderDelves: 29
-  ScenarioHeaderTimer: 20
-  Spacer: 22
-  SpellDisplay: 13
-  StackedResourceTracker: 6
-  StatusBar: 2
-  TextColumnRow: 21
-  TextureAndText: 12
-  TextureAndTextRow: 15
-  TextureWithAnimation: 18
-  TextWithState: 8
-  TextWithSubtext: 25
-  TugOfWar: 28
-  UnitPowerBar: 23
-  ZoneControl: 16
+  values:
+    BulletTextList: 10
+    ButtonHeader: 30
+    CaptureBar: 1
+    CaptureZone: 17
+    DiscreteProgressSteps: 19
+    DoubleIconAndText: 5
+    DoubleStateIconRow: 14
+    DoubleStatusBar: 3
+    FillUpFrames: 24
+    HorizontalCurrencies: 9
+    IconAndText: 0
+    IconTextAndBackground: 4
+    IconTextAndCurrencies: 7
+    ItemDisplay: 27
+    MapPinAnimation: 26
+    PreyHuntProgress: 31
+    ScenarioHeaderCurrenciesAndBackground: 11
+    ScenarioHeaderDelves: 29
+    ScenarioHeaderTimer: 20
+    Spacer: 22
+    SpellDisplay: 13
+    StackedResourceTracker: 6
+    StatusBar: 2
+    TextColumnRow: 21
+    TextureAndText: 12
+    TextureAndTextRow: 15
+    TextureWithAnimation: 18
+    TextWithState: 8
+    TextWithSubtext: 25
+    TugOfWar: 28
+    UnitPowerBar: 23
+    ZoneControl: 16
 UnitAuraSortDirection:
-  Normal: 0
-  Reverse: 1
+  values:
+    Normal: 0
+    Reverse: 1
 UnitAuraSortRule:
-  BigDefensive: 2
-  Default: 1
-  Expiration: 3
-  ExpirationOnly: 4
-  Name: 5
-  NameOnly: 6
-  Unsorted: 0
+  values:
+    BigDefensive: 2
+    Default: 1
+    Expiration: 3
+    ExpirationOnly: 4
+    Name: 5
+    NameOnly: 6
+    Unsorted: 0
 UnitDamageAbsorbClampMode:
-  MaximumHealth: 2
-  MissingHealth: 0
-  MissingHealthWithoutIncomingHeals: 1
+  values:
+    MaximumHealth: 2
+    MissingHealth: 0
+    MissingHealthWithoutIncomingHeals: 1
 UnitHealAbsorbClampMode:
-  CurrentHealth: 0
-  MaximumHealth: 1
+  values:
+    CurrentHealth: 0
+    MaximumHealth: 1
 UnitHealAbsorbMode:
-  ReducedByIncomingHeals: 0
-  Total: 1
+  values:
+    ReducedByIncomingHeals: 0
+    Total: 1
 UnitIncomingHealClampMode:
-  MaximumHealth: 1
-  MissingHealth: 0
+  values:
+    MaximumHealth: 1
+    MissingHealth: 0
 UnitMaximumHealthMode:
-  Default: 0
-  WithAbsorbs: 1
+  values:
+    Default: 0
+    WithAbsorbs: 1
 UnitMirrorPetFlags:
-  Dismissable: 2
-  ExtraPet: 16
-  RecentlyTamed: 4
-  Renameable: 1
-  Stampede: 8
+  values:
+    Dismissable: 2
+    ExtraPet: 16
+    RecentlyTamed: 4
+    Renameable: 1
+    Stampede: 8
 UnitSex:
-  Both: 3
-  Female: 1
-  Male: 0
-  Neutral: 4
-  None: 2
+  values:
+    Both: 3
+    Female: 1
+    Male: 0
+    Neutral: 4
+    None: 2
 UrlTextureResult:
-  Found: 1
-  NotAllowed: 4
-  NotFound: 2
-  Requested: 3
+  values:
+    Found: 1
+    NotAllowed: 4
+    NotFound: 2
+    Requested: 3
 ValidateNameResult:
-  ConsecutiveSpaces: 13
-  DeclensionDoesntMatchBaseName: 16
-  Failure: 1
-  InvalidApostrophe: 9
-  InvalidCharacter: 5
-  InvalidSpace: 12
-  MixedLanguages: 6
-  MultipleApostrophes: 10
-  NoName: 2
-  Profane: 7
-  Reserved: 8
-  RussianConsecutiveSilentCharacters: 14
-  RussianSilentCharacterAtBeginningOrEnd: 15
-  SpacesDisallowed: 17
-  Success: 0
-  ThreeConsecutive: 11
-  TooLong: 4
-  TooShort: 3
+  values:
+    ConsecutiveSpaces: 13
+    DeclensionDoesntMatchBaseName: 16
+    Failure: 1
+    InvalidApostrophe: 9
+    InvalidCharacter: 5
+    InvalidSpace: 12
+    MixedLanguages: 6
+    MultipleApostrophes: 10
+    NoName: 2
+    Profane: 7
+    Reserved: 8
+    RussianConsecutiveSilentCharacters: 14
+    RussianSilentCharacterAtBeginningOrEnd: 15
+    SpacesDisallowed: 17
+    Success: 0
+    ThreeConsecutive: 11
+    TooLong: 4
+    TooShort: 3
 VasPurchaseProgress:
-  ApplyingLicense: 3
-  Complete: 7
-  Invalid: 0
-  PaymentPending: 2
-  PrePurchase: 1
-  ProcessingFactionChange: 6
-  Ready: 5
-  WaitingOnQueue: 4
+  values:
+    ApplyingLicense: 3
+    Complete: 7
+    Invalid: 0
+    PaymentPending: 2
+    PrePurchase: 1
+    ProcessingFactionChange: 6
+    Ready: 5
+    WaitingOnQueue: 4
 VasServiceType:
-  AppearanceChange: 2
-  CharacterTransfer: 4
-  FactionChange: 1
-  FactionTransfer: 5
-  GuildFactionChange: 7
-  GuildFactionTransfer: 9
-  GuildNameChange: 6
-  GuildTransfer: 8
-  NameChange: 0
-  RaceChange: 3
+  values:
+    AppearanceChange: 2
+    CharacterTransfer: 4
+    FactionChange: 1
+    FactionTransfer: 5
+    GuildFactionChange: 7
+    GuildFactionTransfer: 9
+    GuildNameChange: 6
+    GuildTransfer: 8
+    NameChange: 0
+    RaceChange: 3
 VasTransactionPurchaseResult:
-  BeginDbErrors: 20010
-  BeginProxyErrors: 17
-  DbAccountDoesNotOwnCharacter: 20017
-  DbAllianceNotEligible: 20027
-  DbAlreadyRenameFlagged: 20055
-  DbAuthenticatorInsufficient: 20073
-  DbBatchProcessingDisabled: 20028
-  DbBatchStateInvalid: 20067
-  DbBnetAccountNotProvided: 20077
-  DbBoostProcessingDisabled: 20095
-  DbBpayDeliveryPending: 20078
-  DbCagedPetInInventory: 20084
-  DbCannotMoveArenaCaptn: 20064
-  DbCannotMoveGuildmaster: 20012
-  DbCharacterDoesNotExist: 20019
-  DbCharacterWithoutGuild: 20070
-  DbCharLocked: 20026
-  DbCharNotLocked: 20025
-  DbCouldNotObtainCharLock: 20041
-  DbCustomizeAlreadyRequested: 20057
-  DbDeletedGuild: 20071
-  DbDuplicateCharacterName: 20015
-  DbDuplicateSupportRequest: 20063
-  DbEventNotActive: 20068
-  DbEventRealmClosed: 20038
-  DbFactionChangeTooSoon: 20061
-  DbGmSenorityInsufficient: 20072
-  DbGuildLevelInsufficient: 20074
-  DbGuildRankInsufficient: 20069
-  DbHasAuctions: 20033
-  DbHasBpayToken: 20079
-  DbHasCraftingOrders: 20092
-  DbHasHeirloomItem: 20080
-  DbHasMail: 20016
-  DbHasNewPlayerExperienceRestriction: 20091
-  DbHasUnclaimedCacheRewards: 20089
-  DbHouseOwnerRestriction: 20096
-  DbIneligibleMapID: 20076
-  DbIneligibleTargetRealm: 20022
-  DbInvalidName: 20094
-  DbInventoryCorrupt: 20040
-  DbLastCustomizeTooSoon: 20058
-  DbLastRenameTooRecent: 20052
-  DbLastRequestTooSoon: 20054
-  DbLastSaveTooDistant: 20083
-  DbLastSaveTooRecent: 20034
-  DbLockAlreadyRequested: 20044
-  DbLockNotAcknowledged: 20043
-  DbMaxCharactersOnServer: 20013
-  DbMoveInProgress: 20018
-  DbMultipleTransferCn: 20056
-  DbNameChangeSkipped: 20093
-  DbNameNotAvailable: 20051
-  DbNeedsEraChoice: 20090
-  DbNeedsLevelSquish: 20088
-  DbNewLeaderInvalid: 20086
-  DbNewNameTooLong: 20024
-  DbNoCopiesAvailable: 20020
-  DbNoCsiFound: 20065
-  DbNoMixedAlliance: 20014
-  DbNoneBatchQueueID: 20029
-  DbNoneLockID: 20042
-  DbNoneRealmForEvent: 20037
-  DbNoneSupportActionID: 20046
-  DbNoneSupportQueueID: 20045
-  DbNoneTemplateForEvent: 20039
-  DbNotMovebackable: 20048
-  DbNotRollbackable: 20047
-  DbOnBoostCooldown: 20085
-  DbPendingItemAudit: 20066
-  DbPvEPvPTransferNotAllowed: 20087
-  DbRaceClassComboIneligible: 20062
-  DbRealmNotEligible: 20011
-  DbRegionalDbNotFound: 20075
-  DbRenameAlreadyRequested: 20049
-  DbReservationDoesNotMatch: 20053
-  DbReservationExpired: 20050
-  DbResultAccountRestricted: 20082
-  DbResultSourceAccountBanned: 20081
-  DbTooMuchMoneyForLevel: 20032
-  DbTransferDateTooSoon: 20023
-  DbTransferNotCancellable: 20031
-  DbTransferNotFinalized: 20030
-  DbTransferNotLockable: 20035
-  DbTransferNotUnlockable: 20036
-  DbUnableToCustomize: 20060
-  DbUnderMinLevelReq: 20021
-  DbWaitingForPayment: 20059
-  DisallowedDestinationAccount: 9
-  DisallowedSourceAccount: 8
-  EndDbErrors: 20097
-  EndProxyErrors: 56
-  EndServerErrors: 16
-  InvalidBpayDeliverableID: 14
-  InvalidBpayProductID: 13
-  InvalidBpayProductType: 15
-  InvalidDestinationAccount: 6
-  InvalidDestinationRealm: 5
-  InvalidDistribution: 12
-  InvalidSourceAccount: 7
-  LowerBoxLevel: 11
-  None: 0
-  NoneCharacter: 2
-  NoneProduct: 3
-  OnlyOneVasAtATime: 4
-  ProxyAccountDataTooBig: 55
-  ProxyBadDbType: 35
-  ProxyBadObjType: 18
-  ProxyBadRequestContained: 33
-  ProxyBindFailed: 51
-  ProxyCannotDeleteArenaCaptain: 31
-  ProxyCannotDeleteGuildLeader: 30
-  ProxyCannotInsertNull: 45
-  ProxyCannotUndeleteTrialBoostCharacter: 46
-  ProxyCharacterHasWoWToken: 53
-  ProxyCharacterLevelTooHigh: 38
-  ProxyCharacterTransferred: 39
-  ProxyCharacterTransferredNoBoostInProgress: 40
-  ProxyDataInvalid: 22
-  ProxyDbError: 21
-  ProxyDeleteNotSupported: 28
-  ProxyExternalUpdateDetected: 37
-  ProxyGenericError: 44
-  ProxyInsertRequestContainedNoData: 49
-  ProxyInvalidKey: 50
-  ProxyIsReadonly: 34
-  ProxyLockedForToken: 42
-  ProxyLockedForTransfer: 26
-  ProxyLockedForUpgrade: 41
-  ProxyLockedForVas: 43
-  ProxyLocksFailed: 24
-  ProxyLostProxyConnection: 23
-  ProxyMissingResultsPtr: 25
-  ProxyMoneyLimitExceeded: 32
-  ProxyNoReturnValue: 27
-  ProxyObjDropped: 29
-  ProxyObjNotInDb: 19
-  ProxyOperationAlreadyInProgress: 36
-  ProxyPredicateFailed: 47
-  ProxyTooBusyBackOff: 54
-  ProxyTooManyRows: 52
-  ProxyUniqueKey: 20
-  ProxyWeeklyRewardNotFound: 48
-  UnknownError: 10
-  VasPurchaseDisabled: 1
+  values:
+    BeginDbErrors: 20010
+    BeginProxyErrors: 17
+    DbAccountDoesNotOwnCharacter: 20017
+    DbAllianceNotEligible: 20027
+    DbAlreadyRenameFlagged: 20055
+    DbAuthenticatorInsufficient: 20073
+    DbBatchProcessingDisabled: 20028
+    DbBatchStateInvalid: 20067
+    DbBnetAccountNotProvided: 20077
+    DbBoostProcessingDisabled: 20095
+    DbBpayDeliveryPending: 20078
+    DbCagedPetInInventory: 20084
+    DbCannotMoveArenaCaptn: 20064
+    DbCannotMoveGuildmaster: 20012
+    DbCharacterDoesNotExist: 20019
+    DbCharacterWithoutGuild: 20070
+    DbCharLocked: 20026
+    DbCharNotLocked: 20025
+    DbCouldNotObtainCharLock: 20041
+    DbCustomizeAlreadyRequested: 20057
+    DbDeletedGuild: 20071
+    DbDuplicateCharacterName: 20015
+    DbDuplicateSupportRequest: 20063
+    DbEventNotActive: 20068
+    DbEventRealmClosed: 20038
+    DbFactionChangeTooSoon: 20061
+    DbGmSenorityInsufficient: 20072
+    DbGuildLevelInsufficient: 20074
+    DbGuildRankInsufficient: 20069
+    DbHasAuctions: 20033
+    DbHasBpayToken: 20079
+    DbHasCraftingOrders: 20092
+    DbHasHeirloomItem: 20080
+    DbHasMail: 20016
+    DbHasNewPlayerExperienceRestriction: 20091
+    DbHasUnclaimedCacheRewards: 20089
+    DbHouseOwnerRestriction: 20096
+    DbIneligibleMapID: 20076
+    DbIneligibleTargetRealm: 20022
+    DbInvalidName: 20094
+    DbInventoryCorrupt: 20040
+    DbLastCustomizeTooSoon: 20058
+    DbLastRenameTooRecent: 20052
+    DbLastRequestTooSoon: 20054
+    DbLastSaveTooDistant: 20083
+    DbLastSaveTooRecent: 20034
+    DbLockAlreadyRequested: 20044
+    DbLockNotAcknowledged: 20043
+    DbMaxCharactersOnServer: 20013
+    DbMoveInProgress: 20018
+    DbMultipleTransferCn: 20056
+    DbNameChangeSkipped: 20093
+    DbNameNotAvailable: 20051
+    DbNeedsEraChoice: 20090
+    DbNeedsLevelSquish: 20088
+    DbNewLeaderInvalid: 20086
+    DbNewNameTooLong: 20024
+    DbNoCopiesAvailable: 20020
+    DbNoCsiFound: 20065
+    DbNoMixedAlliance: 20014
+    DbNoneBatchQueueID: 20029
+    DbNoneLockID: 20042
+    DbNoneRealmForEvent: 20037
+    DbNoneSupportActionID: 20046
+    DbNoneSupportQueueID: 20045
+    DbNoneTemplateForEvent: 20039
+    DbNotMovebackable: 20048
+    DbNotRollbackable: 20047
+    DbOnBoostCooldown: 20085
+    DbPendingItemAudit: 20066
+    DbPvEPvPTransferNotAllowed: 20087
+    DbRaceClassComboIneligible: 20062
+    DbRealmNotEligible: 20011
+    DbRegionalDbNotFound: 20075
+    DbRenameAlreadyRequested: 20049
+    DbReservationDoesNotMatch: 20053
+    DbReservationExpired: 20050
+    DbResultAccountRestricted: 20082
+    DbResultSourceAccountBanned: 20081
+    DbTooMuchMoneyForLevel: 20032
+    DbTransferDateTooSoon: 20023
+    DbTransferNotCancellable: 20031
+    DbTransferNotFinalized: 20030
+    DbTransferNotLockable: 20035
+    DbTransferNotUnlockable: 20036
+    DbUnableToCustomize: 20060
+    DbUnderMinLevelReq: 20021
+    DbWaitingForPayment: 20059
+    DisallowedDestinationAccount: 9
+    DisallowedSourceAccount: 8
+    EndDbErrors: 20097
+    EndProxyErrors: 56
+    EndServerErrors: 16
+    InvalidBpayDeliverableID: 14
+    InvalidBpayProductID: 13
+    InvalidBpayProductType: 15
+    InvalidDestinationAccount: 6
+    InvalidDestinationRealm: 5
+    InvalidDistribution: 12
+    InvalidSourceAccount: 7
+    LowerBoxLevel: 11
+    None: 0
+    NoneCharacter: 2
+    NoneProduct: 3
+    OnlyOneVasAtATime: 4
+    ProxyAccountDataTooBig: 55
+    ProxyBadDbType: 35
+    ProxyBadObjType: 18
+    ProxyBadRequestContained: 33
+    ProxyBindFailed: 51
+    ProxyCannotDeleteArenaCaptain: 31
+    ProxyCannotDeleteGuildLeader: 30
+    ProxyCannotInsertNull: 45
+    ProxyCannotUndeleteTrialBoostCharacter: 46
+    ProxyCharacterHasWoWToken: 53
+    ProxyCharacterLevelTooHigh: 38
+    ProxyCharacterTransferred: 39
+    ProxyCharacterTransferredNoBoostInProgress: 40
+    ProxyDataInvalid: 22
+    ProxyDbError: 21
+    ProxyDeleteNotSupported: 28
+    ProxyExternalUpdateDetected: 37
+    ProxyGenericError: 44
+    ProxyInsertRequestContainedNoData: 49
+    ProxyInvalidKey: 50
+    ProxyIsReadonly: 34
+    ProxyLockedForToken: 42
+    ProxyLockedForTransfer: 26
+    ProxyLockedForUpgrade: 41
+    ProxyLockedForVas: 43
+    ProxyLocksFailed: 24
+    ProxyLostProxyConnection: 23
+    ProxyMissingResultsPtr: 25
+    ProxyMoneyLimitExceeded: 32
+    ProxyNoReturnValue: 27
+    ProxyObjDropped: 29
+    ProxyObjNotInDb: 19
+    ProxyOperationAlreadyInProgress: 36
+    ProxyPredicateFailed: 47
+    ProxyTooBusyBackOff: 54
+    ProxyTooManyRows: 52
+    ProxyUniqueKey: 20
+    ProxyWeeklyRewardNotFound: 48
+    UnknownError: 10
+    VasPurchaseDisabled: 1
 ViewArenaSize:
-  Three: 1
-  Two: 0
+  values:
+    Three: 1
+    Two: 0
 ViewRaidSize:
-  Forty: 2
-  Ten: 0
-  TwentyFive: 1
+  values:
+    Forty: 2
+    Ten: 0
+    TwentyFive: 1
 VignetteObjectiveType:
-  Defeat: 1
-  DefeatShowRemainingHealth: 2
-  None: 0
+  values:
+    Defeat: 1
+    DefeatShowRemainingHealth: 2
+    None: 0
 VignetteType:
-  FyrakkFlight: 4
-  Normal: 0
-  PvPBounty: 1
-  Torghast: 2
-  Treasure: 3
+  values:
+    FyrakkFlight: 4
+    Normal: 0
+    PvPBounty: 1
+    Torghast: 2
+    Treasure: 3
 Vocalerrorsounds:
-  Abilitycooling: 50
-  Alreadyingroup: 20
-  Alreadyinguild: 21
-  Ammoonlyinbag: 28
-  Bagfull: 29
-  BoundNodrop: 4
-  Cantaffordbankslot: 22
-  CantattackNotarget: 38
-  CantattackNotstandingObsolete: 37
-  Cantattackrongdirection: 36
-  CantcastOutofrange: 46
-  Cantcreate: 18
-  Cantdrinkmore: 6
-  Canteatmore: 7
-  CanteatMoving: 24
-  Cantequip2Hequipped: 42
-  Cantequip2HNoskill: 43
-  Cantequip2HSkill: 41
-  Cantflyhere: 60
-  Cantinvite: 8
-  CantlearnLevel: 13
-  Cantloot: 17
-  CantlootDidntkill: 31
-  CantlootLocked: 33
-  CantlootNotstandingObsolete: 34
-  CantlootToofar: 35
-  CantlootWrongfacing: 32
-  Cantputbag: 26
-  Cantswap: 58
-  CanttaxiNomoney: 54
-  CanttradeSoulbound: 59
-  Cantuseitem: 51
-  Cantuselocked: 55
-  Cantusetoofar: 57
-  Chestinuse: 52
-  Declinegroup: 19
-  ExhaustedObsolete: 67
-  FoodcoolingObsolete: 53
-  Genericnotarget: 45
-  Guildpermissions: 62
-  Invaliditemtarget: 66
-  Invalidtarget: 11
-  Inventoryfull: 0
-  Inviteebusy: 9
-  Itemcooling: 5
-  Itemlocked: 61
-  Itemmaxcount: 30
-  Locked: 14
-  Mustequippitem: 49
-  Noenergy: 64
-  NoequipEver: 3
-  NoequipLevel: 2
-  Noequipslotavailable: 56
-  Noessence: 65
-  Nomana: 15
-  Norage: 63
-  Notabag: 25
-  Notenoughgold: 39
-  Notenoughmoney: 40
-  Notequippable: 44
-  Notwhiledead: 16
-  Outofammo: 1
-  Potioncooling: 47
-  Proficiencyneeded: 48
-  Spellcooling: 12
-  Targettoofar: 10
-  Toomanybankslots: 23
-  Wrongslot: 27
+  values:
+    Abilitycooling: 50
+    Alreadyingroup: 20
+    Alreadyinguild: 21
+    Ammoonlyinbag: 28
+    Bagfull: 29
+    BoundNodrop: 4
+    Cantaffordbankslot: 22
+    CantattackNotarget: 38
+    CantattackNotstandingObsolete: 37
+    Cantattackrongdirection: 36
+    CantcastOutofrange: 46
+    Cantcreate: 18
+    Cantdrinkmore: 6
+    Canteatmore: 7
+    CanteatMoving: 24
+    Cantequip2Hequipped: 42
+    Cantequip2HNoskill: 43
+    Cantequip2HSkill: 41
+    Cantflyhere: 60
+    Cantinvite: 8
+    CantlearnLevel: 13
+    Cantloot: 17
+    CantlootDidntkill: 31
+    CantlootLocked: 33
+    CantlootNotstandingObsolete: 34
+    CantlootToofar: 35
+    CantlootWrongfacing: 32
+    Cantputbag: 26
+    Cantswap: 58
+    CanttaxiNomoney: 54
+    CanttradeSoulbound: 59
+    Cantuseitem: 51
+    Cantuselocked: 55
+    Cantusetoofar: 57
+    Chestinuse: 52
+    Declinegroup: 19
+    ExhaustedObsolete: 67
+    FoodcoolingObsolete: 53
+    Genericnotarget: 45
+    Guildpermissions: 62
+    Invaliditemtarget: 66
+    Invalidtarget: 11
+    Inventoryfull: 0
+    Inviteebusy: 9
+    Itemcooling: 5
+    Itemlocked: 61
+    Itemmaxcount: 30
+    Locked: 14
+    Mustequippitem: 49
+    Noenergy: 64
+    NoequipEver: 3
+    NoequipLevel: 2
+    Noequipslotavailable: 56
+    Noessence: 65
+    Nomana: 15
+    Norage: 63
+    Notabag: 25
+    Notenoughgold: 39
+    Notenoughmoney: 40
+    Notequippable: 44
+    Notwhiledead: 16
+    Outofammo: 1
+    Potioncooling: 47
+    Proficiencyneeded: 48
+    Spellcooling: 12
+    Targettoofar: 10
+    Toomanybankslots: 23
+    Wrongslot: 27
 VoiceChannelErrorReason:
-  IsBattleNetChannel: 1
-  Unknown: 0
+  values:
+    IsBattleNetChannel: 1
+    Unknown: 0
 VoiceChatStatusCode:
-  AlreadyInChannel: 10
-  ChannelAlreadyExists: 9
-  ChannelNameTooLong: 8
-  ChannelNameTooShort: 7
-  ClientAlreadyLoggedIn: 6
-  ClientNotInitialized: 4
-  ClientNotLoggedIn: 5
-  Disabled: 18
-  Failure: 12
-  InvalidCommunityStream: 20
-  InvalidInputDevice: 23
-  InvalidOutputDevice: 24
-  LoginProhibited: 3
-  OperationPending: 1
-  PlayerSilenced: 21
-  PlayerVoiceChatParentalDisabled: 22
-  ProxyConnectionTimeOut: 15
-  ProxyConnectionUnableToConnect: 16
-  ProxyConnectionUnexpectedDisconnect: 17
-  ServiceLost: 13
-  Success: 0
-  TargetNotFound: 11
-  TooManyRequests: 2
-  UnableToLaunchProxy: 14
-  UnsupportedChatChannelType: 19
+  values:
+    AlreadyInChannel: 10
+    ChannelAlreadyExists: 9
+    ChannelNameTooLong: 8
+    ChannelNameTooShort: 7
+    ClientAlreadyLoggedIn: 6
+    ClientNotInitialized: 4
+    ClientNotLoggedIn: 5
+    Disabled: 18
+    Failure: 12
+    InvalidCommunityStream: 20
+    InvalidInputDevice: 23
+    InvalidOutputDevice: 24
+    LoginProhibited: 3
+    OperationPending: 1
+    PlayerSilenced: 21
+    PlayerVoiceChatParentalDisabled: 22
+    ProxyConnectionTimeOut: 15
+    ProxyConnectionUnableToConnect: 16
+    ProxyConnectionUnexpectedDisconnect: 17
+    ServiceLost: 13
+    Success: 0
+    TargetNotFound: 11
+    TooManyRequests: 2
+    UnableToLaunchProxy: 14
+    UnsupportedChatChannelType: 19
 VoiceTtsStatusCode:
-  DestinationQueueFull: 8
-  EngineAllocationFailed: 2
-  EnqueueNotNecessary: 9
-  InputTextEnqueued: 6
-  InternalError: 13
-  InvalidArgument: 12
-  InvalidEngineType: 1
-  ManagerNotFound: 11
-  MaxCharactersExceeded: 4
-  NotSupported: 3
-  SdkNotInitialized: 7
-  Success: 0
-  UtteranceBelowMinimumDuration: 5
-  UtteranceNotFound: 10
+  values:
+    DestinationQueueFull: 8
+    EngineAllocationFailed: 2
+    EnqueueNotNecessary: 9
+    InputTextEnqueued: 6
+    InternalError: 13
+    InvalidArgument: 12
+    InvalidEngineType: 1
+    ManagerNotFound: 11
+    MaxCharactersExceeded: 4
+    NotSupported: 3
+    SdkNotInitialized: 7
+    Success: 0
+    UtteranceBelowMinimumDuration: 5
+    UtteranceNotFound: 10
 WarbandSceneFlags:
-  AwardedAutomatically: 8
-  CannotBeSaved: 4
-  DoNotInclude: 1
-  HiddenUntilCollected: 2
-  IsDefault: 16
+  values:
+    AwardedAutomatically: 8
+    CannotBeSaved: 4
+    DoNotInclude: 1
+    HiddenUntilCollected: 2
+    IsDefault: 16
 WeaponSlot:
-  MainHand: 0
-  OffHand: 1
+  values:
+    MainHand: 0
+    OffHand: 1
 WeeklyRewardChestActivityType:
-  LFGDungeons: 1
-  Scenario: 0
-  World: 2
+  values:
+    LFGDungeons: 1
+    Scenario: 0
+    World: 2
 WeeklyRewardChestClaimRewardResult:
-  CountExceeded: 7
-  DbError: 5
-  InvalidSlot: 3
-  InvalidThreshold: 1
-  LockFailure: 6
-  PlayerNotFound: 2
-  Success: 0
-  TooManyItems: 4
+  values:
+    CountExceeded: 7
+    DbError: 5
+    InvalidSlot: 3
+    InvalidThreshold: 1
+    LockFailure: 6
+    PlayerNotFound: 2
+    Success: 0
+    TooManyItems: 4
 WeeklyRewardChestThresholdType:
-  Activities: 1
-  AlsoReceive: 4
-  Concession: 5
-  None: 0
-  Raid: 3
-  RankedPvP: 2
-  World: 6
+  values:
+    Activities: 1
+    AlsoReceive: 4
+    Concession: 5
+    None: 0
+    Raid: 3
+    RankedPvP: 2
+    World: 6
 WeeklyRewardProgressResult:
-  DbError: 3
-  NoPlayer: 4
-  NoSeason: 1
-  Success: 0
-  TimedOut: 2
+  values:
+    DbError: 3
+    NoPlayer: 4
+    NoSeason: 1
+    Success: 0
+    TimedOut: 2
 WidgetAnimationType:
-  Fade: 1
-  None: 0
+  values:
+    Fade: 1
+    None: 0
 WidgetCurrencyClass:
-  Currency: 0
-  Item: 1
+  values:
+    Currency: 0
+    Item: 1
 WidgetEnabledState:
-  Artifact: 5
-  Black: 6
-  BrightBlue: 7
-  Disabled: 0
-  Green: 4
-  Red: 2
-  White: 3
-  Yellow: 1
+  values:
+    Artifact: 5
+    Black: 6
+    BrightBlue: 7
+    Disabled: 0
+    Green: 4
+    Red: 2
+    White: 3
+    Yellow: 1
 WidgetGlowAnimType:
-  None: 0
-  Pulse: 1
+  values:
+    None: 0
+    Pulse: 1
 WidgetIconSizeType:
-  Large: 2
-  Medium: 1
-  Small: 0
-  Standard: 3
+  values:
+    Large: 2
+    Medium: 1
+    Small: 0
+    Standard: 3
 WidgetIconSourceType:
-  Item: 1
-  Spell: 0
+  values:
+    Item: 1
+    Spell: 0
 WidgetOpacityType:
-  Eighty: 2
-  Fifty: 5
-  Forty: 6
-  Ninety: 1
-  OneHundred: 0
-  Seventy: 3
-  Sixty: 4
-  Ten: 9
-  Thirty: 7
-  Twenty: 8
-  Zero: 10
+  values:
+    Eighty: 2
+    Fifty: 5
+    Forty: 6
+    Ninety: 1
+    OneHundred: 0
+    Seventy: 3
+    Sixty: 4
+    Ten: 9
+    Thirty: 7
+    Twenty: 8
+    Zero: 10
 WidgetShowGlowState:
-  HideGlow: 0
-  ShowGlow: 1
+  values:
+    HideGlow: 0
+    ShowGlow: 1
 WidgetShownState:
-  Hidden: 0
-  Shown: 1
+  values:
+    Hidden: 0
+    Shown: 1
 WidgetTextHorizontalAlignmentType:
-  Center: 1
-  Left: 0
-  Right: 2
+  values:
+    Center: 1
+    Left: 0
+    Right: 2
 WidgetUnitPowerBarFlashMomentType:
-  FlashWhenMax: 0
-  FlashWhenMin: 1
-  NeverFlash: 2
+  values:
+    FlashWhenMax: 0
+    FlashWhenMin: 1
+    NeverFlash: 2
 WorldCursorAnchorType:
-  Cursor: 2
-  Default: 1
-  Nameplate: 3
-  None: 0
+  values:
+    Cursor: 2
+    Default: 1
+    Nameplate: 3
+    None: 0
 WorldElapsedTimerTypes:
-  ChallengeMode: 1
-  None: 0
-  ProvingGround: 2
+  values:
+    ChallengeMode: 1
+    None: 0
+    ProvingGround: 2
 WorldQuestQuality:
-  Common: 0
-  Epic: 2
-  Rare: 1
+  values:
+    Common: 0
+    Epic: 2
+    Rare: 1
 WorldTierDifficulty:
-  Heroic: 2
-  Mythic: 3
-  Normal: 1
+  values:
+    Heroic: 2
+    Mythic: 3
+    Normal: 1
 WoWClientCursorSize:
-  ExtraLarge: 3
-  Large: 2
-  Massive: 4
-  Medium: 1
-  Standard: 0
+  values:
+    ExtraLarge: 3
+    Large: 2
+    Massive: 4
+    Medium: 1
+    Standard: 0
 WoWEntitlementType:
-  Appearance: 4
-  AppearanceSet: 5
-  Battlepet: 2
-  GameTime: 6
-  Illusion: 8
-  Invalid: 9
-  Item: 0
-  Mount: 1
-  Title: 7
-  Toy: 3
+  values:
+    Appearance: 4
+    AppearanceSet: 5
+    Battlepet: 2
+    GameTime: 6
+    Illusion: 8
+    Invalid: 9
+    Item: 0
+    Mount: 1
+    Title: 7
+    Toy: 3
 WoWLabsAreaType:
-  PlunderstormDropDense: 2
-  PlunderstormDropMedium: 1
-  PlunderstormDropSparse: 0
+  values:
+    PlunderstormDropDense: 2
+    PlunderstormDropMedium: 1
+    PlunderstormDropSparse: 0
 ZoneControlActiveState:
-  Active: 1
-  Inactive: 0
+  values:
+    Active: 1
+    Inactive: 0
 ZoneControlDangerFlashType:
-  ShowOnBadStates: 1
-  ShowOnBoth: 2
-  ShowOnGoodStates: 0
-  ShowOnNeither: 3
+  values:
+    ShowOnBadStates: 1
+    ShowOnBoth: 2
+    ShowOnGoodStates: 0
+    ShowOnNeither: 3
 ZoneControlFillType:
-  DoubleFillClockwise: 2
-  DoubleFillCounterClockwise: 3
-  SingleFillClockwise: 0
-  SingleFillCounterClockwise: 1
+  values:
+    DoubleFillClockwise: 2
+    DoubleFillCounterClockwise: 3
+    SingleFillClockwise: 0
+    SingleFillCounterClockwise: 1
 ZoneControlLeadingEdgeType:
-  NoLeadingEdge: 0
-  UseLeadingEdge: 1
+  values:
+    NoLeadingEdge: 0
+    UseLeadingEdge: 1
 ZoneControlMode:
-  BothStatesAreGood: 0
-  NeitherStateIsGood: 3
-  State1IsGood: 1
-  State2IsGood: 2
+  values:
+    BothStatesAreGood: 0
+    NeitherStateIsGood: 3
+    State1IsGood: 1
+    State2IsGood: 2
 ZoneControlState:
-  State1: 0
-  State2: 1
+  values:
+    State1: 0
+    State2: 1

--- a/data/products/wow_anniversary/enums.yaml
+++ b/data/products/wow_anniversary/enums.yaml
@@ -1,7214 +1,8007 @@
 AbbreviationDataError:
-  InvalidBreakpoint: 1
-  InvalidFractionDivisor: 4
-  InvalidSignificandDivisor: 2
-  NotMultipleOfTen: 8
+  values:
+    InvalidBreakpoint: 1
+    InvalidFractionDivisor: 4
+    InvalidSignificandDivisor: 2
+    NotMultipleOfTen: 8
 AccountCurrencyTransferResult:
-  CannotUseCurrency: 8
-  CharacterLoggedIn: 2
-  CurrencyTransferDisabled: 10
-  InsufficientCurrency: 3
-  InvalidCharacter: 1
-  InvalidCurrency: 5
-  MaxQuantity: 4
-  NoValidSourceCharacter: 6
-  ServerError: 7
-  Success: 0
-  TransactionInProgress: 9
+  values:
+    CannotUseCurrency: 8
+    CharacterLoggedIn: 2
+    CurrencyTransferDisabled: 10
+    InsufficientCurrency: 3
+    InvalidCharacter: 1
+    InvalidCurrency: 5
+    MaxQuantity: 4
+    NoValidSourceCharacter: 6
+    ServerError: 7
+    Success: 0
+    TransactionInProgress: 9
 AccountData:
-  Bindings: 2
-  Bindings2: 3
-  CharacterListOrder: 16
-  ChatSettings: 7
-  ClickBindings: 12
-  Config: 0
-  Config2: 1
-  CooldownManager: 17
-  CooldownManager2: 18
-  FlaggedIDs: 10
-  FlaggedIDs2: 11
-  FrontendChatSettings: 15
-  Macros: 4
-  Macros2: 5
-  Shop2PendingOrders: 19
-  TtsSettings: 8
-  TtsSettings2: 9
-  UIEditModeAccount: 13
-  UIEditModeChar: 14
-  UILayout: 6
+  values:
+    Bindings: 2
+    Bindings2: 3
+    CharacterListOrder: 16
+    ChatSettings: 7
+    ClickBindings: 12
+    Config: 0
+    Config2: 1
+    CooldownManager: 17
+    CooldownManager2: 18
+    FlaggedIDs: 10
+    FlaggedIDs2: 11
+    FrontendChatSettings: 15
+    Macros: 4
+    Macros2: 5
+    Shop2PendingOrders: 19
+    TtsSettings: 8
+    TtsSettings2: 9
+    UIEditModeAccount: 13
+    UIEditModeChar: 14
+    UILayout: 6
 AccountDataUpdateStatus:
-  Corrupt: 2
-  Failed: 1
-  Success: 0
-  Toobig: 3
+  values:
+    Corrupt: 2
+    Failed: 1
+    Success: 0
+    Toobig: 3
 AccountExportResult:
-  AlreadyInProgress: 11
-  Cancelled: 2
-  FailedToGenerateFile: 13
-  FailedToLockAccount: 12
-  FileInvalid: 8
-  FileWriteFailed: 9
-  NoAccountFound: 5
-  RequestedInvalidCharacter: 6
-  RpcError: 7
-  ShuttingDown: 3
-  Success: 0
-  TimedOut: 4
-  Unavailable: 10
-  UnknownError: 1
+  values:
+    AlreadyInProgress: 11
+    Cancelled: 2
+    FailedToGenerateFile: 13
+    FailedToLockAccount: 12
+    FileInvalid: 8
+    FileWriteFailed: 9
+    NoAccountFound: 5
+    RequestedInvalidCharacter: 6
+    RpcError: 7
+    ShuttingDown: 3
+    Success: 0
+    TimedOut: 4
+    Unavailable: 10
+    UnknownError: 1
 AccountSequenceCacheType:
-  HouseDecor: 2
-  Invalid: 0
-  Local: 1
+  values:
+    HouseDecor: 2
+    Invalid: 0
+    Local: 1
 AccountStateFlags:
-  AccountUpgradeComplete: 4
-  InPetCombat: 2
-  LoadFailed: 1
-  None: 0
-  TokenEligCheckComplete: 8
+  values:
+    AccountUpgradeComplete: 4
+    InPetCombat: 2
+    LoadFailed: 1
+    None: 0
+    TokenEligCheckComplete: 8
 AccountStateLoadedFlags:
-  AccountCurrenciesLoaded: '0x0000000000200000'
-  AccountFactionsLoaded: '0x0000000200000000'
-  AccountItemsLoaded: '0x0000000400000000'
-  AccountMappingLoaded: '0x0000008000000000'
-  AccountNotificationsLoaded: '0x0000000008000000'
-  AccountWowlabsLoaded: '0x0000000020000000'
-  AchievementsLoaded: '0x0000000000000001'
-  ArchivedPurchasesLoaded: '0x0000000000000200'
-  AuctionableTokensLoaded: '0x0000000000002000'
-  BanktabSettingsLoaded: '0x0000004000000000'
-  BattleNetAccountLoaded: '0x0000000000100000'
-  BitVectorsLoaded: '0x0000000100000000'
-  BpayAddLicenseObjectsLoaded: '0x0000000000000800'
-  BpayDistributionObjectsLoaded: '0x0000000000000100'
-  BpayProductitemObjectsLoaded: '0x0000000000020000'
-  CharacterItemsLoaded: '0x0000010000000000'
-  CharactersLoaded: '0x0000000000000040'
-  CombinedQuestLogLoaded: '0x0000000800000000'
-  ConsumableTokensLoaded: '0x0000000000004000'
-  CriteriaLoaded: '0x0000000000000002'
-  CurrencyCapsLoaded: '0x0000000000000010'
-  CurrencyTransferLogLoaded: '0x0000020000000000'
-  DataElementsLoaded: '0x0000001000000000'
-  DynamicCriteriaLoaded: '0x0000000001000000'
-  EventRecordsLoaded: '0x0000200000000000'
-  HousingDataLoaded: '0x0000080000000000'
-  ItemCollectionsLoaded: '0x0000000000001000'
-  LgVendorPurchaseLoaded: '0x0000040000000000'
-  LoadedNone: '0x0000000000000000'
-  MountsLoaded: '0x0000000000000004'
-  PerksHeldItemLoaded: '0x0000000040000000'
-  PerksPastRewardsLoaded: '0x0000000000008000'
-  PerksPendingPurchaseLoaded: '0x0000000010000000'
-  PerksPendingRewardsLoaded: '0x0000000080000000'
-  PetjournalInitialized: '0x0000000000000008'
-  PurchasesLoaded: '0x0000000000000080'
-  QuestCriteriaLoaded: '0x0000000000080000'
-  QuestLogLoaded: '0x0000000000000020'
-  RafActivityLoaded: '0x0000000002000000'
-  RafBalanceLoaded: '0x0000000000400000'
-  RafRewardsLoaded: '0x0000000000800000'
-  RevokedRafRewardsLoaded: '0x0000000004000000'
-  SettingsLoaded: '0x0000000000000400'
-  TransmogOutfitsLoaded: '0x0000400000000000'
-  TrialBoostHistoryLoaded: '0x0000000000040000'
-  VasTransactionsLoaded: '0x0000000000010000'
-  WarbandScenesLoaded: '0x0000100000000000'
-  WarbandsLoaded: '0x0000002000000000'
+  values:
+    AccountCurrenciesLoaded: '0x0000000000200000'
+    AccountFactionsLoaded: '0x0000000200000000'
+    AccountItemsLoaded: '0x0000000400000000'
+    AccountMappingLoaded: '0x0000008000000000'
+    AccountNotificationsLoaded: '0x0000000008000000'
+    AccountWowlabsLoaded: '0x0000000020000000'
+    AchievementsLoaded: '0x0000000000000001'
+    ArchivedPurchasesLoaded: '0x0000000000000200'
+    AuctionableTokensLoaded: '0x0000000000002000'
+    BanktabSettingsLoaded: '0x0000004000000000'
+    BattleNetAccountLoaded: '0x0000000000100000'
+    BitVectorsLoaded: '0x0000000100000000'
+    BpayAddLicenseObjectsLoaded: '0x0000000000000800'
+    BpayDistributionObjectsLoaded: '0x0000000000000100'
+    BpayProductitemObjectsLoaded: '0x0000000000020000'
+    CharacterItemsLoaded: '0x0000010000000000'
+    CharactersLoaded: '0x0000000000000040'
+    CombinedQuestLogLoaded: '0x0000000800000000'
+    ConsumableTokensLoaded: '0x0000000000004000'
+    CriteriaLoaded: '0x0000000000000002'
+    CurrencyCapsLoaded: '0x0000000000000010'
+    CurrencyTransferLogLoaded: '0x0000020000000000'
+    DataElementsLoaded: '0x0000001000000000'
+    DynamicCriteriaLoaded: '0x0000000001000000'
+    EventRecordsLoaded: '0x0000200000000000'
+    HousingDataLoaded: '0x0000080000000000'
+    ItemCollectionsLoaded: '0x0000000000001000'
+    LgVendorPurchaseLoaded: '0x0000040000000000'
+    LoadedNone: '0x0000000000000000'
+    MountsLoaded: '0x0000000000000004'
+    PerksHeldItemLoaded: '0x0000000040000000'
+    PerksPastRewardsLoaded: '0x0000000000008000'
+    PerksPendingPurchaseLoaded: '0x0000000010000000'
+    PerksPendingRewardsLoaded: '0x0000000080000000'
+    PetjournalInitialized: '0x0000000000000008'
+    PurchasesLoaded: '0x0000000000000080'
+    QuestCriteriaLoaded: '0x0000000000080000'
+    QuestLogLoaded: '0x0000000000000020'
+    RafActivityLoaded: '0x0000000002000000'
+    RafBalanceLoaded: '0x0000000000400000'
+    RafRewardsLoaded: '0x0000000000800000'
+    RevokedRafRewardsLoaded: '0x0000000004000000'
+    SettingsLoaded: '0x0000000000000400'
+    TransmogOutfitsLoaded: '0x0000400000000000'
+    TrialBoostHistoryLoaded: '0x0000000000040000'
+    VasTransactionsLoaded: '0x0000000000010000'
+    WarbandScenesLoaded: '0x0000100000000000'
+    WarbandsLoaded: '0x0000002000000000'
 AccountStoreCategoryType:
-  Creature: 1
-  Icon: 4
-  Mount: 3
-  TransmogSet: 2
+  values:
+    Creature: 1
+    Icon: 4
+    Mount: 3
+    TransmogSet: 2
 AccountStoreFrontFlag:
-  Enabled: 1
-  PurchaseEnabled: 2
-  RefundEnabled: 4
+  values:
+    Enabled: 1
+    PurchaseEnabled: 2
+    RefundEnabled: 4
 AccountStoreItemFlag:
-  DisplayAsNew: 4
-  DisplayDefaultArmor: 1
-  DisplayOnly: 8
-  NotInGameReward: 2
+  values:
+    DisplayAsNew: 4
+    DisplayDefaultArmor: 1
+    DisplayOnly: 8
+    NotInGameReward: 2
 AccountStoreItemMode:
-  Hidden: 2
-  Locked: 3
-  Normal: 1
+  values:
+    Hidden: 2
+    Locked: 3
+    Normal: 1
 AccountStoreItemRewardType:
-  Illusion: 7
-  Misc: 10
-  Mount: 2
-  Pet: 3
-  Tender: 9
-  Toy: 5
-  Transmog: 1
-  TransmogSet: 8
-  WarbandScene: 11
+  values:
+    Illusion: 7
+    Misc: 10
+    Mount: 2
+    Pet: 3
+    Tender: 9
+    Toy: 5
+    Transmog: 1
+    TransmogSet: 8
+    WarbandScene: 11
 AccountStoreItemStatus:
-  Owned: 3
-  Refundable: 2
-  Unowned: 1
+  values:
+    Owned: 3
+    Refundable: 2
+    Unowned: 1
 AccountStoreSettlementAction:
-  Give: 1
-  NotSet: 0
-  Remove: 2
+  values:
+    Give: 1
+    NotSet: 0
+    Remove: 2
 AccountStoreState:
-  Available: 0
-  Unavailable: 2
-  Unknown: 1
+  values:
+    Available: 0
+    Unavailable: 2
+    Unknown: 1
 AccountStoreTransactionResult:
-  Incomplete: 1
-  InsufficientFunds: 4
-  InvalidCurrencyType: 8
-  ItemAlreadyOwned: 6
-  ItemNotOwned: 7
-  ItemUnknown: 5
-  NotSupported: 10
-  OwnedButRefundTimeExpired: 9
-  ProxyError: 12
-  Success: 0
-  TransactionInProgress: 3
-  Unavailable: 11
-  UnknownError: 2
+  values:
+    Incomplete: 1
+    InsufficientFunds: 4
+    InvalidCurrencyType: 8
+    ItemAlreadyOwned: 6
+    ItemNotOwned: 7
+    ItemUnknown: 5
+    NotSupported: 10
+    OwnedButRefundTimeExpired: 9
+    ProxyError: 12
+    Success: 0
+    TransactionInProgress: 3
+    Unavailable: 11
+    UnknownError: 2
 AccountStoreTransactionType:
-  DebugRemoveItem: 4
-  DebugResetHistory: 3
-  Purchase: 1
-  Refund: 2
-  Undefined: 0
+  values:
+    DebugRemoveItem: 4
+    DebugResetHistory: 3
+    Purchase: 1
+    Refund: 2
+    Undefined: 0
 AccountTransType:
-  AccountCurrencies: 26
-  AccountNotifications: 38
-  AccountStore: 54
-  Achievements: 4
-  AddLicense: 16
-  ArchivedPurchases: 9
-  AuctionableToken: 18
-  BankTab: 48
-  BattlenetAccount: 25
-  Battlepet: 3
-  BitVectors: 50
-  CharacterDataMerge: 53
-  CharacterItems: 57
-  Characters: 7
-  CombinedQuestLog: 51
-  ConsumableToken: 19
-  CreateOrderInfo: 32
-  Criteria: 5
-  CriteriaNotif: 13
-  CurrencyCaps: 11
-  CurrencyTransferLog: 58
-  Distribution: 2
-  Distributions: 10
-  DynamicCriteria: 30
-  EventRecords: 63
-  Factions: 49
-  FixedLicense: 15
-  GetOrderStatusByPurchaseID: 46
-  HouseInitiativeFavor: 66
-  HousingItem: 64
-  ItemCollections: 17
-  Items: 47
-  LgVendorPurchase: 59
-  LoadWowlabs: 44
-  Mapping: 56
-  Mounts: 6
-  OutstandingRpc: 43
-  PerkItemHold: 39
-  PerkPastRewards: 41
-  PerkPendingRewards: 40
-  PerkTransaction: 42
-  PlayerDataElements: 52
-  Productitem: 21
-  Profile: 61
-  ProxyCreateAccountHonor: 34
-  ProxyForwarder: 0
-  ProxyGenerateBpayID: 37
-  ProxyGmSetHonor: 36
-  ProxyHonorInitialConversion: 33
-  ProxyValidateAccountHonor: 35
-  Purchase: 1
-  Purchases: 8
-  QuestCriteria: 24
-  QuestLog: 12
-  RafActivity: 31
-  RafFriendMonth: 28
-  RafRecruiterAcceptances: 27
-  RafReward: 29
-  SaveWarbandGroups: 60
-  Settings: 14
-  TransmogOutfitCollection: 65
-  TrialBoostHistories: 23
-  TrialBoostHistory: 22
-  UpgradeAccount: 45
-  VasTransaction: 20
-  WarbandGroups: 55
-  WarbandSceneCollection: 62
+  values:
+    AccountCurrencies: 26
+    AccountNotifications: 38
+    AccountStore: 54
+    Achievements: 4
+    AddLicense: 16
+    ArchivedPurchases: 9
+    AuctionableToken: 18
+    BankTab: 48
+    BattlenetAccount: 25
+    Battlepet: 3
+    BitVectors: 50
+    CharacterDataMerge: 53
+    CharacterItems: 57
+    Characters: 7
+    CombinedQuestLog: 51
+    ConsumableToken: 19
+    CreateOrderInfo: 32
+    Criteria: 5
+    CriteriaNotif: 13
+    CurrencyCaps: 11
+    CurrencyTransferLog: 58
+    Distribution: 2
+    Distributions: 10
+    DynamicCriteria: 30
+    EventRecords: 63
+    Factions: 49
+    FixedLicense: 15
+    GetOrderStatusByPurchaseID: 46
+    HouseInitiativeFavor: 66
+    HousingItem: 64
+    ItemCollections: 17
+    Items: 47
+    LgVendorPurchase: 59
+    LoadWowlabs: 44
+    Mapping: 56
+    Mounts: 6
+    OutstandingRpc: 43
+    PerkItemHold: 39
+    PerkPastRewards: 41
+    PerkPendingRewards: 40
+    PerkTransaction: 42
+    PlayerDataElements: 52
+    Productitem: 21
+    Profile: 61
+    ProxyCreateAccountHonor: 34
+    ProxyForwarder: 0
+    ProxyGenerateBpayID: 37
+    ProxyGmSetHonor: 36
+    ProxyHonorInitialConversion: 33
+    ProxyValidateAccountHonor: 35
+    Purchase: 1
+    Purchases: 8
+    QuestCriteria: 24
+    QuestLog: 12
+    RafActivity: 31
+    RafFriendMonth: 28
+    RafRecruiterAcceptances: 27
+    RafReward: 29
+    SaveWarbandGroups: 60
+    Settings: 14
+    TransmogOutfitCollection: 65
+    TrialBoostHistories: 23
+    TrialBoostHistory: 22
+    UpgradeAccount: 45
+    VasTransaction: 20
+    WarbandGroups: 55
+    WarbandSceneCollection: 62
 ActionBarOrientation:
-  Horizontal: 0
-  Vertical: 1
+  values:
+    Horizontal: 0
+    Vertical: 1
 ActionBarVisibleSetting:
-  Always: 0
-  Hidden: 3
-  InCombat: 1
-  OutOfCombat: 2
+  values:
+    Always: 0
+    Hidden: 3
+    InCombat: 1
+    OutOfCombat: 2
 AddOnEnableState:
-  All: 2
-  None: 0
-  Some: 1
+  values:
+    All: 2
+    None: 0
+    Some: 1
 AddOnPerformanceMessageType:
-  OverallAddOnErrorDialog: 2
-  SpecificAddOnChatWarning: 0
-  SpecificAddOnErrorDialog: 1
+  values:
+    OverallAddOnErrorDialog: 2
+    SpecificAddOnChatWarning: 0
+    SpecificAddOnErrorDialog: 1
 AddOnProfilerMetric:
-  CountTimeOver1000Ms: 11
-  CountTimeOver100Ms: 9
-  CountTimeOver10Ms: 7
-  CountTimeOver1Ms: 5
-  CountTimeOver500Ms: 10
-  CountTimeOver50Ms: 8
-  CountTimeOver5Ms: 6
-  EncounterAverageTime: 2
-  LastTime: 3
-  PeakTime: 4
-  RecentAverageTime: 1
-  SessionAverageTime: 0
+  values:
+    CountTimeOver1000Ms: 11
+    CountTimeOver100Ms: 9
+    CountTimeOver10Ms: 7
+    CountTimeOver1Ms: 5
+    CountTimeOver500Ms: 10
+    CountTimeOver50Ms: 8
+    CountTimeOver5Ms: 6
+    EncounterAverageTime: 2
+    LastTime: 3
+    PeakTime: 4
+    RecentAverageTime: 1
+    SessionAverageTime: 0
 AddOnRestrictionState:
-  Activating: 1
-  Active: 2
-  Inactive: 0
+  values:
+    Activating: 1
+    Active: 2
+    Inactive: 0
 AddOnRestrictionType:
-  ChallengeMode: 2
-  Chat: 5
-  Combat: 0
-  Encounter: 1
-  Map: 4
-  PvPMatch: 3
+  values:
+    ChallengeMode: 2
+    Chat: 5
+    Combat: 0
+    Encounter: 1
+    Map: 4
+    PvPMatch: 3
 AddOnSecurityStatus:
-  Banned: 2
-  Insecure: 1
-  NotAvailable: 3
-  Secure: 0
+  values:
+    Banned: 2
+    Insecure: 1
+    NotAvailable: 3
+    Secure: 0
 ArrowCalloutDirection:
-  Down: 1
-  Left: 2
-  Right: 3
-  Up: 0
+  values:
+    Down: 1
+    Left: 2
+    Right: 3
+    Up: 0
 ArrowCalloutType:
-  Generic: 1
-  None: 0
-  Tutorial: 3
-  WidgetContainerNoBorder: 4
-  WorldLootObject: 2
+  values:
+    Generic: 1
+    None: 0
+    Tutorial: 3
+    WidgetContainerNoBorder: 4
+    WorldLootObject: 2
 AssistActionType:
-  CapturedBuff: 6
-  GraveMarker: 2
-  LoungingPlayer: 1
-  None: 0
-  PlacedVo: 3
-  PlayerGuardian: 4
-  PlayerSlayer: 5
+  values:
+    CapturedBuff: 6
+    GraveMarker: 2
+    LoungingPlayer: 1
+    None: 0
+    PlacedVo: 3
+    PlayerGuardian: 4
+    PlayerSlayer: 5
 AuctionHouseCommoditySortOrder:
-  Quantity: 1
-  UnitPrice: 0
+  values:
+    Quantity: 1
+    UnitPrice: 0
 AuctionHouseError:
-  BidIncrement: 2
-  BidOwn: 3
-  BoundItem: 16
-  ConjuredItem: 17
-  DatabaseError: 10
-  DoubleBid: 23
-  EquippedBag: 20
-  FavoritesMaxed: 24
-  HasRestriction: 6
-  HigherBid: 1
-  IsBag: 19
-  IsBusy: 7
-  ItemBoundToAccountUntilEquip: 26
-  ItemHasQuote: 9
-  ItemNotAvailable: 25
-  ItemNotFound: 4
-  LimitedDurationItem: 18
-  LootItem: 22
-  MinBid: 11
-  NotEnoughItems: 12
-  NotEnoughMoney: 0
-  QuestItem: 15
-  RepairItem: 13
-  RestrictedAccountTrial: 5
-  Unavailable: 8
-  UsedCharges: 14
-  WrappedItem: 21
+  values:
+    BidIncrement: 2
+    BidOwn: 3
+    BoundItem: 16
+    ConjuredItem: 17
+    DatabaseError: 10
+    DoubleBid: 23
+    EquippedBag: 20
+    FavoritesMaxed: 24
+    HasRestriction: 6
+    HigherBid: 1
+    IsBag: 19
+    IsBusy: 7
+    ItemBoundToAccountUntilEquip: 26
+    ItemHasQuote: 9
+    ItemNotAvailable: 25
+    ItemNotFound: 4
+    LimitedDurationItem: 18
+    LootItem: 22
+    MinBid: 11
+    NotEnoughItems: 12
+    NotEnoughMoney: 0
+    QuestItem: 15
+    RepairItem: 13
+    RestrictedAccountTrial: 5
+    Unavailable: 8
+    UsedCharges: 14
+    WrappedItem: 21
 AuctionHouseFilter:
-  ArtifactQuality: 12
-  CommonQuality: 7
-  CurrentExpansionOnly: 3
-  EpicQuality: 10
-  ExactMatch: 5
-  LegendaryCraftedItemOnly: 13
-  LegendaryQuality: 11
-  None: 0
-  PoorQuality: 6
-  RareQuality: 9
-  UncollectedOnly: 1
-  UncommonQuality: 8
-  UpgradesOnly: 4
-  UsableOnly: 2
+  values:
+    ArtifactQuality: 12
+    CommonQuality: 7
+    CurrentExpansionOnly: 3
+    EpicQuality: 10
+    ExactMatch: 5
+    LegendaryCraftedItemOnly: 13
+    LegendaryQuality: 11
+    None: 0
+    PoorQuality: 6
+    RareQuality: 9
+    UncollectedOnly: 1
+    UncommonQuality: 8
+    UpgradesOnly: 4
+    UsableOnly: 2
 AuctionHouseItemSortOrder:
-  Bid: 0
-  Buyout: 1
+  values:
+    Bid: 0
+    Buyout: 1
 AuctionHouseNotification:
-  AuctionExpired: 5
-  AuctionOutbid: 3
-  AuctionRemoved: 1
-  AuctionSold: 4
-  AuctionWon: 2
-  BidPlaced: 0
+  values:
+    AuctionExpired: 5
+    AuctionOutbid: 3
+    AuctionRemoved: 1
+    AuctionSold: 4
+    AuctionWon: 2
+    BidPlaced: 0
 AuctionHouseSortOrder:
-  Bid: 3
-  Buyout: 4
-  Level: 2
-  Name: 1
-  Price: 0
-  TimeRemaining: 5
+  values:
+    Bid: 3
+    Buyout: 4
+    Level: 2
+    Name: 1
+    Price: 0
+    TimeRemaining: 5
 AuctionHouseTimeLeftBand:
-  Long: 2
-  Medium: 1
-  Short: 0
-  VeryLong: 3
+  values:
+    Long: 2
+    Medium: 1
+    Short: 0
+    VeryLong: 3
 AuctionStatus:
-  Active: 0
-  Sold: 1
+  values:
+    Active: 0
+    Sold: 1
 AuraFrameIconDirection:
-  Down: 0
-  Left: 0
-  Right: 1
-  Up: 1
+  values:
+    Down: 0
+    Left: 0
+    Right: 1
+    Up: 1
 AuraFrameIconWrap:
-  Down: 0
-  Left: 0
-  Right: 1
-  Up: 1
+  values:
+    Down: 0
+    Left: 0
+    Right: 1
+    Up: 1
 AuraFrameOrientation:
-  Horizontal: 0
-  Vertical: 1
+  values:
+    Horizontal: 0
+    Vertical: 1
 AuraFrameVisibleSetting:
-  Always: 0
-  Hidden: 2
-  InCombat: 1
+  values:
+    Always: 0
+    Hidden: 2
+    InCombat: 1
 AutoCompleteEntryFlag:
-  AccountCharacter: 128
-  Bnet: 8
-  Friend: 4
-  InAOI: 64
-  InGroup: 1
-  InGuild: 2
-  InteractedWith: 16
-  Online: 32
-  RecentPlayer: 256
+  values:
+    AccountCharacter: 128
+    Bnet: 8
+    Friend: 4
+    InAOI: 64
+    InGroup: 1
+    InGuild: 2
+    InteractedWith: 16
+    Online: 32
+    RecentPlayer: 256
 AutoCompletePriority:
-  AccountCharacter: 5
-  AccountCharacterSameRealm: 6
-  Friend: 4
-  Guild: 3
-  InGroup: 2
-  Interacted: 1
-  Other: 0
+  values:
+    AccountCharacter: 5
+    AccountCharacterSameRealm: 6
+    Friend: 4
+    Guild: 3
+    InGroup: 2
+    Interacted: 1
+    Other: 0
 AvgItemLevelCategories:
-  Base: 0
-  EquippedBase: 1
-  EquippedEffective: 2
-  EquippedEffectiveWeighted: 5
-  PvP: 3
-  PvPWeighted: 4
+  values:
+    Base: 0
+    EquippedBase: 1
+    EquippedEffective: 2
+    EquippedEffectiveWeighted: 5
+    PvP: 3
+    PvPWeighted: 4
 AzeriteEssenceSlot:
-  MainSlot: 0
-  PassiveOneSlot: 1
-  PassiveThreeSlot: 3
-  PassiveTwoSlot: 2
+  values:
+    MainSlot: 0
+    PassiveOneSlot: 1
+    PassiveThreeSlot: 3
+    PassiveTwoSlot: 2
 AzeritePowerLevel:
-  Base: 0
-  Downgraded: 2
-  Upgraded: 1
+  values:
+    Base: 0
+    Downgraded: 2
+    Upgraded: 1
 BagFlag:
-  AllowBagsInNonBagSlots: 1024
-  AllowBuyback: 65536
-  AllowPartialStack: 16384
-  AllowSoulboundItemInAccountBank: 134217728
-  AlreadyBound: 4
-  AlreadyOwner: 2
-  AsymmetricSwap: 1048576
-  BagIsEmpty: 16
-  DontFindStack: 1
-  HasRefund: 33554432
-  IgnoreBankcheck: 512
-  IgnoreBoundItemCheck: 64
-  IgnoreExisting: 8192
-  IgnorePetBankcheck: 131072
-  IgnoreReagentBags: 8388608
-  IgnoreSoulbound: 4194304
-  LookInAccountBankOnly: 16777216
-  LookInBankOnly: 32768
-  LookInInventory: 32
-  PreferNeutralPriorityBags: 524288
-  PreferPriorityBags: 262144
-  PreferQuivers: 2048
-  PreferReagentBags: 2097152
-  RecurseQuivers: 256
-  SkipValidCountCheck: 67108864
-  StackOnly: 128
-  Swap: 8
-  SwapBags: 4096
+  values:
+    AllowBagsInNonBagSlots: 1024
+    AllowBuyback: 65536
+    AllowPartialStack: 16384
+    AllowSoulboundItemInAccountBank: 134217728
+    AlreadyBound: 4
+    AlreadyOwner: 2
+    AsymmetricSwap: 1048576
+    BagIsEmpty: 16
+    DontFindStack: 1
+    HasRefund: 33554432
+    IgnoreBankcheck: 512
+    IgnoreBoundItemCheck: 64
+    IgnoreExisting: 8192
+    IgnorePetBankcheck: 131072
+    IgnoreReagentBags: 8388608
+    IgnoreSoulbound: 4194304
+    LookInAccountBankOnly: 16777216
+    LookInBankOnly: 32768
+    LookInInventory: 32
+    PreferNeutralPriorityBags: 524288
+    PreferPriorityBags: 262144
+    PreferQuivers: 2048
+    PreferReagentBags: 2097152
+    RecurseQuivers: 256
+    SkipValidCountCheck: 67108864
+    StackOnly: 128
+    Swap: 8
+    SwapBags: 4096
 BagIndex:
-  Accountbanktab: -5
-  AccountBankTab_1: 13
-  AccountBankTab_2: 14
-  AccountBankTab_3: 15
-  AccountBankTab_4: 16
-  AccountBankTab_5: 17
-  Backpack: 0
-  Bag_1: 1
-  Bag_2: 2
-  Bag_3: 3
-  Bag_4: 4
-  Bank: -1
-  Bankbag: -4
-  BankBag_1: 6
-  BankBag_2: 7
-  BankBag_3: 8
-  BankBag_4: 9
-  BankBag_5: 10
-  BankBag_6: 11
-  BankBag_7: 12
-  Keyring: -2
-  ReagentBag: 5
-  Reagentbank: -3
+  values:
+    Accountbanktab: -5
+    AccountBankTab_1: 13
+    AccountBankTab_2: 14
+    AccountBankTab_3: 15
+    AccountBankTab_4: 16
+    AccountBankTab_5: 17
+    Backpack: 0
+    Bag_1: 1
+    Bag_2: 2
+    Bag_3: 3
+    Bag_4: 4
+    Bank: -1
+    Bankbag: -4
+    BankBag_1: 6
+    BankBag_2: 7
+    BankBag_3: 8
+    BankBag_4: 9
+    BankBag_5: 10
+    BankBag_6: 11
+    BankBag_7: 12
+    Keyring: -2
+    ReagentBag: 5
+    Reagentbank: -3
 BagsDirection:
-  Down: 1
-  Left: 0
-  Right: 1
-  Up: 0
+  values:
+    Down: 1
+    Left: 0
+    Right: 1
+    Up: 0
 BagSlotFlags:
-  ClassConsumables: 4
-  ClassEquipment: 2
-  ClassJunk: 16
-  ClassProfessionGoods: 8
-  ClassQuestItems: 32
-  ClassReagents: 128
-  DisableAutoSort: 1
-  ExcludeJunkSell: 64
-  ExpansionCurrent: 256
-  ExpansionLegacy: 512
+  values:
+    ClassConsumables: 4
+    ClassEquipment: 2
+    ClassJunk: 16
+    ClassProfessionGoods: 8
+    ClassQuestItems: 32
+    ClassReagents: 128
+    DisableAutoSort: 1
+    ExcludeJunkSell: 64
+    ExpansionCurrent: 256
+    ExpansionLegacy: 512
 BagsOrientation:
-  Horizontal: 0
-  Vertical: 1
+  values:
+    Horizontal: 0
+    Vertical: 1
 BalanceType:
-  Eclipse: 0
-  None: -1
+  values:
+    Eclipse: 0
+    None: -1
 BankLockedReason:
-  BankConversionFailed: 3
-  BankDisabled: 2
-  NoAccountInventoryLock: 1
-  None: 0
+  values:
+    BankConversionFailed: 3
+    BankDisabled: 2
+    NoAccountInventoryLock: 1
+    None: 0
 BankType:
-  Account: 2
-  Character: 0
-  Guild: 1
+  values:
+    Account: 2
+    Character: 0
+    Guild: 1
 Base64Variant:
-  Standard: 0
-  StandardUrlSafe: 1
+  values:
+    Standard: 0
+    StandardUrlSafe: 1
 BattlepayBannerType:
-  Discount: 1
-  Featured: 2
-  New: 3
-  None: 0
+  values:
+    Discount: 1
+    Featured: 2
+    New: 3
+    None: 0
 BattlepayDisplayFlags:
-  CardAlwaysShowsTexture: 4
-  CardDoesNotShowModel: 2
-  Deprecated1: 32
-  Deprecated2: 64
-  Expansion: 1
-  HiddenPrice: 8
-  HideWhenOwned: 256
-  RafReward: 512
-  ShowFancyToast: 1024
-  UseHorizontalLayoutForFullCard: 16
-  UseIconBorderWithOverrideTexture: 2048
-  UseSquareIconBorder: 128
+  values:
+    CardAlwaysShowsTexture: 4
+    CardDoesNotShowModel: 2
+    Deprecated1: 32
+    Deprecated2: 64
+    Expansion: 1
+    HiddenPrice: 8
+    HideWhenOwned: 256
+    RafReward: 512
+    ShowFancyToast: 1024
+    UseHorizontalLayoutForFullCard: 16
+    UseIconBorderWithOverrideTexture: 2048
+    UseSquareIconBorder: 128
 BattlepayGroupDisplayType:
-  ActiveTimeOnly: 2
-  Everyone: 0
-  TrialAndVeteranOnly: 1
+  values:
+    ActiveTimeOnly: 2
+    Everyone: 0
+    TrialAndVeteranOnly: 1
 BattlepayLicenseSynthesisFlags:
-  ForceToGameAccount: 1
+  values:
+    ForceToGameAccount: 1
 BattlepayProductChoiceType:
-  ChoiceNone: 0
-  ChoiceOne: 1
-  SpecAndFaction: 2
-  VasCharacter: 3
-  VasCharacterAndName: 4
+  values:
+    ChoiceNone: 0
+    ChoiceOne: 1
+    SpecAndFaction: 2
+    VasCharacter: 3
+    VasCharacterAndName: 4
 BattlepayProductDecorator:
-  Boost: 0
-  Expansion: 1
-  VasService: 3
-  WoWToken: 2
+  values:
+    Boost: 0
+    Expansion: 1
+    VasService: 3
+    WoWToken: 2
 BattlepayProductGroupFlags:
-  DisableOwnedProducts: 4
-  EnabledForTrial: 2
-  EnabledForVeteran: 8
-  HideOwnedProducts: 1
-  None: 0
-  TrialAndVeteranOnly: 16
+  values:
+    DisableOwnedProducts: 4
+    EnabledForTrial: 2
+    EnabledForVeteran: 8
+    HideOwnedProducts: 1
+    None: 0
+    TrialAndVeteranOnly: 16
 BattlepayShopEntryBannerType:
-  Discount: 1
-  Featured: 0
-  New: 2
+  values:
+    Discount: 1
+    Featured: 0
+    New: 2
 BattlepayShopEntryFlags:
-  None: 0
+  values:
+    None: 0
 BattlePetAction:
-  Ability: 1
-  None: 0
-  Skip: 4
-  SwitchPet: 2
-  Trap: 3
+  values:
+    Ability: 1
+    None: 0
+    Skip: 4
+    SwitchPet: 2
+    Trap: 3
 BattlePetBreedQuality:
-  Common: 1
-  Epic: 4
-  Legendary: 5
-  Poor: 0
-  Rare: 3
-  Uncommon: 2
+  values:
+    Common: 1
+    Epic: 4
+    Legendary: 5
+    Poor: 0
+    Rare: 3
+    Uncommon: 2
 BattlePetOwner:
-  Ally: 1
-  Enemy: 2
-  Weather: 0
+  values:
+    Ally: 1
+    Enemy: 2
+    Weather: 0
 BattlePetSources:
-  Achievement: 5
-  Discovery: 10
-  Drop: 0
-  PetStore: 9
-  Profession: 3
-  Promotion: 7
-  Quest: 1
-  Tcg: 8
-  TradingPost: 11
-  Vendor: 2
-  WildPet: 4
-  WorldEvent: 6
+  values:
+    Achievement: 5
+    Discovery: 10
+    Drop: 0
+    PetStore: 9
+    Profession: 3
+    Promotion: 7
+    Quest: 1
+    Tcg: 8
+    TradingPost: 11
+    Vendor: 2
+    WildPet: 4
+    WorldEvent: 6
 BindingContext:
-  HousingEditor: 1
-  HousingEditorBasicAndExpertDecorMode: 7
-  HousingEditorBasicDecorMode: 2
-  HousingEditorCleanupMode: 5
-  HousingEditorCustomizeMode: 4
-  HousingEditorExpertDecorMode: 3
-  HousingEditorExteriorCustomizationMode: 8
-  HousingEditorLayoutMode: 6
-  None: 0
-  ReservedFutureFeatureBinding01: 9
+  values:
+    HousingEditor: 1
+    HousingEditorBasicAndExpertDecorMode: 7
+    HousingEditorBasicDecorMode: 2
+    HousingEditorCleanupMode: 5
+    HousingEditorCustomizeMode: 4
+    HousingEditorExpertDecorMode: 3
+    HousingEditorExteriorCustomizationMode: 8
+    HousingEditorLayoutMode: 6
+    None: 0
+    ReservedFutureFeatureBinding01: 9
 BindingSet:
-  Account: 1
-  Character: 2
-  Current: 3
-  Default: 0
+  values:
+    Account: 1
+    Character: 2
+    Current: 3
+    Default: 0
 BnetAccountFlag:
-  AccountQuestBitFixUp: 64
-  AchievementsToBi: 128
-  BattlePetTrainer: 1
-  CanBuyAhGameTimeTokens: 32768
-  CataLegendaryMountChecked: 262144
-  CataLegendaryMountObtained: 524288
-  DarkRealmLightCopy: 2048
-  Employee: 16
-  EmployeeFlagIsManual: 32
-  GdprErased: 1024
-  InvalidTransmogsFixUp: 256
-  InvalidTransmogsFixUp2: 512
-  IsLegacy: 131072
-  LockedForExport: 16384
-  MopQuestLogFlagsFixUp: 1048576
-  None: 0
-  PetAchievementFixUp: 65536
-  QuestLogFlagsFixUp: 4096
-  RafVeteranNotified: 2
-  TwitterHasTempSecret: 8
-  TwitterLinked: 4
-  WasSecured: 8192
+  values:
+    AccountQuestBitFixUp: 64
+    AchievementsToBi: 128
+    BattlePetTrainer: 1
+    CanBuyAhGameTimeTokens: 32768
+    CataLegendaryMountChecked: 262144
+    CataLegendaryMountObtained: 524288
+    DarkRealmLightCopy: 2048
+    Employee: 16
+    EmployeeFlagIsManual: 32
+    GdprErased: 1024
+    InvalidTransmogsFixUp: 256
+    InvalidTransmogsFixUp2: 512
+    IsLegacy: 131072
+    LockedForExport: 16384
+    MopQuestLogFlagsFixUp: 1048576
+    None: 0
+    PetAchievementFixUp: 65536
+    QuestLogFlagsFixUp: 4096
+    RafVeteranNotified: 2
+    TwitterHasTempSecret: 8
+    TwitterLinked: 4
+    WasSecured: 8192
 BonusStatIndex:
-  Agility: 3
-  AgilityOrIntellect: 73
-  AgilityOrStrength: 72
-  AgilityOrStrengthOrIntellect: 71
-  ArcaneResistance: 56
-  ArmorPenetrationRating: 44
-  AttackPower: 38
-  BlockRating: 15
-  BlockValue: 48
-  CombatRatingAvoidance: 63
-  CombatRatingLifesteal: 62
-  CombatRatingSpeed: 61
-  CombatRatingSturdiness: 64
-  CombatRatingUnused_0: 58
-  CombatRatingUnused_10: 68
-  CombatRatingUnused_11: 69
-  CombatRatingUnused_12: 70
-  CombatRatingUnused_2: 59
-  CombatRatingUnused_27: 66
-  CombatRatingUnused_3: 60
-  CombatRatingUnused_7: 65
-  CombatRatingUnused_9: 67
-  CritMeleeRating: 19
-  CritRangedRating: 20
-  CritRating: 32
-  CritSpellRating: 21
-  CritTakenMeleeRatingObsolete: 25
-  CritTakenRangedRatingObsolete: 26
-  CritTakenRatingObsolete: 34
-  CritTakenSpellRatingObsolete: 27
-  DefenseSkillRating: 12
-  DodgeRating: 13
-  Endurance: 2
-  Energy: 8
-  ExpertiseRating: 37
-  ExtraArmor: 50
-  FireResistance: 51
-  Focus: 10
-  FrostResistance: 52
-  HasteMeleeRatingObsolete: 28
-  HasteRangedRatingObsolete: 29
-  HasteRating: 36
-  HasteSpellRatingObsolete: 30
-  Health: 1
-  HealthRegen: 46
-  HitMeleeRating: 16
-  HitRangedRating: 17
-  HitRating: 31
-  HitSpellRating: 18
-  HitTakenMeleeRatingObsolete: 22
-  HitTakenRangedRatingObsolete: 23
-  HitTakenRatingObsolete: 33
-  HitTakenSpellRatingObsolete: 24
-  HolyResistance: 53
-  Intellect: 5
-  Mana: 0
-  ManaRegeneration: 43
-  MasteryRating: 49
-  NatureResistance: 55
-  ParryRating: 14
-  ProfessionCraftingSpeed: 80
-  ProfessionDeftness: 78
-  ProfessionFinesse: 77
-  ProfessionIngenuity: 82
-  ProfessionInspiration: 75
-  ProfessionMulticraft: 81
-  ProfessionPerception: 79
-  ProfessionResourcefulness: 76
-  PvPPower: 57
-  Rage: 9
-  RangedAttackPower: 39
-  ResilienceRating: 35
-  ShadowResistance: 54
-  SpellDamageDone: 42
-  SpellHealingDone: 41
-  SpellPenetration: 47
-  SpellPower: 45
-  Spirit: 6
-  Stamina: 7
-  Strength: 4
-  StrengthOrIntellect: 74
-  Versatility: 40
-  WeaponSkillRating: 11
+  values:
+    Agility: 3
+    AgilityOrIntellect: 73
+    AgilityOrStrength: 72
+    AgilityOrStrengthOrIntellect: 71
+    ArcaneResistance: 56
+    ArmorPenetrationRating: 44
+    AttackPower: 38
+    BlockRating: 15
+    BlockValue: 48
+    CombatRatingAvoidance: 63
+    CombatRatingLifesteal: 62
+    CombatRatingSpeed: 61
+    CombatRatingSturdiness: 64
+    CombatRatingUnused_0: 58
+    CombatRatingUnused_10: 68
+    CombatRatingUnused_11: 69
+    CombatRatingUnused_12: 70
+    CombatRatingUnused_2: 59
+    CombatRatingUnused_27: 66
+    CombatRatingUnused_3: 60
+    CombatRatingUnused_7: 65
+    CombatRatingUnused_9: 67
+    CritMeleeRating: 19
+    CritRangedRating: 20
+    CritRating: 32
+    CritSpellRating: 21
+    CritTakenMeleeRatingObsolete: 25
+    CritTakenRangedRatingObsolete: 26
+    CritTakenRatingObsolete: 34
+    CritTakenSpellRatingObsolete: 27
+    DefenseSkillRating: 12
+    DodgeRating: 13
+    Endurance: 2
+    Energy: 8
+    ExpertiseRating: 37
+    ExtraArmor: 50
+    FireResistance: 51
+    Focus: 10
+    FrostResistance: 52
+    HasteMeleeRatingObsolete: 28
+    HasteRangedRatingObsolete: 29
+    HasteRating: 36
+    HasteSpellRatingObsolete: 30
+    Health: 1
+    HealthRegen: 46
+    HitMeleeRating: 16
+    HitRangedRating: 17
+    HitRating: 31
+    HitSpellRating: 18
+    HitTakenMeleeRatingObsolete: 22
+    HitTakenRangedRatingObsolete: 23
+    HitTakenRatingObsolete: 33
+    HitTakenSpellRatingObsolete: 24
+    HolyResistance: 53
+    Intellect: 5
+    Mana: 0
+    ManaRegeneration: 43
+    MasteryRating: 49
+    NatureResistance: 55
+    ParryRating: 14
+    ProfessionCraftingSpeed: 80
+    ProfessionDeftness: 78
+    ProfessionFinesse: 77
+    ProfessionIngenuity: 82
+    ProfessionInspiration: 75
+    ProfessionMulticraft: 81
+    ProfessionPerception: 79
+    ProfessionResourcefulness: 76
+    PvPPower: 57
+    Rage: 9
+    RangedAttackPower: 39
+    ResilienceRating: 35
+    ShadowResistance: 54
+    SpellDamageDone: 42
+    SpellHealingDone: 41
+    SpellPenetration: 47
+    SpellPower: 45
+    Spirit: 6
+    Stamina: 7
+    Strength: 4
+    StrengthOrIntellect: 74
+    Versatility: 40
+    WeaponSkillRating: 11
 BrawlType:
-  Arena: 2
-  Battleground: 1
-  LFG: 3
-  None: 0
-  SoloRbg: 5
-  SoloShuffle: 4
+  values:
+    Arena: 2
+    Battleground: 1
+    LFG: 3
+    None: 0
+    SoloRbg: 5
+    SoloShuffle: 4
 BulkPurchaseResult:
-  ResultFailed: 3
-  ResultInProgress: 1
-  ResultInsufficientFunds: 6
-  ResultOk: 0
-  ResultPartialSuccess: 2
-  ResultPurchaseTimeout: 7
-  ResultSystemDisabled: 5
-  ResultTooManyProducts: 4
+  values:
+    ResultFailed: 3
+    ResultInProgress: 1
+    ResultInsufficientFunds: 6
+    ResultOk: 0
+    ResultPartialSuccess: 2
+    ResultPurchaseTimeout: 7
+    ResultSystemDisabled: 5
+    ResultTooManyProducts: 4
 BulkPurchaseStatus:
-  Done: 3
-  Failed: 4
-  FetchEntitlements: 2
-  PlacingOrders: 0
-  PurchasesPending: 1
+  values:
+    Done: 3
+    Failed: 4
+    FetchEntitlements: 2
+    PlacingOrders: 0
+    PurchasesPending: 1
 BulkRefundResult:
-  ResultFailed: 1
-  ResultInvalidRequest: 2
-  ResultOk: 0
-  ResultRefundWindowExpired: 3
-  ResultSystemDisabled: 4
-  ResultTimeout: 5
+  values:
+    ResultFailed: 1
+    ResultInvalidRequest: 2
+    ResultOk: 0
+    ResultRefundWindowExpired: 3
+    ResultSystemDisabled: 4
+    ResultTimeout: 5
 CachedRewardType:
-  Currency: 2
-  Item: 1
-  None: 0
-  Quest: 3
+  values:
+    Currency: 2
+    Item: 1
+    None: 0
+    Quest: 3
 CalendarCommandType:
-  Complain: 10
-  Create: 0
-  GetCalendar: 7
-  GetEvent: 8
-  Invite: 1
-  ModeratorStatus: 6
-  Notes: 11
-  RemoveEvent: 4
-  RemoveInvite: 3
-  Rsvp: 2
-  Status: 5
-  UpdateEvent: 9
+  values:
+    Complain: 10
+    Create: 0
+    GetCalendar: 7
+    GetEvent: 8
+    Invite: 1
+    ModeratorStatus: 6
+    Notes: 11
+    RemoveEvent: 4
+    RemoveInvite: 3
+    Rsvp: 2
+    Status: 5
+    UpdateEvent: 9
 CalendarErrorType:
-  ArenaEventsExceeded: 27
-  CalendarDisabled: 25
-  CommunityEventsExceeded: 1
-  ComplaintAdded: 50
-  ComplaintDisabled: 31
-  ComplaintGm: 34
-  ComplaintLimit: 35
-  ComplaintNotFound: 36
-  ComplaintSameGuild: 33
-  ComplaintSelf: 32
-  CreatorNotFound: 46
-  DataAlreadySet: 24
-  DeleteCreatorFailed: 23
-  EventInvalid: 6
-  EventLocked: 22
-  EventPassed: 21
-  EventsExceeded: 2
-  EventThrottled: 47
-  EventWrongServer: 37
-  Ignored: 14
-  Internal: 49
-  InvalidClub: 45
-  InvalidDate: 17
-  InvalidDescription: 44
-  InvalidMaxSize: 16
-  InvalidNotes: 42
-  InvalidSignup: 39
-  InvalidTime: 18
-  InvalidTitle: 43
-  InvitesExceeded: 15
-  InviteThrottled: 48
-  ModeratorRestricted: 41
-  NameNotFound: 12
-  NeedsTitle: 20
-  NoCommunityInvites: 38
-  NoInvite: 30
-  NoInvites: 19
-  NoModerator: 40
-  NoPermission: 5
-  NotInCommunity: 10
-  NotInGuild: 9
-  NotInvited: 7
-  OtherInvitesExceeded: 4
-  RestrictedAccount: 26
-  RestrictedLevel: 28
-  SelfInvitesExceeded: 3
-  Squelched: 29
-  Success: 0
-  TargetAlreadyInvited: 11
-  UnknownError: 8
-  WrongFaction: 13
+  values:
+    ArenaEventsExceeded: 27
+    CalendarDisabled: 25
+    CommunityEventsExceeded: 1
+    ComplaintAdded: 50
+    ComplaintDisabled: 31
+    ComplaintGm: 34
+    ComplaintLimit: 35
+    ComplaintNotFound: 36
+    ComplaintSameGuild: 33
+    ComplaintSelf: 32
+    CreatorNotFound: 46
+    DataAlreadySet: 24
+    DeleteCreatorFailed: 23
+    EventInvalid: 6
+    EventLocked: 22
+    EventPassed: 21
+    EventsExceeded: 2
+    EventThrottled: 47
+    EventWrongServer: 37
+    Ignored: 14
+    Internal: 49
+    InvalidClub: 45
+    InvalidDate: 17
+    InvalidDescription: 44
+    InvalidMaxSize: 16
+    InvalidNotes: 42
+    InvalidSignup: 39
+    InvalidTime: 18
+    InvalidTitle: 43
+    InvitesExceeded: 15
+    InviteThrottled: 48
+    ModeratorRestricted: 41
+    NameNotFound: 12
+    NeedsTitle: 20
+    NoCommunityInvites: 38
+    NoInvite: 30
+    NoInvites: 19
+    NoModerator: 40
+    NoPermission: 5
+    NotInCommunity: 10
+    NotInGuild: 9
+    NotInvited: 7
+    OtherInvitesExceeded: 4
+    RestrictedAccount: 26
+    RestrictedLevel: 28
+    SelfInvitesExceeded: 3
+    Squelched: 29
+    Success: 0
+    TargetAlreadyInvited: 11
+    UnknownError: 8
+    WrongFaction: 13
 CalendarEventBits:
-  ArenaDeprecated: 256
-  AutoApprove: 32
-  CantComplain: 3788
-  CommunityAnnouncement: 64
-  CommunitySignup: 1024
-  CommunityWide: 3136
-  GuildDeprecated: 2
-  GuildSignup: 2048
-  Holiday: 8
-  Locked: 16
-  Player: 1
-  PlayerCreated: 3395
-  RaidLockout: 128
-  RaidReset: 512
-  System: 4
+  values:
+    ArenaDeprecated: 256
+    AutoApprove: 32
+    CantComplain: 3788
+    CommunityAnnouncement: 64
+    CommunitySignup: 1024
+    CommunityWide: 3136
+    GuildDeprecated: 2
+    GuildSignup: 2048
+    Holiday: 8
+    Locked: 16
+    Player: 1
+    PlayerCreated: 3395
+    RaidLockout: 128
+    RaidReset: 512
+    System: 4
 CalendarEventRepeatOptions:
-  Biweekly: 2
-  Monthly: 3
-  Never: 0
-  Weekly: 1
+  values:
+    Biweekly: 2
+    Monthly: 3
+    Never: 0
+    Weekly: 1
 CalendarEventType:
-  Dungeon: 1
-  HeroicDeprecated: 5
-  Meeting: 3
-  Other: 4
-  PvP: 2
-  Raid: 0
+  values:
+    Dungeon: 1
+    HeroicDeprecated: 5
+    Meeting: 3
+    Other: 4
+    PvP: 2
+    Raid: 0
 CalendarFilterFlags:
-  Battleground: 4
-  Darkmoon: 2
-  RaidLockout: 8
-  RaidReset: 16
-  WeeklyHoliday: 1
+  values:
+    Battleground: 4
+    Darkmoon: 2
+    RaidLockout: 8
+    RaidReset: 16
+    WeeklyHoliday: 1
 CalendarGetEventType:
-  Add: 1
-  Copy: 2
-  Get: 0
+  values:
+    Add: 1
+    Copy: 2
+    Get: 0
 CalendarHolidayFilterType:
-  Battleground: 2
-  Darkmoon: 1
-  Weekly: 0
+  values:
+    Battleground: 2
+    Darkmoon: 1
+    Weekly: 0
 CalendarInviteBits:
-  Creator: 4
-  Moderator: 2
-  None: 0
-  PendingInvite: 1
-  Signup: 8
+  values:
+    Creator: 4
+    Moderator: 2
+    None: 0
+    PendingInvite: 1
+    Signup: 8
 CalendarInviteSortType:
-  Class: 2
-  Level: 1
-  Name: 0
-  Notes: 5
-  Party: 4
-  Status: 3
+  values:
+    Class: 2
+    Level: 1
+    Name: 0
+    Notes: 5
+    Party: 4
+    Status: 3
 CalendarInviteType:
-  Normal: 0
-  Signup: 1
+  values:
+    Normal: 0
+    Signup: 1
 CalendarModeratorStatus:
-  Creator: 2
-  Moderator: 1
-  None: 0
+  values:
+    Creator: 2
+    Moderator: 1
+    None: 0
 CalendarStatus:
-  Available: 1
-  Confirmed: 3
-  Declined: 2
-  Invited: 0
-  NotSignedup: 7
-  Out: 4
-  Signedup: 6
-  Standby: 5
-  Tentative: 8
+  values:
+    Available: 1
+    Confirmed: 3
+    Declined: 2
+    Invited: 0
+    NotSignedup: 7
+    Out: 4
+    Signedup: 6
+    Standby: 5
+    Tentative: 8
 CalendarTexturesType:
-  Dungeons: 0
-  Raid: 1
+  values:
+    Dungeons: 0
+    Raid: 1
 CalendarType:
-  Community: 1
-  Holiday: 4
-  HolidayBattleground: 7
-  HolidayDarkmoon: 6
-  HolidayWeekly: 5
-  Player: 0
-  RaidLockout: 2
-  RaidReset: 3
+  values:
+    Community: 1
+    Holiday: 4
+    HolidayBattleground: 7
+    HolidayDarkmoon: 6
+    HolidayWeekly: 5
+    Player: 0
+    RaidLockout: 2
+    RaidReset: 3
 CalendarWebActionType:
-  Accept: 0
-  Decline: 1
-  Remove: 2
-  ReportSpam: 3
-  Signup: 4
-  Tentative: 5
-  TentativeSignup: 6
+  values:
+    Accept: 0
+    Decline: 1
+    Remove: 2
+    ReportSpam: 3
+    Signup: 4
+    Tentative: 5
+    TentativeSignup: 6
 CameraModeAspectRatio:
-  Cinemascope_2_Dot_4_X_1: 3
-  Default: 0
-  HighDefinition_16_X_9: 2
-  LegacyLetterbox: 1
+  values:
+    Cinemascope_2_Dot_4_X_1: 3
+    Default: 0
+    HighDefinition_16_X_9: 2
+    LegacyLetterbox: 1
 CanRedeemTokenForBalanceResult:
-  FailureCap: 1
-  Ok: 0
+  values:
+    FailureCap: 1
+    Ok: 0
 CaptureBarWidgetFillDirectionType:
-  LeftToRight: 1
-  RightToLeft: 0
+  values:
+    LeftToRight: 1
+    RightToLeft: 0
 Causeofdeath:
-  Creature: 3
-  Drowning: 5
-  Falling: 4
-  Fatigue: 6
-  Fire: 9
-  Lava: 8
-  None: 0
-  PlayerDuel: 2
-  PlayerPvP: 1
-  Slime: 7
+  values:
+    Creature: 3
+    Drowning: 5
+    Falling: 4
+    Fatigue: 6
+    Fire: 9
+    Lava: 8
+    None: 0
+    PlayerDuel: 2
+    PlayerPvP: 1
+    Slime: 7
 CauseofdeathFlags:
-  CreatureNameNeeded: 2
-  NoneNeeded: 0
-  PlayerNameNeeded: 1
-  ZoneNameNeeded: 4
+  values:
+    CreatureNameNeeded: 2
+    NoneNeeded: 0
+    PlayerNameNeeded: 1
+    ZoneNameNeeded: 4
 ChallengeModeHistoryFlags:
-  ConfirmedLeaver: 1
-  None: 0
+  values:
+    ConfirmedLeaver: 1
+    None: 0
 ChallengeModeHistoryResult:
-  Leaver: 1
-  Successful: 0
+  values:
+    Leaver: 1
+    Successful: 0
 ChallengeModeHistoryStatus:
-  Leaver: 1
-  Normal: 0
+  values:
+    Leaver: 1
+    Normal: 0
 ChannelPlayerFlags:
-  ChannelPlayerHidden: 8
-  ChannelPlayerModerator: 2
-  ChannelPlayerNone: 0
-  ChannelPlayerOwner: 1
-  ChannelPlayerTextAllow: 4
+  values:
+    ChannelPlayerHidden: 8
+    ChannelPlayerModerator: 2
+    ChannelPlayerNone: 0
+    ChannelPlayerOwner: 1
+    ChannelPlayerTextAllow: 4
 CharacterServiceInfoFlag:
-  AllowMaxLevelBoost: 2
-  RestrictToRecommendedSpecs: 1
+  values:
+    AllowMaxLevelBoost: 2
+    RestrictToRecommendedSpecs: 1
 CharCustomizationType:
-  CustomOptionFacewear: 7
-  CustomOptionHorn: 6
-  CustomOptionTattoo: 5
-  CustomOptionTattooColor: 8
-  Face: 1
-  FacialHair: 4
-  Hair: 2
-  HairColor: 3
-  Skin: 0
+  values:
+    CustomOptionFacewear: 7
+    CustomOptionHorn: 6
+    CustomOptionTattoo: 5
+    CustomOptionTattooColor: 8
+    Face: 1
+    FacialHair: 4
+    Hair: 2
+    HairColor: 3
+    Skin: 0
 ChatChannelRuleset:
-  ChromieTimeBuringCrusade: 4
-  ChromieTimeCataclysm: 3
-  ChromieTimeLegion: 8
-  ChromieTimeMists: 6
-  ChromieTimeWoD: 7
-  ChromieTimeWrath: 5
-  Disabled: 2
-  Mentor: 1
-  None: 0
+  values:
+    ChromieTimeBuringCrusade: 4
+    ChromieTimeCataclysm: 3
+    ChromieTimeLegion: 8
+    ChromieTimeMists: 6
+    ChromieTimeWoD: 7
+    ChromieTimeWrath: 5
+    Disabled: 2
+    Mentor: 1
+    None: 0
 ChatChannelType:
-  Communities: 4
-  Custom: 1
-  None: 0
-  PrivateParty: 2
-  PublicParty: 3
+  values:
+    Communities: 4
+    Custom: 1
+    None: 0
+    PrivateParty: 2
+    PublicParty: 3
 ChatToxityFilterOptOut:
-  ExcludeFilterAll: 4294967295
-  ExcludeFilterFriend: 1
-  ExcludeFilterGuild: 2
-  FilterAll: 0
+  values:
+    ExcludeFilterAll: 4294967295
+    ExcludeFilterFriend: 1
+    ExcludeFilterGuild: 2
+    FilterAll: 0
 ChatWhisperTargetStatus:
-  CanWhisper: 0
-  CanWhisperGuild: 1
-  Offline: 2
-  WrongFaction: 3
+  values:
+    CanWhisper: 0
+    CanWhisperGuild: 1
+    Offline: 2
+    WrongFaction: 3
 ChrCustomizationCategoryFlag:
-  Subcategory: 2
-  UndressModel: 1
+  values:
+    Subcategory: 2
+    UndressModel: 1
 ChrCustomizationOptionType:
-  Checkbox: 1
-  Dropdown: 0
-  Slider: 2
+  values:
+    Checkbox: 1
+    Dropdown: 0
+    Slider: 2
 ChrModelFeatureFlags:
-  Deprecated0: 8
-  Forms: 2
-  HunterPets: 32
-  Identity: 4
-  Mounts: 16
-  None: 0
-  Players: 64
-  Summons: 1
+  values:
+    Deprecated0: 8
+    Forms: 2
+    HunterPets: 32
+    Identity: 4
+    Mounts: 16
+    None: 0
+    Players: 64
+    Summons: 1
 ChrRacesAllianceType:
-  Alliance: 0
-  Horde: 1
-  NeutralOrNpc: 2
+  values:
+    Alliance: 0
+    Horde: 1
+    NeutralOrNpc: 2
 CinematicType:
-  GameCinematicSequence: 3
-  GameClientScene: 2
-  GameMovie: 1
-  GlueMovie: 0
+  values:
+    GameCinematicSequence: 3
+    GameClientScene: 2
+    GameMovie: 1
+    GlueMovie: 0
 ClientPlatformType:
-  Macintosh: 1
-  Windows: 0
+  values:
+    Macintosh: 1
+    Windows: 0
 ClientSceneType:
-  DefaultSceneType: 0
-  MinigameSceneType: 1
+  values:
+    DefaultSceneType: 0
+    MinigameSceneType: 1
 ClientSettingsConfigFlag:
-  ClientSettingsConfigBeta: 64
-  ClientSettingsConfigBetaRetail: 128
-  ClientSettingsConfigDebug: 1
-  ClientSettingsConfigGm: 8
-  ClientSettingsConfigInternal: 2
-  ClientSettingsConfigPerf: 4
-  ClientSettingsConfigRetail: 256
-  ClientSettingsConfigTest: 16
-  ClientSettingsConfigTestRetail: 32
+  values:
+    ClientSettingsConfigBeta: 64
+    ClientSettingsConfigBetaRetail: 128
+    ClientSettingsConfigDebug: 1
+    ClientSettingsConfigGm: 8
+    ClientSettingsConfigInternal: 2
+    ClientSettingsConfigPerf: 4
+    ClientSettingsConfigRetail: 256
+    ClientSettingsConfigTest: 16
+    ClientSettingsConfigTestRetail: 32
 ClubActionType:
-  ErrorClubActionAcceptInvitation: 13
-  ErrorClubActionAddBan: 22
-  ErrorClubActionCreate: 1
-  ErrorClubActionCreateMessage: 24
-  ErrorClubActionCreateStream: 15
-  ErrorClubActionCreateTicket: 5
-  ErrorClubActionDeclineInvitation: 14
-  ErrorClubActionDestroy: 3
-  ErrorClubActionDestroyMessage: 26
-  ErrorClubActionDestroyStream: 17
-  ErrorClubActionDestroyTicket: 6
-  ErrorClubActionEdit: 2
-  ErrorClubActionEditMember: 19
-  ErrorClubActionEditMemberNote: 20
-  ErrorClubActionEditMessage: 25
-  ErrorClubActionEditStream: 16
-  ErrorClubActionGetBans: 10
-  ErrorClubActionGetInvitations: 11
-  ErrorClubActionGetTicket: 8
-  ErrorClubActionGetTickets: 9
-  ErrorClubActionInviteMember: 18
-  ErrorClubActionKickMember: 21
-  ErrorClubActionLeave: 4
-  ErrorClubActionRedeemTicket: 7
-  ErrorClubActionRemoveBan: 23
-  ErrorClubActionRevokeInvitation: 12
-  ErrorClubActionSubscribe: 0
+  values:
+    ErrorClubActionAcceptInvitation: 13
+    ErrorClubActionAddBan: 22
+    ErrorClubActionCreate: 1
+    ErrorClubActionCreateMessage: 24
+    ErrorClubActionCreateStream: 15
+    ErrorClubActionCreateTicket: 5
+    ErrorClubActionDeclineInvitation: 14
+    ErrorClubActionDestroy: 3
+    ErrorClubActionDestroyMessage: 26
+    ErrorClubActionDestroyStream: 17
+    ErrorClubActionDestroyTicket: 6
+    ErrorClubActionEdit: 2
+    ErrorClubActionEditMember: 19
+    ErrorClubActionEditMemberNote: 20
+    ErrorClubActionEditMessage: 25
+    ErrorClubActionEditStream: 16
+    ErrorClubActionGetBans: 10
+    ErrorClubActionGetInvitations: 11
+    ErrorClubActionGetTicket: 8
+    ErrorClubActionGetTickets: 9
+    ErrorClubActionInviteMember: 18
+    ErrorClubActionKickMember: 21
+    ErrorClubActionLeave: 4
+    ErrorClubActionRedeemTicket: 7
+    ErrorClubActionRemoveBan: 23
+    ErrorClubActionRevokeInvitation: 12
+    ErrorClubActionSubscribe: 0
 ClubErrorType:
-  ErrorClubAlreadyMember: 19
-  ErrorClubBanAlreadyExists: 35
-  ErrorClubBanCountAtMax: 36
-  ErrorClubDoesntAllowCrossFaction: 40
-  ErrorClubEditHasCrossFactionMembers: 41
-  ErrorClubFull: 16
-  ErrorClubInsufficientPrivileges: 24
-  ErrorClubInvalidRoleID: 23
-  ErrorClubInvitationAlreadyExists: 22
-  ErrorClubMemberHasRequiredRole: 31
-  ErrorClubNoClub: 17
-  ErrorClubNoSuchInvitation: 21
-  ErrorClubNoSuchMember: 20
-  ErrorClubNotMember: 18
-  ErrorClubReceivedInvitationCountAtMax: 33
-  ErrorClubSentInvitationCountAtMax: 32
-  ErrorClubStreamCountAtMax: 30
-  ErrorClubStreamCountAtMin: 29
-  ErrorClubStreamInvalidName: 28
-  ErrorClubStreamNoStream: 27
-  ErrorClubTargetIsBanned: 34
-  ErrorClubTicketCountAtMax: 37
-  ErrorClubTicketHasConsumedAllowedRedeemCount: 39
-  ErrorClubTicketNoSuchTicket: 38
-  ErrorClubTooManyClubsJoined: 25
-  ErrorClubVoiceFull: 26
-  ErrorCommunitiesBadTarget: 4
-  ErrorCommunitiesChatMute: 15
-  ErrorCommunitiesGuild: 8
-  ErrorCommunitiesIgnored: 7
-  ErrorCommunitiesMissingShortName: 11
-  ErrorCommunitiesNeutralFaction: 2
-  ErrorCommunitiesNone: 0
-  ErrorCommunitiesProfanity: 12
-  ErrorCommunitiesRestricted: 6
-  ErrorCommunitiesTrial: 13
-  ErrorCommunitiesUnknown: 1
-  ErrorCommunitiesUnknownRealm: 3
-  ErrorCommunitiesUnknownTicket: 10
-  ErrorCommunitiesVeteranTrial: 14
-  ErrorCommunitiesWrongFaction: 5
-  ErrorCommunitiesWrongRegion: 9
+  values:
+    ErrorClubAlreadyMember: 19
+    ErrorClubBanAlreadyExists: 35
+    ErrorClubBanCountAtMax: 36
+    ErrorClubDoesntAllowCrossFaction: 40
+    ErrorClubEditHasCrossFactionMembers: 41
+    ErrorClubFull: 16
+    ErrorClubInsufficientPrivileges: 24
+    ErrorClubInvalidRoleID: 23
+    ErrorClubInvitationAlreadyExists: 22
+    ErrorClubMemberHasRequiredRole: 31
+    ErrorClubNoClub: 17
+    ErrorClubNoSuchInvitation: 21
+    ErrorClubNoSuchMember: 20
+    ErrorClubNotMember: 18
+    ErrorClubReceivedInvitationCountAtMax: 33
+    ErrorClubSentInvitationCountAtMax: 32
+    ErrorClubStreamCountAtMax: 30
+    ErrorClubStreamCountAtMin: 29
+    ErrorClubStreamInvalidName: 28
+    ErrorClubStreamNoStream: 27
+    ErrorClubTargetIsBanned: 34
+    ErrorClubTicketCountAtMax: 37
+    ErrorClubTicketHasConsumedAllowedRedeemCount: 39
+    ErrorClubTicketNoSuchTicket: 38
+    ErrorClubTooManyClubsJoined: 25
+    ErrorClubVoiceFull: 26
+    ErrorCommunitiesBadTarget: 4
+    ErrorCommunitiesChatMute: 15
+    ErrorCommunitiesGuild: 8
+    ErrorCommunitiesIgnored: 7
+    ErrorCommunitiesMissingShortName: 11
+    ErrorCommunitiesNeutralFaction: 2
+    ErrorCommunitiesNone: 0
+    ErrorCommunitiesProfanity: 12
+    ErrorCommunitiesRestricted: 6
+    ErrorCommunitiesTrial: 13
+    ErrorCommunitiesUnknown: 1
+    ErrorCommunitiesUnknownRealm: 3
+    ErrorCommunitiesUnknownTicket: 10
+    ErrorCommunitiesVeteranTrial: 14
+    ErrorCommunitiesWrongFaction: 5
+    ErrorCommunitiesWrongRegion: 9
 ClubFieldType:
-  ClubBroadcast: 3
-  ClubDescription: 2
-  ClubName: 0
-  ClubShortName: 1
-  ClubStreamName: 4
-  ClubStreamSubject: 5
-  NumTypes: 6
+  values:
+    ClubBroadcast: 3
+    ClubDescription: 2
+    ClubName: 0
+    ClubShortName: 1
+    ClubStreamName: 4
+    ClubStreamSubject: 5
+    NumTypes: 6
 ClubFinderApplicationUpdateType:
-  AcceptInvite: 1
-  Cancel: 3
-  DeclineInvite: 2
-  None: 0
+  values:
+    AcceptInvite: 1
+    Cancel: 3
+    DeclineInvite: 2
+    None: 0
 ClubFinderClubPostingStatusFlags:
-  Banned: 5
-  FakePost: 6
-  ForceDescriptionChange: 2
-  ForceNameChange: 3
-  NeedsCacheUpdate: 1
-  None: 0
-  PendingDelete: 7
-  PostDelisted: 8
-  UnderReview: 4
+  values:
+    Banned: 5
+    FakePost: 6
+    ForceDescriptionChange: 2
+    ForceNameChange: 3
+    NeedsCacheUpdate: 1
+    None: 0
+    PendingDelete: 7
+    PostDelisted: 8
+    UnderReview: 4
 ClubFinderDisableReason:
-  Muted: 0
-  Silenced: 1
-  VeteranTrial: 2
+  values:
+    Muted: 0
+    Silenced: 1
+    VeteranTrial: 2
 ClubFinderPostingReportType:
-  ApplicantsName: 3
-  ClubName: 1
-  JoinNote: 4
-  PostersName: 0
-  PostingDescription: 2
+  values:
+    ApplicantsName: 3
+    ClubName: 1
+    JoinNote: 4
+    PostersName: 0
+    PostingDescription: 2
 ClubFinderRequestType:
-  All: 3
-  Community: 2
-  Guild: 1
-  None: 0
+  values:
+    All: 3
+    Community: 2
+    Guild: 1
+    None: 0
 ClubFinderSettingFlags:
-  AutoAccept: 14
-  Damage: 11
-  Dungeons: 1
-  EnableListing: 12
-  FactionAlliance: 16
-  FactionHorde: 15
-  FactionNeutral: 17
-  Healer: 10
-  LanguageReserved1: 21
-  LanguageReserved2: 22
-  LanguageReserved3: 23
-  LanguageReserved4: 24
-  LanguageReserved5: 25
-  Large: 8
-  MaxLevelOnly: 13
-  Medium: 7
-  None: 0
-  PvP: 3
-  Raids: 2
-  RP: 4
-  Small: 6
-  Social: 5
-  SortMemberCount: 19
-  SortNewest: 20
-  SortRelevance: 18
-  Tank: 9
+  values:
+    AutoAccept: 14
+    Damage: 11
+    Dungeons: 1
+    EnableListing: 12
+    FactionAlliance: 16
+    FactionHorde: 15
+    FactionNeutral: 17
+    Healer: 10
+    LanguageReserved1: 21
+    LanguageReserved2: 22
+    LanguageReserved3: 23
+    LanguageReserved4: 24
+    LanguageReserved5: 25
+    Large: 8
+    MaxLevelOnly: 13
+    Medium: 7
+    None: 0
+    PvP: 3
+    Raids: 2
+    RP: 4
+    Small: 6
+    Social: 5
+    SortMemberCount: 19
+    SortNewest: 20
+    SortRelevance: 18
+    Tank: 9
 ClubInvitationCandidateStatus:
-  AlreadyMember: 2
-  Available: 0
-  InvitePending: 1
+  values:
+    AlreadyMember: 2
+    Available: 0
+    InvitePending: 1
 ClubMemberPresence:
-  Away: 4
-  Busy: 5
-  Offline: 3
-  Online: 1
-  OnlineMobile: 2
-  Unknown: 0
+  values:
+    Away: 4
+    Busy: 5
+    Offline: 3
+    Online: 1
+    OnlineMobile: 2
+    Unknown: 0
 ClubRemovedReason:
-  Banned: 1
-  ClubDestroyed: 3
-  None: 0
-  Removed: 2
+  values:
+    Banned: 1
+    ClubDestroyed: 3
+    None: 0
+    Removed: 2
 ClubRestrictionReason:
-  None: 0
-  Unavailable: 1
+  values:
+    None: 0
+    Unavailable: 1
 ClubRoleIdentifier:
-  Leader: 2
-  Member: 4
-  Moderator: 3
-  Owner: 1
+  values:
+    Leader: 2
+    Member: 4
+    Moderator: 3
+    Owner: 1
 ClubStreamNotificationFilter:
-  All: 2
-  Mention: 1
-  None: 0
+  values:
+    All: 2
+    Mention: 1
+    None: 0
 ClubStreamType:
-  General: 0
-  Guild: 1
-  Officer: 2
-  Other: 3
+  values:
+    General: 0
+    Guild: 1
+    Officer: 2
+    Other: 3
 ClubType:
-  BattleNet: 0
-  Character: 1
-  Guild: 2
-  Other: 3
+  values:
+    BattleNet: 0
+    Character: 1
+    Guild: 2
+    Other: 3
 ColorOverride:
-  ItemQualityAccount: 7
-  ItemQualityArtifact: 6
-  ItemQualityCommon: 1
-  ItemQualityEpic: 4
-  ItemQualityLegendary: 5
-  ItemQualityPoor: 0
-  ItemQualityRare: 3
-  ItemQualityUncommon: 2
+  values:
+    ItemQualityAccount: 7
+    ItemQualityArtifact: 6
+    ItemQualityCommon: 1
+    ItemQualityEpic: 4
+    ItemQualityLegendary: 5
+    ItemQualityPoor: 0
+    ItemQualityRare: 3
+    ItemQualityUncommon: 2
 CombatAudioAlertCastState:
-  Off: 0
-  OnCastEnd: 2
-  OnCastStart: 1
+  values:
+    Off: 0
+    OnCastEnd: 2
+    OnCastStart: 1
 CombatAudioAlertCategory:
-  General: 0
-  PartyHealth: 7
-  PlayerCast: 3
-  PlayerDebuffs: 8
-  PlayerHealth: 1
-  PlayerResource1: 5
-  PlayerResource2: 6
-  TargetCast: 4
-  TargetHealth: 2
+  values:
+    General: 0
+    PartyHealth: 7
+    PlayerCast: 3
+    PlayerDebuffs: 8
+    PlayerHealth: 1
+    PlayerResource1: 5
+    PlayerResource2: 6
+    TargetCast: 4
+    TargetHealth: 2
 CombatAudioAlertDebuffSelfAlertValues:
-  DispelType: 1
-  Off: 0
+  values:
+    DispelType: 1
+    Off: 0
 CombatAudioAlertPartyPercentValues:
-  Off: 0
-  Under100Percent: 1
-  Under10Percent: 10
-  Under20Percent: 9
-  Under30Percent: 8
-  Under40Percent: 7
-  Under50Percent: 6
-  Under60Percent: 5
-  Under70Percent: 4
-  Under80Percent: 3
-  Under90Percent: 2
+  values:
+    Off: 0
+    Under100Percent: 1
+    Under10Percent: 10
+    Under20Percent: 9
+    Under30Percent: 8
+    Under40Percent: 7
+    Under50Percent: 6
+    Under60Percent: 5
+    Under70Percent: 4
+    Under80Percent: 3
+    Under90Percent: 2
 CombatAudioAlertPercentValues:
-  Every10Percent: 1
-  Every20Percent: 2
-  Every30Percent: 3
-  Every40Percent: 4
-  Every50Percent: 5
-  Off: 0
+  values:
+    Every10Percent: 1
+    Every20Percent: 2
+    Every30Percent: 3
+    Every40Percent: 4
+    Every50Percent: 5
+    Off: 0
 CombatAudioAlertPlayerCastFormatValues:
-  Cast: 3
-  Casting: 2
-  CastingSpellname: 0
-  CastSpellname: 1
-  Spellname: 4
+  values:
+    Cast: 3
+    Casting: 2
+    CastingSpellname: 0
+    CastSpellname: 1
+    Spellname: 4
 CombatAudioAlertPlayerDebuffFormatValues:
-  Full: 0
-  NoSpellname: 1
+  values:
+    Full: 0
+    NoSpellname: 1
 CombatAudioAlertPlayerHealthFormatValues:
-  HealthFull: 0
-  HealthNoPercent: 1
-  HealthNoPercentDiv10: 2
-  NoHealthFull: 3
-  NoHealthNoPercent: 4
-  NoHealthNoPercentDiv10: 5
+  values:
+    HealthFull: 0
+    HealthNoPercent: 1
+    HealthNoPercentDiv10: 2
+    NoHealthFull: 3
+    NoHealthNoPercent: 4
+    NoHealthNoPercentDiv10: 5
 CombatAudioAlertPlayerResourceFormatValues:
-  NoResourceFull: 3
-  NoResourceNoPercent: 4
-  NoResourceNoPercentDiv10: 5
-  ResourceFull: 0
-  ResourceNoPercent: 1
-  ResourceNoPercentDiv10: 2
+  values:
+    NoResourceFull: 3
+    NoResourceNoPercent: 4
+    NoResourceNoPercentDiv10: 5
+    ResourceFull: 0
+    ResourceNoPercent: 1
+    ResourceNoPercentDiv10: 2
 CombatAudioAlertSayIfTargetedType:
-  Aggro: 1
-  None: 0
-  Targeted: 2
-  TargetedBy: 3
+  values:
+    Aggro: 1
+    None: 0
+    Targeted: 2
+    TargetedBy: 3
 CombatAudioAlertSpecSetting:
-  Resource1Format: 1
-  Resource1Percent: 0
-  Resource1Voice: 2
-  Resource1Volume: 3
-  Resource2Format: 5
-  Resource2Percent: 4
-  Resource2Voice: 6
-  Resource2Volume: 7
-  SayIfTargeted: 8
+  values:
+    Resource1Format: 1
+    Resource1Percent: 0
+    Resource1Voice: 2
+    Resource1Volume: 3
+    Resource2Format: 5
+    Resource2Percent: 4
+    Resource2Voice: 6
+    Resource2Volume: 7
+    SayIfTargeted: 8
 CombatAudioAlertTargetCastFormatValues:
-  Cast: 5
-  Casting: 4
-  CastingSpellname: 2
-  CastSpellname: 3
-  Spellname: 6
-  TargetCastingSpellname: 0
-  TargetCastSpellname: 1
+  values:
+    Cast: 5
+    Casting: 4
+    CastingSpellname: 2
+    CastSpellname: 3
+    Spellname: 6
+    TargetCastingSpellname: 0
+    TargetCastSpellname: 1
 CombatAudioAlertTargetDeathBehavior:
-  Default: 0
-  SayTargetDead: 1
+  values:
+    Default: 0
+    SayTargetDead: 1
 CombatAudioAlertTargetHealthFormatValues:
-  HealthFull: 3
-  HealthNoPercent: 4
-  HealthNoPercentDiv10: 5
-  NoHealthFull: 0
-  NoHealthNoPercent: 1
-  NoHealthNoPercentDiv10: 2
-  TargetFull: 6
-  TargetNoPercent: 7
-  TargetNoPercentDiv10: 8
+  values:
+    HealthFull: 3
+    HealthNoPercent: 4
+    HealthNoPercentDiv10: 5
+    NoHealthFull: 0
+    NoHealthNoPercent: 1
+    NoHealthNoPercentDiv10: 2
+    TargetFull: 6
+    TargetNoPercent: 7
+    TargetNoPercentDiv10: 8
 CombatAudioAlertThrottle:
-  PlayerCast: 3
-  PlayerHealth: 1
-  PlayerHealthSamePercent: 7
-  PlayerResource1: 5
-  PlayerResource1SamePercent: 9
-  PlayerResource2: 6
-  PlayerResource2SamePercent: 10
-  Sample: 0
-  TargetCast: 4
-  TargetHealth: 2
-  TargetHealthSamePercent: 8
+  values:
+    PlayerCast: 3
+    PlayerHealth: 1
+    PlayerHealthSamePercent: 7
+    PlayerResource1: 5
+    PlayerResource1SamePercent: 9
+    PlayerResource2: 6
+    PlayerResource2SamePercent: 10
+    Sample: 0
+    TargetCast: 4
+    TargetHealth: 2
+    TargetHealthSamePercent: 8
 CombatAudioAlertType:
-  Cast: 1
-  Health: 0
+  values:
+    Cast: 1
+    Health: 0
 CombatAudioAlertUnit:
-  Player: 0
-  Target: 1
+  values:
+    Player: 0
+    Target: 1
 CombatLogMessageOrder:
-  Newest: 0
-  Oldest: 1
+  values:
+    Newest: 0
+    Oldest: 1
 CombatLogObject:
-  AffiliationMine: 1
-  AffiliationOutsider: 8
-  AffiliationParty: 2
-  AffiliationRaid: 4
-  ControlNpc: 512
-  ControlPlayer: 256
-  Empty: 0
-  Focus: 131072
-  Mainassist: 524288
-  Maintank: 262144
-  None: 2147483648
-  ReactionFriendly: 16
-  ReactionHostile: 64
-  ReactionNeutral: 32
-  Target: 65536
-  TypeGuardian: 8192
-  TypeNpc: 2048
-  TypeObject: 16384
-  TypePet: 4096
-  TypePlayer: 1024
+  values:
+    AffiliationMine: 1
+    AffiliationOutsider: 8
+    AffiliationParty: 2
+    AffiliationRaid: 4
+    ControlNpc: 512
+    ControlPlayer: 256
+    Empty: 0
+    Focus: 131072
+    Mainassist: 524288
+    Maintank: 262144
+    None: 2147483648
+    ReactionFriendly: 16
+    ReactionHostile: 64
+    ReactionNeutral: 32
+    Target: 65536
+    TypeGuardian: 8192
+    TypeNpc: 2048
+    TypeObject: 16384
+    TypePet: 4096
+    TypePlayer: 1024
 CombatLogObjectTarget:
-  RaidNone: 2147483648
-  Raidtarget1: 1
-  Raidtarget2: 2
-  Raidtarget3: 4
-  Raidtarget4: 8
-  Raidtarget5: 16
-  Raidtarget6: 32
-  Raidtarget7: 64
-  Raidtarget8: 128
+  values:
+    RaidNone: 2147483648
+    Raidtarget1: 1
+    Raidtarget2: 2
+    Raidtarget3: 4
+    Raidtarget4: 8
+    Raidtarget5: 16
+    Raidtarget6: 32
+    Raidtarget7: 64
+    Raidtarget8: 128
 CombinedQuestLogStatus:
-  Available: 0
-  Complete: 1
-  CompleteDaily: 2
-  CompleteGameReset: 6
-  CompleteMonthly: 4
-  CompleteWeekly: 3
-  CompleteYearly: 5
-  Reset: 7
+  values:
+    Available: 0
+    Complete: 1
+    CompleteDaily: 2
+    CompleteGameReset: 6
+    CompleteMonthly: 4
+    CompleteWeekly: 3
+    CompleteYearly: 5
+    Reset: 7
 CombinedQuestStatus:
-  Completed: 1
-  Invalid: 0
-  NotCompleted: 2
+  values:
+    Completed: 1
+    Invalid: 0
+    NotCompleted: 2
 CommunicationMode:
-  OpenMic: 1
-  PushToTalk: 0
+  values:
+    OpenMic: 1
+    PushToTalk: 0
 CompanionConfigSlotTypes:
-  Combat: 2
-  Role: 0
-  Utility: 1
+  values:
+    Combat: 2
+    Role: 0
+    Utility: 1
 CompressionLevel:
-  Default: 0
-  OptimizeForSize: 2
-  OptimizeForSpeed: 1
+  values:
+    Default: 0
+    OptimizeForSize: 2
+    OptimizeForSpeed: 1
 CompressionMethod:
-  Deflate: 0
-  Gzip: 2
-  Zlib: 1
+  values:
+    Deflate: 0
+    Gzip: 2
+    Zlib: 1
 ConfirmationPromptUIType:
-  BonusRoll: 1
-  SimpleWarning: 2
-  SimpleWarningAlert: 4
-  StaticText: 0
-  StaticTextAlert: 3
+  values:
+    BonusRoll: 1
+    SimpleWarning: 2
+    SimpleWarningAlert: 4
+    StaticText: 0
+    StaticTextAlert: 3
 ConsoleCategory:
-  Combat: 3
-  Console: 2
-  Debug: 0
-  Default: 5
-  Game: 4
-  Gm: 8
-  Graphics: 1
-  Net: 6
-  None: 10
-  Reveal: 9
-  Sound: 7
+  values:
+    Combat: 3
+    Console: 2
+    Debug: 0
+    Default: 5
+    Game: 4
+    Gm: 8
+    Graphics: 1
+    Net: 6
+    None: 10
+    Reveal: 9
+    Sound: 7
 ConsoleColorType:
-  AdminColor: 6
-  BackgroundColor: 8
-  ClickbufferColor: 9
-  DefaultColor: 0
-  DefaultGreen: 11
-  EchoColor: 2
-  ErrorColor: 3
-  GlobalColor: 5
-  HighlightColor: 7
-  InputColor: 1
-  PrivateColor: 10
-  WarningColor: 4
+  values:
+    AdminColor: 6
+    BackgroundColor: 8
+    ClickbufferColor: 9
+    DefaultColor: 0
+    DefaultGreen: 11
+    EchoColor: 2
+    ErrorColor: 3
+    GlobalColor: 5
+    HighlightColor: 7
+    InputColor: 1
+    PrivateColor: 10
+    WarningColor: 4
 ConsoleCommandType:
-  Command: 1
-  Cvar: 0
-  Macro: 2
-  Script: 3
+  values:
+    Command: 1
+    Cvar: 0
+    Macro: 2
+    Script: 3
 ContentTrackingError:
-  AlreadyTracked: 2
-  MaxTracked: 1
-  Untrackable: 0
+  values:
+    AlreadyTracked: 2
+    MaxTracked: 1
+    Untrackable: 0
 ContentTrackingResult:
-  DataPending: 1
-  Failure: 2
-  Success: 0
+  values:
+    DataPending: 1
+    Failure: 2
+    Success: 0
 ContentTrackingStopType:
-  Collected: 1
-  Invalidated: 0
-  Manual: 2
+  values:
+    Collected: 1
+    Invalidated: 0
+    Manual: 2
 ContentTrackingTargetType:
-  Achievement: 2
-  JournalEncounter: 0
-  Profession: 3
-  Quest: 4
-  Vendor: 1
+  values:
+    Achievement: 2
+    JournalEncounter: 0
+    Profession: 3
+    Quest: 4
+    Vendor: 1
 ContentTrackingType:
-  Achievement: 2
-  Appearance: 0
-  Decor: 3
-  Mount: 1
+  values:
+    Achievement: 2
+    Appearance: 0
+    Decor: 3
+    Mount: 1
 ContributionAppearanceFlags:
-  TooltipUseTimeRemaining: 0
+  values:
+    TooltipUseTimeRemaining: 0
 ContributionResult:
-  FailedConditionCheck: 5
-  IncorrectState: 2
-  InternalError: 7
-  InvalidID: 3
-  MustBeNearNpc: 1
-  QuestDataMissing: 4
-  Success: 0
-  UnableToCompleteTurnIn: 6
+  values:
+    FailedConditionCheck: 5
+    IncorrectState: 2
+    InternalError: 7
+    InvalidID: 3
+    MustBeNearNpc: 1
+    QuestDataMissing: 4
+    Success: 0
+    UnableToCompleteTurnIn: 6
 ContributionState:
-  Active: 2
-  Building: 1
-  Destroyed: 4
-  None: 0
-  UnderAttack: 3
+  values:
+    Active: 2
+    Building: 1
+    Destroyed: 4
+    None: 0
+    UnderAttack: 3
 CooldownSetLinkedSpellFlags:
-  UseAsTooltip: 1
+  values:
+    UseAsTooltip: 1
 CooldownSetSpellFlags:
-  HideAura: 1
-  HideByDefault: 2
+  values:
+    HideAura: 1
+    HideByDefault: 2
 CooldownViewerAddAlertStatus:
-  DuplicateAlert: 3
-  InvalidAlertType: 1
-  InvalidEventType: 2
-  Success: 0
+  values:
+    DuplicateAlert: 3
+    InvalidAlertType: 1
+    InvalidEventType: 2
+    Success: 0
 CooldownViewerAlertEventType:
-  Available: 1
-  ChargeGained: 4
-  OnAuraApplied: 5
-  OnAuraRemoved: 6
-  OnCooldown: 3
-  PandemicTime: 2
+  values:
+    Available: 1
+    ChargeGained: 4
+    OnAuraApplied: 5
+    OnAuraRemoved: 6
+    OnCooldown: 3
+    PandemicTime: 2
 CooldownViewerAlertType:
-  Sound: 1
-  Visual: 2
+  values:
+    Sound: 1
+    Visual: 2
 CooldownViewerBarContent:
-  IconAndName: 0
-  IconOnly: 1
-  NameOnly: 2
+  values:
+    IconAndName: 0
+    IconOnly: 1
+    NameOnly: 2
 CooldownViewerCategory:
-  Essential: 0
-  TrackedBar: 3
-  TrackedBuff: 2
-  Utility: 1
+  values:
+    Essential: 0
+    TrackedBar: 3
+    TrackedBuff: 2
+    Utility: 1
 CooldownViewerIconDirection:
-  Left: 0
-  Right: 1
+  values:
+    Left: 0
+    Right: 1
 CooldownViewerOrientation:
-  Horizontal: 0
-  Vertical: 1
+  values:
+    Horizontal: 0
+    Vertical: 1
 CooldownViewerVisibleSetting:
-  Always: 0
-  Hidden: 2
-  InCombat: 1
+  values:
+    Always: 0
+    Hidden: 2
+    InCombat: 1
 CornerstonePurchaseMode:
-  Basic: 0
-  Import: 1
-  Move: 2
+  values:
+    Basic: 0
+    Import: 1
+    Move: 2
 CovenantSkill:
-  Kyrian: 2730
-  Necrolord: 2733
-  NightFae: 2732
-  Venthyr: 2731
+  values:
+    Kyrian: 2730
+    Necrolord: 2733
+    NightFae: 2732
+    Venthyr: 2731
 CovenantType:
-  Kyrian: 1
-  Necrolord: 4
-  NightFae: 3
-  None: 0
-  Venthyr: 2
+  values:
+    Kyrian: 1
+    Necrolord: 4
+    NightFae: 3
+    None: 0
+    Venthyr: 2
 CraftingOrderDuration:
-  Long: 2
-  Medium: 1
-  Short: 0
+  values:
+    Long: 2
+    Medium: 1
+    Short: 0
 CraftingOrderFlags:
-  HasAllReagents: 8
-  HasNoneReagents: 2
-  HasSomeReagents: 4
-  IsFulfillable: 16
-  IsRecraft: 1
-  None: 0
+  values:
+    HasAllReagents: 8
+    HasNoneReagents: 2
+    HasSomeReagents: 4
+    IsFulfillable: 16
+    IsRecraft: 1
+    None: 0
 CraftingOrderItemFlags:
-  HasEnchantmentData: 2
-  None: 0
-  NpcProvided: 1
+  values:
+    HasEnchantmentData: 2
+    None: 0
+    NpcProvided: 1
 CraftingOrderItemType:
-  CraftedResult: 2
-  Currency: 5
-  Deprecated: 4
-  Item: 0
-  Recraft: 1
-  RemoveReagent: 3
+  values:
+    CraftedResult: 2
+    Currency: 5
+    Deprecated: 4
+    Item: 0
+    Recraft: 1
+    RemoveReagent: 3
 CraftingOrderReagentSource:
-  Any: 0
-  Crafter: 2
-  Customer: 1
-  None: 3
+  values:
+    Any: 0
+    Crafter: 2
+    Customer: 1
+    None: 3
 CraftingOrderResult:
-  Aborted: 1
-  AlreadyClaimed: 2
-  AlreadyCrafted: 3
-  CannotBeOrdered: 4
-  CannotCancel: 5
-  CannotClaim: 6
-  CannotClaimOwnOrder: 7
-  CannotCraft: 8
-  CannotCreate: 9
-  CannotFulfill: 10
-  CannotRecraft: 11
-  CannotReject: 12
-  CannotRelease: 13
-  CrafterIsIgnored: 14
-  DatabaseError: 15
-  Expired: 16
-  InvalidDuration: 18
-  InvalidMinQuality: 19
-  InvalidNotes: 20
-  InvalidReagent: 21
-  InvalidRealm: 22
-  InvalidRecipe: 23
-  InvalidRecraftItem: 24
-  InvalidSort: 25
-  InvalidTarget: 26
-  InvalidType: 27
-  Locked: 17
-  MaxOrdersReached: 28
-  MissingCraftingTable: 29
-  MissingCurrency: 30
-  MissingItem: 31
-  MissingNpc: 32
-  MissingOrder: 33
-  MissingRecraftItem: 34
-  NoAccountItems: 35
-  NotClaimed: 36
-  NotCrafted: 37
-  NotInGuild: 38
-  NotYetImplemented: 39
-  Ok: 0
-  OutOfPublicOrderCapacity: 40
-  ServerIsNotAvailable: 41
-  TargetCannotCraft: 43
-  TargetLocked: 44
-  ThrottleViolation: 42
-  Timeout: 45
-  TooManyCurrencies: 46
-  TooManyItems: 47
-  WrongVersion: 48
+  values:
+    Aborted: 1
+    AlreadyClaimed: 2
+    AlreadyCrafted: 3
+    CannotBeOrdered: 4
+    CannotCancel: 5
+    CannotClaim: 6
+    CannotClaimOwnOrder: 7
+    CannotCraft: 8
+    CannotCreate: 9
+    CannotFulfill: 10
+    CannotRecraft: 11
+    CannotReject: 12
+    CannotRelease: 13
+    CrafterIsIgnored: 14
+    DatabaseError: 15
+    Expired: 16
+    InvalidDuration: 18
+    InvalidMinQuality: 19
+    InvalidNotes: 20
+    InvalidReagent: 21
+    InvalidRealm: 22
+    InvalidRecipe: 23
+    InvalidRecraftItem: 24
+    InvalidSort: 25
+    InvalidTarget: 26
+    InvalidType: 27
+    Locked: 17
+    MaxOrdersReached: 28
+    MissingCraftingTable: 29
+    MissingCurrency: 30
+    MissingItem: 31
+    MissingNpc: 32
+    MissingOrder: 33
+    MissingRecraftItem: 34
+    NoAccountItems: 35
+    NotClaimed: 36
+    NotCrafted: 37
+    NotInGuild: 38
+    NotYetImplemented: 39
+    Ok: 0
+    OutOfPublicOrderCapacity: 40
+    ServerIsNotAvailable: 41
+    TargetCannotCraft: 43
+    TargetLocked: 44
+    ThrottleViolation: 42
+    Timeout: 45
+    TooManyCurrencies: 46
+    TooManyItems: 47
+    WrongVersion: 48
 CraftingOrderSortType:
-  AveTip: 1
-  ItemName: 0
-  MaxTip: 2
-  Quantity: 3
-  Reagents: 4
-  Status: 7
-  TimeRemaining: 6
-  Tip: 5
+  values:
+    AveTip: 1
+    ItemName: 0
+    MaxTip: 2
+    Quantity: 3
+    Reagents: 4
+    Status: 7
+    TimeRemaining: 6
+    Tip: 5
 CraftingOrderState:
-  Canceled: 13
-  Canceling: 12
-  Claimed: 4
-  Claiming: 3
-  Crafting: 8
-  Created: 2
-  Creating: 1
-  Expired: 15
-  Expiring: 14
-  Fulfilled: 11
-  Fulfilling: 10
-  None: 0
-  Recrafting: 9
-  Rejected: 6
-  Rejecting: 5
-  Releasing: 7
+  values:
+    Canceled: 13
+    Canceling: 12
+    Claimed: 4
+    Claiming: 3
+    Crafting: 8
+    Created: 2
+    Creating: 1
+    Expired: 15
+    Expiring: 14
+    Fulfilled: 11
+    Fulfilling: 10
+    None: 0
+    Recrafting: 9
+    Rejected: 6
+    Rejecting: 5
+    Releasing: 7
 CraftingOrderType:
-  Guild: 1
-  Npc: 3
-  Personal: 2
-  Public: 0
+  values:
+    Guild: 1
+    Npc: 3
+    Personal: 2
+    Public: 0
 CraftingReagentItemFlag:
-  TooltipShowsAsStatModifications: 1
+  values:
+    TooltipShowsAsStatModifications: 1
 CraftingReagentType:
-  Automatic: 3
-  Basic: 1
-  Finishing: 2
-  Modifying: 0
+  values:
+    Automatic: 3
+    Basic: 1
+    Finishing: 2
+    Modifying: 0
 CreateAllAccountData:
-  AccountCurrenciesDone: '0x0000000000200000'
-  AccountDynamicCriteriaDone: '0x0000000001000000'
-  AccountFactionsDone: '0x0000000200000000'
-  AccountItemsDone: '0x0000000400000000'
-  AccountMappingDone: '0x0000008000000000'
-  AccountNotificationsDone: '0x0000000008000000'
-  AccountStateHousingData: '0x0000080000000000'
-  AchievementsDone: '0x0000000000000001'
-  ArchivedPurchasesDone: '0x0000000000000200'
-  AuctionableTokensDone: '0x0000000000002000'
-  BanktabSettingsDone: '0x0000004000000000'
-  BattlepetsDone: '0x0000000000000008'
-  BitVectorsDone: '0x0000000100000000'
-  BpayAddLicenseObjectsDone: '0x0000000000000800'
-  BpayDistributionObjectsDone: '0x0000000000000100'
-  BpayProductitemObjectsDone: '0x0000000000020000'
-  CharacterItemsDone: '0x0000010000000000'
-  CharactersDone: '0x0000000000000040'
-  CombinedQuestLogEntriesDone: '0x0000000800000000'
-  ConsumableTokensDone: '0x0000000000004000'
-  CriteriaDone: '0x0000000000000002'
-  CurrencycapsDone: '0x0000000000000010'
-  CurrencyTransferLogDone: '0x0000020000000000'
-  DataElementsDone: '0x0000001000000000'
-  EventRecordsDone: '0x0000200000000000'
-  ItemCollectionItemsDone: '0x0000000000001000'
-  LgVendorPurchaseDone: '0x0000040000000000'
-  MountsDone: '0x0000000000000004'
-  None: '0x0000000000000000'
-  Object: '0x0000000000100000'
-  PerkHeldItemsDone: '0x0000000040000000'
-  PerkPastRewardsDone: '0x0000000000008000'
-  PerkPendingPurchasesDone: '0x0000000010000000'
-  PerkPendingRewardsDone: '0x0000000080000000'
-  PurchasesDone: '0x0000000000000080'
-  QuestCriteriaDone: '0x0000000000080000'
-  QuestLogDone: '0x0000000000000020'
-  RafActivitiesDone: '0x0000000002000000'
-  RafBalanceDone: '0x0000000000400000'
-  RafRewardsDone: '0x0000000000800000'
-  RevokedRafRewardsDone: '0x0000000004000000'
-  SettingsDone: '0x0000000000000400'
-  TransmogOutfitsLoadedDone: '0x0000400000000000'
-  TrialBoostHistoryDone: '0x0000000000040000'
-  VasTransactionsDone: '0x0000000000010000'
-  WarbandGroupsDone: '0x0000002000000000'
-  WarbandScenesLoadedDone: '0x0000100000000000'
-  WowlabsDataDone: '0x0000000020000000'
+  values:
+    AccountCurrenciesDone: '0x0000000000200000'
+    AccountDynamicCriteriaDone: '0x0000000001000000'
+    AccountFactionsDone: '0x0000000200000000'
+    AccountItemsDone: '0x0000000400000000'
+    AccountMappingDone: '0x0000008000000000'
+    AccountNotificationsDone: '0x0000000008000000'
+    AccountStateHousingData: '0x0000080000000000'
+    AchievementsDone: '0x0000000000000001'
+    ArchivedPurchasesDone: '0x0000000000000200'
+    AuctionableTokensDone: '0x0000000000002000'
+    BanktabSettingsDone: '0x0000004000000000'
+    BattlepetsDone: '0x0000000000000008'
+    BitVectorsDone: '0x0000000100000000'
+    BpayAddLicenseObjectsDone: '0x0000000000000800'
+    BpayDistributionObjectsDone: '0x0000000000000100'
+    BpayProductitemObjectsDone: '0x0000000000020000'
+    CharacterItemsDone: '0x0000010000000000'
+    CharactersDone: '0x0000000000000040'
+    CombinedQuestLogEntriesDone: '0x0000000800000000'
+    ConsumableTokensDone: '0x0000000000004000'
+    CriteriaDone: '0x0000000000000002'
+    CurrencycapsDone: '0x0000000000000010'
+    CurrencyTransferLogDone: '0x0000020000000000'
+    DataElementsDone: '0x0000001000000000'
+    EventRecordsDone: '0x0000200000000000'
+    ItemCollectionItemsDone: '0x0000000000001000'
+    LgVendorPurchaseDone: '0x0000040000000000'
+    MountsDone: '0x0000000000000004'
+    None: '0x0000000000000000'
+    Object: '0x0000000000100000'
+    PerkHeldItemsDone: '0x0000000040000000'
+    PerkPastRewardsDone: '0x0000000000008000'
+    PerkPendingPurchasesDone: '0x0000000010000000'
+    PerkPendingRewardsDone: '0x0000000080000000'
+    PurchasesDone: '0x0000000000000080'
+    QuestCriteriaDone: '0x0000000000080000'
+    QuestLogDone: '0x0000000000000020'
+    RafActivitiesDone: '0x0000000002000000'
+    RafBalanceDone: '0x0000000000400000'
+    RafRewardsDone: '0x0000000000800000'
+    RevokedRafRewardsDone: '0x0000000004000000'
+    SettingsDone: '0x0000000000000400'
+    TransmogOutfitsLoadedDone: '0x0000400000000000'
+    TrialBoostHistoryDone: '0x0000000000040000'
+    VasTransactionsDone: '0x0000000000010000'
+    WarbandGroupsDone: '0x0000002000000000'
+    WarbandScenesLoadedDone: '0x0000100000000000'
+    WowlabsDataDone: '0x0000000020000000'
 CreateNeighborhoodErrorType:
-  None: 0
-  OversizedGuild: 3
-  Profanity: 1
-  UndersizedGuild: 2
+  values:
+    None: 0
+    OversizedGuild: 3
+    Profanity: 1
+    UndersizedGuild: 2
 CurioRarity:
-  Common: 1
-  Epic: 4
-  Rare: 3
-  Uncommon: 2
+  values:
+    Common: 1
+    Epic: 4
+    Rare: 3
+    Uncommon: 2
 CurrencyConversionResult:
-  Conversion: 1
-  NoConversion: 0
-  SkippedAccountCurrency: 2
+  values:
+    Conversion: 1
+    NoConversion: 0
+    SkippedAccountCurrency: 2
 CurrencyDestroyReason:
-  BonusRoll: 9
-  Capped: 6
-  Cheat: 0
-  DroppedToCorpse: 8
-  Garrison: 7
-  LegacyConversion: 10
-  QuestTurnin: 3
-  Spell: 1
-  Trade: 5
-  Vendor: 4
-  VersionUpdate: 2
+  values:
+    BonusRoll: 9
+    Capped: 6
+    Cheat: 0
+    DroppedToCorpse: 8
+    Garrison: 7
+    LegacyConversion: 10
+    QuestTurnin: 3
+    Spell: 1
+    Trade: 5
+    Vendor: 4
+    VersionUpdate: 2
 CurrencyFlags:
-  Currency_100_Scaler: 8
-  CurrencyAccountWide: 16777216
-  CurrencyAllowOverflowMailer: 33554432
-  CurrencyAppearsInLootWindow: 2
-  CurrencyComputedWeeklyMaximum: 4
-  CurrencyDeprecated: 131072
-  CurrencyDestroyExtraOnLoot: 2097152
-  CurrencyDoNotCompressChat: 8192
-  CurrencyDoNotLogAcquisitionToBi: 16384
-  CurrencyDoNotToast: 1048576
-  CurrencyDontCoalesceInLootWindow: 8388608
-  CurrencyDontShowTotalInTooltip: 4194304
-  CurrencyDynamicMaximum: 262144
-  CurrencyHasWarmodeBonus: 134217728
-  CurrencyHasWeeklyCatchup: 4096
-  CurrencyHideAsReward: 67108864
-  CurrencyIgnoreMaxQtyOnLoad: 32
-  CurrencyIsAllianceOnly: 268435456
-  CurrencyIsHordeOnly: 536870912
-  CurrencyLimitWarmodeBonusOncePerTooltip: 1073741824
-  CurrencyLogOnWorldChange: 64
-  CurrencyNoLowLevelDrop: 16
-  CurrencyNoRaidDrop: 32768
-  CurrencyNotPersistent: 65536
-  CurrencyResetTrackedQuantity: 256
-  CurrencySingleDropInLoot: 2048
-  CurrencySuppressChatMessageOnVersionChange: 1024
-  CurrencySuppressChatMessages: 524288
-  CurrencyTrackQuantity: 128
-  CurrencyTradable: 1
-  CurrencyUpdateVersionIgnoreMax: 512
-  CurrencyUsesLedgerBalance: 2147483648
+  values:
+    Currency_100_Scaler: 8
+    CurrencyAccountWide: 16777216
+    CurrencyAllowOverflowMailer: 33554432
+    CurrencyAppearsInLootWindow: 2
+    CurrencyComputedWeeklyMaximum: 4
+    CurrencyDeprecated: 131072
+    CurrencyDestroyExtraOnLoot: 2097152
+    CurrencyDoNotCompressChat: 8192
+    CurrencyDoNotLogAcquisitionToBi: 16384
+    CurrencyDoNotToast: 1048576
+    CurrencyDontCoalesceInLootWindow: 8388608
+    CurrencyDontShowTotalInTooltip: 4194304
+    CurrencyDynamicMaximum: 262144
+    CurrencyHasWarmodeBonus: 134217728
+    CurrencyHasWeeklyCatchup: 4096
+    CurrencyHideAsReward: 67108864
+    CurrencyIgnoreMaxQtyOnLoad: 32
+    CurrencyIsAllianceOnly: 268435456
+    CurrencyIsHordeOnly: 536870912
+    CurrencyLimitWarmodeBonusOncePerTooltip: 1073741824
+    CurrencyLogOnWorldChange: 64
+    CurrencyNoLowLevelDrop: 16
+    CurrencyNoRaidDrop: 32768
+    CurrencyNotPersistent: 65536
+    CurrencyResetTrackedQuantity: 256
+    CurrencySingleDropInLoot: 2048
+    CurrencySuppressChatMessageOnVersionChange: 1024
+    CurrencySuppressChatMessages: 524288
+    CurrencyTrackQuantity: 128
+    CurrencyTradable: 1
+    CurrencyUpdateVersionIgnoreMax: 512
+    CurrencyUsesLedgerBalance: 2147483648
 CurrencyFlagsB:
-  CurrencyBAllowReductionByResourcefulness: 1024
-  CurrencyBBattlenetVirtualCurrency: 8
-  CurrencyBDontDisplayIfZero: 32
-  CurrencyBForceMaxQuantityOnConversion: 256
-  CurrencyBNoBonusXP: 2048
-  CurrencyBNoNotificationMailOnOfflineProgress: 4
-  CurrencyBScaleMaxQuantityBySeasonWeeks: 64
-  CurrencyBScaleMaxQuantityByWeeksSinceStart: 128
-  CurrencyBShowQuestXPGainInTooltip: 2
-  CurrencyBUnearnableBeforeMaxQuantityStart: 512
-  CurrencyBUseTotalEarnedForEarned: 1
-  FutureCurrencyFlag: 16
+  values:
+    CurrencyBAllowReductionByResourcefulness: 1024
+    CurrencyBBattlenetVirtualCurrency: 8
+    CurrencyBDontDisplayIfZero: 32
+    CurrencyBForceMaxQuantityOnConversion: 256
+    CurrencyBNoBonusXP: 2048
+    CurrencyBNoNotificationMailOnOfflineProgress: 4
+    CurrencyBScaleMaxQuantityBySeasonWeeks: 64
+    CurrencyBScaleMaxQuantityByWeeksSinceStart: 128
+    CurrencyBShowQuestXPGainInTooltip: 2
+    CurrencyBUnearnableBeforeMaxQuantityStart: 512
+    CurrencyBUseTotalEarnedForEarned: 1
+    FutureCurrencyFlag: 16
 CurrencyGainFlags:
-  Autotracking: 8
-  BonusAward: 1
-  DroppedFromDeath: 2
-  FromAccountServer: 4
-  None: 0
+  values:
+    Autotracking: 8
+    BonusAward: 1
+    DroppedFromDeath: 2
+    FromAccountServer: 4
+    None: 0
 CurrencySource:
-  AccountCopy: 37
-  AccountServerConversion: 46
-  Arena: 17
-  ArenaPoints: 38
-  AuctionDeposit: 41
-  AzeriteRespec: 34
-  Barbershop: 42
-  BonusRoll: 33
-  ChallengeModeDungeon: 44
-  Cheat: 4
-  ConvertOldItem: 0
-  ConvertOldPvPCurrency: 1
-  ExceededMaxQty: 18
-  GarrisonBuilding: 23
-  GarrisonBuildingRefund: 26
-  GarrisonFollowerActivation: 25
-  GarrisonMissionReward: 27
-  GarrisonResourceOverTime: 28
-  GarrisonTalent: 30
-  GarrisonWorldQuestBonus: 31
-  GuildBankWithdrawal: 21
-  InitiativeReward: 45
-  ItemDeletion: 14
-  ItemRefund: 2
-  LFGReward: 11
-  Loot: 9
-  Pushloot: 22
-  PvPCompletionBonus: 19
-  PvPDrop: 24
-  PvPHonorQuestReward: 40
-  PvPHonorReward: 32
-  PvPKillCredit: 6
-  PvPMetaCredit: 7
-  PvPScriptedAward: 8
-  PvPTeamContribution: 39
-  QuestReward: 3
-  QuestRewardIgnoreCaps: 29
-  RandomBattleground: 16
-  RatedBattleground: 15
-  Script: 20
-  SimulateLoot: 43
-  Spell: 13
-  Trade: 12
-  UpdatingVersion: 10
-  Vendor: 5
-  WorldQuestReward: 35
-  WorldQuestRewardIgnoreCaps: 36
+  values:
+    AccountCopy: 37
+    AccountServerConversion: 46
+    Arena: 17
+    ArenaPoints: 38
+    AuctionDeposit: 41
+    AzeriteRespec: 34
+    Barbershop: 42
+    BonusRoll: 33
+    ChallengeModeDungeon: 44
+    Cheat: 4
+    ConvertOldItem: 0
+    ConvertOldPvPCurrency: 1
+    ExceededMaxQty: 18
+    GarrisonBuilding: 23
+    GarrisonBuildingRefund: 26
+    GarrisonFollowerActivation: 25
+    GarrisonMissionReward: 27
+    GarrisonResourceOverTime: 28
+    GarrisonTalent: 30
+    GarrisonWorldQuestBonus: 31
+    GuildBankWithdrawal: 21
+    InitiativeReward: 45
+    ItemDeletion: 14
+    ItemRefund: 2
+    LFGReward: 11
+    Loot: 9
+    Pushloot: 22
+    PvPCompletionBonus: 19
+    PvPDrop: 24
+    PvPHonorQuestReward: 40
+    PvPHonorReward: 32
+    PvPKillCredit: 6
+    PvPMetaCredit: 7
+    PvPScriptedAward: 8
+    PvPTeamContribution: 39
+    QuestReward: 3
+    QuestRewardIgnoreCaps: 29
+    RandomBattleground: 16
+    RatedBattleground: 15
+    Script: 20
+    SimulateLoot: 43
+    Spell: 13
+    Trade: 12
+    UpdatingVersion: 10
+    Vendor: 5
+    WorldQuestReward: 35
+    WorldQuestRewardIgnoreCaps: 36
 CurrencyTokenCategoryFlags:
-  FlagPlayerItemAssignment: 2
-  FlagSortLast: 1
-  Hidden: 4
-  StartsCollapsed: 16
-  Virtual: 8
+  values:
+    FlagPlayerItemAssignment: 2
+    FlagSortLast: 1
+    Hidden: 4
+    StartsCollapsed: 16
+    Virtual: 8
 CurrencyType:
-  Copper: 0
-  Gold: 2
-  Silver: 1
+  values:
+    Copper: 0
+    Gold: 2
+    Silver: 1
 Cursormode:
-  AttackCursor: 4
-  AttackErrorCursor: 50
-  BroomCursor: 42
-  BroomErrorCursor: 88
-  BuyCursor: 3
-  BuyErrorCursor: 49
-  CampaignQuestCursor: 23
-  CampaignQuestErrorCursor: 69
-  CampaignQuestTurninCursor: 24
-  CampaignQuestTurninErrorCursor: 70
-  CastCursor: 2
-  CastErrorCursor: 48
-  CustomCursor: 91
-  EnchantCursor: 39
-  EnchantErrorCursor: 85
-  GatherCursor: 13
-  GatherErrorCursor: 59
-  GrabbingHandCursor: 44
-  GrabbingHandErrorCursor: 90
-  HoldingHandCursor: 43
-  HoldingHandErrorCursor: 89
-  InnkeeperCursor: 22
-  InnkeeperErrorCursor: 68
-  InspectCursor: 7
-  InspectErrorCursor: 53
-  InteractCursor: 5
-  InteractErrorCursor: 51
-  ItemCursor: 19
-  ItemErrorCursor: 65
-  LockCursor: 14
-  LockErrorCursor: 60
-  LootAllCursor: 16
-  LootAllErrorCursor: 62
-  MailCursor: 15
-  MailErrorCursor: 61
-  MapPinCursor: 37
-  MapPinErrorCursor: 83
-  MineCursor: 11
-  MineErrorCursor: 57
-  NoCursor: 0
-  PaletteCursor: 41
-  PaletteErrorCursor: 87
-  PickupCursor: 8
-  PickupErrorCursor: 54
-  PingCursor: 38
-  PingErrorCursor: 84
-  PointCursor: 1
-  PointErrorCursor: 47
-  QuestCursor: 25
-  QuestErrorCursor: 71
-  QuestImportantCursor: 30
-  QuestImportantErrorCursor: 76
-  QuestImportantTurninCursor: 31
-  QuestImportantTurninErrorCursor: 77
-  QuestLegendaryCursor: 28
-  QuestLegendaryErrorCursor: 74
-  QuestLegendaryTurninCursor: 29
-  QuestLegendaryTurninErrorCursor: 75
-  QuestMetaCursor: 32
-  QuestMetaErrorCursor: 78
-  QuestMetaTurninCursor: 33
-  QuestMetaTurninErrorCursor: 79
-  QuestRecurringCursor: 34
-  QuestRecurringErrorCursor: 80
-  QuestRecurringTurninCursor: 35
-  QuestRecurringTurninErrorCursor: 81
-  QuestRepeatableCursor: 26
-  QuestRepeatableErrorCursor: 72
-  QuestTurninCursor: 27
-  QuestTurninErrorCursor: 73
-  RepairCursor: 17
-  RepairErrorCursor: 63
-  RepairnpcCursor: 18
-  RepairnpcErrorCursor: 64
-  SkinAllianceCursor: 21
-  SkinAllianceErrorCursor: 67
-  SkinCursor: 12
-  SkinErrorCursor: 58
-  SkinHordeCursor: 20
-  SkinHordeErrorCursor: 66
-  SpeakCursor: 6
-  SpeakErrorCursor: 52
-  StablemasterCursor: 40
-  StablemasterErrorCursor: 86
-  TaxiCursor: 9
-  TaxiErrorCursor: 55
-  TrainerCursor: 10
-  TrainerErrorCursor: 56
-  UIMoveCursor: 45
-  UIResizeCursor: 46
-  VehicleCursor: 36
-  VehicleErrorCursor: 82
+  values:
+    AttackCursor: 4
+    AttackErrorCursor: 50
+    BroomCursor: 42
+    BroomErrorCursor: 88
+    BuyCursor: 3
+    BuyErrorCursor: 49
+    CampaignQuestCursor: 23
+    CampaignQuestErrorCursor: 69
+    CampaignQuestTurninCursor: 24
+    CampaignQuestTurninErrorCursor: 70
+    CastCursor: 2
+    CastErrorCursor: 48
+    CustomCursor: 91
+    EnchantCursor: 39
+    EnchantErrorCursor: 85
+    GatherCursor: 13
+    GatherErrorCursor: 59
+    GrabbingHandCursor: 44
+    GrabbingHandErrorCursor: 90
+    HoldingHandCursor: 43
+    HoldingHandErrorCursor: 89
+    InnkeeperCursor: 22
+    InnkeeperErrorCursor: 68
+    InspectCursor: 7
+    InspectErrorCursor: 53
+    InteractCursor: 5
+    InteractErrorCursor: 51
+    ItemCursor: 19
+    ItemErrorCursor: 65
+    LockCursor: 14
+    LockErrorCursor: 60
+    LootAllCursor: 16
+    LootAllErrorCursor: 62
+    MailCursor: 15
+    MailErrorCursor: 61
+    MapPinCursor: 37
+    MapPinErrorCursor: 83
+    MineCursor: 11
+    MineErrorCursor: 57
+    NoCursor: 0
+    PaletteCursor: 41
+    PaletteErrorCursor: 87
+    PickupCursor: 8
+    PickupErrorCursor: 54
+    PingCursor: 38
+    PingErrorCursor: 84
+    PointCursor: 1
+    PointErrorCursor: 47
+    QuestCursor: 25
+    QuestErrorCursor: 71
+    QuestImportantCursor: 30
+    QuestImportantErrorCursor: 76
+    QuestImportantTurninCursor: 31
+    QuestImportantTurninErrorCursor: 77
+    QuestLegendaryCursor: 28
+    QuestLegendaryErrorCursor: 74
+    QuestLegendaryTurninCursor: 29
+    QuestLegendaryTurninErrorCursor: 75
+    QuestMetaCursor: 32
+    QuestMetaErrorCursor: 78
+    QuestMetaTurninCursor: 33
+    QuestMetaTurninErrorCursor: 79
+    QuestRecurringCursor: 34
+    QuestRecurringErrorCursor: 80
+    QuestRecurringTurninCursor: 35
+    QuestRecurringTurninErrorCursor: 81
+    QuestRepeatableCursor: 26
+    QuestRepeatableErrorCursor: 72
+    QuestTurninCursor: 27
+    QuestTurninErrorCursor: 73
+    RepairCursor: 17
+    RepairErrorCursor: 63
+    RepairnpcCursor: 18
+    RepairnpcErrorCursor: 64
+    SkinAllianceCursor: 21
+    SkinAllianceErrorCursor: 67
+    SkinCursor: 12
+    SkinErrorCursor: 58
+    SkinHordeCursor: 20
+    SkinHordeErrorCursor: 66
+    SpeakCursor: 6
+    SpeakErrorCursor: 52
+    StablemasterCursor: 40
+    StablemasterErrorCursor: 86
+    TaxiCursor: 9
+    TaxiErrorCursor: 55
+    TrainerCursor: 10
+    TrainerErrorCursor: 56
+    UIMoveCursor: 45
+    UIResizeCursor: 46
+    VehicleCursor: 36
+    VehicleErrorCursor: 82
 CursorStyle:
-  Crosshair: 1
-  Mouse: 0
+  values:
+    Crosshair: 1
+    Mouse: 0
 CustomBindingType:
-  VoicePushToTalk: 0
+  values:
+    VoicePushToTalk: 0
 Damageclass:
-  All: 127
-  AllMagical: 126
-  AllPhysical: 1
-  Arcane: 6
-  Fire: 2
-  FirstResist: 2
-  Frost: 4
-  Holy: 1
-  LastResist: 6
-  MaskArcane: 64
-  MaskChaos: 124
-  MaskChromatic: 62
-  MaskCosmic: 106
-  MaskDivine: 66
-  MaskElemental: 28
-  MaskFire: 4
-  MaskFirestorm: 12
-  MaskFlamestrike: 5
-  MaskFrost: 16
-  MaskFrostfire: 20
-  MaskFroststorm: 24
-  MaskFroststrike: 17
-  MaskHoly: 2
-  MaskHolyfire: 6
-  MaskHolyfrost: 18
-  MaskHolystorm: 10
-  MaskHolystrike: 3
-  MaskMagical: 126
-  MaskNature: 8
-  MaskNone: 0
-  MaskPhysical: 1
-  MaskShadow: 32
-  MaskShadowflame: 36
-  MaskShadowfrost: 48
-  MaskShadowstorm: 40
-  MaskShadowstrike: 33
-  MaskSpellfire: 68
-  MaskSpellfrost: 80
-  MaskSpellshadow: 96
-  MaskSpellstorm: 72
-  MaskSpellstrike: 65
-  MaskStormstrike: 9
-  MaskTwilight: 34
-  Nature: 3
-  Physical: 0
-  Shadow: 5
+  values:
+    All: 127
+    AllMagical: 126
+    AllPhysical: 1
+    Arcane: 6
+    Fire: 2
+    FirstResist: 2
+    Frost: 4
+    Holy: 1
+    LastResist: 6
+    MaskArcane: 64
+    MaskChaos: 124
+    MaskChromatic: 62
+    MaskCosmic: 106
+    MaskDivine: 66
+    MaskElemental: 28
+    MaskFire: 4
+    MaskFirestorm: 12
+    MaskFlamestrike: 5
+    MaskFrost: 16
+    MaskFrostfire: 20
+    MaskFroststorm: 24
+    MaskFroststrike: 17
+    MaskHoly: 2
+    MaskHolyfire: 6
+    MaskHolyfrost: 18
+    MaskHolystorm: 10
+    MaskHolystrike: 3
+    MaskMagical: 126
+    MaskNature: 8
+    MaskNone: 0
+    MaskPhysical: 1
+    MaskShadow: 32
+    MaskShadowflame: 36
+    MaskShadowfrost: 48
+    MaskShadowstorm: 40
+    MaskShadowstrike: 33
+    MaskSpellfire: 68
+    MaskSpellfrost: 80
+    MaskSpellshadow: 96
+    MaskSpellstorm: 72
+    MaskSpellstrike: 65
+    MaskStormstrike: 9
+    MaskTwilight: 34
+    Nature: 3
+    Physical: 0
+    Shadow: 5
 DamageclassType:
-  Magical: 1
-  Physical: 0
+  values:
+    Magical: 1
+    Physical: 0
 DamageMeterCombineSessionType:
-  Arena: 2
-  ArenaMultiRound: 3
-  ChallengeMode: 1
-  None: 0
+  values:
+    Arena: 2
+    ArenaMultiRound: 3
+    ChallengeMode: 1
+    None: 0
 DamageMeterNumbers:
-  Compact: 1
-  Complete: 2
-  Minimal: 0
+  values:
+    Compact: 1
+    Complete: 2
+    Minimal: 0
 DamageMeterOverrideType:
-  AllowFriendlyFire: 1
-  Ignore: 0
-  IgnoreForAbsorbSpell: 4
-  RedirectSourceToAuraCaster: 3
-  RedirectSourceToOwner: 2
+  values:
+    AllowFriendlyFire: 1
+    Ignore: 0
+    IgnoreForAbsorbSpell: 4
+    RedirectSourceToAuraCaster: 3
+    RedirectSourceToOwner: 2
 DamageMeterSessionType:
-  Current: 1
-  Expired: 2
-  Overall: 0
+  values:
+    Current: 1
+    Expired: 2
+    Overall: 0
 DamageMeterSourceDisplayType:
-  Ally: 1
-  Enemy: 2
-  None: 0
+  values:
+    Ally: 1
+    Enemy: 2
+    None: 0
 DamageMeterSpellDetailsDisplayType:
-  Deaths: 3
-  EnemyDamageTaken: 4
-  SpellAffected: 2
-  SpellCasted: 0
-  UnitSpecificSpellCasted: 1
+  values:
+    Deaths: 3
+    EnemyDamageTaken: 4
+    SpellAffected: 2
+    SpellCasted: 0
+    UnitSpecificSpellCasted: 1
 DamageMeterStorageType:
-  Absorbs: 2
-  AvoidableDamageTaken: 6
-  Damage: 0
-  DamageTaken: 5
-  Deaths: 7
-  Dispels: 4
-  EnemyDamageTaken: 8
-  HealingAndAbsorbs: 1
-  Interrupts: 3
+  values:
+    Absorbs: 2
+    AvoidableDamageTaken: 6
+    Damage: 0
+    DamageTaken: 5
+    Deaths: 7
+    Dispels: 4
+    EnemyDamageTaken: 8
+    HealingAndAbsorbs: 1
+    Interrupts: 3
 DamageMeterStyle:
-  Bordered: 2
-  Default: 0
-  FullBackground: 3
-  Thin: 1
+  values:
+    Bordered: 2
+    Default: 0
+    FullBackground: 3
+    Thin: 1
 DamageMeterType:
-  Absorbs: 4
-  AvoidableDamageTaken: 8
-  DamageDone: 0
-  DamageTaken: 7
-  Deaths: 9
-  Dispels: 6
-  Dps: 1
-  EnemyDamageTaken: 10
-  HealingDone: 2
-  Hps: 3
-  Interrupts: 5
+  values:
+    Absorbs: 4
+    AvoidableDamageTaken: 8
+    DamageDone: 0
+    DamageTaken: 7
+    Deaths: 9
+    Dispels: 6
+    Dps: 1
+    EnemyDamageTaken: 10
+    HealingDone: 2
+    Hps: 3
+    Interrupts: 5
 DamageMeterVisibility:
-  Always: 0
-  Hidden: 2
-  InCombat: 1
-  InGroup: 3
+  values:
+    Always: 0
+    Hidden: 2
+    InCombat: 1
+    InGroup: 3
 DeveloperLogAssertDomain:
-  Art: 1
-  Design: 2
-  Engineering: 4
-  LiveOperations: 64
-  Performance: 32
-  Sound: 8
-  Tools: 16
+  values:
+    Art: 1
+    Design: 2
+    Engineering: 4
+    LiveOperations: 64
+    Performance: 32
+    Sound: 8
+    Tools: 16
 DeveloperLogErrorDomain:
-  Assert: 0
-  AssertData: 1
-  Frame: 2
-  TestSuite: 3
+  values:
+    Assert: 0
+    AssertData: 1
+    Frame: 2
+    TestSuite: 3
 DeveloperLogTrafficType:
-  ClientToServer: 1
-  GameEvent: 2
-  LuaToClient: 3
-  ServerToClient: 0
+  values:
+    ClientToServer: 1
+    GameEvent: 2
+    LuaToClient: 3
+    ServerToClient: 0
 DisableAccountProfilesFlags:
-  DecorsCollections: 32
-  Document: 1
-  ItemsCollections: 16
-  MountsCollections: 4
-  None: 0
-  PetsCollections: 8
-  SharedCollections: 2
+  values:
+    DecorsCollections: 32
+    Document: 1
+    ItemsCollections: 16
+    MountsCollections: 4
+    None: 0
+    PetsCollections: 8
+    SharedCollections: 2
 DurationTextBindingProperty:
-  ElapsedDuration: 2
-  ElapsedPercent: 3
-  EndTime: 6
-  RemainingDuration: 0
-  RemainingPercent: 1
-  StartTime: 5
-  TotalDuration: 4
+  values:
+    ElapsedDuration: 2
+    ElapsedPercent: 3
+    EndTime: 6
+    RemainingDuration: 0
+    RemainingPercent: 1
+    StartTime: 5
+    TotalDuration: 4
 DurationTimeModifier:
-  BaseTime: 1
-  RealTime: 0
+  values:
+    BaseTime: 1
+    RealTime: 0
 EditModeAccountSetting:
-  DeprecatedShowDebuffFrame: 11
-  EnableAdvancedOptions: 23
-  EnableSnap: 22
-  GridSpacing: 1
-  SettingsExpanded: 2
-  ShowArchaeologyBar: 27
-  ShowArenaFrames: 17
-  ShowBossFrames: 16
-  ShowBuffsAndDebuffs: 10
-  ShowCastBar: 7
-  ShowCooldownViewer: 28
-  ShowDamageMeter: 31
-  ShowDurabilityFrame: 21
-  ShowEncounterBar: 8
-  ShowEncounterEvents: 30
-  ShowExternalDefensives: 32
-  ShowExtraAbilities: 9
-  ShowGrid: 0
-  ShowHudTooltip: 19
-  ShowLootFrame: 18
-  ShowPartyFrames: 12
-  ShowPersonalResourceDisplay: 29
-  ShowPetActionBar: 5
-  ShowPetFrame: 24
-  ShowPossessActionBar: 6
-  ShowRaidFrames: 13
-  ShowStanceBar: 4
-  ShowStatusTrackingBar2: 20
-  ShowTalkingHeadFrame: 14
-  ShowTargetAndFocus: 3
-  ShowTimerBars: 25
-  ShowTotemActionBar: 33
-  ShowVehicleLeaveButton: 15
-  ShowVehicleSeatIndicator: 26
+  values:
+    DeprecatedShowDebuffFrame: 11
+    EnableAdvancedOptions: 23
+    EnableSnap: 22
+    GridSpacing: 1
+    SettingsExpanded: 2
+    ShowArchaeologyBar: 27
+    ShowArenaFrames: 17
+    ShowBossFrames: 16
+    ShowBuffsAndDebuffs: 10
+    ShowCastBar: 7
+    ShowCooldownViewer: 28
+    ShowDamageMeter: 31
+    ShowDurabilityFrame: 21
+    ShowEncounterBar: 8
+    ShowEncounterEvents: 30
+    ShowExternalDefensives: 32
+    ShowExtraAbilities: 9
+    ShowGrid: 0
+    ShowHudTooltip: 19
+    ShowLootFrame: 18
+    ShowPartyFrames: 12
+    ShowPersonalResourceDisplay: 29
+    ShowPetActionBar: 5
+    ShowPetFrame: 24
+    ShowPossessActionBar: 6
+    ShowRaidFrames: 13
+    ShowStanceBar: 4
+    ShowStatusTrackingBar2: 20
+    ShowTalkingHeadFrame: 14
+    ShowTargetAndFocus: 3
+    ShowTimerBars: 25
+    ShowTotemActionBar: 33
+    ShowVehicleLeaveButton: 15
+    ShowVehicleSeatIndicator: 26
 EditModeActionBarSetting:
-  AlwaysShowButtons: 9
-  DeprecatedSnapToSide: 7
-  HideBarArt: 6
-  HideBarScrolling: 8
-  IconPadding: 4
-  IconSize: 3
-  NumIcons: 2
-  NumRows: 1
-  Orientation: 0
-  VisibleSetting: 5
+  values:
+    AlwaysShowButtons: 9
+    DeprecatedSnapToSide: 7
+    HideBarArt: 6
+    HideBarScrolling: 8
+    IconPadding: 4
+    IconSize: 3
+    NumIcons: 2
+    NumRows: 1
+    Orientation: 0
+    VisibleSetting: 5
 EditModeActionBarSystemIndices:
-  Bar2: 2
-  Bar3: 3
-  ExtraBar1: 6
-  ExtraBar2: 7
-  ExtraBar3: 8
-  MainBar: 1
-  PetActionBar: 12
-  PossessActionBar: 13
-  RightBar1: 4
-  RightBar2: 5
-  StanceBar: 11
+  values:
+    Bar2: 2
+    Bar3: 3
+    ExtraBar1: 6
+    ExtraBar2: 7
+    ExtraBar3: 8
+    MainBar: 1
+    PetActionBar: 12
+    PossessActionBar: 13
+    RightBar1: 4
+    RightBar2: 5
+    StanceBar: 11
 EditModeArchaeologyBarSetting:
-  Size: 0
+  values:
+    Size: 0
 EditModeAuraFrameSetting:
-  DeprecatedShowFull: 7
-  IconDirection: 2
-  IconLimitBuffFrame: 3
-  IconLimitDebuffFrame: 4
-  IconPadding: 6
-  IconSize: 5
-  IconWrap: 1
-  Opacity: 9
-  Orientation: 0
-  ShowDispelType: 10
-  VisibleSetting: 8
+  values:
+    DeprecatedShowFull: 7
+    IconDirection: 2
+    IconLimitBuffFrame: 3
+    IconLimitDebuffFrame: 4
+    IconPadding: 6
+    IconSize: 5
+    IconWrap: 1
+    Opacity: 9
+    Orientation: 0
+    ShowDispelType: 10
+    VisibleSetting: 8
 EditModeAuraFrameSystemIndices:
-  BuffFrame: 1
-  DebuffFrame: 2
-  ExternalDefensivesFrame: 3
+  values:
+    BuffFrame: 1
+    DebuffFrame: 2
+    ExternalDefensivesFrame: 3
 EditModeBagsSetting:
-  BagSlotPadding: 3
-  Direction: 1
-  Orientation: 0
-  Size: 2
+  values:
+    BagSlotPadding: 3
+    Direction: 1
+    Orientation: 0
+    Size: 2
 EditModeCastBarSetting:
-  BarSize: 0
-  LockToPlayerFrame: 1
-  ShowCastTime: 2
+  values:
+    BarSize: 0
+    LockToPlayerFrame: 1
+    ShowCastTime: 2
 EditModeChatFrameSetting:
-  HeightHundreds: 2
-  HeightTensAndOnes: 3
-  WidthHundreds: 0
-  WidthTensAndOnes: 1
+  values:
+    HeightHundreds: 2
+    HeightTensAndOnes: 3
+    WidthHundreds: 0
+    WidthTensAndOnes: 1
 EditModeCooldownViewerSetting:
-  BarContent: 7
-  BarWidthScale: 11
-  HideWhenInactive: 8
-  IconDirection: 2
-  IconLimit: 1
-  IconPadding: 4
-  IconSize: 3
-  Opacity: 5
-  Orientation: 0
-  ShowTimer: 9
-  ShowTooltips: 10
-  VisibleSetting: 6
+  values:
+    BarContent: 7
+    BarWidthScale: 11
+    HideWhenInactive: 8
+    IconDirection: 2
+    IconLimit: 1
+    IconPadding: 4
+    IconSize: 3
+    Opacity: 5
+    Orientation: 0
+    ShowTimer: 9
+    ShowTooltips: 10
+    VisibleSetting: 6
 EditModeCooldownViewerSystemIndices:
-  BuffBar: 4
-  BuffIcon: 3
-  Essential: 1
-  Utility: 2
+  values:
+    BuffBar: 4
+    BuffIcon: 3
+    Essential: 1
+    Utility: 2
 EditModeDamageMeterSetting:
-  BackgroundTransparency: 12
-  BarHeight: 10
-  FrameHeight: 4
-  FrameWidth: 3
-  Numbers: 2
-  ObsoleteReuse1: 7
-  Padding: 5
-  ShowClassColor: 9
-  ShowSpecIcon: 8
-  Style: 1
-  TextSize: 11
-  Transparency: 6
-  Visibility: 0
+  values:
+    BackgroundTransparency: 12
+    BarHeight: 10
+    FrameHeight: 4
+    FrameWidth: 3
+    Numbers: 2
+    ObsoleteReuse1: 7
+    Padding: 5
+    ShowClassColor: 9
+    ShowSpecIcon: 8
+    Style: 1
+    TextSize: 11
+    Transparency: 6
+    Visibility: 0
 EditModeDurabilityFrameSetting:
-  Size: 0
+  values:
+    Size: 0
 EditModeEncounterEventsSetting:
-  BackgroundTransparency: 5
-  BarWidth: 12
-  FlipHorizontally: 11
-  IconDirection: 1
-  IconSize: 3
-  Orientation: 0
-  OverallSize: 4
-  Padding: 13
-  ShowSpellName: 2
-  ShowTimer: 9
-  TooltipAnchor: 8
-  Transparency: 6
-  ViewType: 10
-  Visibility: 7
+  values:
+    BackgroundTransparency: 5
+    BarWidth: 12
+    FlipHorizontally: 11
+    IconDirection: 1
+    IconSize: 3
+    Orientation: 0
+    OverallSize: 4
+    Padding: 13
+    ShowSpellName: 2
+    ShowTimer: 9
+    TooltipAnchor: 8
+    Transparency: 6
+    ViewType: 10
+    Visibility: 7
 EditModeEncounterEventsSystemIndices:
-  CriticalWarnings: 2
-  MediumWarnings: 3
-  NormalWarnings: 4
-  Timeline: 1
+  values:
+    CriticalWarnings: 2
+    MediumWarnings: 3
+    NormalWarnings: 4
+    Timeline: 1
 EditModeLayoutType:
-  Account: 1
-  Character: 2
-  Override: 3
-  Preset: 0
+  values:
+    Account: 1
+    Character: 2
+    Override: 3
+    Preset: 0
 EditModeMicroMenuSetting:
-  EyeSize: 3
-  Order: 1
-  Orientation: 0
-  Size: 2
+  values:
+    EyeSize: 3
+    Order: 1
+    Orientation: 0
+    Size: 2
 EditModeMinimapSetting:
-  HeaderUnderneath: 0
-  RotateMinimap: 1
-  Size: 2
+  values:
+    HeaderUnderneath: 0
+    RotateMinimap: 1
+    Size: 2
 EditModeObjectiveTrackerSetting:
-  Height: 0
-  Opacity: 1
-  TextSize: 2
+  values:
+    Height: 0
+    Opacity: 1
+    TextSize: 2
 EditModePersonalResourceDisplaySetting:
-  BarWidth: 12
-  DeprecatedOnlyShowInCombat: 1
-  HealthBarHeight: 4
-  HideAltPower: 14
-  HideClassInfo: 3
-  HideClassInfoOnPlayerFrame: 10
-  HideHealth: 0
-  HidePower: 2
-  Opacity: 7
-  Padding: 6
-  PowerBarHeight: 5
-  ShowBarText: 13
-  ShowClassColor: 11
-  Size: 9
-  VisibleSetting: 8
+  values:
+    BarWidth: 12
+    DeprecatedOnlyShowInCombat: 1
+    HealthBarHeight: 4
+    HideAltPower: 14
+    HideClassInfo: 3
+    HideClassInfoOnPlayerFrame: 10
+    HideHealth: 0
+    HidePower: 2
+    Opacity: 7
+    Padding: 6
+    PowerBarHeight: 5
+    ShowBarText: 13
+    ShowClassColor: 11
+    Size: 9
+    VisibleSetting: 8
 EditModePresetLayouts:
-  Classic: 1
-  Modern: 0
+  values:
+    Classic: 1
+    Modern: 0
 EditModeSettingDisplayType:
-  Checkbox: 1
-  Dropdown: 0
-  Slider: 2
+  values:
+    Checkbox: 1
+    Dropdown: 0
+    Slider: 2
 EditModeStatusTrackingBarSetting:
-  Height: 0
-  Size: 3
-  TextSize: 2
-  Width: 1
+  values:
+    Height: 0
+    Size: 3
+    TextSize: 2
+    Width: 1
 EditModeStatusTrackingBarSystemIndices:
-  StatusTrackingBar1: 1
-  StatusTrackingBar2: 2
+  values:
+    StatusTrackingBar1: 1
+    StatusTrackingBar2: 2
 EditModeSystem:
-  ActionBar: 0
-  ArchaeologyBar: 19
-  AuraFrame: 6
-  Bags: 14
-  CastBar: 1
-  ChatFrame: 8
-  CooldownViewer: 20
-  DamageMeter: 23
-  DurabilityFrame: 16
-  EncounterBar: 4
-  EncounterEvents: 22
-  ExtraAbilities: 5
-  HudTooltip: 11
-  LootFrame: 10
-  MicroMenu: 13
-  Minimap: 2
-  ObjectiveTracker: 12
-  PersonalResourceDisplay: 21
-  StatusTrackingBar: 15
-  TalkingHeadFrame: 7
-  TimerBars: 17
-  TotemActionBar: 24
-  UnitFrame: 3
-  VehicleLeaveButton: 9
-  VehicleSeatIndicator: 18
+  values:
+    ActionBar: 0
+    ArchaeologyBar: 19
+    AuraFrame: 6
+    Bags: 14
+    CastBar: 1
+    ChatFrame: 8
+    CooldownViewer: 20
+    DamageMeter: 23
+    DurabilityFrame: 16
+    EncounterBar: 4
+    EncounterEvents: 22
+    ExtraAbilities: 5
+    HudTooltip: 11
+    LootFrame: 10
+    MicroMenu: 13
+    Minimap: 2
+    ObjectiveTracker: 12
+    PersonalResourceDisplay: 21
+    StatusTrackingBar: 15
+    TalkingHeadFrame: 7
+    TimerBars: 17
+    TotemActionBar: 24
+    UnitFrame: 3
+    VehicleLeaveButton: 9
+    VehicleSeatIndicator: 18
 EditModeTimerBarsSetting:
-  Size: 0
+  values:
+    Size: 0
 EditModeUnitFrameSetting:
-  AuraOrganizationType: 18
-  BigDefensiveIconSize: 21
-  BuffsOnTop: 2
-  CastBarOnSide: 7
-  CastBarUnderneath: 1
-  DisplayBorder: 12
-  FrameHeight: 11
-  FrameSize: 16
-  FrameWidth: 10
-  HidePortrait: 0
-  IconSize: 19
-  Opacity: 20
-  RaidGroupDisplayType: 13
-  RowSize: 15
-  ShowCastTime: 8
-  ShowPartyFrameBackground: 5
-  SortPlayersBy: 14
-  UseHorizontalGroups: 6
-  UseLargerFrame: 3
-  UseRaidStylePartyFrames: 4
-  ViewArenaSize: 17
-  ViewRaidSize: 9
+  values:
+    AuraOrganizationType: 18
+    BigDefensiveIconSize: 21
+    BuffsOnTop: 2
+    CastBarOnSide: 7
+    CastBarUnderneath: 1
+    DisplayBorder: 12
+    FrameHeight: 11
+    FrameSize: 16
+    FrameWidth: 10
+    HidePortrait: 0
+    IconSize: 19
+    Opacity: 20
+    RaidGroupDisplayType: 13
+    RowSize: 15
+    ShowCastTime: 8
+    ShowPartyFrameBackground: 5
+    SortPlayersBy: 14
+    UseHorizontalGroups: 6
+    UseLargerFrame: 3
+    UseRaidStylePartyFrames: 4
+    ViewArenaSize: 17
+    ViewRaidSize: 9
 EditModeUnitFrameSystemIndices:
-  Arena: 7
-  Boss: 6
-  Focus: 3
-  Party: 4
-  Pet: 8
-  Player: 1
-  Raid: 5
-  Target: 2
+  values:
+    Arena: 7
+    Boss: 6
+    Focus: 3
+    Party: 4
+    Pet: 8
+    Player: 1
+    Raid: 5
+    Target: 2
 EditModeVehicleSeatIndicatorSetting:
-  Size: 0
+  values:
+    Size: 0
 EncounterEventCastState:
-  Casting: 1
-  Expired: 3
-  NotCasting: 2
+  values:
+    Casting: 1
+    Expired: 3
+    NotCasting: 2
 EncounterEventColorTrigger:
-  TextWarning: 0
-  TimelineEvent: 1
-  TimelineEventHighlight: 2
+  values:
+    TextWarning: 0
+    TimelineEvent: 1
+    TimelineEventHighlight: 2
 EncounterEventIconmask:
-  BleedEffect: 4
-  CurseEffect: 32
-  DeadlyEffect: 1
-  DiseaseEffect: 16
-  DpsRole: 512
-  EnrageEffect: 2
-  HealerRole: 256
-  MagicEffect: 8
-  PoisonEffect: 64
-  TankRole: 128
+  values:
+    BleedEffect: 4
+    CurseEffect: 32
+    DeadlyEffect: 1
+    DiseaseEffect: 16
+    DpsRole: 512
+    EnrageEffect: 2
+    HealerRole: 256
+    MagicEffect: 8
+    PoisonEffect: 64
+    TankRole: 128
 EncounterEventSeverity:
-  High: 2
-  Low: 0
-  Medium: 1
+  values:
+    High: 2
+    Low: 0
+    Medium: 1
 EncounterEventsIconDirection:
-  Bottom: 1
-  Left: 0
-  Right: 1
-  Top: 0
+  values:
+    Bottom: 1
+    Left: 0
+    Right: 1
+    Top: 0
 EncounterEventsOrientation:
-  Horizontal: 0
-  Vertical: 1
+  values:
+    Horizontal: 0
+    Vertical: 1
 EncounterEventSoundTrigger:
-  OnTextWarningShown: 0
-  OnTimelineEventFinished: 1
-  OnTimelineEventHighlight: 2
+  values:
+    OnTextWarningShown: 0
+    OnTimelineEventFinished: 1
+    OnTimelineEventHighlight: 2
 EncounterEventsTooltipAnchor:
-  Cursor: 2
-  Default: 1
-  Hidden: 0
+  values:
+    Cursor: 2
+    Default: 1
+    Hidden: 0
 EncounterEventsViewType:
-  Bars: 1
-  Timeline: 0
+  values:
+    Bars: 1
+    Timeline: 0
 EncounterEventsVisibility:
-  Always: 0
-  DeprecatedHidden: 2
-  InEncounter: 1
+  values:
+    Always: 0
+    DeprecatedHidden: 2
+    InEncounter: 1
 EncounterTimelineEventSortDirection:
-  Ascending: 1
-  Descending: 0
+  values:
+    Ascending: 1
+    Descending: 0
 EncounterTimelineEventSource:
-  EditMode: 2
-  Encounter: 0
-  Script: 1
+  values:
+    EditMode: 2
+    Encounter: 0
+    Script: 1
 EncounterTimelineEventState:
-  Active: 0
-  Canceled: 3
-  Finished: 2
-  Paused: 1
+  values:
+    Active: 0
+    Canceled: 3
+    Finished: 2
+    Paused: 1
 EncounterTimelineIconSet:
-  DamageAlert: 3
-  Deadly: 4
-  Dispel: 5
-  Enrage: 6
-  HealerAlert: 2
-  TankAlert: 1
+  values:
+    DamageAlert: 3
+    Deadly: 4
+    Dispel: 5
+    Enrage: 6
+    HealerAlert: 2
+    TankAlert: 1
 EncounterTimelineTrack:
-  Indeterminate: 4
-  Long: 3
-  Medium: 2
-  Queued: 0
-  Short: 1
+  values:
+    Indeterminate: 4
+    Long: 3
+    Medium: 2
+    Queued: 0
+    Short: 1
 EncounterTimelineTrackType:
-  Hidden: 0
-  Linear: 2
-  Sorted: 1
+  values:
+    Hidden: 0
+    Linear: 2
+    Sorted: 1
 EncounterTimelineViewType:
-  Bars: 2
-  None: 0
-  Timeline: 1
+  values:
+    Bars: 2
+    None: 0
+    Timeline: 1
 EndOfMatchType:
-  None: 0
-  Plunderstorm: 1
+  values:
+    None: 0
+    Plunderstorm: 1
 EnvironmentalDamageFlags:
-  DmgIsPct: 2
-  OneTime: 1
+  values:
+    DmgIsPct: 2
+    OneTime: 1
 Environmentaldamagetype:
-  Drowning: 1
-  Falling: 2
-  Fatigue: 0
-  Fire: 5
-  Lava: 3
-  Slime: 4
+  values:
+    Drowning: 1
+    Falling: 2
+    Fatigue: 0
+    Fire: 5
+    Lava: 3
+    Slime: 4
 EventRealmQueues:
-  None: 0
-  PlunderstormDuo: 2
-  PlunderstormSolo: 1
-  PlunderstormTraining: 8
-  PlunderstormTrio: 4
+  values:
+    None: 0
+    PlunderstormDuo: 2
+    PlunderstormSolo: 1
+    PlunderstormTraining: 8
+    PlunderstormTrio: 4
 EventToastDisplayType:
-  CapstoneUnlocked: 12
-  ChallengeMode: 7
-  FlightpointDiscovered: 11
-  HouseUpgradeAvailable: 15
-  LargeTextWithIcon: 4
-  NormalBlockText: 1
-  NormalSingleLine: 0
-  NormalTextWithIcon: 3
-  NormalTextWithIconAndRarity: 5
-  NormalTitleAndSubTitle: 2
-  Scenario: 6
-  ScenarioClickExpand: 8
-  Scoreboard: 14
-  SingleLineWithIcon: 13
-  WeeklyRewardUnlock: 9
-  WeeklyRewardUpgrade: 10
+  values:
+    CapstoneUnlocked: 12
+    ChallengeMode: 7
+    FlightpointDiscovered: 11
+    HouseUpgradeAvailable: 15
+    LargeTextWithIcon: 4
+    NormalBlockText: 1
+    NormalSingleLine: 0
+    NormalTextWithIcon: 3
+    NormalTextWithIconAndRarity: 5
+    NormalTitleAndSubTitle: 2
+    Scenario: 6
+    ScenarioClickExpand: 8
+    Scoreboard: 14
+    SingleLineWithIcon: 13
+    WeeklyRewardUnlock: 9
+    WeeklyRewardUpgrade: 10
 EventToastEventType:
-  BattlePetLevelChanged: 8
-  BattlePetLevelUpAbility: 9
-  CriteriaUpdated: 19
-  FlightpointDiscovered: 25
-  HouseUpgradeAvailable: 26
-  LevelUp: 0
-  LevelUpDungeon: 2
-  LevelUpOther: 15
-  LevelUpPvP: 4
-  LevelUpRaid: 3
-  LevelUpSpell: 1
-  MythicPlusWeeklyRecord: 11
-  PetBattleCapture: 7
-  PetBattleFinalRound: 6
-  PetBattleNewAbility: 5
-  PlayerAuraAdded: 16
-  PlayerAuraRemoved: 17
-  PvPTierUpdate: 20
-  QuestBossEmote: 10
-  QuestTurnedIn: 12
-  Scenario: 14
-  SpellLearned: 21
-  SpellScript: 18
-  TreasureItem: 22
-  WeeklyRewardUnlock: 23
-  WeeklyRewardUpgrade: 24
-  WorldStateChange: 13
+  values:
+    BattlePetLevelChanged: 8
+    BattlePetLevelUpAbility: 9
+    CriteriaUpdated: 19
+    FlightpointDiscovered: 25
+    HouseUpgradeAvailable: 26
+    LevelUp: 0
+    LevelUpDungeon: 2
+    LevelUpOther: 15
+    LevelUpPvP: 4
+    LevelUpRaid: 3
+    LevelUpSpell: 1
+    MythicPlusWeeklyRecord: 11
+    PetBattleCapture: 7
+    PetBattleFinalRound: 6
+    PetBattleNewAbility: 5
+    PlayerAuraAdded: 16
+    PlayerAuraRemoved: 17
+    PvPTierUpdate: 20
+    QuestBossEmote: 10
+    QuestTurnedIn: 12
+    Scenario: 14
+    SpellLearned: 21
+    SpellScript: 18
+    TreasureItem: 22
+    WeeklyRewardUnlock: 23
+    WeeklyRewardUpgrade: 24
+    WorldStateChange: 13
 EventToastFlags:
-  DisableRightClickDismiss: 1
+  values:
+    DisableRightClickDismiss: 1
 ExcludedCensorSources:
-  All: 255
-  Friends: 1
-  Guild: 2
-  None: 0
-  Reserve1: 4
-  Reserve2: 8
-  Reserve3: 16
-  Reserve4: 32
-  Reserve5: 64
-  Reserve6: 128
+  values:
+    All: 255
+    Friends: 1
+    Guild: 2
+    None: 0
+    Reserve1: 4
+    Reserve2: 8
+    Reserve3: 16
+    Reserve4: 32
+    Reserve5: 64
+    Reserve6: 128
 ExpansionLandingPageType:
-  Midnight: 1
-  None: 0
+  values:
+    Midnight: 1
+    None: 0
 ExpansionLevel:
-  BattleForAzeroth: 7
-  BurningCrusade: 1
-  Cataclysm: 3
-  Draenor: 5
-  Dragonflight: 9
-  LastTitan: 12
-  Legion: 6
-  Midnight: 11
-  MistsOfPandaria: 4
-  None: 0
-  Northrend: 2
-  Shadowlands: 8
-  WarWithin: 10
+  values:
+    BattleForAzeroth: 7
+    BurningCrusade: 1
+    Cataclysm: 3
+    Draenor: 5
+    Dragonflight: 9
+    LastTitan: 12
+    Legion: 6
+    Midnight: 11
+    MistsOfPandaria: 4
+    None: 0
+    Northrend: 2
+    Shadowlands: 8
+    WarWithin: 10
 FlightPathFaction:
-  Alliance: 2
-  Horde: 1
-  Neutral: 0
+  values:
+    Alliance: 2
+    Horde: 1
+    Neutral: 0
 FlightPathState:
-  Current: 0
-  Reachable: 1
-  Unreachable: 2
+  values:
+    Current: 0
+    Reachable: 1
+    Unreachable: 2
 FollowerAbilityCastResult:
-  AlreadyAtMaxDurability: 13
-  CannotTargetLimitedUseFollower: 11
-  CannotTargetNonAutoMissionFollower: 14
-  Failure: 1
-  InvalidFollowerSpell: 4
-  InvalidFollowerType: 9
-  InvalidTarget: 3
-  MustBeUnique: 10
-  MustTargetFollower: 7
-  MustTargetLimitedUseFollower: 12
-  MustTargetTrait: 8
-  NoPendingCast: 2
-  RerollNotAllowed: 5
-  SingleMissionDuration: 6
-  Success: 0
+  values:
+    AlreadyAtMaxDurability: 13
+    CannotTargetLimitedUseFollower: 11
+    CannotTargetNonAutoMissionFollower: 14
+    Failure: 1
+    InvalidFollowerSpell: 4
+    InvalidFollowerType: 9
+    InvalidTarget: 3
+    MustBeUnique: 10
+    MustTargetFollower: 7
+    MustTargetLimitedUseFollower: 12
+    MustTargetTrait: 8
+    NoPendingCast: 2
+    RerollNotAllowed: 5
+    SingleMissionDuration: 6
+    Success: 0
 FontStringScaleAnimationMode:
-  FontSize: 0
-  Vertex: 1
+  values:
+    FontSize: 0
+    Vertex: 1
 FragmentID:
-  Actor: 15
-  CgObject: 2
-  ClientObservablesData: 6
-  DeferredMessages: 9
-  EntityPosition: 1
-  FHousingDecor: 20
-  FHousingDecorActor: 28
-  FHousingDecorProxy: 26
-  FHousingFixture: 34
-  FHousingHouseDecorSet: 24
-  FHousingHouseFixtureSet: 35
-  FHousingHouseRoomSet: 25
-  FHousingPlayerHouse: 23
-  FHousingPlotAreaTrigger: 29
-  FHousingRoom: 21
-  FHousingRoomComponentMesh: 22
-  FHousingStorageMirrorData: 33
-  FJamHousingCornerstone: 27
-  FLootObjectList: 12
-  FMeshObjectData: 19
-  FMirroredPositionData: 31
-  FNeighborhoodMirrorData: 30
-  FNeighborhoodStateData: 38
-  FPathingDoor: 41
-  FPathingDynamicLinks: 40
-  FPersistableJamServers: 10
-  FPhaseShiftData: 16
-  FPlayerHouseInfo: 32
-  FPlayerInitiativeInfo: 37
-  FPlayerJamServers: 11
-  FPlayerOwnershipLink: 13
-  FTransportLink: 5
-  FUnitAIGroupLink: 39
-  FUnitAreaTriggerLink: 14
-  FVendor: 17
-  HeartbeatData: 4
-  JamDispatcher: 3
-  MirroredObjectC: 18
-  MirrorState: 0
-  ReservedArchetypeSeparator: 255
-  TagActiveClientS: 216
-  TagActiveObjectC: 217
-  TagActivePlayer: 215
-  TagAIGroup: 212
-  TagAreaTrigger: 209
-  TagAzeriteEmpoweredItem: 202
-  TagAzeriteItem: 203
-  TagContainer: 201
-  TagConversation: 211
-  TagCorpse: 208
-  TagDynamicObject: 207
-  TagGameObject: 206
-  TagHouseExteriorPiece: 224
-  TagHouseExteriorRoot: 225
-  TagHousingDecorProxyGameObject: 226
-  TagHousingPoolObject: 223
-  TagHousingRoom: 220
-  TagHousingSubdivisionObject: 222
-  TagItem: 200
-  TagLootObject: 214
-  TagMeshObject: 221
-  TagPlayer: 205
-  TagScenario: 213
-  TagSceneObject: 210
-  TagUnit: 204
-  TagUnitVehicle: 219
-  TagVisibleObjectC: 218
-  TestFragment_1: 250
-  TestFragment_2: 251
-  TestFragment_3: 252
-  TestFragment_4: 253
-  TestFragment_5: 254
-  Timer: 36
-  TimerQueues: 7
-  TransferSuspensionData: 8
+  values:
+    Actor: 15
+    CgObject: 2
+    ClientObservablesData: 6
+    DeferredMessages: 9
+    EntityPosition: 1
+    FHousingDecor: 20
+    FHousingDecorActor: 28
+    FHousingDecorProxy: 26
+    FHousingFixture: 34
+    FHousingHouseDecorSet: 24
+    FHousingHouseFixtureSet: 35
+    FHousingHouseRoomSet: 25
+    FHousingPlayerHouse: 23
+    FHousingPlotAreaTrigger: 29
+    FHousingRoom: 21
+    FHousingRoomComponentMesh: 22
+    FHousingStorageMirrorData: 33
+    FJamHousingCornerstone: 27
+    FLootObjectList: 12
+    FMeshObjectData: 19
+    FMirroredPositionData: 31
+    FNeighborhoodMirrorData: 30
+    FNeighborhoodStateData: 38
+    FPathingDoor: 41
+    FPathingDynamicLinks: 40
+    FPersistableJamServers: 10
+    FPhaseShiftData: 16
+    FPlayerHouseInfo: 32
+    FPlayerInitiativeInfo: 37
+    FPlayerJamServers: 11
+    FPlayerOwnershipLink: 13
+    FTransportLink: 5
+    FUnitAIGroupLink: 39
+    FUnitAreaTriggerLink: 14
+    FVendor: 17
+    HeartbeatData: 4
+    JamDispatcher: 3
+    MirroredObjectC: 18
+    MirrorState: 0
+    ReservedArchetypeSeparator: 255
+    TagActiveClientS: 216
+    TagActiveObjectC: 217
+    TagActivePlayer: 215
+    TagAIGroup: 212
+    TagAreaTrigger: 209
+    TagAzeriteEmpoweredItem: 202
+    TagAzeriteItem: 203
+    TagContainer: 201
+    TagConversation: 211
+    TagCorpse: 208
+    TagDynamicObject: 207
+    TagGameObject: 206
+    TagHouseExteriorPiece: 224
+    TagHouseExteriorRoot: 225
+    TagHousingDecorProxyGameObject: 226
+    TagHousingPoolObject: 223
+    TagHousingRoom: 220
+    TagHousingSubdivisionObject: 222
+    TagItem: 200
+    TagLootObject: 214
+    TagMeshObject: 221
+    TagPlayer: 205
+    TagScenario: 213
+    TagSceneObject: 210
+    TagUnit: 204
+    TagUnitVehicle: 219
+    TagVisibleObjectC: 218
+    TestFragment_1: 250
+    TestFragment_2: 251
+    TestFragment_3: 252
+    TestFragment_4: 253
+    TestFragment_5: 254
+    Timer: 36
+    TimerQueues: 7
+    TransferSuspensionData: 8
 FrameTutorialAccount:
-  AccountWideReputation: 9
-  AssistedCombatRotationActionButton: 22
-  AssistedCombatRotationDragSpell: 21
-  BindToAccountUntilEquip: 11
-  CompletedQuestsFilter: 12
-  CompletedQuestsFilterSeen: 13
-  ConcentrationCurrency: 14
-  EditModeManager: 3
-  EnconterJournalTutorialsTabSeen: 33
-  EventSchedulerTabSeen: 20
-  HeirloomJournalLevel: 7
-  HousingCleanupMode: 40
-  HousingDecorCleanup: 23
-  HousingDecorClippingGrid: 25
-  HousingDecorCustomization: 26
-  HousingDecorLayout: 27
-  HousingDecorPlace: 24
-  HousingEndeavorsTabSeen: 48
-  HousingExpertMode: 39
-  HousingHouseFinderMap: 28
-  HousingHouseFinderVisitHouse: 29
-  HousingInvalidCollision: 37
-  HousingItemAcquisition: 30
-  HousingMarketTab: 34
-  HousingModesUnlocked: 38
-  HousingNewPip: 31
-  HousingTeleportButton: 35
-  HudRevampBagChanges: 1
-  LFGList: 6
-  LocalStoriesFilterSeen: 19
-  MapLegendOpened: 15
-  MountCollectionDragonriding: 5
-  NpcCraftingOrderCreateButton: 17
-  NpcCraftingOrders: 16
-  NpcCraftingOrderTabNew: 18
-  PerksProgramActivitiesIntro: 2
-  PerksProgramActivitiesOpen: 32
-  RPETalentStarterBuild: 36
-  RunesOfPower: 49
-  TimerunnersAdvantage: 8
-  TransferableCurrencies: 10
-  TransmogCustomSets: 43
-  TransmogCustomSetsMigration: 47
-  TransmogOutfits: 41
-  TransmogSets: 42
-  TransmogSetsTab: 4
-  TransmogSituations: 44
-  TransmogTrialOfStyle: 46
-  TransmogWeaponOptions: 45
+  values:
+    AccountWideReputation: 9
+    AssistedCombatRotationActionButton: 22
+    AssistedCombatRotationDragSpell: 21
+    BindToAccountUntilEquip: 11
+    CompletedQuestsFilter: 12
+    CompletedQuestsFilterSeen: 13
+    ConcentrationCurrency: 14
+    EditModeManager: 3
+    EnconterJournalTutorialsTabSeen: 33
+    EventSchedulerTabSeen: 20
+    HeirloomJournalLevel: 7
+    HousingCleanupMode: 40
+    HousingDecorCleanup: 23
+    HousingDecorClippingGrid: 25
+    HousingDecorCustomization: 26
+    HousingDecorLayout: 27
+    HousingDecorPlace: 24
+    HousingEndeavorsTabSeen: 48
+    HousingExpertMode: 39
+    HousingHouseFinderMap: 28
+    HousingHouseFinderVisitHouse: 29
+    HousingInvalidCollision: 37
+    HousingItemAcquisition: 30
+    HousingMarketTab: 34
+    HousingModesUnlocked: 38
+    HousingNewPip: 31
+    HousingTeleportButton: 35
+    HudRevampBagChanges: 1
+    LFGList: 6
+    LocalStoriesFilterSeen: 19
+    MapLegendOpened: 15
+    MountCollectionDragonriding: 5
+    NpcCraftingOrderCreateButton: 17
+    NpcCraftingOrders: 16
+    NpcCraftingOrderTabNew: 18
+    PerksProgramActivitiesIntro: 2
+    PerksProgramActivitiesOpen: 32
+    RPETalentStarterBuild: 36
+    RunesOfPower: 49
+    TimerunnersAdvantage: 8
+    TransferableCurrencies: 10
+    TransmogCustomSets: 43
+    TransmogCustomSetsMigration: 47
+    TransmogOutfits: 41
+    TransmogSets: 42
+    TransmogSetsTab: 4
+    TransmogSituations: 44
+    TransmogTrialOfStyle: 46
+    TransmogWeaponOptions: 45
 GameMode:
-  Plunderstorm: 2
-  Standard: 1
-  WoWHack: 3
+  values:
+    Plunderstorm: 2
+    Standard: 1
+    WoWHack: 3
 GamePadPowerLevel:
-  Critical: 0
-  High: 3
-  Low: 1
-  Medium: 2
-  Unknown: 5
-  Wired: 4
+  values:
+    Critical: 0
+    High: 3
+    Low: 1
+    Medium: 2
+    Unknown: 5
+    Wired: 4
 GameRule:
-  AchievementsPanelDisabled: 40
-  ActionbarIconIntroDisabled: 60
-  ActionButtonTypeOverlayStrategy: 165
-  ActionCombatTargetLockEnabled: 87
-  AfterDeathSpectatingUI: 49
-  AllPlayersAreFastMovers: 53
-  AlwaysAllowAlliedRaces: 59
-  AutoAttacksDisabled: 103
-  BagSpaceOverride: 172
-  BagsUIDisabled: 64
-  BlockWhileSheathedAllowed: 88
-  CharacterCreateUseFixedBackgroundModel: 55
-  CharacterlessLogin: 14
-  CharacterPanelDisabled: 37
-  CharNameReservationEnabled: 2
-  CharReservationsPerRealmReopenThreshold: 8
-  ChatLinkLevelToastsDisabled: 63
-  ClearMailOnRealmTransfer: 92
-  CollectionsPanelDisabled: 36
-  CommunitiesPanelDisabled: 41
-  CompactRaidFrameManagerDisabled: 81
-  CustomActionbarOverlayHeightOffset: 33
-  DeleteItemConfirmationDisabled: 62
-  DisableCampsites: 114
-  DisableHonorDecay: 23
-  DisablePct: 9
-  DisableQuickJoin: 162
-  DisableRaidGroups: 163
-  DisableRealmSelection: 113
-  DisableVas: 119
-  DoesNotCountTowardAccountCharacterMax: 142
-  EditModeDisabled: 82
-  EjDungeonsDisabled: 149
-  EjItemSetsDisabled: 151
-  EjJourneysDisabled: 156
-  EjRaidsDisabled: 150
-  EjSuggestedContentDisabled: 148
-  EncounterJournalDisabled: 42
-  EtaRealmLaunchTime: 5
-  ExperienceBarDisabled: 159
-  FastAreaTriggerTick: 52
-  FinderPanelDisabled: 43
-  ForceAlteredFormsOn: 56
-  ForcedChatLanguage: 34
-  ForcedMultiActionBarSetting: 133
-  ForcedPartyFrameScale: 32
-  FrontEndChat: 50
-  FullCharacterCreateDisabled: 84
-  GameMode: 13
-  GdapiCharacterProfileDisabled: 153
-  GroupFinderCapabilities: 98
-  GuildsDisabled: 46
-  HardcoreRuleset: 10
-  HelpPanelDisabled: 45
-  HideAllMultiActionBars: 135
-  HideFaction: 116
-  HideTransmogZeroCost: 161
-  HideUnavailableTransmogSlots: 160
-  HousingDashboardDisabled: 102
-  HousingEnabled: 154
-  IgnoreChrclassDisabledFlag: 54
-  IngameCalendarDisabled: 75
-  IngameFriendsListDisabled: 79
-  IngameMailNotificationDisabled: 74
-  IngameTrackingDisabled: 76
-  IngameWhoListDisabled: 77
-  InstanceDifficultyBannerDisabled: 83
-  LandingPageFactionID: 35
-  LootMethodStyle: 157
-  MacrosDisabled: 80
-  MailGameRule: 132
-  MapPlunderstormCircle: 48
-  MaxAccountCharReservationsPerContentset: 4
-  MaxCharactersPerContentSet: 139
-  MaxCharReservationsPerRealm: 3
-  MaximizeWorldMapDisabled: 67
-  MaxLootDropLevel: 25
-  MaxNameplateDistance: 28
-  MaxUnitNameDistance: 27
-  MerchantFilterDisabled: 101
-  MicrobarScale: 26
-  MinimapDisabled: 146
-  MinUndeleteLevelRequired: 140
-  NameplateCastBarDisabled: 107
-  NoDebuffLimit: 1
-  NonPlayerNameplateScale: 31
-  ObjectiveTrackerDisabled: 104
-  PerksProgramActivityTrackingDisabled: 66
-  PersonalResourceDisplayDisabled: 129
-  PetBattlesDisabled: 65
-  PlayerCastBarDisabled: 105
-  PlayerFrameDisabled: 131
-  PlayerNameplateAlternateHealthColor: 58
-  PlayerNameplateDifficultyIcon: 57
-  PlunderstormAreaSelection: 94
-  PremadeGroupFinderStyle: 93
-  PvPInitialRatingOverride: 190
-  QuestLogMicrobuttonDisabled: 47
-  QuestLogPanelDisabled: 71
-  QuestLogSuperTrackingDisabled: 72
-  RaceAlteredFormsDisabled: 78
-  RecommendLeastPopulatedRealm: 169
-  ReleaseSpiritGhostDisabled: 61
-  RepairArmorDisabled: 147
-  ReplaceAbsentGmSeconds: 11
-  ReplaceGmRankLastOnlineSeconds: 12
-  RestrictedAchievementCategoryID: 155
-  Runecarving: 17
-  SelfFoundAllowed: 22
-  SpellbookPanelDisabled: 38
-  StoreDisabled: 44
-  SummoningStones: 108
-  TalentRespecCostMax: 19
-  TalentRespecCostMin: 18
-  TalentRespecCostStep: 20
-  TalentsPanelDisabled: 39
-  TargetCastBarDisabled: 106
-  TargetFrameBuffsDisabled: 85
-  TargetFrameDisabled: 130
-  TimerunningAllowed: 137
-  TransmogEnabled: 109
-  TrivialGroupXPPercent: 7
-  TutorialFrameDisabled: 73
-  UnflaggedPlayersCanAttackPvPFlaggedPlayers: 173
-  UnitFramePvPContextualDisabled: 86
-  UniversalNameplateOcclusion: 51
-  UseGameTableVariation: 164
-  UserAddonsDisabled: 29
-  UserScriptsDisabled: 30
-  UseSimpleCharacterSelectList: 115
-  VanillaAccountMailInstant: 91
-  VanillaNpcKnockback: 16
-  VanillaRageGenerationModifier: 21
-  WorldMapDisabled: 145
-  WorldMapFrameStrata: 100
-  WorldMapHelpPlateDisabled: 70
-  WorldMapLegendDisabled: 99
-  WorldMapTrackingOptionsDisabled: 68
-  WorldMapTrackingPinDisabled: 69
+  values:
+    AchievementsPanelDisabled: 40
+    ActionbarIconIntroDisabled: 60
+    ActionButtonTypeOverlayStrategy: 165
+    ActionCombatTargetLockEnabled: 87
+    AfterDeathSpectatingUI: 49
+    AllPlayersAreFastMovers: 53
+    AlwaysAllowAlliedRaces: 59
+    AutoAttacksDisabled: 103
+    BagSpaceOverride: 172
+    BagsUIDisabled: 64
+    BlockWhileSheathedAllowed: 88
+    CharacterCreateUseFixedBackgroundModel: 55
+    CharacterlessLogin: 14
+    CharacterPanelDisabled: 37
+    CharNameReservationEnabled: 2
+    CharReservationsPerRealmReopenThreshold: 8
+    ChatLinkLevelToastsDisabled: 63
+    ClearMailOnRealmTransfer: 92
+    CollectionsPanelDisabled: 36
+    CommunitiesPanelDisabled: 41
+    CompactRaidFrameManagerDisabled: 81
+    CustomActionbarOverlayHeightOffset: 33
+    DeleteItemConfirmationDisabled: 62
+    DisableCampsites: 114
+    DisableHonorDecay: 23
+    DisablePct: 9
+    DisableQuickJoin: 162
+    DisableRaidGroups: 163
+    DisableRealmSelection: 113
+    DisableVas: 119
+    DoesNotCountTowardAccountCharacterMax: 142
+    EditModeDisabled: 82
+    EjDungeonsDisabled: 149
+    EjItemSetsDisabled: 151
+    EjJourneysDisabled: 156
+    EjRaidsDisabled: 150
+    EjSuggestedContentDisabled: 148
+    EncounterJournalDisabled: 42
+    EtaRealmLaunchTime: 5
+    ExperienceBarDisabled: 159
+    FastAreaTriggerTick: 52
+    FinderPanelDisabled: 43
+    ForceAlteredFormsOn: 56
+    ForcedChatLanguage: 34
+    ForcedMultiActionBarSetting: 133
+    ForcedPartyFrameScale: 32
+    FrontEndChat: 50
+    FullCharacterCreateDisabled: 84
+    GameMode: 13
+    GdapiCharacterProfileDisabled: 153
+    GroupFinderCapabilities: 98
+    GuildsDisabled: 46
+    HardcoreRuleset: 10
+    HelpPanelDisabled: 45
+    HideAllMultiActionBars: 135
+    HideFaction: 116
+    HideTransmogZeroCost: 161
+    HideUnavailableTransmogSlots: 160
+    HousingDashboardDisabled: 102
+    HousingEnabled: 154
+    IgnoreChrclassDisabledFlag: 54
+    IngameCalendarDisabled: 75
+    IngameFriendsListDisabled: 79
+    IngameMailNotificationDisabled: 74
+    IngameTrackingDisabled: 76
+    IngameWhoListDisabled: 77
+    InstanceDifficultyBannerDisabled: 83
+    LandingPageFactionID: 35
+    LootMethodStyle: 157
+    MacrosDisabled: 80
+    MailGameRule: 132
+    MapPlunderstormCircle: 48
+    MaxAccountCharReservationsPerContentset: 4
+    MaxCharactersPerContentSet: 139
+    MaxCharReservationsPerRealm: 3
+    MaximizeWorldMapDisabled: 67
+    MaxLootDropLevel: 25
+    MaxNameplateDistance: 28
+    MaxUnitNameDistance: 27
+    MerchantFilterDisabled: 101
+    MicrobarScale: 26
+    MinimapDisabled: 146
+    MinUndeleteLevelRequired: 140
+    NameplateCastBarDisabled: 107
+    NoDebuffLimit: 1
+    NonPlayerNameplateScale: 31
+    ObjectiveTrackerDisabled: 104
+    PerksProgramActivityTrackingDisabled: 66
+    PersonalResourceDisplayDisabled: 129
+    PetBattlesDisabled: 65
+    PlayerCastBarDisabled: 105
+    PlayerFrameDisabled: 131
+    PlayerNameplateAlternateHealthColor: 58
+    PlayerNameplateDifficultyIcon: 57
+    PlunderstormAreaSelection: 94
+    PremadeGroupFinderStyle: 93
+    PvPInitialRatingOverride: 190
+    QuestLogMicrobuttonDisabled: 47
+    QuestLogPanelDisabled: 71
+    QuestLogSuperTrackingDisabled: 72
+    RaceAlteredFormsDisabled: 78
+    RecommendLeastPopulatedRealm: 169
+    ReleaseSpiritGhostDisabled: 61
+    RepairArmorDisabled: 147
+    ReplaceAbsentGmSeconds: 11
+    ReplaceGmRankLastOnlineSeconds: 12
+    RestrictedAchievementCategoryID: 155
+    Runecarving: 17
+    SelfFoundAllowed: 22
+    SpellbookPanelDisabled: 38
+    StoreDisabled: 44
+    SummoningStones: 108
+    TalentRespecCostMax: 19
+    TalentRespecCostMin: 18
+    TalentRespecCostStep: 20
+    TalentsPanelDisabled: 39
+    TargetCastBarDisabled: 106
+    TargetFrameBuffsDisabled: 85
+    TargetFrameDisabled: 130
+    TimerunningAllowed: 137
+    TransmogEnabled: 109
+    TrivialGroupXPPercent: 7
+    TutorialFrameDisabled: 73
+    UnflaggedPlayersCanAttackPvPFlaggedPlayers: 173
+    UnitFramePvPContextualDisabled: 86
+    UniversalNameplateOcclusion: 51
+    UseGameTableVariation: 164
+    UserAddonsDisabled: 29
+    UserScriptsDisabled: 30
+    UseSimpleCharacterSelectList: 115
+    VanillaAccountMailInstant: 91
+    VanillaNpcKnockback: 16
+    VanillaRageGenerationModifier: 21
+    WorldMapDisabled: 145
+    WorldMapFrameStrata: 100
+    WorldMapHelpPlateDisabled: 70
+    WorldMapLegendDisabled: 99
+    WorldMapTrackingOptionsDisabled: 68
+    WorldMapTrackingPinDisabled: 69
 GameRuleFlags:
-  AllowClient: 1
-  None: 0
-  RequiresDefault: 2
+  values:
+    AllowClient: 1
+    None: 0
+    RequiresDefault: 2
 GameRuleType:
-  Bool: 2
-  Float: 1
-  Int: 0
+  values:
+    Bool: 2
+    Float: 1
+    Int: 0
 GarrAutoBoardIndex:
-  AllyCenterFront: 3
-  AllyLeftBack: 0
-  AllyLeftFront: 2
-  AllyRightBack: 1
-  AllyRightFront: 4
-  EnemyCenterLeftBack: 10
-  EnemyCenterLeftFront: 6
-  EnemyCenterRightBack: 11
-  EnemyCenterRightFront: 7
-  EnemyLeftBack: 9
-  EnemyLeftFront: 5
-  EnemyRightBack: 12
-  EnemyRightFront: 8
-  None: -1
+  values:
+    AllyCenterFront: 3
+    AllyLeftBack: 0
+    AllyLeftFront: 2
+    AllyRightBack: 1
+    AllyRightFront: 4
+    EnemyCenterLeftBack: 10
+    EnemyCenterLeftFront: 6
+    EnemyCenterRightBack: 11
+    EnemyCenterRightFront: 7
+    EnemyLeftBack: 9
+    EnemyLeftFront: 5
+    EnemyRightBack: 12
+    EnemyRightFront: 8
+    None: -1
 GarrAutoCombatantRole:
-  HealSupport: 4
-  Melee: 1
-  None: 0
-  RangedMagic: 3
-  RangedPhysical: 2
-  Tank: 5
+  values:
+    HealSupport: 4
+    Melee: 1
+    None: 0
+    RangedMagic: 3
+    RangedPhysical: 2
+    Tank: 5
 GarrAutoCombatSpellTutorialFlag:
-  All: 4
-  Column: 2
-  None: 0
-  Row: 3
-  Single: 1
+  values:
+    All: 4
+    Column: 2
+    None: 0
+    Row: 3
+    Single: 1
 GarrAutoCombatTutorial:
-  AttackAll: 256
-  AttackColumn: 64
-  AttackRow: 128
-  AttackSingle: 32
-  BeneficialEffect: 16
-  EnvironmentalEffect: 1024
-  HealCompanion: 4
-  LevelHeal: 8
-  PlaceCompanion: 2
-  SelectMission: 1
-  TroopTutorial: 512
+  values:
+    AttackAll: 256
+    AttackColumn: 64
+    AttackRow: 128
+    AttackSingle: 32
+    BeneficialEffect: 16
+    EnvironmentalEffect: 1024
+    HealCompanion: 4
+    LevelHeal: 8
+    PlaceCompanion: 2
+    SelectMission: 1
+    TroopTutorial: 512
 GarrAutoEventFlags:
-  AutoAttack: 1
-  Environment: 4
-  None: 0
-  Passive: 2
+  values:
+    AutoAttack: 1
+    Environment: 4
+    None: 0
+    Passive: 2
 GarrAutoMissionEventType:
-  ApplyAura: 7
-  Died: 9
-  Heal: 4
-  MeleeDamage: 0
-  PeriodicDamage: 5
-  PeriodicHeal: 6
-  RangeDamage: 1
-  RemoveAura: 8
-  SpellMeleeDamage: 2
-  SpellRangeDamage: 3
+  values:
+    ApplyAura: 7
+    Died: 9
+    Heal: 4
+    MeleeDamage: 0
+    PeriodicDamage: 5
+    PeriodicHeal: 6
+    RangeDamage: 1
+    RemoveAura: 8
+    SpellMeleeDamage: 2
+    SpellRangeDamage: 3
 GarrAutoPreviewTargetType:
-  Buff: 4
-  Damage: 1
-  Debuff: 8
-  Heal: 2
-  None: 0
+  values:
+    Buff: 4
+    Damage: 1
+    Debuff: 8
+    Heal: 2
+    None: 0
 GarrFollowerMissionCompleteState:
-  Alive: 0
-  KilledByMissionFailure: 1
-  OutOfDurability: 3
-  SavedByPreventDeath: 2
+  values:
+    Alive: 0
+    KilledByMissionFailure: 1
+    OutOfDurability: 3
+    SavedByPreventDeath: 2
 GarrFollowerQuality:
-  Common: 1
-  Epic: 4
-  Legendary: 5
-  None: 0
-  Rare: 3
-  Title: 6
-  Uncommon: 2
+  values:
+    Common: 1
+    Epic: 4
+    Legendary: 5
+    None: 0
+    Rare: 3
+    Title: 6
+    Uncommon: 2
 GarrisonFollowerType:
-  FollowerType_6_0_Boat: 2
-  FollowerType_6_0_GarrisonFollower: 1
-  FollowerType_7_0_GarrisonFollower: 4
-  FollowerType_8_0_GarrisonFollower: 22
-  FollowerType_9_0_GarrisonFollower: 123
+  values:
+    FollowerType_6_0_Boat: 2
+    FollowerType_6_0_GarrisonFollower: 1
+    FollowerType_7_0_GarrisonFollower: 4
+    FollowerType_8_0_GarrisonFollower: 22
+    FollowerType_9_0_GarrisonFollower: 123
 GarrisonTalentAvailability:
-  Available: 0
-  Unavailable: 1
-  UnavailableAlreadyHave: 7
-  UnavailableAnotherIsResearching: 2
-  UnavailableNotEnoughGold: 4
-  UnavailableNotEnoughResources: 3
-  UnavailablePlayerCondition: 6
-  UnavailableRequiresPrerequisiteTalent: 8
-  UnavailableTierUnavailable: 5
+  values:
+    Available: 0
+    Unavailable: 1
+    UnavailableAlreadyHave: 7
+    UnavailableAnotherIsResearching: 2
+    UnavailableNotEnoughGold: 4
+    UnavailableNotEnoughResources: 3
+    UnavailablePlayerCondition: 6
+    UnavailableRequiresPrerequisiteTalent: 8
+    UnavailableTierUnavailable: 5
 GarrisonType:
-  Type_6_0_Garrison: 2
-  Type_7_0_Garrison: 3
-  Type_8_0_Garrison: 9
-  Type_9_0_Garrison: 111
+  values:
+    Type_6_0_Garrison: 2
+    Type_7_0_Garrison: 3
+    Type_8_0_Garrison: 9
+    Type_9_0_Garrison: 111
 GarrTalentCostType:
-  Initial: 0
-  MakePermanent: 2
-  Respec: 1
-  TreeReset: 3
+  values:
+    Initial: 0
+    MakePermanent: 2
+    Respec: 1
+    TreeReset: 3
 GarrTalentFeatureSubtype:
-  Ardenweald: 3
-  Bastion: 1
-  Generic: 0
-  Maldraxxus: 4
-  Revendreth: 2
+  values:
+    Ardenweald: 3
+    Bastion: 1
+    Generic: 0
+    Maldraxxus: 4
+    Revendreth: 2
 GarrTalentFeatureType:
-  Adventures: 3
-  AnimaDiversion: 1
-  AnimaDiversionMap: 7
-  Cyphers: 8
-  Generic: 0
-  ReservoirUpgrades: 4
-  SanctumUnique: 5
-  SoulBinds: 6
-  TravelPortals: 2
+  values:
+    Adventures: 3
+    AnimaDiversion: 1
+    AnimaDiversionMap: 7
+    Cyphers: 8
+    Generic: 0
+    ReservoirUpgrades: 4
+    SanctumUnique: 5
+    SoulBinds: 6
+    TravelPortals: 2
 GarrTalentResearchCostSource:
-  Talent: 0
-  Tree: 1
+  values:
+    Talent: 0
+    Tree: 1
 GarrTalentSocketType:
-  Conduit: 2
-  None: 0
-  Spell: 1
+  values:
+    Conduit: 2
+    None: 0
+    Spell: 1
 GarrTalentTreeType:
-  Classic: 1
-  Tiers: 0
+  values:
+    Classic: 1
+    Tiers: 0
 GarrTalentType:
-  Major: 2
-  Minor: 1
-  Socket: 3
-  Standard: 0
+  values:
+    Major: 2
+    Minor: 1
+    Socket: 3
+    Standard: 0
 GarrTalentUI:
-  AnimaDiversionMap: 3
-  CovenantSanctum: 1
-  Generic: 0
-  SoulBinds: 2
+  values:
+    AnimaDiversionMap: 3
+    CovenantSanctum: 1
+    Generic: 0
+    SoulBinds: 2
 GossipNpcOption:
-  AccountBanker: 57
-  AdventureMap: 31
-  ArtifactRespec: 21
-  Auctioneer: 10
-  AzeriteRespec: 35
-  Banker: 6
-  BarbersChoice: 52
-  Battlemaster: 9
-  Binder: 5
-  BlackMarketAuctionHouse: 46
-  CemeterySelect: 22
-  CharacterBanker: 56
-  ChromieTimeNpc: 40
-  ContributionCollector: 33
-  CovenantPreviewNpc: 41
-  CovenantRenownNpc: 45
-  DisableXPGain: 16
-  EnableXPGain: 17
-  ForgeMaster: 55
-  GarrisonArchitect: 26
-  GarrisonMissionNpc: 27
-  GarrisonRecruitment: 30
-  GarrisonTalent: 32
-  GarrisonTradeskillNpc: 29
-  GlyphMaster: 24
-  GuildBanker: 14
-  GuildRename: 62
-  GuildTabardVendor: 8
-  HouseFinder: 65
-  HousingCreateGuildNeighborhood: 60
-  HousingGetNeighborhoodCharter: 61
-  HousingOpenCharterConfirmation: 63
-  IslandsMissionNpc: 36
-  ItemUpgrade: 64
-  LFGDungeon: 20
-  Mailbox: 18
-  MajorFactionRenown: 53
-  NewPlayerGuide: 43
-  None: 0
-  PerksProgramVendor: 47
-  PersonalTabardVendor: 54
-  PetitionVendor: 7
-  PetUntrainer: 13
-  ProfessionRespec: 58
-  ProfessionsCraftingOrder: 48
-  ProfessionsCustomerOrder: 50
-  ProfessionsOpen: 49
-  QueueScenario: 25
-  RenameNeighborhood: 59
-  RuneforgeLegendaryCrafting: 42
-  RuneforgeLegendaryUpgrade: 44
-  ShipmentCrafter: 28
-  Soulbind: 39
-  SpecializationMaster: 23
-  Spellclick: 15
-  SpiritHealer: 4
-  Stablemaster: 12
-  TalentMaster: 11
-  Taxinode: 2
-  TieredEntrance: 66
-  Trainer: 3
-  TraitSystem: 51
-  Transmogrify: 34
-  UIItemInteraction: 37
-  Vendor: 1
-  WorldMap: 38
-  WorldPvPQueue: 19
+  values:
+    AccountBanker: 57
+    AdventureMap: 31
+    ArtifactRespec: 21
+    Auctioneer: 10
+    AzeriteRespec: 35
+    Banker: 6
+    BarbersChoice: 52
+    Battlemaster: 9
+    Binder: 5
+    BlackMarketAuctionHouse: 46
+    CemeterySelect: 22
+    CharacterBanker: 56
+    ChromieTimeNpc: 40
+    ContributionCollector: 33
+    CovenantPreviewNpc: 41
+    CovenantRenownNpc: 45
+    DisableXPGain: 16
+    EnableXPGain: 17
+    ForgeMaster: 55
+    GarrisonArchitect: 26
+    GarrisonMissionNpc: 27
+    GarrisonRecruitment: 30
+    GarrisonTalent: 32
+    GarrisonTradeskillNpc: 29
+    GlyphMaster: 24
+    GuildBanker: 14
+    GuildRename: 62
+    GuildTabardVendor: 8
+    HouseFinder: 65
+    HousingCreateGuildNeighborhood: 60
+    HousingGetNeighborhoodCharter: 61
+    HousingOpenCharterConfirmation: 63
+    IslandsMissionNpc: 36
+    ItemUpgrade: 64
+    LFGDungeon: 20
+    Mailbox: 18
+    MajorFactionRenown: 53
+    NewPlayerGuide: 43
+    None: 0
+    PerksProgramVendor: 47
+    PersonalTabardVendor: 54
+    PetitionVendor: 7
+    PetUntrainer: 13
+    ProfessionRespec: 58
+    ProfessionsCraftingOrder: 48
+    ProfessionsCustomerOrder: 50
+    ProfessionsOpen: 49
+    QueueScenario: 25
+    RenameNeighborhood: 59
+    RuneforgeLegendaryCrafting: 42
+    RuneforgeLegendaryUpgrade: 44
+    ShipmentCrafter: 28
+    Soulbind: 39
+    SpecializationMaster: 23
+    Spellclick: 15
+    SpiritHealer: 4
+    Stablemaster: 12
+    TalentMaster: 11
+    Taxinode: 2
+    TieredEntrance: 66
+    Trainer: 3
+    TraitSystem: 51
+    Transmogrify: 34
+    UIItemInteraction: 37
+    Vendor: 1
+    WorldMap: 38
+    WorldPvPQueue: 19
 GossipNpcOptionDisplayFlags:
-  ForceInteractionOnSingleChoice: 1
+  values:
+    ForceInteractionOnSingleChoice: 1
 GossipOptionRecFlags:
-  HideOptionIDFromClient: 2
-  PlayMovieLabelPrepend: 4
-  QuestLabelPrepend: 1
+  values:
+    HideOptionIDFromClient: 2
+    PlayMovieLabelPrepend: 4
+    QuestLabelPrepend: 1
 GossipOptionStatus:
-  AlreadyComplete: 3
-  Available: 0
-  Locked: 2
-  Unavailable: 1
+  values:
+    AlreadyComplete: 3
+    Available: 0
+    Locked: 2
+    Unavailable: 1
 GraphicsValidationResult:
-  AmdGpuUnsupported: 36
-  AppleGpuUnsupported: 35
-  CompatMode: 41
-  CpuMem_2: 6
-  CpuMem_4: 7
-  CpuMem_8: 8
-  DualCore: 4
-  Dx11Unsupported: 30
-  Dx12Win7Unsupported: 31
-  GpuDriver: 40
-  Graphics: 3
-  Illegal: 1
-  IntelGpuUnsupported: 37
-  LegacyUnsupported: 29
-  MacOsUnsupported: 27
-  Needs_5_0: 9
-  Needs_6_0: 10
-  NeedsAmdGpu: 15
-  NeedsAppleGpu: 14
-  NeedsDx12: 12
-  NeedsDx12Vrs2: 13
-  NeedsIntelGpu: 16
-  NeedsMacOs_10_13: 19
-  NeedsMacOs_10_14: 20
-  NeedsMacOs_10_15: 21
-  NeedsMacOs_11_0: 22
-  NeedsMacOs_12_0: 23
-  NeedsMacOs_13_0: 24
-  NeedsNvidiaGpu: 17
-  NeedsQualcommGpu: 18
-  NeedsRt: 11
-  NeedsWindows_10: 25
-  NeedsWindows_11: 26
-  NvapiWineUnsupported: 34
-  NvidiaGpuUnsupported: 38
-  QuadCore: 5
-  QualcommGpuUnsupported: 39
-  RemoteDesktopUnsupported: 32
-  Supported: 0
-  Unknown: 42
-  Unsupported: 2
-  WindowsUnsupported: 28
-  WineUnsupported: 33
+  values:
+    AmdGpuUnsupported: 36
+    AppleGpuUnsupported: 35
+    CompatMode: 41
+    CpuMem_2: 6
+    CpuMem_4: 7
+    CpuMem_8: 8
+    DualCore: 4
+    Dx11Unsupported: 30
+    Dx12Win7Unsupported: 31
+    GpuDriver: 40
+    Graphics: 3
+    Illegal: 1
+    IntelGpuUnsupported: 37
+    LegacyUnsupported: 29
+    MacOsUnsupported: 27
+    Needs_5_0: 9
+    Needs_6_0: 10
+    NeedsAmdGpu: 15
+    NeedsAppleGpu: 14
+    NeedsDx12: 12
+    NeedsDx12Vrs2: 13
+    NeedsIntelGpu: 16
+    NeedsMacOs_10_13: 19
+    NeedsMacOs_10_14: 20
+    NeedsMacOs_10_15: 21
+    NeedsMacOs_11_0: 22
+    NeedsMacOs_12_0: 23
+    NeedsMacOs_13_0: 24
+    NeedsNvidiaGpu: 17
+    NeedsQualcommGpu: 18
+    NeedsRt: 11
+    NeedsWindows_10: 25
+    NeedsWindows_11: 26
+    NvapiWineUnsupported: 34
+    NvidiaGpuUnsupported: 38
+    QuadCore: 5
+    QualcommGpuUnsupported: 39
+    RemoteDesktopUnsupported: 32
+    Supported: 0
+    Unknown: 42
+    Unsupported: 2
+    WindowsUnsupported: 28
+    WineUnsupported: 33
 GuildErrorType:
-  AlreadyInGuild: 2
-  BadItem: 29
-  BankNotFound: 43
-  BankTabFull: 28
-  BankTabLocked: 35
-  Busy: 20
-  CantInviteSelf: 41
-  DeleteNoAppropriateLeader: 47
-  GuildBankNotAvailable: 45
-  GuildRepTooLow: 40
-  HasRestriction: 42
-  HousingEvictError: 51
-  Ignored: 19
-  InCooldown: 49
-  InvalidBankTab: 24
-  InvitedToGuild: 4
-  LockedForMove: 39
-  NameAlreadyExists: 7
-  NameInvalid: 6
-  NewLeaderWrongFaction: 44
-  NewLeaderWrongRealm: 46
-  NoPermisson: 8
-  NotEnoughMoney: 26
-  NotInGuild: 9
-  PlayerNotFound: 11
-  RankInUse: 18
-  RankRequiresAuthenticator: 34
-  RanksLocked: 17
-  RealmMismatch: 48
-  ReservationExpired: 50
-  Success: 0
-  TargetAlreadyInGuild: 3
-  TargetInvitedToGuild: 5
-  TargetLevelTooHigh: 22
-  TargetLevelTooLow: 21
-  TargetNotInGuild: 10
-  TargetTooHigh: 13
-  TargetTooLow: 14
-  TeamNotFound: 27
-  TeamsLocked: 30
-  Throttled: 52
-  TooFewRanks: 16
-  TooManyCreate: 33
-  TooManyMembers: 23
-  TooManyRanks: 15
-  TooMuchMoney: 31
-  TrialAccount: 36
-  UndeletableDueToLevel: 38
-  UnknownError: 1
-  VeteranAccount: 37
-  WithdrawLimit: 25
-  WrongBankTab: 32
-  WrongFaction: 12
+  values:
+    AlreadyInGuild: 2
+    BadItem: 29
+    BankNotFound: 43
+    BankTabFull: 28
+    BankTabLocked: 35
+    Busy: 20
+    CantInviteSelf: 41
+    DeleteNoAppropriateLeader: 47
+    GuildBankNotAvailable: 45
+    GuildRepTooLow: 40
+    HasRestriction: 42
+    HousingEvictError: 51
+    Ignored: 19
+    InCooldown: 49
+    InvalidBankTab: 24
+    InvitedToGuild: 4
+    LockedForMove: 39
+    NameAlreadyExists: 7
+    NameInvalid: 6
+    NewLeaderWrongFaction: 44
+    NewLeaderWrongRealm: 46
+    NoPermisson: 8
+    NotEnoughMoney: 26
+    NotInGuild: 9
+    PlayerNotFound: 11
+    RankInUse: 18
+    RankRequiresAuthenticator: 34
+    RanksLocked: 17
+    RealmMismatch: 48
+    ReservationExpired: 50
+    Success: 0
+    TargetAlreadyInGuild: 3
+    TargetInvitedToGuild: 5
+    TargetLevelTooHigh: 22
+    TargetLevelTooLow: 21
+    TargetNotInGuild: 10
+    TargetTooHigh: 13
+    TargetTooLow: 14
+    TeamNotFound: 27
+    TeamsLocked: 30
+    Throttled: 52
+    TooFewRanks: 16
+    TooManyCreate: 33
+    TooManyMembers: 23
+    TooManyRanks: 15
+    TooMuchMoney: 31
+    TrialAccount: 36
+    UndeletableDueToLevel: 38
+    UnknownError: 1
+    VeteranAccount: 37
+    WithdrawLimit: 25
+    WrongBankTab: 32
+    WrongFaction: 12
 HolidayCalendarFlags:
-  Alliance: 1
-  Horde: 2
+  values:
+    Alliance: 1
+    Horde: 2
 HolidayFlags:
-  BeginEventOnlyOnStageChange: 64
-  DontDisplayBanner: 8
-  DontDisplayEnd: 4
-  DontShowInCalendar: 2
-  DurationUseMinutes: 32
-  IsRegionwide: 1
-  NotAvailableClientSide: 16
+  values:
+    BeginEventOnlyOnStageChange: 64
+    DontDisplayBanner: 8
+    DontDisplayEnd: 4
+    DontShowInCalendar: 2
+    DurationUseMinutes: 32
+    IsRegionwide: 1
+    NotAvailableClientSide: 16
 HouseEditingContext:
-  Decor: 1
-  Fixture: 3
-  None: 0
-  Room: 2
+  values:
+    Decor: 1
+    Fixture: 3
+    None: 0
+    Room: 2
 HouseEditorMode:
-  BasicDecor: 1
-  Cleanup: 5
-  Customize: 4
-  ExpertDecor: 2
-  ExteriorCustomization: 6
-  Layout: 3
-  None: 0
+  values:
+    BasicDecor: 1
+    Cleanup: 5
+    Customize: 4
+    ExpertDecor: 2
+    ExteriorCustomization: 6
+    Layout: 3
+    None: 0
 HouseExteriorWMODataFlags:
-  AllowedInAllianceNeighborhoods: 4
-  AllowedInHordeNeighborhoods: 2
-  HiddenUnlessOwned: 8
-  None: 0
-  UnlockedByDefault: 1
+  values:
+    AllowedInAllianceNeighborhoods: 4
+    AllowedInHordeNeighborhoods: 2
+    HiddenUnlessOwned: 8
+    None: 0
+    UnlockedByDefault: 1
 HouseFinderSuggestionReason:
-  BNetFriends: 8
-  CharterInvite: 2
-  Guild: 4
-  HomeOwner: 64
-  None: 0
-  Owner: 1
-  PartySync: 16
-  Random: 32
+  values:
+    BNetFriends: 8
+    CharterInvite: 2
+    Guild: 4
+    HomeOwner: 64
+    None: 0
+    Owner: 1
+    PartySync: 16
+    Random: 32
 HouseLevelRewardType:
-  Object: 1
-  Value: 0
+  values:
+    Object: 1
+    Value: 0
 HouseLevelRewardValueType:
-  ExteriorDecor: 0
-  Fixtures: 3
-  InteriorDecor: 1
-  Rooms: 2
+  values:
+    ExteriorDecor: 0
+    Fixtures: 3
+    InteriorDecor: 1
+    Rooms: 2
 HouseOwnerError:
-  Faction: 1
-  GenericPermission: 3
-  Guild: 2
-  None: 0
+  values:
+    Faction: 1
+    GenericPermission: 3
+    Guild: 2
+    None: 0
 HouseSettingFlags:
-  HouseAccessAnyone: 1
-  HouseAccessFriends: 8
-  HouseAccessGuild: 4
-  HouseAccessNeighbors: 2
-  HouseAccessParty: 16
-  None: 0
-  PlotAccessAnyone: 32
-  PlotAccessFriends: 256
-  PlotAccessGuild: 128
-  PlotAccessNeighbors: 64
-  PlotAccessParty: 512
+  values:
+    HouseAccessAnyone: 1
+    HouseAccessFriends: 8
+    HouseAccessGuild: 4
+    HouseAccessNeighbors: 2
+    HouseAccessParty: 16
+    None: 0
+    PlotAccessAnyone: 32
+    PlotAccessFriends: 256
+    PlotAccessGuild: 128
+    PlotAccessNeighbors: 64
+    PlotAccessParty: 512
 HouseVisitType:
-  Friend: 1
-  Guild: 2
-  Party: 3
-  Unknown: 0
+  values:
+    Friend: 1
+    Guild: 2
+    Party: 3
+    Unknown: 0
 HousingBasicModeTargetType:
-  Decor: 1
-  House: 2
-  None: 0
+  values:
+    Decor: 1
+    House: 2
+    None: 0
 HousingCatalogEntryModelScenePresets:
-  DecorCeiling: 1338
-  DecorDefault: 1317
-  DecorFlat: 1318
-  DecorHorizontalSurface: 1452
-  DecorHuge: 1337
-  DecorLarge: 1336
-  DecorMedium: 1335
-  DecorSmall: 1334
-  DecorTiny: 1333
-  DecorWall: 1339
+  values:
+    DecorCeiling: 1338
+    DecorDefault: 1317
+    DecorFlat: 1318
+    DecorHorizontalSurface: 1452
+    DecorHuge: 1337
+    DecorLarge: 1336
+    DecorMedium: 1335
+    DecorSmall: 1334
+    DecorTiny: 1333
+    DecorWall: 1339
 HousingCatalogEntrySize:
-  Huge: 69
-  Large: 68
-  Medium: 67
-  None: 0
-  Small: 66
-  Tiny: 65
+  values:
+    Huge: 69
+    Large: 68
+    Medium: 67
+    None: 0
+    Small: 66
+    Tiny: 65
 HousingCatalogEntryType:
-  Decor: 1
-  Invalid: 0
-  Room: 2
+  values:
+    Decor: 1
+    Invalid: 0
+    Room: 2
 HousingCatalogSortType:
-  Alphabetical: 1
-  DateAdded: 0
+  values:
+    Alphabetical: 1
+    DateAdded: 0
 HousingCleanupModeTargetType:
-  Decor: 1
-  HouseExterior: 2
-  None: 0
+  values:
+    Decor: 1
+    HouseExterior: 2
+    None: 0
 HousingCustomizeModeTargetType:
-  Decor: 1
-  ExteriorHouse: 3
-  None: 0
-  RoomComponent: 2
+  values:
+    Decor: 1
+    ExteriorHouse: 3
+    None: 0
+    RoomComponent: 2
 HousingDecorActionFlags:
-  Add: 1
-  ClickTarget: 16
-  DragMove: 4
-  HoverTarget: 32
-  IncludeTargetChildren: 512
-  MaintainLastTarget: 256
-  None: 0
-  PrecisionMove: 8
-  PreviewDecor: 2048
-  Remove: 2
-  TargetHouseExterior: 128
-  TargetRoomComponents: 64
-  UsePlacedDecorList: 1024
+  values:
+    Add: 1
+    ClickTarget: 16
+    DragMove: 4
+    HoverTarget: 32
+    IncludeTargetChildren: 512
+    MaintainLastTarget: 256
+    None: 0
+    PrecisionMove: 8
+    PreviewDecor: 2048
+    Remove: 2
+    TargetHouseExterior: 128
+    TargetRoomComponents: 64
+    UsePlacedDecorList: 1024
 HousingDecorModelType:
-  M2: 1
-  None: 0
-  WMO: 2
+  values:
+    M2: 1
+    None: 0
+    WMO: 2
 HousingDecorPlacementRestriction:
-  ChildOutsideBounds: 8
-  InvalidCollision: 32
-  InvalidLightOverlap: 64
-  InvalidTarget: 16
-  OutsidePlotBounds: 4
-  OutsideRoomBounds: 2
-  TooFarAway: 1
+  values:
+    ChildOutsideBounds: 8
+    InvalidCollision: 32
+    InvalidLightOverlap: 64
+    InvalidTarget: 16
+    OutsidePlotBounds: 4
+    OutsideRoomBounds: 2
+    TooFarAway: 1
 HousingDecorTheme:
-  BloodElf: 5
-  Folk: 1
-  Generic: 3
-  NightElf: 4
-  None: 0
-  Rugged: 2
+  values:
+    BloodElf: 5
+    Folk: 1
+    Generic: 3
+    NightElf: 4
+    None: 0
+    Rugged: 2
 HousingDecorType:
-  Ceiling: 3
-  Floor: 1
-  Flooring: 4
-  None: 0
-  Wall: 2
+  values:
+    Ceiling: 3
+    Floor: 1
+    Flooring: 4
+    None: 0
+    Wall: 2
 HousingExpertModeTargetType:
-  Decor: 1
-  House: 2
-  None: 0
+  values:
+    Decor: 1
+    House: 2
+    None: 0
 HousingExpertSubmodeRestriction:
-  NoHouseExteriorScale: 2
-  None: 0
-  NotInExpertMode: 1
-  NoWMOScale: 3
+  values:
+    NoHouseExteriorScale: 2
+    None: 0
+    NotInExpertMode: 1
+    NoWMOScale: 3
 HousingFavorUpdateSource:
-  DecorCollection: 1
-  DeferredRewards: 2
-  InitiativeChest: 6
-  InitiativeTask: 5
-  NewHouseDecorFavor: 4
-  Quest: 7
-  RetroactiveDecor: 3
-  Unknown: 0
+  values:
+    DecorCollection: 1
+    DeferredRewards: 2
+    InitiativeChest: 6
+    InitiativeTask: 5
+    NewHouseDecorFavor: 4
+    Quest: 7
+    RetroactiveDecor: 3
+    Unknown: 0
 HousingFavorUpdateType:
-  Add: 0
-  InitiativeAdd: 1
-  Set: 2
+  values:
+    Add: 0
+    InitiativeAdd: 1
+    Set: 2
 HousingFixtureDecorAction:
-  Detach: 1
-  Store: 0
+  values:
+    Detach: 1
+    Store: 0
 HousingFixtureFlags:
-  IsDefaultFixture: 1
-  None: 0
-  UnlockedByDefault: 2
+  values:
+    IsDefaultFixture: 1
+    None: 0
+    UnlockedByDefault: 2
 HousingFixtureSize:
-  Any: 1
-  Large: 4
-  Medium: 3
-  None: 0
-  Small: 2
+  values:
+    Any: 1
+    Large: 4
+    Medium: 3
+    None: 0
+    Small: 2
 HousingFixtureType:
-  Base: 9
-  Chimney: 16
-  Door: 11
-  None: 0
-  Roof: 10
-  RoofDetail: 13
-  RoofWindow: 14
-  Tower: 15
-  Window: 12
+  values:
+    Base: 9
+    Chimney: 16
+    Door: 11
+    None: 0
+    Roof: 10
+    RoofDetail: 13
+    RoofWindow: 14
+    Tower: 15
+    Window: 12
 HousingIncrementType:
-  Back: 8
-  Down: 32
-  Forward: 4
-  Left: 1
-  Right: 2
-  RotateLeft: 64
-  RotateRight: 128
-  ScaleDown: 512
-  ScaleUp: 256
-  Up: 16
+  values:
+    Back: 8
+    Down: 32
+    Forward: 4
+    Left: 1
+    Right: 2
+    RotateLeft: 64
+    RotateRight: 128
+    ScaleDown: 512
+    ScaleUp: 256
+    Up: 16
 HousingItemToastType:
-  Customization: 2
-  Decor: 3
-  Fixture: 1
-  HouseType: 4
-  Room: 0
+  values:
+    Customization: 2
+    Decor: 3
+    Fixture: 1
+    HouseType: 4
+    Room: 0
 HousingLayoutCameraDirection:
-  Down: 2
-  Left: 4
-  None: 0
-  Right: 8
-  Up: 1
+  values:
+    Down: 2
+    Left: 4
+    None: 0
+    Right: 8
+    Up: 1
 HousingLayoutPinType:
-  Door: 0
-  Room: 1
+  values:
+    Door: 0
+    Room: 1
 HousingLayoutRestriction:
-  IsBaseRoom: 4
-  LastRoom: 7
-  None: 0
-  NotHouseOwner: 3
-  NotInsideHouse: 2
-  RoomNotFound: 1
-  RoomNotLeaf: 5
-  SingleDoor: 9
-  StairwellConnection: 6
-  UnreachableRoom: 8
+  values:
+    IsBaseRoom: 4
+    LastRoom: 7
+    None: 0
+    NotHouseOwner: 3
+    NotInsideHouse: 2
+    RoomNotFound: 1
+    RoomNotLeaf: 5
+    SingleDoor: 9
+    StairwellConnection: 6
+    UnreachableRoom: 8
 HousingLayoutStairDirection:
-  Down: 1
-  Up: 0
+  values:
+    Down: 1
+    Up: 0
 HousingPlotOwnerType:
-  Friend: 2
-  None: 0
-  Self: 3
-  Stranger: 1
+  values:
+    Friend: 2
+    None: 0
+    Self: 3
+    Stranger: 1
 HousingPrecisionSubmode:
-  Rotate: 1
-  Scale: 2
-  Translate: 0
+  values:
+    Rotate: 1
+    Scale: 2
+    Translate: 0
 HousingResult:
-  ActionLockedByCombat: 1
-  BoundsFailureChildren: 2
-  BoundsFailurePlot: 3
-  BoundsFailureRoom: 4
-  BoundToStartingArea: 5
-  CannotAfford: 6
-  CharterComplete: 7
-  CollisionInvalid: 8
-  DbError: 9
-  DecorCannotBeRedeemed: 10
-  DecorItemNotDestroyable: 11
-  DecorNotFound: 12
-  DecorNotFoundInStorage: 13
-  DuplicateCharterSignature: 14
-  FilterRejected: 15
-  FixtureCantDeleteDoor: 16
-  FixtureHookEmpty: 17
-  FixtureHookOccupied: 18
-  FixtureHouseTypeMismatch: 19
-  FixtureNotFound: 20
-  FixtureSizeMismatch: 21
-  FixtureTypeMismatch: 22
-  GenericFailure: 23
-  GuildMoreAccountsNeeded: 24
-  GuildMoreActivePlayersNeeded: 25
-  GuildNotLoaded: 26
-  HookNotChildOfFixture: 35
-  HouseEditLockFailed: 27
-  HouseExteriorAlreadyThatSize: 28
-  HouseExteriorAlreadyThatType: 29
-  HouseExteriorRootNotFound: 30
-  HouseExteriorSizeNotAvailable: 34
-  HouseExteriorTypeNeighborhoodMismatch: 31
-  HouseExteriorTypeNotFound: 32
-  HouseExteriorTypeSizeMismatch: 33
-  HouseNotFound: 36
-  IncorrectFaction: 37
-  InvalidDecorItem: 38
-  InvalidDistance: 39
-  InvalidGuild: 40
-  InvalidHouse: 41
-  InvalidInstance: 42
-  InvalidInteraction: 43
-  InvalidLightOverlap: 44
-  InvalidMap: 45
-  InvalidNeighborhoodName: 46
-  InvalidRoomLayout: 47
-  LockedByOtherPlayer: 48
-  LockOperationFailed: 49
-  MaxDecorReached: 50
-  MaxPreviewDecorReached: 51
-  MissingCoreFixture: 52
-  MissingDye: 53
-  MissingExpansionAccess: 54
-  MissingFactionMap: 55
-  MissingPrivateNeighborhoodInvite: 56
-  MoreHouseSlotsNeeded: 57
-  MoreSignaturesNeeded: 58
-  NeighborhoodNotFound: 59
-  NoNeighborhoodOwnershipRequests: 60
-  NotInDecorEditMode: 61
-  NotInFixtureEditMode: 62
-  NotInLayoutEditMode: 63
-  NotInsideHouse: 64
-  NotOnOwnedPlot: 65
-  OperationAborted: 66
-  OwnerNotInGuild: 67
-  PermissionDenied: 68
-  PlacementTargetInvalid: 69
-  PlayerNotFound: 70
-  PlayerNotInInstance: 71
-  PlotNotFound: 72
-  PlotNotVacant: 73
-  PlotReservationCooldown: 74
-  PlotReserved: 75
-  RoomNotFound: 76
-  RoomUpdateFailed: 77
-  RpcFailure: 78
-  ServiceNotAvailable: 79
-  StaticDataNotFound: 80
-  Success: 0
-  TimeoutLimit: 81
-  TimerunningNotAllowed: 82
-  TokenRequired: 83
-  TooManyRequests: 84
-  TransactionFailure: 85
-  UncollectedExteriorFixture: 86
-  UncollectedHouseType: 87
-  UncollectedRoom: 88
-  UncollectedRoomMaterial: 89
-  UncollectedRoomTheme: 90
-  UnlockOperationFailed: 91
+  values:
+    ActionLockedByCombat: 1
+    BoundsFailureChildren: 2
+    BoundsFailurePlot: 3
+    BoundsFailureRoom: 4
+    BoundToStartingArea: 5
+    CannotAfford: 6
+    CharterComplete: 7
+    CollisionInvalid: 8
+    DbError: 9
+    DecorCannotBeRedeemed: 10
+    DecorItemNotDestroyable: 11
+    DecorNotFound: 12
+    DecorNotFoundInStorage: 13
+    DuplicateCharterSignature: 14
+    FilterRejected: 15
+    FixtureCantDeleteDoor: 16
+    FixtureHookEmpty: 17
+    FixtureHookOccupied: 18
+    FixtureHouseTypeMismatch: 19
+    FixtureNotFound: 20
+    FixtureSizeMismatch: 21
+    FixtureTypeMismatch: 22
+    GenericFailure: 23
+    GuildMoreAccountsNeeded: 24
+    GuildMoreActivePlayersNeeded: 25
+    GuildNotLoaded: 26
+    HookNotChildOfFixture: 35
+    HouseEditLockFailed: 27
+    HouseExteriorAlreadyThatSize: 28
+    HouseExteriorAlreadyThatType: 29
+    HouseExteriorRootNotFound: 30
+    HouseExteriorSizeNotAvailable: 34
+    HouseExteriorTypeNeighborhoodMismatch: 31
+    HouseExteriorTypeNotFound: 32
+    HouseExteriorTypeSizeMismatch: 33
+    HouseNotFound: 36
+    IncorrectFaction: 37
+    InvalidDecorItem: 38
+    InvalidDistance: 39
+    InvalidGuild: 40
+    InvalidHouse: 41
+    InvalidInstance: 42
+    InvalidInteraction: 43
+    InvalidLightOverlap: 44
+    InvalidMap: 45
+    InvalidNeighborhoodName: 46
+    InvalidRoomLayout: 47
+    LockedByOtherPlayer: 48
+    LockOperationFailed: 49
+    MaxDecorReached: 50
+    MaxPreviewDecorReached: 51
+    MissingCoreFixture: 52
+    MissingDye: 53
+    MissingExpansionAccess: 54
+    MissingFactionMap: 55
+    MissingPrivateNeighborhoodInvite: 56
+    MoreHouseSlotsNeeded: 57
+    MoreSignaturesNeeded: 58
+    NeighborhoodNotFound: 59
+    NoNeighborhoodOwnershipRequests: 60
+    NotInDecorEditMode: 61
+    NotInFixtureEditMode: 62
+    NotInLayoutEditMode: 63
+    NotInsideHouse: 64
+    NotOnOwnedPlot: 65
+    OperationAborted: 66
+    OwnerNotInGuild: 67
+    PermissionDenied: 68
+    PlacementTargetInvalid: 69
+    PlayerNotFound: 70
+    PlayerNotInInstance: 71
+    PlotNotFound: 72
+    PlotNotVacant: 73
+    PlotReservationCooldown: 74
+    PlotReserved: 75
+    RoomNotFound: 76
+    RoomUpdateFailed: 77
+    RpcFailure: 78
+    ServiceNotAvailable: 79
+    StaticDataNotFound: 80
+    Success: 0
+    TimeoutLimit: 81
+    TimerunningNotAllowed: 82
+    TokenRequired: 83
+    TooManyRequests: 84
+    TransactionFailure: 85
+    UncollectedExteriorFixture: 86
+    UncollectedHouseType: 87
+    UncollectedRoom: 88
+    UncollectedRoomMaterial: 89
+    UncollectedRoomTheme: 90
+    UnlockOperationFailed: 91
 HousingRoomComponentCeilingType:
-  Flat: 0
-  Vaulted: 1
+  values:
+    Flat: 0
+    Vaulted: 1
 HousingRoomComponentDoorType:
-  Doorway: 1
-  None: 0
-  Threshold: 2
+  values:
+    Doorway: 1
+    None: 0
+    Threshold: 2
 HousingRoomComponentFlags:
-  HiddenInLayoutMode: 1
-  None: 0
+  values:
+    HiddenInLayoutMode: 1
+    None: 0
 HousingRoomComponentFloorType:
-  Floor: 0
+  values:
+    Floor: 0
 HousingRoomComponentOptionFlags:
-  IsDefault: 1
-  None: 0
+  values:
+    IsDefault: 1
+    None: 0
 HousingRoomComponentOptionType:
-  Cosmetic: 0
-  Doorway: 2
-  DoorwayWall: 1
+  values:
+    Cosmetic: 0
+    Doorway: 2
+    DoorwayWall: 1
 HousingRoomComponentStairType:
-  MiddleToEnd: 4
-  MiddleToMiddle: 3
-  None: 0
-  StartToEnd: 1
-  StartToMiddle: 2
+  values:
+    MiddleToEnd: 4
+    MiddleToMiddle: 3
+    None: 0
+    StartToEnd: 1
+    StartToMiddle: 2
 HousingRoomComponentTextureFlags:
-  None: 0
-  UnlockedByDefault: 1
+  values:
+    None: 0
+    UnlockedByDefault: 1
 HousingRoomComponentType:
-  Ceiling: 3
-  Doorway: 7
-  DoorwayWall: 6
-  Floor: 2
-  None: 0
-  Pillar: 5
-  Stairs: 4
-  Wall: 1
+  values:
+    Ceiling: 3
+    Doorway: 7
+    DoorwayWall: 6
+    Floor: 2
+    None: 0
+    Pillar: 5
+    Stairs: 4
+    Wall: 1
 HousingRoomFlags:
-  BaseRoom: 1
-  HasCustomGeometry: 8
-  HasStairs: 2
-  None: 0
-  UnlockedByDefault: 4
+  values:
+    BaseRoom: 1
+    HasCustomGeometry: 8
+    HasStairs: 2
+    None: 0
+    UnlockedByDefault: 4
 HousingTeleportReason:
-  Booted: 3
-  Cheat: 1
-  ExitingHouse: 9
-  Friend: 6
-  GuildMember: 7
-  Homestone: 4
-  None: 0
-  PartyMember: 8
-  Portal: 10
-  Tutorial: 11
-  UnspecifiedSpellcast: 2
-  Visit: 5
+  values:
+    Booted: 3
+    Cheat: 1
+    ExitingHouse: 9
+    Friend: 6
+    GuildMember: 7
+    Homestone: 4
+    None: 0
+    PartyMember: 8
+    Portal: 10
+    Tutorial: 11
+    UnspecifiedSpellcast: 2
+    Visit: 5
 HousingThemeFlags:
-  None: 0
-  ShowInStyleSelector: 2
-  UnlockedByDefault: 1
+  values:
+    None: 0
+    ShowInStyleSelector: 2
+    UnlockedByDefault: 1
 HousingThrottleType:
-  Decoration: 1
-  General: 0
+  values:
+    Decoration: 1
+    General: 0
 IconAndTextShiftTextType:
-  None: 0
-  ShiftText: 1
+  values:
+    None: 0
+    ShiftText: 1
 IconAndTextWidgetState:
-  Hidden: 0
-  Shown: 1
-  ShownWithDynamicIconFlashing: 2
-  ShownWithDynamicIconNotFlashing: 3
+  values:
+    Hidden: 0
+    Shown: 1
+    ShownWithDynamicIconFlashing: 2
+    ShownWithDynamicIconNotFlashing: 3
 IconState:
-  Hidden: 0
-  ShowState1: 1
-  ShowState2: 2
+  values:
+    Hidden: 0
+    ShowState1: 1
+    ShowState2: 2
 ImageSharingResult:
-  AccountDataRequestFailure: 6
-  EncryptionFailure: 11
-  EncryptionSecretNotSet: 14
-  FailedToCreateHeader: 10
-  Failure: 0
-  GetAccountDataRequestFailure: 7
-  InvalidOAuthExpiration: 12
-  InvalidRefreshExpiration: 13
-  MissingFieldApiError: 5
-  NotConfigured: 2
-  PlatformApiError: 4
-  RefreshTokenExpired: 9
-  RetrievedExisting: 3
-  SetAccountDataRequestFailure: 8
-  Success: 1
+  values:
+    AccountDataRequestFailure: 6
+    EncryptionFailure: 11
+    EncryptionSecretNotSet: 14
+    FailedToCreateHeader: 10
+    Failure: 0
+    GetAccountDataRequestFailure: 7
+    InvalidOAuthExpiration: 12
+    InvalidRefreshExpiration: 13
+    MissingFieldApiError: 5
+    NotConfigured: 2
+    PlatformApiError: 4
+    RefreshTokenExpired: 9
+    RetrievedExisting: 3
+    SetAccountDataRequestFailure: 8
+    Success: 1
 InitiativeMilestoneFlags:
-  FinalMilestone: 1
+  values:
+    FinalMilestone: 1
 InitiativeRewardFlags:
-  PermanentWorldState: 1
+  values:
+    PermanentWorldState: 1
 InputContext:
-  GamePad: 3
-  Keyboard: 1
-  Mouse: 2
-  None: 0
+  values:
+    GamePad: 3
+    Keyboard: 1
+    Mouse: 2
+    None: 0
 InvalidPlotScreenshotReason:
-  Facing: 2
-  NoActivePlayer: 4
-  None: 0
-  NoNeighborhoodFound: 3
-  OutOfBounds: 1
+  values:
+    Facing: 2
+    NoActivePlayer: 4
+    None: 0
+    NoNeighborhoodFound: 3
+    OutOfBounds: 1
 InventoryType:
-  Index2HweaponType: 17
-  IndexAmmoType: 24
-  IndexBagType: 18
-  IndexBodyType: 4
-  IndexChestType: 5
-  IndexCloakType: 16
-  IndexEquipablespellDefensiveType: 33
-  IndexEquipablespellOffensiveType: 31
-  IndexEquipablespellUtilityType: 32
-  IndexEquipablespellWeaponType: 34
-  IndexFeetType: 8
-  IndexFingerType: 11
-  IndexHandType: 10
-  IndexHeadType: 1
-  IndexHoldableType: 23
-  IndexLegsType: 7
-  IndexNeckType: 2
-  IndexNonEquipType: 0
-  IndexProfessionGearType: 30
-  IndexProfessionToolType: 29
-  IndexQuiverType: 27
-  IndexRangedrightType: 26
-  IndexRangedType: 15
-  IndexRelicType: 28
-  IndexRobeType: 20
-  IndexShieldType: 14
-  IndexShoulderType: 3
-  IndexTabardType: 19
-  IndexThrownType: 25
-  IndexTrinketType: 12
-  IndexWaistType: 6
-  IndexWeaponmainhandType: 21
-  IndexWeaponoffhandType: 22
-  IndexWeaponType: 13
-  IndexWristType: 9
+  values:
+    Index2HweaponType: 17
+    IndexAmmoType: 24
+    IndexBagType: 18
+    IndexBodyType: 4
+    IndexChestType: 5
+    IndexCloakType: 16
+    IndexEquipablespellDefensiveType: 33
+    IndexEquipablespellOffensiveType: 31
+    IndexEquipablespellUtilityType: 32
+    IndexEquipablespellWeaponType: 34
+    IndexFeetType: 8
+    IndexFingerType: 11
+    IndexHandType: 10
+    IndexHeadType: 1
+    IndexHoldableType: 23
+    IndexLegsType: 7
+    IndexNeckType: 2
+    IndexNonEquipType: 0
+    IndexProfessionGearType: 30
+    IndexProfessionToolType: 29
+    IndexQuiverType: 27
+    IndexRangedrightType: 26
+    IndexRangedType: 15
+    IndexRelicType: 28
+    IndexRobeType: 20
+    IndexShieldType: 14
+    IndexShoulderType: 3
+    IndexTabardType: 19
+    IndexThrownType: 25
+    IndexTrinketType: 12
+    IndexWaistType: 6
+    IndexWeaponmainhandType: 21
+    IndexWeaponoffhandType: 22
+    IndexWeaponType: 13
+    IndexWristType: 9
 ItemArmorSubclass:
-  Cloth: 1
-  Cosmetic: 5
-  Generic: 0
-  Idol: 8
-  Leather: 2
-  Libram: 7
-  Mail: 3
-  Plate: 4
-  Relic: 11
-  Shield: 6
-  Sigil: 10
-  Totem: 9
+  values:
+    Cloth: 1
+    Cosmetic: 5
+    Generic: 0
+    Idol: 8
+    Leather: 2
+    Libram: 7
+    Mail: 3
+    Plate: 4
+    Relic: 11
+    Shield: 6
+    Sigil: 10
+    Totem: 9
 ItemBind:
-  Multi: 6
-  None: 0
-  OnAcquire: 1
-  OnEquip: 2
-  OnUse: 3
-  Quest: 4
-  QuestMulti: 5
-  ToBnetAccount: 8
-  ToBnetAccountUntilEquipped: 9
-  ToWoWAccount: 7
+  values:
+    Multi: 6
+    None: 0
+    OnAcquire: 1
+    OnEquip: 2
+    OnUse: 3
+    Quest: 4
+    QuestMulti: 5
+    ToBnetAccount: 8
+    ToBnetAccountUntilEquipped: 9
+    ToWoWAccount: 7
 ItemClass:
-  Armor: 4
-  Battlepet: 17
-  Consumable: 0
-  Container: 1
-  CurrencyTokenObsolete: 10
-  Gem: 3
-  Glyph: 16
-  Housing: 20
-  ItemEnhancement: 8
-  Key: 13
-  Miscellaneous: 15
-  PermanentObsolete: 14
-  Profession: 19
-  Projectile: 6
-  Questitem: 12
-  Quiver: 11
-  Reagent: 5
-  Recipe: 9
-  Tradegoods: 7
-  Weapon: 2
-  WoWToken: 18
+  values:
+    Armor: 4
+    Battlepet: 17
+    Consumable: 0
+    Container: 1
+    CurrencyTokenObsolete: 10
+    Gem: 3
+    Glyph: 16
+    Housing: 20
+    ItemEnhancement: 8
+    Key: 13
+    Miscellaneous: 15
+    PermanentObsolete: 14
+    Profession: 19
+    Projectile: 6
+    Questitem: 12
+    Quiver: 11
+    Reagent: 5
+    Recipe: 9
+    Tradegoods: 7
+    Weapon: 2
+    WoWToken: 18
 Itemclassfilterflags:
-  Armor: 16
-  Battlepet: 131072
-  Consumable: 1
-  Container: 2
-  CurrencyTokenObsolete: 1024
-  Gem: 8
-  Glyph: 65536
-  ItemEnhancement: 256
-  Key: 8192
-  Miscellaneous: 32768
-  PermanentObsolete: 16384
-  Projectile: 64
-  Questitemclassfilterflags: 4096
-  Quiver: 2048
-  Reagent: 32
-  Recipe: 512
-  Tradegoods: 128
-  Weapon: 4
+  values:
+    Armor: 16
+    Battlepet: 131072
+    Consumable: 1
+    Container: 2
+    CurrencyTokenObsolete: 1024
+    Gem: 8
+    Glyph: 65536
+    ItemEnhancement: 256
+    Key: 8192
+    Miscellaneous: 32768
+    PermanentObsolete: 16384
+    Projectile: 64
+    Questitemclassfilterflags: 4096
+    Quiver: 2048
+    Reagent: 32
+    Recipe: 512
+    Tradegoods: 128
+    Weapon: 4
 ItemCollectionType:
-  ExteriorFixture: 9
-  Heirloom: 2
-  HouseType: 13
-  None: 0
-  Room: 8
-  RoomMaterial: 11
-  RoomTheme: 10
-  RuneforgeLegendaryAbility: 5
-  Toy: 1
-  Transmog: 3
-  TransmogIllusion: 6
-  TransmogOutfit: 12
-  TransmogSetFavorite: 4
-  WarbandScene: 7
+  values:
+    ExteriorFixture: 9
+    Heirloom: 2
+    HouseType: 13
+    None: 0
+    Room: 8
+    RoomMaterial: 11
+    RoomTheme: 10
+    RuneforgeLegendaryAbility: 5
+    Toy: 1
+    Transmog: 3
+    TransmogIllusion: 6
+    TransmogOutfit: 12
+    TransmogSetFavorite: 4
+    WarbandScene: 7
 ItemConsumableSubclass:
-  Bandage: 7
-  CombatCurio: 11
-  Elixir: 2
-  Flasksphials: 3
-  Fooddrink: 5
-  Generic: 0
-  Itemenhancement: 6
-  Other: 8
-  Potion: 1
-  Relic: 12
-  Scroll: 4
-  UtilityCurio: 10
-  VantusRune: 9
+  values:
+    Bandage: 7
+    CombatCurio: 11
+    Elixir: 2
+    Flasksphials: 3
+    Fooddrink: 5
+    Generic: 0
+    Itemenhancement: 6
+    Other: 8
+    Potion: 1
+    Relic: 12
+    Scroll: 4
+    UtilityCurio: 10
+    VantusRune: 9
 ItemCreationContext:
-  BlackMarket: 15
-  ChallengeMode_1: 16
-  ChallengeMode_2: 33
-  ChallengeMode_3: 34
-  ChallengeMode_4: 87
-  ChallengeModeJackpot: 35
-  CharacterBoost_1: 61
-  CharacterBoost_2: 62
-  CharacterBoost_3: 86
-  CorpseRecovery: 80
-  Delves_1: 104
-  Delves_2: 106
-  Delves_3: 107
-  DelvesBonus_1: 129
-  DelvesBonus_10: 138
-  DelvesBonus_2: 130
-  DelvesBonus_3: 131
-  DelvesBonus_4: 132
-  DelvesBonus_5: 133
-  DelvesBonus_6: 134
-  DelvesBonus_7: 135
-  DelvesBonus_8: 136
-  DelvesBonus_9: 137
-  DelvesBounty_1: 117
-  DelvesBounty_2: 118
-  DelvesBounty_3: 119
-  DelvesBounty_4: 120
-  DelvesBounty_5: 121
-  DelvesBounty_6: 122
-  DelvesBounty_7: 123
-  DelvesBounty_8: 124
-  DelvesJackpot: 108
-  DelvesKey_1: 109
-  DelvesKey_2: 110
-  DelvesKey_3: 111
-  DelvesKey_4: 112
-  DelvesKey_5: 113
-  DelvesKey_6: 114
-  DelvesKey_7: 115
-  DelvesKey_8: 116
-  DelvesLevelUp_1: 125
-  DelvesLevelUp_2: 126
-  DelvesLevelUp_3: 127
-  DelvesLevelUp_4: 128
-  DungeonBonus_1: 139
-  DungeonBonus_10: 148
-  DungeonBonus_2: 140
-  DungeonBonus_3: 141
-  DungeonBonus_4: 142
-  DungeonBonus_5: 143
-  DungeonBonus_6: 144
-  DungeonBonus_7: 145
-  DungeonBonus_8: 146
-  DungeonBonus_9: 147
-  DungeonHardMode_1: 159
-  DungeonHardMode_2: 160
-  DungeonHardMode_3: 161
-  DungeonHeroic: 2
-  DungeonHeroicJackpot: 102
-  DungeonLevelUp_1: 17
-  DungeonLevelUp_2: 18
-  DungeonLevelUp_3: 19
-  DungeonLevelUp_4: 20
-  DungeonMythic: 23
-  DungeonMythicJackpot: 103
-  DungeonNormal: 1
-  DungeonNormalJackpot: 101
-  Endeavors: 185
-  ForceNone: 21
-  LegendaryCrafting_1: 63
-  LegendaryCrafting_2: 64
-  LegendaryCrafting_3: 65
-  LegendaryCrafting_4: 66
-  LegendaryCrafting_5: 67
-  LegendaryCrafting_6: 68
-  LegendaryCrafting_7: 69
-  LegendaryCrafting_8: 70
-  LegendaryCrafting_9: 71
-  LegendaryForge: 59
-  MissionReward_1: 31
-  MissionReward_2: 32
-  NewCharacter: 75
-  None: 0
-  PvPBrawl_1: 77
-  PvPBrawl_2: 78
-  PvPHonorReward: 24
-  PvPRanked_1: 8
-  PvPRanked_2: 38
-  PvPRanked_3: 39
-  PvPRanked_4: 40
-  PvPRanked_5: 44
-  PvPRanked_6: 45
-  PvPRanked_7: 46
-  PvPRanked_8: 52
-  PvPRanked_9: 88
-  PvPRankedJackpot: 56
-  PvPUnranked_1: 7
-  PvPUnranked_2: 41
-  PvPUnranked_3: 47
-  PvPUnranked_4: 48
-  PvPUnranked_5: 49
-  PvPUnranked_6: 50
-  PvPUnranked_7: 51
-  QuestBonusLoot: 60
-  QuestReward: 11
-  RaidBonus_1: 149
-  RaidBonus_10: 158
-  RaidBonus_2: 150
-  RaidBonus_3: 151
-  RaidBonus_4: 152
-  RaidBonus_5: 153
-  RaidBonus_6: 154
-  RaidBonus_7: 155
-  RaidBonus_8: 156
-  RaidBonus_9: 157
-  RaidFinder: 4
-  RaidFinderExtended: 83
-  RaidFinderExtended_2: 90
-  RaidFinderExtended_3: 94
-  RaidHeroic: 5
-  RaidHeroicExtended: 84
-  RaidHeroicExtended_2: 91
-  RaidHeroicExtended_3: 95
-  RaidMythic: 6
-  RaidMythicExtended: 85
-  RaidMythicExtended_2: 92
-  RaidMythicExtended_3: 96
-  RaidNormal: 3
-  RaidNormalExtended: 82
-  RaidNormalExtended_2: 89
-  RaidNormalExtended_3: 93
-  Relinquished: 58
-  ScenarioHeroic: 10
-  ScenarioNormal: 9
-  Store: 12
-  TemplateCharacter_1: 97
-  TemplateCharacter_2: 98
-  TemplateCharacter_3: 99
-  TemplateCharacter_4: 100
-  Timerunning: 105
-  TimewalkerLevelUp: 22
-  TimewalkerMaxLevel: 186
-  Torghast: 79
-  TournamentRealm_1: 57
-  TournamentRealm_2: 162
-  TournamentRealm_3: 163
-  TournamentRealm_4: 164
-  TradeSkill: 13
-  Vendor: 14
-  Warbound_1: 165
-  Warbound_10: 174
-  Warbound_11: 175
-  Warbound_12: 176
-  Warbound_13: 177
-  Warbound_14: 178
-  Warbound_15: 179
-  Warbound_16: 180
-  Warbound_17: 181
-  Warbound_18: 182
-  Warbound_19: 183
-  Warbound_2: 166
-  Warbound_20: 184
-  Warbound_3: 167
-  Warbound_4: 168
-  Warbound_5: 169
-  Warbound_6: 170
-  Warbound_7: 171
-  Warbound_8: 172
-  Warbound_9: 173
-  WarMode: 76
-  WeeklyRewardsAdditional: 72
-  WeeklyRewardsConcession: 73
-  WorldBoss: 81
-  WorldQuest_1: 25
-  WorldQuest_10: 43
-  WorldQuest_11: 53
-  WorldQuest_12: 54
-  WorldQuest_13: 55
-  WorldQuest_2: 26
-  WorldQuest_3: 27
-  WorldQuest_4: 28
-  WorldQuest_5: 29
-  WorldQuest_6: 30
-  WorldQuest_7: 36
-  WorldQuest_8: 37
-  WorldQuest_9: 42
-  WorldQuestJackpot: 74
+  values:
+    BlackMarket: 15
+    ChallengeMode_1: 16
+    ChallengeMode_2: 33
+    ChallengeMode_3: 34
+    ChallengeMode_4: 87
+    ChallengeModeJackpot: 35
+    CharacterBoost_1: 61
+    CharacterBoost_2: 62
+    CharacterBoost_3: 86
+    CorpseRecovery: 80
+    Delves_1: 104
+    Delves_2: 106
+    Delves_3: 107
+    DelvesBonus_1: 129
+    DelvesBonus_10: 138
+    DelvesBonus_2: 130
+    DelvesBonus_3: 131
+    DelvesBonus_4: 132
+    DelvesBonus_5: 133
+    DelvesBonus_6: 134
+    DelvesBonus_7: 135
+    DelvesBonus_8: 136
+    DelvesBonus_9: 137
+    DelvesBounty_1: 117
+    DelvesBounty_2: 118
+    DelvesBounty_3: 119
+    DelvesBounty_4: 120
+    DelvesBounty_5: 121
+    DelvesBounty_6: 122
+    DelvesBounty_7: 123
+    DelvesBounty_8: 124
+    DelvesJackpot: 108
+    DelvesKey_1: 109
+    DelvesKey_2: 110
+    DelvesKey_3: 111
+    DelvesKey_4: 112
+    DelvesKey_5: 113
+    DelvesKey_6: 114
+    DelvesKey_7: 115
+    DelvesKey_8: 116
+    DelvesLevelUp_1: 125
+    DelvesLevelUp_2: 126
+    DelvesLevelUp_3: 127
+    DelvesLevelUp_4: 128
+    DungeonBonus_1: 139
+    DungeonBonus_10: 148
+    DungeonBonus_2: 140
+    DungeonBonus_3: 141
+    DungeonBonus_4: 142
+    DungeonBonus_5: 143
+    DungeonBonus_6: 144
+    DungeonBonus_7: 145
+    DungeonBonus_8: 146
+    DungeonBonus_9: 147
+    DungeonHardMode_1: 159
+    DungeonHardMode_2: 160
+    DungeonHardMode_3: 161
+    DungeonHeroic: 2
+    DungeonHeroicJackpot: 102
+    DungeonLevelUp_1: 17
+    DungeonLevelUp_2: 18
+    DungeonLevelUp_3: 19
+    DungeonLevelUp_4: 20
+    DungeonMythic: 23
+    DungeonMythicJackpot: 103
+    DungeonNormal: 1
+    DungeonNormalJackpot: 101
+    Endeavors: 185
+    ForceNone: 21
+    LegendaryCrafting_1: 63
+    LegendaryCrafting_2: 64
+    LegendaryCrafting_3: 65
+    LegendaryCrafting_4: 66
+    LegendaryCrafting_5: 67
+    LegendaryCrafting_6: 68
+    LegendaryCrafting_7: 69
+    LegendaryCrafting_8: 70
+    LegendaryCrafting_9: 71
+    LegendaryForge: 59
+    MissionReward_1: 31
+    MissionReward_2: 32
+    NewCharacter: 75
+    None: 0
+    PvPBrawl_1: 77
+    PvPBrawl_2: 78
+    PvPHonorReward: 24
+    PvPRanked_1: 8
+    PvPRanked_2: 38
+    PvPRanked_3: 39
+    PvPRanked_4: 40
+    PvPRanked_5: 44
+    PvPRanked_6: 45
+    PvPRanked_7: 46
+    PvPRanked_8: 52
+    PvPRanked_9: 88
+    PvPRankedJackpot: 56
+    PvPUnranked_1: 7
+    PvPUnranked_2: 41
+    PvPUnranked_3: 47
+    PvPUnranked_4: 48
+    PvPUnranked_5: 49
+    PvPUnranked_6: 50
+    PvPUnranked_7: 51
+    QuestBonusLoot: 60
+    QuestReward: 11
+    RaidBonus_1: 149
+    RaidBonus_10: 158
+    RaidBonus_2: 150
+    RaidBonus_3: 151
+    RaidBonus_4: 152
+    RaidBonus_5: 153
+    RaidBonus_6: 154
+    RaidBonus_7: 155
+    RaidBonus_8: 156
+    RaidBonus_9: 157
+    RaidFinder: 4
+    RaidFinderExtended: 83
+    RaidFinderExtended_2: 90
+    RaidFinderExtended_3: 94
+    RaidHeroic: 5
+    RaidHeroicExtended: 84
+    RaidHeroicExtended_2: 91
+    RaidHeroicExtended_3: 95
+    RaidMythic: 6
+    RaidMythicExtended: 85
+    RaidMythicExtended_2: 92
+    RaidMythicExtended_3: 96
+    RaidNormal: 3
+    RaidNormalExtended: 82
+    RaidNormalExtended_2: 89
+    RaidNormalExtended_3: 93
+    Relinquished: 58
+    ScenarioHeroic: 10
+    ScenarioNormal: 9
+    Store: 12
+    TemplateCharacter_1: 97
+    TemplateCharacter_2: 98
+    TemplateCharacter_3: 99
+    TemplateCharacter_4: 100
+    Timerunning: 105
+    TimewalkerLevelUp: 22
+    TimewalkerMaxLevel: 186
+    Torghast: 79
+    TournamentRealm_1: 57
+    TournamentRealm_2: 162
+    TournamentRealm_3: 163
+    TournamentRealm_4: 164
+    TradeSkill: 13
+    Vendor: 14
+    Warbound_1: 165
+    Warbound_10: 174
+    Warbound_11: 175
+    Warbound_12: 176
+    Warbound_13: 177
+    Warbound_14: 178
+    Warbound_15: 179
+    Warbound_16: 180
+    Warbound_17: 181
+    Warbound_18: 182
+    Warbound_19: 183
+    Warbound_2: 166
+    Warbound_20: 184
+    Warbound_3: 167
+    Warbound_4: 168
+    Warbound_5: 169
+    Warbound_6: 170
+    Warbound_7: 171
+    Warbound_8: 172
+    Warbound_9: 173
+    WarMode: 76
+    WeeklyRewardsAdditional: 72
+    WeeklyRewardsConcession: 73
+    WorldBoss: 81
+    WorldQuest_1: 25
+    WorldQuest_10: 43
+    WorldQuest_11: 53
+    WorldQuest_12: 54
+    WorldQuest_13: 55
+    WorldQuest_2: 26
+    WorldQuest_3: 27
+    WorldQuest_4: 28
+    WorldQuest_5: 29
+    WorldQuest_6: 30
+    WorldQuest_7: 36
+    WorldQuest_8: 37
+    WorldQuest_9: 42
+    WorldQuestJackpot: 74
 ItemDisplayTextDisplayStyle:
-  ItemNameAndInfoText: 1
-  ItemNameOnlyCentered: 2
-  PlayerChoiceReward: 3
-  WorldQuestReward: 0
+  values:
+    ItemNameAndInfoText: 1
+    ItemNameOnlyCentered: 2
+    PlayerChoiceReward: 3
+    WorldQuestReward: 0
 ItemDisplayTooltipEnabledType:
-  Disabled: 1
-  Enabled: 0
+  values:
+    Disabled: 1
+    Enabled: 0
 ItemGemColor:
-  Arcane: 1024
-  Blood: 128
-  Blue: 8
-  Cogwheel: 32
-  Cypher: 8388608
-  DominationBlood: 1048576
-  DominationFrost: 2097152
-  DominationUnholy: 4194304
-  Fel: 512
-  Fiber: 1073741824
-  Fire: 4096
-  Fragrance: 67108864
-  Frost: 2048
-  Holy: 65536
-  Hydraulic: 16
-  Iron: 64
-  Life: 16384
-  Meta: 1
-  Primordial: 33554432
-  PunchcardBlue: 524288
-  PunchcardRed: 131072
-  PunchcardYellow: 262144
-  Red: 2
-  Shadow: 256
-  SingingSea: 268435456
-  SingingThunder: 134217728
-  SingingWind: 536870912
-  Tinker: 16777216
-  Water: 8192
-  Wind: 32768
-  Yellow: 4
+  values:
+    Arcane: 1024
+    Blood: 128
+    Blue: 8
+    Cogwheel: 32
+    Cypher: 8388608
+    DominationBlood: 1048576
+    DominationFrost: 2097152
+    DominationUnholy: 4194304
+    Fel: 512
+    Fiber: 1073741824
+    Fire: 4096
+    Fragrance: 67108864
+    Frost: 2048
+    Holy: 65536
+    Hydraulic: 16
+    Iron: 64
+    Life: 16384
+    Meta: 1
+    Primordial: 33554432
+    PunchcardBlue: 524288
+    PunchcardRed: 131072
+    PunchcardYellow: 262144
+    Red: 2
+    Shadow: 256
+    SingingSea: 268435456
+    SingingThunder: 134217728
+    SingingWind: 536870912
+    Tinker: 16777216
+    Water: 8192
+    Wind: 32768
+    Yellow: 4
 ItemGemSubclass:
-  Blue: 1
-  Green: 4
-  Meta: 6
-  Orange: 5
-  Prismatic: 8
-  Purple: 3
-  Red: 0
-  Simple: 7
-  Yellow: 2
+  values:
+    Blue: 1
+    Green: 4
+    Meta: 6
+    Orange: 5
+    Prismatic: 8
+    Purple: 3
+    Red: 0
+    Simple: 7
+    Yellow: 2
 ItemHousingSubclass:
-  Decor: 0
-  Dye: 1
-  ExteriorCustomization: 4
-  Room: 2
-  RoomCustomization: 3
-  ServiceItem: 5
+  values:
+    Decor: 0
+    Dye: 1
+    ExteriorCustomization: 4
+    Room: 2
+    RoomCustomization: 3
+    ServiceItem: 5
 ItemMiscellaneousSubclass:
-  CompanionPet: 2
-  Holiday: 3
-  Junk: 0
-  Mount: 5
-  MountEquipment: 6
-  Other: 4
-  Reagent: 1
+  values:
+    CompanionPet: 2
+    Holiday: 3
+    Junk: 0
+    Mount: 5
+    MountEquipment: 6
+    Other: 4
+    Reagent: 1
 ItemModification:
-  ArtifactAppearanceID: 8
-  ArtifactTier: 24
-  BattlePetBreed: 4
-  BattlePetCreaturedisplayid: 6
-  BattlePetLevel: 5
-  BattlePetSpecies: 3
-  ChangeModifiedCraftingStat_1: 29
-  ChangeModifiedCraftingStat_2: 30
-  ContentTuningID: 28
-  CraftingDataID: 40
-  CraftingQualityID: 38
-  CraftingReagentSlot_0: 43
-  CraftingReagentSlot_1: 44
-  CraftingReagentSlot_10: 53
-  CraftingReagentSlot_11: 54
-  CraftingReagentSlot_12: 55
-  CraftingReagentSlot_13: 56
-  CraftingReagentSlot_14: 57
-  CraftingReagentSlot_2: 45
-  CraftingReagentSlot_3: 46
-  CraftingReagentSlot_4: 47
-  CraftingReagentSlot_5: 48
-  CraftingReagentSlot_6: 49
-  CraftingReagentSlot_7: 50
-  CraftingReagentSlot_8: 51
-  CraftingReagentSlot_9: 52
-  CraftingSkillLineAbilityID: 39
-  CraftingSkillReagents: 41
-  CraftingSkillWatermark: 42
-  CurrencyWalletID: 61
-  CurrencyWalletQuantity: 62
-  CurrencyWalletVersion: 63
-  DbidHigh: 59
-  DbidLow: 60
-  IncrementLevel: 2
-  KeystoneAffix0: 19
-  KeystoneAffix01: 20
-  KeystoneAffix02: 21
-  KeystoneAffix03: 22
-  KeystoneMapChallengeModeID: 17
-  KeystonePowerLevel: 18
-  LegionArtifactKnowledgeObsolete: 23
-  PvPRating: 26
-  RedirectedBaseStats: 64
-  Reforge: 58
-  SoulbindConduitRank: 37
-  TimewalkerLevel: 9
-  TransmogrifyItemModifiedAppearanceIDSpec_0: 1
-  TransmogrifyItemModifiedAppearanceIDSpec_1: 11
-  TransmogrifyItemModifiedAppearanceIDSpec_2: 13
-  TransmogrifyItemModifiedAppearanceIDSpec_3: 15
-  TransmogrifyItemModifiedAppearanceIDSpec_4: 25
-  TransmogrifyItemModifiedAppearanceIDSpecAll: 0
-  TransmogrifyOverrideEnchantVisualIDSpec_0: 10
-  TransmogrifyOverrideEnchantVisualIDSpec_1: 12
-  TransmogrifyOverrideEnchantVisualIDSpec_2: 14
-  TransmogrifyOverrideEnchantVisualIDSpec_3: 16
-  TransmogrifyOverrideEnchantVisualIDSpec_4: 27
-  TransmogrifyOverrideEnchantVisualIDSpecAll: 7
-  TransmogrifySecondaryItemModifiedAppearanceIDSpec_0: 32
-  TransmogrifySecondaryItemModifiedAppearanceIDSpec_1: 33
-  TransmogrifySecondaryItemModifiedAppearanceIDSpec_2: 34
-  TransmogrifySecondaryItemModifiedAppearanceIDSpec_3: 35
-  TransmogrifySecondaryItemModifiedAppearanceIDSpec_4: 36
-  TransmogrifySecondaryItemModifiedAppearanceIDSpecAll: 31
+  values:
+    ArtifactAppearanceID: 8
+    ArtifactTier: 24
+    BattlePetBreed: 4
+    BattlePetCreaturedisplayid: 6
+    BattlePetLevel: 5
+    BattlePetSpecies: 3
+    ChangeModifiedCraftingStat_1: 29
+    ChangeModifiedCraftingStat_2: 30
+    ContentTuningID: 28
+    CraftingDataID: 40
+    CraftingQualityID: 38
+    CraftingReagentSlot_0: 43
+    CraftingReagentSlot_1: 44
+    CraftingReagentSlot_10: 53
+    CraftingReagentSlot_11: 54
+    CraftingReagentSlot_12: 55
+    CraftingReagentSlot_13: 56
+    CraftingReagentSlot_14: 57
+    CraftingReagentSlot_2: 45
+    CraftingReagentSlot_3: 46
+    CraftingReagentSlot_4: 47
+    CraftingReagentSlot_5: 48
+    CraftingReagentSlot_6: 49
+    CraftingReagentSlot_7: 50
+    CraftingReagentSlot_8: 51
+    CraftingReagentSlot_9: 52
+    CraftingSkillLineAbilityID: 39
+    CraftingSkillReagents: 41
+    CraftingSkillWatermark: 42
+    CurrencyWalletID: 61
+    CurrencyWalletQuantity: 62
+    CurrencyWalletVersion: 63
+    DbidHigh: 59
+    DbidLow: 60
+    IncrementLevel: 2
+    KeystoneAffix0: 19
+    KeystoneAffix01: 20
+    KeystoneAffix02: 21
+    KeystoneAffix03: 22
+    KeystoneMapChallengeModeID: 17
+    KeystonePowerLevel: 18
+    LegionArtifactKnowledgeObsolete: 23
+    PvPRating: 26
+    RedirectedBaseStats: 64
+    Reforge: 58
+    SoulbindConduitRank: 37
+    TimewalkerLevel: 9
+    TransmogrifyItemModifiedAppearanceIDSpec_0: 1
+    TransmogrifyItemModifiedAppearanceIDSpec_1: 11
+    TransmogrifyItemModifiedAppearanceIDSpec_2: 13
+    TransmogrifyItemModifiedAppearanceIDSpec_3: 15
+    TransmogrifyItemModifiedAppearanceIDSpec_4: 25
+    TransmogrifyItemModifiedAppearanceIDSpecAll: 0
+    TransmogrifyOverrideEnchantVisualIDSpec_0: 10
+    TransmogrifyOverrideEnchantVisualIDSpec_1: 12
+    TransmogrifyOverrideEnchantVisualIDSpec_2: 14
+    TransmogrifyOverrideEnchantVisualIDSpec_3: 16
+    TransmogrifyOverrideEnchantVisualIDSpec_4: 27
+    TransmogrifyOverrideEnchantVisualIDSpecAll: 7
+    TransmogrifySecondaryItemModifiedAppearanceIDSpec_0: 32
+    TransmogrifySecondaryItemModifiedAppearanceIDSpec_1: 33
+    TransmogrifySecondaryItemModifiedAppearanceIDSpec_2: 34
+    TransmogrifySecondaryItemModifiedAppearanceIDSpec_3: 35
+    TransmogrifySecondaryItemModifiedAppearanceIDSpec_4: 36
+    TransmogrifySecondaryItemModifiedAppearanceIDSpecAll: 31
 ItemProfessionSubclass:
-  Alchemy: 2
-  Archaeology: 13
-  Blacksmithing: 0
-  Cooking: 4
-  Enchanting: 8
-  Engineering: 7
-  Fishing: 9
-  Herbalism: 3
-  Inscription: 12
-  Jewelcrafting: 11
-  Leatherworking: 1
-  Mining: 5
-  Skinning: 10
-  Tailoring: 6
+  values:
+    Alchemy: 2
+    Archaeology: 13
+    Blacksmithing: 0
+    Cooking: 4
+    Enchanting: 8
+    Engineering: 7
+    Fishing: 9
+    Herbalism: 3
+    Inscription: 12
+    Jewelcrafting: 11
+    Leatherworking: 1
+    Mining: 5
+    Skinning: 10
+    Tailoring: 6
 ItemQuality:
-  Artifact: 6
-  Epic: 4
-  Good: 2
-  Heirloom: 7
-  Legendary: 5
-  Poor: 0
-  Rare: 3
-  Standard: 1
-  WoWToken: 8
+  values:
+    Artifact: 6
+    Epic: 4
+    Good: 2
+    Heirloom: 7
+    Legendary: 5
+    Poor: 0
+    Rare: 3
+    Standard: 1
+    WoWToken: 8
 ItemReagentSubclass:
-  ContextToken: 2
-  Keystone: 1
-  Reagent: 0
+  values:
+    ContextToken: 2
+    Keystone: 1
+    Reagent: 0
 ItemRecipeSubclass:
-  Alchemy: 6
-  Blacksmithing: 4
-  Book: 0
-  Cooking: 5
-  Enchanting: 8
-  Engineering: 3
-  FirstAid: 7
-  Fishing: 9
-  Inscription: 11
-  Jewelcrafting: 10
-  Leatherworking: 1
-  Tailoring: 2
+  values:
+    Alchemy: 6
+    Blacksmithing: 4
+    Book: 0
+    Cooking: 5
+    Enchanting: 8
+    Engineering: 3
+    FirstAid: 7
+    Fishing: 9
+    Inscription: 11
+    Jewelcrafting: 10
+    Leatherworking: 1
+    Tailoring: 2
 ItemRecraftFlags:
-  Invalid: 1
+  values:
+    Invalid: 1
 Itemsetflags:
-  Legacy: 1
-  RequiresPvPTalentsActive: 4
-  UseItemHistorySetSlots: 2
+  values:
+    Legacy: 1
+    RequiresPvPTalentsActive: 4
+    UseItemHistorySetSlots: 2
 ItemSlotFilterType:
-  Chest: 4
-  Cloak: 3
-  Feet: 9
-  Finger: 12
-  Hand: 6
-  Head: 0
-  Legs: 8
-  MainHand: 10
-  Neck: 1
-  NoFilter: 15
-  OffHand: 11
-  Other: 14
-  Shoulder: 2
-  Trinket: 13
-  Waist: 7
-  Wrist: 5
+  values:
+    Chest: 4
+    Cloak: 3
+    Feet: 9
+    Finger: 12
+    Hand: 6
+    Head: 0
+    Legs: 8
+    MainHand: 10
+    Neck: 1
+    NoFilter: 15
+    OffHand: 11
+    Other: 14
+    Shoulder: 2
+    Trinket: 13
+    Waist: 7
+    Wrist: 5
 ItemSocketInfoUIType:
-  Default: 0
+  values:
+    Default: 0
 ItemSocketType:
-  Arcane: 12
-  Blood: 9
-  Blue: 4
-  Cogwheel: 6
-  Cypher: 23
-  Domination: 22
-  Fel: 11
-  Fiber: 30
-  Fire: 14
-  Fragrance: 26
-  Frost: 13
-  Holy: 18
-  Hydraulic: 5
-  Iron: 8
-  Life: 16
-  Meta: 1
-  None: 0
-  Primordial: 25
-  Prismatic: 7
-  PunchcardBlue: 21
-  PunchcardRed: 19
-  PunchcardYellow: 20
-  Red: 2
-  Shadow: 10
-  SingingSea: 28
-  SingingThunder: 27
-  SingingWind: 29
-  Tinker: 24
-  Water: 15
-  Wind: 17
-  Yellow: 3
+  values:
+    Arcane: 12
+    Blood: 9
+    Blue: 4
+    Cogwheel: 6
+    Cypher: 23
+    Domination: 22
+    Fel: 11
+    Fiber: 30
+    Fire: 14
+    Fragrance: 26
+    Frost: 13
+    Holy: 18
+    Hydraulic: 5
+    Iron: 8
+    Life: 16
+    Meta: 1
+    None: 0
+    Primordial: 25
+    Prismatic: 7
+    PunchcardBlue: 21
+    PunchcardRed: 19
+    PunchcardYellow: 20
+    Red: 2
+    Shadow: 10
+    SingingSea: 28
+    SingingThunder: 27
+    SingingWind: 29
+    Tinker: 24
+    Water: 15
+    Wind: 17
+    Yellow: 3
 ItemSoundType:
-  Close: 3
-  Drop: 1
-  Pickup: 0
-  Use: 2
+  values:
+    Close: 3
+    Drop: 1
+    Pickup: 0
+    Use: 2
 ItemSubclassDisplay:
-  HideSubclassInAuction: 2
-  HideSubclassInTooltips: 1
-  ShowItemCount: 4
+  values:
+    HideSubclassInAuction: 2
+    HideSubclassInTooltips: 1
+    ShowItemCount: 4
 ItemSubclassFlag:
-  ArmorsubclassLfgscalingarmor: 1024
-  ItemsubclassQuivernotrequired: 64
-  ItemsubclassUsesInvtype: 512
-  WeaponsubclassCanparry: 1
-  WeaponsubclassDeprecatedReuseMe: 256
-  WeaponsubclassIsrifle: 8
-  WeaponsubclassIsthrown: 16
-  WeaponsubclassIsunarmed: 4
-  WeaponsubclassRanged: 128
-  WeaponsubclassRighthandRanged: 32
-  WeaponsubclassSetfingerseq: 2
+  values:
+    ArmorsubclassLfgscalingarmor: 1024
+    ItemsubclassQuivernotrequired: 64
+    ItemsubclassUsesInvtype: 512
+    WeaponsubclassCanparry: 1
+    WeaponsubclassDeprecatedReuseMe: 256
+    WeaponsubclassIsrifle: 8
+    WeaponsubclassIsthrown: 16
+    WeaponsubclassIsunarmed: 4
+    WeaponsubclassRanged: 128
+    WeaponsubclassRighthandRanged: 32
+    WeaponsubclassSetfingerseq: 2
 ItemTryOnReason:
-  DataPending: 3
-  NotEquippable: 2
-  Success: 0
-  WrongRace: 1
+  values:
+    DataPending: 3
+    NotEquippable: 2
+    Success: 0
+    WrongRace: 1
 ItemWeaponSubclass:
-  Axe1H: 0
-  Axe2H: 1
-  Bearclaw: 11
-  Bows: 2
-  Catclaw: 12
-  Crossbow: 18
-  Dagger: 15
-  Fishingpole: 20
-  Generic: 14
-  Guns: 3
-  Mace1H: 4
-  Mace2H: 5
-  Obsolete3: 17
-  Polearm: 6
-  Staff: 10
-  Sword1H: 7
-  Sword2H: 8
-  Thrown: 16
-  Unarmed: 13
-  Wand: 19
-  Warglaive: 9
+  values:
+    Axe1H: 0
+    Axe2H: 1
+    Bearclaw: 11
+    Bows: 2
+    Catclaw: 12
+    Crossbow: 18
+    Dagger: 15
+    Fishingpole: 20
+    Generic: 14
+    Guns: 3
+    Mace1H: 4
+    Mace2H: 5
+    Obsolete3: 17
+    Polearm: 6
+    Staff: 10
+    Sword1H: 7
+    Sword2H: 8
+    Thrown: 16
+    Unarmed: 13
+    Wand: 19
+    Warglaive: 9
 JailersTowerType:
-  AdamantVaults: 11
-  ArkobanHall: 7
-  BossRush: 14
-  Coldheart: 4
-  ForgottenCatacombs: 12
-  FractureChambers: 2
-  Mortregar: 5
-  Ossuary: 13
-  SkoldusHalls: 1
-  Soulforges: 3
-  TormentChamberAnduin: 10
-  TormentChamberJaina: 8
-  TormentChamberThrall: 9
-  TwistingCorridors: 0
-  UpperReaches: 6
+  values:
+    AdamantVaults: 11
+    ArkobanHall: 7
+    BossRush: 14
+    Coldheart: 4
+    ForgottenCatacombs: 12
+    FractureChambers: 2
+    Mortregar: 5
+    Ossuary: 13
+    SkoldusHalls: 1
+    Soulforges: 3
+    TormentChamberAnduin: 10
+    TormentChamberJaina: 8
+    TormentChamberThrall: 9
+    TwistingCorridors: 0
+    UpperReaches: 6
 JournalEncounterFlags:
-  AllianceOnly: 4
-  DoNotDisplayEncounter: 64
-  HordeOnly: 8
-  InternalOnly: 32
-  LimitDifficulties: 2
-  NoMap: 16
-  Obsolete: 1
+  values:
+    AllianceOnly: 4
+    DoNotDisplayEncounter: 64
+    HordeOnly: 8
+    InternalOnly: 32
+    LimitDifficulties: 2
+    NoMap: 16
+    Obsolete: 1
 JournalEncounterIconFlags:
-  Bleed: 8192
-  Curse: 256
-  Deadly: 16
-  Disease: 1024
-  Dps: 2
-  Enrage: 2048
-  Healer: 4
-  Heroic: 8
-  Important: 32
-  Interruptible: 64
-  Magic: 128
-  Mythic: 4096
-  Poison: 512
-  Tank: 1
+  values:
+    Bleed: 8192
+    Curse: 256
+    Deadly: 16
+    Disease: 1024
+    Dps: 2
+    Enrage: 2048
+    Healer: 4
+    Heroic: 8
+    Important: 32
+    Interruptible: 64
+    Magic: 128
+    Mythic: 4096
+    Poison: 512
+    Tank: 1
 JournalEncounterItemFlags:
-  DisplayAsExtremelyRare: 16
-  DisplayAsPerPlayerLoot: 4
-  DisplayAsVeryRare: 8
-  LimitDifficulties: 2
-  Obsolete: 1
+  values:
+    DisplayAsExtremelyRare: 16
+    DisplayAsPerPlayerLoot: 4
+    DisplayAsVeryRare: 8
+    LimitDifficulties: 2
+    Obsolete: 1
 JournalEncounterLocFlags:
-  Primary: 1
+  values:
+    Primary: 1
 JournalEncounterSectionFlags:
-  LimitDifficulties: 2
-  StartExpanded: 1
+  values:
+    LimitDifficulties: 2
+    StartExpanded: 1
 JournalEncounterSecTypes:
-  Ability: 2
-  Creature: 1
-  Generic: 0
-  Overview: 3
+  values:
+    Ability: 2
+    Creature: 1
+    Generic: 0
+    Overview: 3
 JournalInstanceFlags:
-  DoNotDisplayInstance: 4
-  HideUserSelectableDifficulty: 2
-  Timewalker: 1
+  values:
+    DoNotDisplayInstance: 4
+    HideUserSelectableDifficulty: 2
+    Timewalker: 1
 JournalLinkTypes:
-  Encounter: 1
-  Instance: 0
-  Section: 2
-  Tier: 3
+  values:
+    Encounter: 1
+    Instance: 0
+    Section: 2
+    Tier: 3
 LanguageFlag:
-  HiddenFromPlayer: 2
-  HideLanguageNameInChat: 4
-  IsExotic: 1
+  values:
+    HiddenFromPlayer: 2
+    HideLanguageNameInChat: 4
+    IsExotic: 1
 LeavePartyConfirmReason:
-  QuestSync: 0
-  RestrictedChallengeMode: 1
+  values:
+    QuestSync: 0
+    RestrictedChallengeMode: 1
 LFGEntryGeneralPlaystyle:
-  Expert: 4
-  FunRelaxed: 2
-  FunSerious: 3
-  Learning: 1
-  None: 0
+  values:
+    Expert: 4
+    FunRelaxed: 2
+    FunSerious: 3
+    Learning: 1
+    None: 0
 LFGEntryPlaystyle:
-  Casual: 2
-  Hardcore: 3
-  None: 0
-  Standard: 1
+  values:
+    Casual: 2
+    Hardcore: 3
+    None: 0
+    Standard: 1
 LFGListDisplayType:
-  ClassEnumerate: 2
-  Comment: 5
-  HideAll: 3
-  PlayerCount: 4
-  RoleCount: 0
-  RoleEnumerate: 1
+  values:
+    ClassEnumerate: 2
+    Comment: 5
+    HideAll: 3
+    PlayerCount: 4
+    RoleCount: 0
+    RoleEnumerate: 1
 LFGListFilter:
-  CurrentExpansion: 32
-  CurrentSeason: 64
-  NotCurrentSeason: 128
-  NotRecommended: 2
-  PvE: 4
-  PvP: 8
-  Recommended: 1
-  Timerunning: 16
+  values:
+    CurrentExpansion: 32
+    CurrentSeason: 64
+    NotCurrentSeason: 128
+    NotRecommended: 2
+    PvE: 4
+    PvP: 8
+    Recommended: 1
+    Timerunning: 16
 LFGRole:
-  Damage: 2
-  Healer: 1
-  Tank: 0
+  values:
+    Damage: 2
+    Healer: 1
+    Tank: 0
 LFGSlotInvalidReason:
-  AreaNotExplored: 9
-  CannotRunAnyChildDungeon: 14
-  ChromieTime: 16
-  EngagedInPvP: 12
-  ExpansionTooLow: 1
-  GearTooHigh: 5
-  GearTooLow: 4
-  LevelTargetTooHigh: 8
-  LevelTargetTooLow: 7
-  LevelTooHigh: 3
-  LevelTooLow: 2
-  None: 0
-  NoSpec: 13
-  NoValidRoles: 11
-  Npe: 17
-  PlayerConditionFailed: 19
-  RaidLocked: 6
-  Restricted: 15
-  Timerunning: 18
-  WrongFaction: 10
+  values:
+    AreaNotExplored: 9
+    CannotRunAnyChildDungeon: 14
+    ChromieTime: 16
+    EngagedInPvP: 12
+    ExpansionTooLow: 1
+    GearTooHigh: 5
+    GearTooLow: 4
+    LevelTargetTooHigh: 8
+    LevelTargetTooLow: 7
+    LevelTooHigh: 3
+    LevelTooLow: 2
+    None: 0
+    NoSpec: 13
+    NoValidRoles: 11
+    Npe: 17
+    PlayerConditionFailed: 19
+    RaidLocked: 6
+    Restricted: 15
+    Timerunning: 18
+    WrongFaction: 10
 LgVendorPurchaseSettlementState:
-  NotSettled: 1
-  Settled: 0
+  values:
+    NotSettled: 1
+    Settled: 0
 LgVendorPurchaseSqlResults:
-  AlreadyOwned: 102
-  Failed: 0
-  InsufficientFunds: 101
-  InsufficientSpent: 103
-  InvalidState: 107
-  NoRecord: 106
-  NotOwned: 104
-  RefundExpired: 105
-  Success: 100
+  values:
+    AlreadyOwned: 102
+    Failed: 0
+    InsufficientFunds: 101
+    InsufficientSpent: 103
+    InvalidState: 107
+    NoRecord: 106
+    NotOwned: 104
+    RefundExpired: 105
+    Success: 100
 LgVendorPurchaseState:
-  NotOwned: 0
-  Owned: 1
+  values:
+    NotOwned: 0
+    Owned: 1
 LightRadiusIndicatorType:
-  Always: 0
-  Never: 2
-  Overlap: 1
+  values:
+    Always: 0
+    Never: 2
+    Overlap: 1
 LimitedInputType:
-  MouseDown: 1
-  MouseMove: 0
-  MouseUp: 2
-  MouseWheel: 3
+  values:
+    MouseDown: 1
+    MouseMove: 0
+    MouseUp: 2
+    MouseWheel: 3
 LinkedCurrencyFlags:
-  AddIgnoresMax: 8
-  IgnoreAdd: 1
-  IgnoreSubtract: 2
-  SuppressChatLog: 4
+  values:
+    AddIgnoresMax: 8
+    IgnoreAdd: 1
+    IgnoreSubtract: 2
+    SuppressChatLog: 4
 LogicLogicop:
-  And: 1
-  None: 0
-  Or: 2
-  Xor: 3
+  values:
+    And: 1
+    None: 0
+    Or: 2
+    Xor: 3
 LogicMathop:
-  Div: 4
-  Minus: 2
-  Mod: 5
-  None: 0
-  Plus: 1
-  Times: 3
+  values:
+    Div: 4
+    Minus: 2
+    Mod: 5
+    None: 0
+    Plus: 1
+    Times: 3
 LogicRelop:
-  Equal: 1
-  Gt: 5
-  Gteq: 6
-  Lt: 3
-  Lteq: 4
-  None: 0
-  Notequal: 2
+  values:
+    Equal: 1
+    Gt: 5
+    Gteq: 6
+    Lt: 3
+    Lteq: 4
+    None: 0
+    Notequal: 2
 LogPriority:
-  Debug: 30
-  Error: 2
-  Fatal: 1
-  Normal: 10
-  Spam: 40
-  Warning: 3
+  values:
+    Debug: 30
+    Error: 2
+    Fatal: 1
+    Normal: 10
+    Spam: 40
+    Warning: 3
 LootMethod:
-  Freeforall: 0
-  Group: 3
-  Masterlooter: 2
-  Needbeforegreed: 4
-  Personal: 5
-  Roundrobin: 1
+  values:
+    Freeforall: 0
+    Group: 3
+    Masterlooter: 2
+    Needbeforegreed: 4
+    Personal: 5
+    Roundrobin: 1
 LootMethodStyles:
-  Mainline: 0
-  Vanilla: 1
+  values:
+    Mainline: 0
+    Vanilla: 1
 LootSlotType:
-  Currency: 3
-  Item: 1
-  Money: 2
-  None: 0
+  values:
+    Currency: 3
+    Item: 1
+    Money: 2
+    None: 0
 LuaCurveType:
-  Cosine: 2
-  Cubic: 3
-  Linear: 0
-  Step: 1
+  values:
+    Cosine: 2
+    Cubic: 3
+    Linear: 0
+    Step: 1
 ManipulatorEventType:
-  Complete: 2
-  Delete: 3
-  Move: 1
-  Start: 0
+  values:
+    Complete: 2
+    Delete: 3
+    Move: 1
+    Start: 0
 MapCanvasPosition:
-  BottomLeft: 1
-  BottomRight: 2
-  None: 0
-  TopLeft: 3
-  TopRight: 4
+  values:
+    BottomLeft: 1
+    BottomRight: 2
+    None: 0
+    TopLeft: 3
+    TopRight: 4
 MapIconUIWidgetSetType:
-  AdventureMapDetails: 2
-  BehindIcon: 1
-  Tooltip: 0
+  values:
+    AdventureMapDetails: 2
+    BehindIcon: 1
+    Tooltip: 0
 MapobjEventTypes:
-  PlayAnim: 0
-  SetAnimSpeed: 1
+  values:
+    PlayAnim: 0
+    SetAnimSpeed: 1
 MapPinAnimationType:
-  None: 0
-  Pulse: 1
+  values:
+    None: 0
+    Pulse: 1
 MatchDetailType:
-  Kills: 1
-  Placement: 0
-  PlunderAcquired: 2
+  values:
+    Kills: 1
+    Placement: 0
+    PlunderAcquired: 2
 MicroMenuOrder:
-  Default: 0
-  Reverse: 1
+  values:
+    Default: 0
+    Reverse: 1
 MicroMenuOrientation:
-  Horizontal: 0
-  Vertical: 1
+  values:
+    Horizontal: 0
+    Vertical: 1
 MinimapTrackingFilter:
-  AccountBanker: 4194304
-  AccountCompletedQuests: 2097152
-  Auctioneer: 1
-  Banker: 2
-  Battlemaster: 4
-  Digsites: 131072
-  Focus: 32768
-  Innkeeper: 32
-  Mailbox: 64
-  POI: 8192
-  QuestPOIs: 65536
-  Repair: 512
-  Stablemaster: 2048
-  Target: 16384
-  TaxiNode: 8
-  TrainerClass: 262144
-  TrainerProfession: 128
-  Transmogrifier: 4096
-  TrivialQuests: 1024
-  Unfiltered: 0
-  VenderFood: 16
-  VendorAmmo: 524288
-  VendorPoison: 1048576
-  VendorReagent: 256
+  values:
+    AccountBanker: 4194304
+    AccountCompletedQuests: 2097152
+    Auctioneer: 1
+    Banker: 2
+    Battlemaster: 4
+    Digsites: 131072
+    Focus: 32768
+    Innkeeper: 32
+    Mailbox: 64
+    POI: 8192
+    QuestPOIs: 65536
+    Repair: 512
+    Stablemaster: 2048
+    Target: 16384
+    TaxiNode: 8
+    TrainerClass: 262144
+    TrainerProfession: 128
+    Transmogrifier: 4096
+    TrivialQuests: 1024
+    Unfiltered: 0
+    VenderFood: 16
+    VendorAmmo: 524288
+    VendorPoison: 1048576
+    VendorReagent: 256
 ModelBlendOperation:
-  Anim: 1
-  None: 0
+  values:
+    Anim: 1
+    None: 0
 ModelLightType:
-  Directional: 0
-  Point: 1
+  values:
+    Directional: 0
+    Point: 1
 ModelSceneSetting:
-  AlignLightToOrbitDelta: 1
+  values:
+    AlignLightToOrbitDelta: 1
 ModelSceneType:
-  ArtifactRelicTalentEffect: 9
-  ArtifactTier2: 5
-  ArtifactTier2ForgingScene: 6
-  ArtifactTier2SlamEffect: 7
-  AzeriteItemLevelUpToast: 13
-  AzeritePowers: 14
-  AzeriteRewardGlow: 15
-  CommentatorVictoryFanfare: 8
-  EncounterJournal: 3
-  MountJournal: 0
-  PartyPose: 12
-  PetJournalCard: 1
-  PetJournalLoadout: 4
-  PvPWarModeFire: 11
-  PvPWarModeOrb: 10
-  ShopCard: 2
+  values:
+    ArtifactRelicTalentEffect: 9
+    ArtifactTier2: 5
+    ArtifactTier2ForgingScene: 6
+    ArtifactTier2SlamEffect: 7
+    AzeriteItemLevelUpToast: 13
+    AzeritePowers: 14
+    AzeriteRewardGlow: 15
+    CommentatorVictoryFanfare: 8
+    EncounterJournal: 3
+    MountJournal: 0
+    PartyPose: 12
+    PetJournalCard: 1
+    PetJournalLoadout: 4
+    PvPWarModeFire: 11
+    PvPWarModeOrb: 10
+    ShopCard: 2
 ModelSoundOverrideType:
-  Mute: 2
-  UseOverride: 1
-  UseParent: 0
+  values:
+    Mute: 2
+    UseOverride: 1
+    UseParent: 0
 ModelSoundTagType:
-  Looping: 2
-  Oneshot: 1
+  values:
+    Looping: 2
+    Oneshot: 1
 MountType:
-  Aquatic: 2
-  Dragonriding: 3
-  Flying: 1
-  Ground: 0
-  RideAlong: 4
+  values:
+    Aquatic: 2
+    Dragonriding: 3
+    Flying: 1
+    Ground: 0
+    RideAlong: 4
 MountTypeFlag:
-  IsAquaticMount: 2
-  IsDragonRidingMount: 4
-  IsFlyingMount: 1
-  IsRideAlongMount: 8
+  values:
+    IsAquaticMount: 2
+    IsDragonRidingMount: 4
+    IsFlyingMount: 1
+    IsRideAlongMount: 8
 NamePlateCastBarDisplay:
-  HighlightImportantCasts: 4
-  HighlightWhenCastTarget: 5
-  None: 0
-  SpellIcon: 2
-  SpellName: 1
-  SpellTarget: 3
+  values:
+    HighlightImportantCasts: 4
+    HighlightWhenCastTarget: 5
+    None: 0
+    SpellIcon: 2
+    SpellName: 1
+    SpellTarget: 3
 NamePlateEnemyNpcAuraDisplay:
-  Buffs: 1
-  CrowdControl: 3
-  Debuffs: 2
-  None: 0
+  values:
+    Buffs: 1
+    CrowdControl: 3
+    Debuffs: 2
+    None: 0
 NamePlateEnemyPlayerAuraDisplay:
-  Buffs: 1
-  Debuffs: 2
-  LossOfControl: 3
-  None: 0
+  values:
+    Buffs: 1
+    Debuffs: 2
+    LossOfControl: 3
+    None: 0
 NamePlateFriendlyPlayerAuraDisplay:
-  Buffs: 1
-  Debuffs: 2
-  LossOfControl: 3
-  None: 0
+  values:
+    Buffs: 1
+    Debuffs: 2
+    LossOfControl: 3
+    None: 0
 NamePlateInfoDisplay:
-  CurrentHealthPercent: 1
-  CurrentHealthValue: 2
-  None: 0
-  RarityIcon: 3
+  values:
+    CurrentHealthPercent: 1
+    CurrentHealthValue: 2
+    None: 0
+    RarityIcon: 3
 NamePlateSimplifiedType:
-  FriendlyNpc: 4
-  FriendlyPlayer: 3
-  Minion: 1
-  MinusMob: 2
-  None: 0
+  values:
+    FriendlyNpc: 4
+    FriendlyPlayer: 3
+    Minion: 1
+    MinusMob: 2
+    None: 0
 NamePlateSize:
-  ExtraLarge: 4
-  Huge: 5
-  Large: 3
-  Medium: 2
-  Small: 1
+  values:
+    ExtraLarge: 4
+    Huge: 5
+    Large: 3
+    Medium: 2
+    Small: 1
 NamePlateStackType:
-  Enemy: 1
-  Friendly: 2
-  None: 0
+  values:
+    Enemy: 1
+    Friendly: 2
+    None: 0
 NamePlateStyle:
-  Block: 2
-  CastFocus: 4
-  Classic: 6
-  HealthFocus: 3
-  Legacy: 5
-  Modern: 0
-  Thin: 1
+  values:
+    Block: 2
+    CastFocus: 4
+    Classic: 6
+    HealthFocus: 3
+    Legacy: 5
+    Modern: 0
+    Thin: 1
 NamePlateThreatDisplay:
-  Flash: 2
-  HealthBarColor: 3
-  None: 0
-  Progressive: 1
+  values:
+    Flash: 2
+    HealthBarColor: 3
+    None: 0
+    Progressive: 1
 NamePlateType:
-  Enemy: 1
-  Friendly: 0
+  values:
+    Enemy: 1
+    Friendly: 0
 NeighborhoodFlags:
-  None: 0
-  OpenToPublic: 2
-  PoolParent: 1
+  values:
+    None: 0
+    OpenToPublic: 2
+    PoolParent: 1
 NeighborhoodInitiativeChestResult:
-  NiNoHouseFound: 2
-  NiNoRewards: 3
-  NiServiceDisabled: 5
-  NiSuccess: 0
-  NiThrottled: 4
-  NiUnspecifiedFailure: 1
+  values:
+    NiNoHouseFound: 2
+    NiNoRewards: 3
+    NiServiceDisabled: 5
+    NiSuccess: 0
+    NiThrottled: 4
+    NiUnspecifiedFailure: 1
 NeighborhoodInitiativeFlags:
-  Disabled: 1
-  NoAbandon: 2
-  NoRepeat: 4
+  values:
+    Disabled: 1
+    NoAbandon: 2
+    NoRepeat: 4
 NeighborhoodInitiativeNeighborhoodTypes:
-  NiNeighborhoodTypePool: 1
-  NiNeighborhoodTypeSingleton: 0
+  values:
+    NiNeighborhoodTypePool: 1
+    NiNeighborhoodTypeSingleton: 0
 NeighborhoodInitiativesCompletionStates:
-  NiCompletionStateNotCompleted: 0
-  NiCompletionStatePlayerCompleted: 1
-  NiCompletionStateSystemAbandoned: 2
+  values:
+    NiCompletionStateNotCompleted: 0
+    NiCompletionStatePlayerCompleted: 1
+    NiCompletionStateSystemAbandoned: 2
 NeighborhoodInitiativeTaskType:
-  RepeatableFinite: 1
-  RepeatableInfinite: 2
-  Single: 0
+  values:
+    RepeatableFinite: 1
+    RepeatableInfinite: 2
+    Single: 0
 NeighborhoodInitiativeUpdateStatus:
-  Completed: 2
-  Failed: 3
-  MilestoneCompleted: 1
-  Started: 0
+  values:
+    Completed: 2
+    Failed: 3
+    MilestoneCompleted: 1
+    Started: 0
 NeighborhoodInviteResult:
-  AlreadyInNeighborhood: 11
-  DbError: 1
-  Faction: 5
-  GenericFailure: 3
-  InviteLimit: 7
-  NotEnoughPlots: 8
-  NotFound: 9
-  PendingInvitation: 6
-  Permission: 4
-  RpcFailure: 2
-  Success: 0
-  TooManyRequests: 10
+  values:
+    AlreadyInNeighborhood: 11
+    DbError: 1
+    Faction: 5
+    GenericFailure: 3
+    InviteLimit: 7
+    NotEnoughPlots: 8
+    NotFound: 9
+    PendingInvitation: 6
+    Permission: 4
+    RpcFailure: 2
+    Success: 0
+    TooManyRequests: 10
 NeighborhoodMapFlags:
-  AlliancePurchasable: 1
-  CanSystemGenerate: 4
-  HordePurchasable: 2
-  None: 0
+  values:
+    AlliancePurchasable: 1
+    CanSystemGenerate: 4
+    HordePurchasable: 2
+    None: 0
 NeighborhoodOwnerType:
-  Charter: 2
-  Guild: 1
-  None: 0
+  values:
+    Charter: 2
+    Guild: 1
+    None: 0
 NeighborhoodType:
-  Open: 0
-  Private: 1
-  Public: 2
+  values:
+    Open: 0
+    Private: 1
+    Public: 2
 NewCharGear:
-  Preview: 1
-  Start: 0
+  values:
+    Preview: 1
+    Start: 0
 NodeOpFailureReason:
-  AccountDataNoMatch: 25
-  DataError: 13
-  EntryNotFound: 19
-  HasMutuallyExclusiveEdge: 4
-  LevelTooLow: 22
-  MaxRank: 12
-  MissingAchievement: 8
-  MissingEdgeConnection: 1
-  MissingQuest: 9
-  MissingRequiredEdge: 3
-  NodeNeverPurchasable: 24
-  NodeNotFound: 18
-  None: 0
-  NotEnoughCurrency: 15
-  NotEnoughCurrencySpent: 6
-  NotEnoughGold: 16
-  NotEnoughGoldSpent: 7
-  NotEnoughRanksInEntry: 26
-  NotEnoughSourcedCurrency: 14
-  NotEnoughSourcedCurrencySpent: 5
-  RequiredForCondition: 20
-  RequiredForEdge: 2
-  SameSelection: 17
-  TreeFlaggedNoRefund: 23
-  WrongSelection: 11
-  WrongSpec: 10
-  WrongTreeID: 21
+  values:
+    AccountDataNoMatch: 25
+    DataError: 13
+    EntryNotFound: 19
+    HasMutuallyExclusiveEdge: 4
+    LevelTooLow: 22
+    MaxRank: 12
+    MissingAchievement: 8
+    MissingEdgeConnection: 1
+    MissingQuest: 9
+    MissingRequiredEdge: 3
+    NodeNeverPurchasable: 24
+    NodeNotFound: 18
+    None: 0
+    NotEnoughCurrency: 15
+    NotEnoughCurrencySpent: 6
+    NotEnoughGold: 16
+    NotEnoughGoldSpent: 7
+    NotEnoughRanksInEntry: 26
+    NotEnoughSourcedCurrency: 14
+    NotEnoughSourcedCurrencySpent: 5
+    RequiredForCondition: 20
+    RequiredForEdge: 2
+    SameSelection: 17
+    TreeFlaggedNoRefund: 23
+    WrongSelection: 11
+    WrongSpec: 10
+    WrongTreeID: 21
 NoRPEReason:
-  BNetToken: 8
-  FactionOrRaceChange: 7
-  HasRPE: 0
-  IneligibleMap: 3
-  LowLevel: 1
-  PlayerLocked: 9
-  RecentlyActive: 4
-  RecentlyBoosted: 5
-  Timerunner: 2
-  UpgradeInProgress: 6
+  values:
+    BNetToken: 8
+    FactionOrRaceChange: 7
+    HasRPE: 0
+    IneligibleMap: 3
+    LowLevel: 1
+    PlayerLocked: 9
+    RecentlyActive: 4
+    RecentlyBoosted: 5
+    Timerunner: 2
+    UpgradeInProgress: 6
 NpcCraftingOrderSetFlags:
-  AllowDuplicate: 2
-  AllowMultiple: 1
+  values:
+    AllowDuplicate: 2
+    AllowMultiple: 1
 NumericRuleFormatRounding:
-  Down: 2
-  Nearest: 0
-  Up: 1
+  values:
+    Down: 2
+    Nearest: 0
+    Up: 1
 PartyPlaylistEntry:
-  DuoGameMode: 1
-  SoloGameMode: 0
-  TrainingGameMode: 3
-  TrioGameMode: 2
+  values:
+    DuoGameMode: 1
+    SoloGameMode: 0
+    TrainingGameMode: 3
+    TrioGameMode: 2
 PartyPoseFlags:
-  HideLeaveInstanceButton: 1
+  values:
+    HideLeaveInstanceButton: 1
 PartyRequestJoinRelation:
-  Club: 3
-  Friend: 1
-  Guild: 2
-  None: 0
-  RecentAllies: 4
+  values:
+    Club: 3
+    Friend: 1
+    Guild: 2
+    None: 0
+    RecentAllies: 4
 PerksVendorCategoryType:
-  Achievement: 23
-  Activity: 21
-  GmAdjustment: 22
-  Illusion: 7
-  Mount: 2
-  Pet: 3
-  RefundUnused: 24
-  Stipend: 20
-  Toy: 5
-  Transmog: 1
-  Transmogset: 8
-  WarbandScene: 9
+  values:
+    Achievement: 23
+    Activity: 21
+    GmAdjustment: 22
+    Illusion: 7
+    Mount: 2
+    Pet: 3
+    RefundUnused: 24
+    Stipend: 20
+    Toy: 5
+    Transmog: 1
+    Transmogset: 8
+    WarbandScene: 9
 PermanentChatChannelType:
-  Communities: 2
-  Custom: 3
-  None: 0
-  Zone: 1
+  values:
+    Communities: 2
+    Custom: 3
+    None: 0
+    Zone: 1
 PersonalResourceDisplayVisibleSetting:
-  Always: 0
-  Hidden: 2
-  InCombat: 1
+  values:
+    Always: 0
+    Hidden: 2
+    InCombat: 1
 PetActionbuttonType:
-  Max: 18
-  Mode: 6
-  None: 0
-  Orders: 7
-  Slot1: 8
-  Slot10: 17
-  Slot1Obsolete: 2
-  Slot2: 9
-  Slot2Obsolete: 3
-  Slot3: 10
-  Slot3Obsolete: 4
-  Slot4: 11
-  Slot4Obsolete: 5
-  Slot5: 12
-  Slot6: 13
-  Slot7: 14
-  Slot8: 15
-  Slot9: 16
-  Spell: 1
-  VehicleAction: 19
+  values:
+    Max: 18
+    Mode: 6
+    None: 0
+    Orders: 7
+    Slot1: 8
+    Slot10: 17
+    Slot1Obsolete: 2
+    Slot2: 9
+    Slot2Obsolete: 3
+    Slot3: 10
+    Slot3Obsolete: 4
+    Slot4: 11
+    Slot4Obsolete: 5
+    Slot5: 12
+    Slot6: 13
+    Slot7: 14
+    Slot8: 15
+    Slot9: 16
+    Spell: 1
+    VehicleAction: 19
 PetActionFeedback:
-  Dead: 1
-  FriendlyTarget: 3
-  InvalidTarget: 2
-  NoPath: 4
-  Success: 0
+  values:
+    Dead: 1
+    FriendlyTarget: 3
+    InvalidTarget: 2
+    NoPath: 4
+    Success: 0
 PetBattleQueueStatus:
-  AlreadyQueued: 3
-  InBattle: 20
-  JoinFailed: 4
-  JoinFailedJournalLock: 6
-  JoinFailedNeutral: 7
-  JoinFailedSlots: 5
-  LostConnection: 16
-  MatchAccepted: 8
-  MatchDeclined: 9
-  Matchmaking: 15
-  MatchOpponentDeclined: 10
-  NoBattlingHere: 21
-  None: 0
-  ProposalTimedOut: 11
-  Queued: 1
-  QueuedUpdate: 2
-  Removed: 12
-  RequeuedAfterInternalError: 13
-  RequeuedAfterOpponentRemoved: 14
-  Shutdown: 17
-  Suspended: 18
-  Unsuspended: 19
+  values:
+    AlreadyQueued: 3
+    InBattle: 20
+    JoinFailed: 4
+    JoinFailedJournalLock: 6
+    JoinFailedNeutral: 7
+    JoinFailedSlots: 5
+    LostConnection: 16
+    MatchAccepted: 8
+    MatchDeclined: 9
+    Matchmaking: 15
+    MatchOpponentDeclined: 10
+    NoBattlingHere: 21
+    None: 0
+    ProposalTimedOut: 11
+    Queued: 1
+    QueuedUpdate: 2
+    Removed: 12
+    RequeuedAfterInternalError: 13
+    RequeuedAfterOpponentRemoved: 14
+    Shutdown: 17
+    Suspended: 18
+    Unsuspended: 19
 PetbattleSlot:
-  Slot_0: 0
-  Slot_1: 1
-  Slot_2: 2
+  values:
+    Slot_0: 0
+    Slot_1: 1
+    Slot_2: 2
 PetbattleState:
-  Created: 0
-  CreatedFailed: 4
-  FinalRound: 5
-  Finished: 6
-  RoundInProgress: 2
-  WaitingForFrontPets: 3
-  WaitingPreBattle: 1
+  values:
+    Created: 0
+    CreatedFailed: 4
+    FinalRound: 5
+    Finished: 6
+    RoundInProgress: 2
+    WaitingForFrontPets: 3
+    WaitingPreBattle: 1
 PetJournalError:
-  InvalidFaction: 3
-  JournalIsLocked: 2
-  NoFavoritesToSummon: 4
-  None: 0
-  NoValidRandomSummon: 5
-  PetIsDead: 1
+  values:
+    InvalidFaction: 3
+    JournalIsLocked: 2
+    NoFavoritesToSummon: 4
+    None: 0
+    NoValidRandomSummon: 5
+    PetIsDead: 1
 PetMode:
-  Aggressive: 2
-  Assist: 3
-  Defensive: 1
-  Passive: 0
+  values:
+    Aggressive: 2
+    Assist: 3
+    Defensive: 1
+    Passive: 0
 PetOrders:
-  Attack: 2
-  Dismiss: 3
-  Follow: 1
-  MoveTo: 4
-  Wait: 0
+  values:
+    Attack: 2
+    Dismiss: 3
+    Follow: 1
+    MoveTo: 4
+    Wait: 0
 PetOverride:
-  AICombatControl: 1
-  AICombatPassive: 2
-  None: 0
-  OwnerMounted: 4
+  values:
+    AICombatControl: 1
+    AICombatPassive: 2
+    None: 0
+    OwnerMounted: 4
 Pettameresult:
-  Anothersummonactive: 5
-  Cantcontrolexotic: 12
-  Creaturealreadyowned: 3
-  Dead: 10
-  EliteToohighlevel: 14
-  Internalerror: 8
-  Invalidcreature: 1
-  Invalidslot: 13
-  Nopetavailable: 7
-  Notdead: 11
-  Nottameable: 4
-  Numresults: 15
-  Ok: 0
-  Toohighlevel: 9
-  Toomany: 2
-  Unitscanttame: 6
+  values:
+    Anothersummonactive: 5
+    Cantcontrolexotic: 12
+    Creaturealreadyowned: 3
+    Dead: 10
+    EliteToohighlevel: 14
+    Internalerror: 8
+    Invalidcreature: 1
+    Invalidslot: 13
+    Nopetavailable: 7
+    Notdead: 11
+    Nottameable: 4
+    Numresults: 15
+    Ok: 0
+    Toohighlevel: 9
+    Toomany: 2
+    Unitscanttame: 6
 PhaseReason:
-  ChromieTime: 3
-  Phasing: 0
-  Sharding: 1
-  TimerunningHwt: 4
-  WarMode: 2
+  values:
+    ChromieTime: 3
+    Phasing: 0
+    Sharding: 1
+    TimerunningHwt: 4
+    WarMode: 2
 PhotoSharingStatus:
-  AADCRestricted: 6
-  Configured: 2
-  Disabled: 0
-  Error: 7
-  Expired: 3
-  FailedToClear: 8
-  NotConfigured: 1
-  ParentalControl: 4
-  TrialOrVeteran: 5
+  values:
+    AADCRestricted: 6
+    Configured: 2
+    Disabled: 0
+    Error: 7
+    Expired: 3
+    FailedToClear: 8
+    NotConfigured: 1
+    ParentalControl: 4
+    TrialOrVeteran: 5
 PhotoSharingUploadStatus:
-  CreatePageApiCallFailed: 13
-  CreatePageBadRequest: 14
-  CreatePageForbidden: 16
-  CreatePageGenericFailure: 19
-  CreatePageNoBoardIDFound: 20
-  CreatePageNotFound: 17
-  CreatePageTooManyRequests: 18
-  CreatePageUnauthorized: 15
-  CreatePostApiCallFailed: 21
-  CreatePostBadRequest: 22
-  CreatePostForbidden: 24
-  CreatePostGenericFailure: 27
-  CreatePostNoIDFound: 28
-  CreatePostNotFound: 25
-  CreatePostThrottled: 29
-  CreatePostTooManyRequests: 26
-  CreatePostUnauthorized: 23
-  Disabled: 0
-  Failed: 1
-  ListPagesApiCallFailed: 4
-  ListPagesBadRequest: 5
-  ListPagesEmptyBoardID: 11
-  ListPagesForbidden: 7
-  ListPagesGenericFailure: 10
-  ListPagesInvalidBookmark: 12
-  ListPagesNotFound: 8
-  ListPagesTooManyRequests: 9
-  ListPagesUnauthorized: 6
-  Locked: 3
-  Success: 2
+  values:
+    CreatePageApiCallFailed: 13
+    CreatePageBadRequest: 14
+    CreatePageForbidden: 16
+    CreatePageGenericFailure: 19
+    CreatePageNoBoardIDFound: 20
+    CreatePageNotFound: 17
+    CreatePageTooManyRequests: 18
+    CreatePageUnauthorized: 15
+    CreatePostApiCallFailed: 21
+    CreatePostBadRequest: 22
+    CreatePostForbidden: 24
+    CreatePostGenericFailure: 27
+    CreatePostNoIDFound: 28
+    CreatePostNotFound: 25
+    CreatePostThrottled: 29
+    CreatePostTooManyRequests: 26
+    CreatePostUnauthorized: 23
+    Disabled: 0
+    Failed: 1
+    ListPagesApiCallFailed: 4
+    ListPagesBadRequest: 5
+    ListPagesEmptyBoardID: 11
+    ListPagesForbidden: 7
+    ListPagesGenericFailure: 10
+    ListPagesInvalidBookmark: 12
+    ListPagesNotFound: 8
+    ListPagesTooManyRequests: 9
+    ListPagesUnauthorized: 6
+    Locked: 3
+    Success: 2
 PingSubjectType:
-  AlertNotThreat: 5
-  AlertThreat: 4
-  Assist: 2
-  Attack: 0
-  OnMyWay: 3
-  Warning: 1
+  values:
+    AlertNotThreat: 5
+    AlertThreat: 4
+    Assist: 2
+    Attack: 0
+    OnMyWay: 3
+    Warning: 1
 PingTextureType:
-  Center: 0
-  Expand: 1
-  Rotation: 2
+  values:
+    Center: 0
+    Expand: 1
+    Rotation: 2
 PingTypeFlags:
-  DefaultPing: 1
+  values:
+    DefaultPing: 1
 PlayerClubRequestStatus:
-  Approved: 4
-  AutoApproved: 2
-  Canceled: 7
-  Declined: 3
-  Joined: 5
-  JoinedAnother: 6
-  None: 0
-  Pending: 1
+  values:
+    Approved: 4
+    AutoApproved: 2
+    Canceled: 7
+    Declined: 3
+    Joined: 5
+    JoinedAnother: 6
+    None: 0
+    Pending: 1
 PlayerCompanionInfoFlags:
-  IgnoreSeasonInScenarios: 1
+  values:
+    IgnoreSeasonInScenarios: 1
 PlayerCurrencyFlags:
-  Incremented: 1
-  Loading: 2
+  values:
+    Incremented: 1
+    Loading: 2
 PlayerCurrencyFlagsDbFlags:
-  IgnoreMaxQtyOnload: 1
-  InBackpack: 4
-  Reuse1: 2
-  Reuse2: 16
-  UnusedInUI: 8
+  values:
+    IgnoreMaxQtyOnload: 1
+    InBackpack: 4
+    Reuse1: 2
+    Reuse2: 16
+    UnusedInUI: 8
 PlayerDataElementType:
-  Float: 1
-  Int: 0
+  values:
+    Float: 1
+    Int: 0
 PlayerInteractionType:
-  AccountBanker: 68
-  AdventureJournal: 54
-  AdventureMap: 28
-  AlliedRaceDetailsGiver: 9
-  AnimaDiversion: 47
-  AreaSpiritHealer: 19
-  ArtifactForge: 38
-  Auctioneer: 21
-  AzeriteForge: 56
-  AzeriteRespec: 42
-  Banker: 8
-  BarbersChoice: 62
-  BattleMaster: 23
-  Binder: 20
-  BlackMarketAuctioneer: 27
-  CharacterBanker: 67
-  ChromieTime: 45
-  ContributionCollector: 41
-  CornerstoneInteraction: 70
-  CovenantPreview: 46
-  CovenantSanctum: 51
-  CreateGuildNeighborhood: 74
-  ForgeMaster: 66
-  GarrArchitect: 30
-  GarrMission: 32
-  GarrRecruitment: 34
-  GarrTalent: 35
-  GarrTradeskill: 31
-  Gossip: 3
-  GuildBanker: 10
-  GuildRename: 76
-  GuildTabardVendor: 14
-  HousingBulletinBoard: 72
-  HousingPedestal: 73
-  IslandQueue: 43
-  Item: 2
-  ItemInteraction: 44
-  ItemUpgrade: 53
-  JailersTowerBuffs: 63
-  LegendaryCrafting: 48
-  LFGDungeon: 25
-  MailInfo: 17
-  MajorFactionRenown: 64
-  Merchant: 5
-  NeighborhoodCharter: 75
-  NewPlayerGuide: 52
-  None: 0
-  ObliterumForge: 39
-  OpenHouseFinder: 78
-  OpenNeighborhoodCharterConfirmation: 77
-  PerksProgramVendor: 57
-  PersonalTabardVendor: 65
-  PetitionVendor: 13
-  PlayerChoice: 37
-  ProfessionRespec: 69
-  Professions: 59
-  ProfessionsCraftingOrder: 58
-  ProfessionsCustomerOrder: 60
-  QuestGiver: 4
-  Registrar: 11
-  RenameNeighborhood: 71
-  Renown: 55
-  ScrappingMachine: 40
-  ShipmentCrafter: 33
-  Soulbind: 50
-  SpecializationMaster: 16
-  SpiritHealer: 18
-  StableMaster: 22
-  TalentMaster: 15
-  TaxiNode: 6
-  TieredEntrance: 79
-  TradePartner: 1
-  Trainer: 7
-  TraitSystem: 61
-  Transmogrifier: 24
-  Trophy: 36
-  Vendor: 12
-  VoidStorageBanker: 26
-  WeeklyRewards: 49
-  WorldMap: 29
+  values:
+    AccountBanker: 68
+    AdventureJournal: 54
+    AdventureMap: 28
+    AlliedRaceDetailsGiver: 9
+    AnimaDiversion: 47
+    AreaSpiritHealer: 19
+    ArtifactForge: 38
+    Auctioneer: 21
+    AzeriteForge: 56
+    AzeriteRespec: 42
+    Banker: 8
+    BarbersChoice: 62
+    BattleMaster: 23
+    Binder: 20
+    BlackMarketAuctioneer: 27
+    CharacterBanker: 67
+    ChromieTime: 45
+    ContributionCollector: 41
+    CornerstoneInteraction: 70
+    CovenantPreview: 46
+    CovenantSanctum: 51
+    CreateGuildNeighborhood: 74
+    ForgeMaster: 66
+    GarrArchitect: 30
+    GarrMission: 32
+    GarrRecruitment: 34
+    GarrTalent: 35
+    GarrTradeskill: 31
+    Gossip: 3
+    GuildBanker: 10
+    GuildRename: 76
+    GuildTabardVendor: 14
+    HousingBulletinBoard: 72
+    HousingPedestal: 73
+    IslandQueue: 43
+    Item: 2
+    ItemInteraction: 44
+    ItemUpgrade: 53
+    JailersTowerBuffs: 63
+    LegendaryCrafting: 48
+    LFGDungeon: 25
+    MailInfo: 17
+    MajorFactionRenown: 64
+    Merchant: 5
+    NeighborhoodCharter: 75
+    NewPlayerGuide: 52
+    None: 0
+    ObliterumForge: 39
+    OpenHouseFinder: 78
+    OpenNeighborhoodCharterConfirmation: 77
+    PerksProgramVendor: 57
+    PersonalTabardVendor: 65
+    PetitionVendor: 13
+    PlayerChoice: 37
+    ProfessionRespec: 69
+    Professions: 59
+    ProfessionsCraftingOrder: 58
+    ProfessionsCustomerOrder: 60
+    QuestGiver: 4
+    Registrar: 11
+    RenameNeighborhood: 71
+    Renown: 55
+    ScrappingMachine: 40
+    ShipmentCrafter: 33
+    Soulbind: 50
+    SpecializationMaster: 16
+    SpiritHealer: 18
+    StableMaster: 22
+    TalentMaster: 15
+    TaxiNode: 6
+    TieredEntrance: 79
+    TradePartner: 1
+    Trainer: 7
+    TraitSystem: 61
+    Transmogrifier: 24
+    Trophy: 36
+    Vendor: 12
+    VoidStorageBanker: 26
+    WeeklyRewards: 49
+    WorldMap: 29
 PlayerMentorshipApplicationResult:
-  AlreadyMentor: 1
-  Ineligible: 2
-  Success: 0
+  values:
+    AlreadyMentor: 1
+    Ineligible: 2
+    Success: 0
 PlayerMentorshipStatus:
-  Mentor: 2
-  Newcomer: 1
-  None: 0
+  values:
+    Mentor: 2
+    Newcomer: 1
+    None: 0
 PlunderstormQueueState:
-  None: 0
-  Proposed: 2
-  Queued: 1
-  Suspended: 3
+  values:
+    None: 0
+    Proposed: 2
+    Queued: 1
+    Suspended: 3
 PowerType:
-  Alternate: 10
-  AlternateEncounter: 24
-  AlternateMount: 25
-  AlternateQuest: 23
-  ArcaneCharges: 16
-  Balance: 26
-  BurningEmbers: 14
-  Chi: 12
-  ComboPoints: 4
-  DemonicFury: 15
-  Energy: 3
-  Essence: 19
-  Focus: 2
-  Fury: 17
-  Happiness: 27
-  HolyPower: 9
-  Insanity: 13
-  LunarPower: 8
-  Maelstrom: 11
-  Mana: 0
-  Pain: 18
-  Rage: 1
-  RuneBlood: 20
-  RuneChromatic: 29
-  RuneFrost: 21
-  Runes: 5
-  RuneUnholy: 22
-  RunicPower: 6
-  ShadowOrbs: 28
-  SoulShards: 7
+  values:
+    Alternate: 10
+    AlternateEncounter: 24
+    AlternateMount: 25
+    AlternateQuest: 23
+    ArcaneCharges: 16
+    Balance: 26
+    BurningEmbers: 14
+    Chi: 12
+    ComboPoints: 4
+    DemonicFury: 15
+    Energy: 3
+    Essence: 19
+    Focus: 2
+    Fury: 17
+    Happiness: 27
+    HolyPower: 9
+    Insanity: 13
+    LunarPower: 8
+    Maelstrom: 11
+    Mana: 0
+    Pain: 18
+    Rage: 1
+    RuneBlood: 20
+    RuneChromatic: 29
+    RuneFrost: 21
+    Runes: 5
+    RuneUnholy: 22
+    RunicPower: 6
+    ShadowOrbs: 28
+    SoulShards: 7
 PowerTypeSign:
-  Negative: 1
-  None: -1
-  Positive: 0
+  values:
+    Negative: 1
+    None: -1
+    Positive: 0
 PowerTypeSlot:
-  Slot_0: 0
-  Slot_1: 1
-  Slot_2: 2
-  Slot_3: 3
-  Slot_4: 4
-  Slot_5: 5
-  Slot_6: 6
-  Slot_7: 7
-  Slot_8: 8
-  Slot_9: 9
+  values:
+    Slot_0: 0
+    Slot_1: 1
+    Slot_2: 2
+    Slot_3: 3
+    Slot_4: 4
+    Slot_5: 5
+    Slot_6: 6
+    Slot_7: 7
+    Slot_8: 8
+    Slot_9: 9
 PremadeGroupFinderStyle:
-  Disabled: 0
-  Mainline: 1
-  Vanilla: 2
+  values:
+    Disabled: 0
+    Mainline: 1
+    Vanilla: 2
 PreyHuntProgressState:
-  Cold: 0
-  Final: 3
-  Hot: 2
-  Warm: 1
+  values:
+    Cold: 0
+    Final: 3
+    Hot: 2
+    Warm: 1
 ProceduralSpawnInteractionMode:
-  Manipulate: 2
-  None: 0
-  Paint: 1
+  values:
+    Manipulate: 2
+    None: 0
+    Paint: 1
 ProceduralSpawnVolumeChunkFlags:
-  AllSubChunksSet: 1
-  None: 0
+  values:
+    AllSubChunksSet: 1
+    None: 0
 Profession:
-  Alchemy: 3
-  Archaeology: 14
-  Blacksmithing: 1
-  Cooking: 5
-  Enchanting: 9
-  Engineering: 8
-  FirstAid: 0
-  Fishing: 10
-  Herbalism: 4
-  Inscription: 13
-  Jewelcrafting: 12
-  Leatherworking: 2
-  Mining: 6
-  Skinning: 11
-  Tailoring: 7
+  values:
+    Alchemy: 3
+    Archaeology: 14
+    Blacksmithing: 1
+    Cooking: 5
+    Enchanting: 9
+    Engineering: 8
+    FirstAid: 0
+    Fishing: 10
+    Herbalism: 4
+    Inscription: 13
+    Jewelcrafting: 12
+    Leatherworking: 2
+    Mining: 6
+    Skinning: 11
+    Tailoring: 7
 ProfessionActionType:
-  Craft: 0
-  Gather: 1
+  values:
+    Craft: 0
+    Gather: 1
 ProfessionEffect:
-  AccumulateRanksByLabel: 25
-  ConcentrationRefund: 30
-  DecreaseDifficulty: 22
-  IncreaseDifficulty: 23
-  ModConcentration: 27
-  ModCraftCritSize: 20
-  ModCraftExtraQuantity: 18
-  ModCraftingSpeed: 14
-  ModCraftReductionQuantity: 21
-  ModDeftness: 12
-  ModFinesse: 11
-  ModGatherExtraQuantity: 19
-  ModIngenuity: 29
-  ModInspiration: 9
-  ModMulticraft: 15
-  ModPerception: 13
-  ModResourcefulness: 10
-  ModSkillGain: 24
-  ModUnused_1: 16
-  ModUnused_2: 17
-  Skill: 0
-  StatCraftingSpeed: 6
-  StatDeftness: 4
-  StatFinesse: 3
-  StatIngenuity: 26
-  StatInspiration: 1
-  StatMulticraft: 7
-  StatPerception: 5
-  StatResourcefulness: 2
-  Tokenizer: 28
-  UnlockReagentSlot: 8
+  values:
+    AccumulateRanksByLabel: 25
+    ConcentrationRefund: 30
+    DecreaseDifficulty: 22
+    IncreaseDifficulty: 23
+    ModConcentration: 27
+    ModCraftCritSize: 20
+    ModCraftExtraQuantity: 18
+    ModCraftingSpeed: 14
+    ModCraftReductionQuantity: 21
+    ModDeftness: 12
+    ModFinesse: 11
+    ModGatherExtraQuantity: 19
+    ModIngenuity: 29
+    ModInspiration: 9
+    ModMulticraft: 15
+    ModPerception: 13
+    ModResourcefulness: 10
+    ModSkillGain: 24
+    ModUnused_1: 16
+    ModUnused_2: 17
+    Skill: 0
+    StatCraftingSpeed: 6
+    StatDeftness: 4
+    StatFinesse: 3
+    StatIngenuity: 26
+    StatInspiration: 1
+    StatMulticraft: 7
+    StatPerception: 5
+    StatResourcefulness: 2
+    Tokenizer: 28
+    UnlockReagentSlot: 8
 ProfessionRating:
-  CraftingSpeed: 5
-  Deftness: 3
-  Finesse: 2
-  Ingenuity: 7
-  Inspiration: 0
-  Multicraft: 6
-  Perception: 4
-  Resourcefulness: 1
-  Unused_2: 8
+  values:
+    CraftingSpeed: 5
+    Deftness: 3
+    Finesse: 2
+    Ingenuity: 7
+    Inspiration: 0
+    Multicraft: 6
+    Perception: 4
+    Resourcefulness: 1
+    Unused_2: 8
 ProfessionRatingType:
-  Craft: 0
-  Gather: 1
+  values:
+    Craft: 0
+    Gather: 1
 PurchaseEligibility:
-  ExpansionTooHigh: 4
-  ExpansionTooLow: 3
-  MissingRequiredDeliverable: 5
-  Ok: 0
-  Owned: 2
-  PartiallyOwned: 1
+  values:
+    ExpansionTooHigh: 4
+    ExpansionTooLow: 3
+    MissingRequiredDeliverable: 5
+    Ok: 0
+    Owned: 2
+    PartiallyOwned: 1
 PurchaseHouseDisabledReason:
-  CharterLockout: 7
-  GuildLockout: 6
-  MaxHouses: 8
-  NoExpansion: 4
-  NoGameTimeRemaining: 9
-  None: 0
-  NotInvited: 3
-  Reserved: 5
-  WrongFaction: 1
-  WrongGuild: 2
+  values:
+    CharterLockout: 7
+    GuildLockout: 6
+    MaxHouses: 8
+    NoExpansion: 4
+    NoGameTimeRemaining: 9
+    None: 0
+    NotInvited: 3
+    Reserved: 5
+    WrongFaction: 1
+    WrongGuild: 2
 PurchaseResult:
-  ErrorAuthorizingPayment: 37
-  ErrorBattlepayDisabled: 14
-  ErrorBattlepayTemporarilyUnavailable: 13
-  ErrorBattlepayTimeoutMopAndRisk: 11
-  ErrorBattlepayTimeoutValidatePurchase: 56
-  ErrorBattlepayTimeoutValidationHash: 62
-  ErrorBlockedByParentalControls: 33
-  ErrorBuyingProductNotAllowedInGlueScreen: 27
-  ErrorBuyingProductNotAllowedInWorld: 32
-  ErrorCharacterUpgradeOperationInProgress: 51
-  ErrorClientCheckoutCanceledOrFailed: 63
-  ErrorClientCheckoutTimeout: 60
-  ErrorClientDeclined: 4
-  ErrorClientDeclinedChallenge: 41
-  ErrorClientGone: 9
-  ErrorClientRestricted: 66
-  ErrorClientTimeout: 3
-  ErrorClientTimeoutChallenge: 40
-  ErrorCommerceServerDisabled: 48
-  ErrorCouldNotGetValidationHash: 64
-  ErrorCurrencyInvalidInRegion: 12
-  ErrorDistributionObjectAlreadyAssigned: 20
-  ErrorDistributionObjectExpansionBlocked: 45
-  ErrorDistributionObjectInvalidChoice: 35
-  ErrorDistributionObjectInvalidTarget: 42
-  ErrorDistributionObjectNotFound: 19
-  ErrorDistributionObjectTrialBlocked: 44
-  ErrorDistributionObjectWrongGameAccount: 65
-  ErrorFailedOldPurchaseFlow: 59
-  ErrorFailedToCreatePurchaseRecord: 5
-  ErrorFailedToGetPurchaseID: 6
-  ErrorFailedToSaveClientCheckoutStatus: 58
-  ErrorFailedToSaveMopAndRiskResponse: 8
-  ErrorFailedToSaveMopAndRiskStatus: 7
-  ErrorFailedToSavePlaceOrderStatus: 10
-  ErrorFailedToSaveRedeemTokenStatus: 67
-  ErrorFailedToSaveValidatePurchaseResponse: 55
-  ErrorFailedToSaveValidatePurchaseStatus: 54
-  ErrorFailedToSaveValidationHashStatus: 61
-  ErrorFailedToWriteVasLicenseID: 50
-  ErrorFailedToWriteVasPurchaseID: 49
-  ErrorFixedLicenseProductAlreadyExists: 43
-  ErrorInManualReview: 71
-  ErrorInvalidCreditCardExpiryDate: 36
-  ErrorInvalidDeviceID: 53
-  ErrorInvalidPlatform: 52
-  ErrorInvalidProduct: 16
-  ErrorInvalidPurchaseID: 68
-  ErrorInvalidRegionGroupMask: 17
-  ErrorMopAndRiskAmqpRpcFailed: 22
-  ErrorMopAndRiskNotEnoughBalance: 28
-  ErrorMopAndRiskNoValidPaymentMethods: 25
-  ErrorMopAndRiskRpcErrorFromBattlepay: 23
-  ErrorMopAndRiskUnexpectedResponseFromBattlepay: 24
-  ErrorNoStorePurchaseFlagIsSet: 34
-  ErrorOrderCanceledPriceChange: 26
-  ErrorOrderFailed: 2
-  ErrorOverSpendingLimit: 39
-  ErrorOwnsConsumableToken: 46
-  ErrorPaymentProviderDeniedPayment: 38
-  ErrorPlaceOrderNotEnoughBalance: 29
-  ErrorProductInvalidInRegion: 18
-  ErrorProductNotPurchasable: 57
-  ErrorProgrammerManualFail: 30
-  ErrorRiskDenied: 1
-  ErrorRiskResponseMissingScore: 21
-  ErrorServerRestarted: 15
-  ErrorThrottledByUserServer: 31
-  ErrorTokenRedemptionOrderFailed: 69
-  ErrorTooManyTokens: 47
-  ErrorVasTransactionCreateFailed: 70
-  Ok: 0
+  values:
+    ErrorAuthorizingPayment: 37
+    ErrorBattlepayDisabled: 14
+    ErrorBattlepayTemporarilyUnavailable: 13
+    ErrorBattlepayTimeoutMopAndRisk: 11
+    ErrorBattlepayTimeoutValidatePurchase: 56
+    ErrorBattlepayTimeoutValidationHash: 62
+    ErrorBlockedByParentalControls: 33
+    ErrorBuyingProductNotAllowedInGlueScreen: 27
+    ErrorBuyingProductNotAllowedInWorld: 32
+    ErrorCharacterUpgradeOperationInProgress: 51
+    ErrorClientCheckoutCanceledOrFailed: 63
+    ErrorClientCheckoutTimeout: 60
+    ErrorClientDeclined: 4
+    ErrorClientDeclinedChallenge: 41
+    ErrorClientGone: 9
+    ErrorClientRestricted: 66
+    ErrorClientTimeout: 3
+    ErrorClientTimeoutChallenge: 40
+    ErrorCommerceServerDisabled: 48
+    ErrorCouldNotGetValidationHash: 64
+    ErrorCurrencyInvalidInRegion: 12
+    ErrorDistributionObjectAlreadyAssigned: 20
+    ErrorDistributionObjectExpansionBlocked: 45
+    ErrorDistributionObjectInvalidChoice: 35
+    ErrorDistributionObjectInvalidTarget: 42
+    ErrorDistributionObjectNotFound: 19
+    ErrorDistributionObjectTrialBlocked: 44
+    ErrorDistributionObjectWrongGameAccount: 65
+    ErrorFailedOldPurchaseFlow: 59
+    ErrorFailedToCreatePurchaseRecord: 5
+    ErrorFailedToGetPurchaseID: 6
+    ErrorFailedToSaveClientCheckoutStatus: 58
+    ErrorFailedToSaveMopAndRiskResponse: 8
+    ErrorFailedToSaveMopAndRiskStatus: 7
+    ErrorFailedToSavePlaceOrderStatus: 10
+    ErrorFailedToSaveRedeemTokenStatus: 67
+    ErrorFailedToSaveValidatePurchaseResponse: 55
+    ErrorFailedToSaveValidatePurchaseStatus: 54
+    ErrorFailedToSaveValidationHashStatus: 61
+    ErrorFailedToWriteVasLicenseID: 50
+    ErrorFailedToWriteVasPurchaseID: 49
+    ErrorFixedLicenseProductAlreadyExists: 43
+    ErrorInManualReview: 71
+    ErrorInvalidCreditCardExpiryDate: 36
+    ErrorInvalidDeviceID: 53
+    ErrorInvalidPlatform: 52
+    ErrorInvalidProduct: 16
+    ErrorInvalidPurchaseID: 68
+    ErrorInvalidRegionGroupMask: 17
+    ErrorMopAndRiskAmqpRpcFailed: 22
+    ErrorMopAndRiskNotEnoughBalance: 28
+    ErrorMopAndRiskNoValidPaymentMethods: 25
+    ErrorMopAndRiskRpcErrorFromBattlepay: 23
+    ErrorMopAndRiskUnexpectedResponseFromBattlepay: 24
+    ErrorNoStorePurchaseFlagIsSet: 34
+    ErrorOrderCanceledPriceChange: 26
+    ErrorOrderFailed: 2
+    ErrorOverSpendingLimit: 39
+    ErrorOwnsConsumableToken: 46
+    ErrorPaymentProviderDeniedPayment: 38
+    ErrorPlaceOrderNotEnoughBalance: 29
+    ErrorProductInvalidInRegion: 18
+    ErrorProductNotPurchasable: 57
+    ErrorProgrammerManualFail: 30
+    ErrorRiskDenied: 1
+    ErrorRiskResponseMissingScore: 21
+    ErrorServerRestarted: 15
+    ErrorThrottledByUserServer: 31
+    ErrorTokenRedemptionOrderFailed: 69
+    ErrorTooManyTokens: 47
+    ErrorVasTransactionCreateFailed: 70
+    Ok: 0
 PvPFaction:
-  Alliance: 1
-  Horde: 0
+  values:
+    Alliance: 1
+    Horde: 0
 PvPMatchmakingType:
-  Arena: 1
-  Battleground: 0
+  values:
+    Arena: 1
+    Battleground: 0
 PvPMatchState:
-  Complete: 5
-  Engaged: 3
-  Inactive: 0
-  PostRound: 4
-  StartUp: 2
-  Waiting: 1
+  values:
+    Complete: 5
+    Engaged: 3
+    Inactive: 0
+    PostRound: 4
+    StartUp: 2
+    Waiting: 1
 PvPRanks:
-  Rank_1: 5
-  Rank_10: 14
-  Rank_11: 15
-  Rank_12: 16
-  Rank_13: 17
-  Rank_14: 18
-  Rank_2: 6
-  Rank_3: 7
-  Rank_4: 8
-  Rank_5: 9
-  Rank_6: 10
-  Rank_7: 11
-  Rank_8: 12
-  Rank_9: 13
-  RankDishonored: 4
-  RankExiled: 3
-  RankNone: 0
-  RankOutlaw: 2
-  RankPariah: 1
+  values:
+    Rank_1: 5
+    Rank_10: 14
+    Rank_11: 15
+    Rank_12: 16
+    Rank_13: 17
+    Rank_14: 18
+    Rank_2: 6
+    Rank_3: 7
+    Rank_4: 8
+    Rank_5: 9
+    Rank_6: 10
+    Rank_7: 11
+    Rank_8: 12
+    Rank_9: 13
+    RankDishonored: 4
+    RankExiled: 3
+    RankNone: 0
+    RankOutlaw: 2
+    RankPariah: 1
 PvPUnitClassification:
-  AssassinAlliance: 6
-  AssassinHorde: 5
-  CartRunnerAlliance: 4
-  CartRunnerHorde: 3
-  FlagCarrierAlliance: 1
-  FlagCarrierHorde: 0
-  FlagCarrierNeutral: 2
-  OrbCarrierBlue: 7
-  OrbCarrierGreen: 8
-  OrbCarrierOrange: 9
-  OrbCarrierPurple: 10
+  values:
+    AssassinAlliance: 6
+    AssassinHorde: 5
+    CartRunnerAlliance: 4
+    CartRunnerHorde: 3
+    FlagCarrierAlliance: 1
+    FlagCarrierHorde: 0
+    FlagCarrierNeutral: 2
+    OrbCarrierBlue: 7
+    OrbCarrierGreen: 8
+    OrbCarrierOrange: 9
+    OrbCarrierPurple: 10
 QuestClassification:
-  BonusObjective: 8
-  Calling: 3
-  Campaign: 2
-  Important: 0
-  Legendary: 1
-  Meta: 4
-  Normal: 7
-  Questline: 6
-  Recurring: 5
-  Threat: 9
-  WorldQuest: 10
+  values:
+    BonusObjective: 8
+    Calling: 3
+    Campaign: 2
+    Important: 0
+    Legendary: 1
+    Meta: 4
+    Normal: 7
+    Questline: 6
+    Recurring: 5
+    Threat: 9
+    WorldQuest: 10
 QuestCompleteSpellType:
-  Ability: 3
-  Aura: 4
-  Companion: 7
-  Follower: 1
-  LegacyBehavior: 0
-  PossibleReward: 11
-  QuestlineReward: 9
-  QuestlineUnlock: 8
-  QuestlineUnlockPart: 10
-  Spell: 5
-  Tradeskill: 2
-  Unlock: 6
+  values:
+    Ability: 3
+    Aura: 4
+    Companion: 7
+    Follower: 1
+    LegacyBehavior: 0
+    PossibleReward: 11
+    QuestlineReward: 9
+    QuestlineUnlock: 8
+    QuestlineUnlockPart: 10
+    Spell: 5
+    Tradeskill: 2
+    Unlock: 6
 QuestFrequency:
-  Daily: 1
-  Default: 0
-  ResetByScheduler: 3
-  Weekly: 2
+  values:
+    Daily: 1
+    Default: 0
+    ResetByScheduler: 3
+    Weekly: 2
 QuestLineFloorLocation:
-  Above: 0
-  Below: 1
-  Same: 2
+  values:
+    Above: 0
+    Below: 1
+    Same: 2
 QuestRepeatability:
-  Daily: 1
-  None: 0
-  Turnin: 3
-  Weekly: 2
-  World: 4
+  values:
+    Daily: 1
+    None: 0
+    Turnin: 3
+    Weekly: 2
+    World: 4
 QuestRewardContextFlags:
-  FirstCompletionBonus: 1
-  None: 0
-  RepeatCompletionBonus: 2
+  values:
+    FirstCompletionBonus: 1
+    None: 0
+    RepeatCompletionBonus: 2
 QuestSessionCommand:
-  None: 0
-  SessionActiveNoCommand: 3
-  Start: 1
-  Stop: 2
+  values:
+    None: 0
+    SessionActiveNoCommand: 3
+    Start: 1
+    Stop: 2
 QuestSessionResult:
-  AlreadyActive: 3
-  AlreadyJoined: 20
-  AlreadyMember: 17
-  AlreadyOwner: 19
-  Busy: 22
-  Disabled: 8
-  Empty: 25
-  InCombat: 32
-  InPetBattle: 29
-  InRaid: 5
-  InvalidOwner: 2
-  InvalidPublicParty: 30
-  Joined: 11
-  JoinRejected: 23
-  Left: 12
-  Logout: 24
-  MemberInCombat: 33
-  MemberTimeout: 16
-  NotActive: 4
-  NotInParty: 1
-  NotMember: 21
-  NotOwner: 18
-  Ok: 0
-  OwnerLeft: 13
-  OwnerRefused: 6
-  PartyDestroyed: 15
-  QuestNotCompleted: 26
-  ReadyCheckFailed: 14
-  Restricted: 28
-  RestrictedCrossFaction: 34
-  Resync: 27
-  Started: 9
-  Stopped: 10
-  Timeout: 7
-  Unknown: 31
+  values:
+    AlreadyActive: 3
+    AlreadyJoined: 20
+    AlreadyMember: 17
+    AlreadyOwner: 19
+    Busy: 22
+    Disabled: 8
+    Empty: 25
+    InCombat: 32
+    InPetBattle: 29
+    InRaid: 5
+    InvalidOwner: 2
+    InvalidPublicParty: 30
+    Joined: 11
+    JoinRejected: 23
+    Left: 12
+    Logout: 24
+    MemberInCombat: 33
+    MemberTimeout: 16
+    NotActive: 4
+    NotInParty: 1
+    NotMember: 21
+    NotOwner: 18
+    Ok: 0
+    OwnerLeft: 13
+    OwnerRefused: 6
+    PartyDestroyed: 15
+    QuestNotCompleted: 26
+    ReadyCheckFailed: 14
+    Restricted: 28
+    RestrictedCrossFaction: 34
+    Resync: 27
+    Started: 9
+    Stopped: 10
+    Timeout: 7
+    Unknown: 31
 QuestTag:
-  Account: 102
-  Delve: 288
-  Dungeon: 81
-  Group: 1
-  Heroic: 85
-  Legendary: 83
-  PvP: 41
-  Raid: 62
-  Raid10: 88
-  Raid25: 89
-  Scenario: 98
+  values:
+    Account: 102
+    Delve: 288
+    Dungeon: 81
+    Group: 1
+    Heroic: 85
+    Legendary: 83
+    PvP: 41
+    Raid: 62
+    Raid10: 88
+    Raid25: 89
+    Scenario: 98
 QuestTagType:
-  Bounty: 5
-  Capstone: 17
-  Contribution: 9
-  CovenantCalling: 15
-  DragonRiderRacing: 16
-  Dungeon: 6
-  FactionAssault: 12
-  Invasion: 7
-  InvasionWrapper: 11
-  Islands: 13
-  Normal: 2
-  PetBattle: 4
-  Prey: 19
-  Profession: 1
-  PvP: 3
-  Raid: 8
-  RatedReward: 10
-  Tag: 0
-  Threat: 14
-  WorldBoss: 18
+  values:
+    Bounty: 5
+    Capstone: 17
+    Contribution: 9
+    CovenantCalling: 15
+    DragonRiderRacing: 16
+    Dungeon: 6
+    FactionAssault: 12
+    Invasion: 7
+    InvasionWrapper: 11
+    Islands: 13
+    Normal: 2
+    PetBattle: 4
+    Prey: 19
+    Profession: 1
+    PvP: 3
+    Raid: 8
+    RatedReward: 10
+    Tag: 0
+    Threat: 14
+    WorldBoss: 18
 QuestTreasurePickerType:
-  Hidden: 1
-  Select: 2
-  Visible: 0
+  values:
+    Hidden: 1
+    Select: 2
+    Visible: 0
 RafLinkType:
-  Both: 3
-  Friend: 2
-  None: 0
-  Recruit: 1
+  values:
+    Both: 3
+    Friend: 2
+    None: 0
+    Recruit: 1
 RafRecruitActivityState:
-  Complete: 1
-  Incomplete: 0
-  RewardClaimed: 2
+  values:
+    Complete: 1
+    Incomplete: 0
+    RewardClaimed: 2
 RafRecruitSubStatus:
-  Active: 1
-  Inactive: 2
-  Trial: 0
+  values:
+    Active: 1
+    Inactive: 2
+    Trial: 0
 RafRewardType:
-  Appearance: 2
-  AppearanceSet: 5
-  GameTime: 4
-  Illusion: 6
-  Invalid: 7
-  Mount: 1
-  Pet: 0
-  Title: 3
+  values:
+    Appearance: 2
+    AppearanceSet: 5
+    GameTime: 4
+    Illusion: 6
+    Invalid: 7
+    Mount: 1
+    Pet: 0
+    Title: 3
 RaidAuraOrganizationType:
-  BuffsRightDebuffsLeft: 2
-  BuffsTopDebuffsBottom: 1
-  Legacy: 0
+  values:
+    BuffsRightDebuffsLeft: 2
+    BuffsTopDebuffsBottom: 1
+    Legacy: 0
 RaidDispelDisplayType:
-  Disabled: 0
-  DispellableByMe: 1
-  DisplayAll: 2
+  values:
+    Disabled: 0
+    DispellableByMe: 1
+    DisplayAll: 2
 RaidGroupDisplayType:
-  CombineGroupsHorizontal: 3
-  CombineGroupsVertical: 2
-  SeparateGroupsHorizontal: 1
-  SeparateGroupsVertical: 0
+  values:
+    CombineGroupsHorizontal: 3
+    CombineGroupsVertical: 2
+    SeparateGroupsHorizontal: 1
+    SeparateGroupsVertical: 0
 RcoCloseReason:
-  Cancel: 2
-  CrafterFulfill: 5
-  Expire: 1
-  Fulfill: 0
-  GmCancel: 4
-  Invalid: 6
-  Reject: 3
+  values:
+    Cancel: 2
+    CrafterFulfill: 5
+    Expire: 1
+    Fulfill: 0
+    GmCancel: 4
+    Invalid: 6
+    Reject: 3
 RecentAllyPinResult:
-  ServerError: 1
-  Success: 0
+  values:
+    ServerError: 1
+    Success: 0
 RecruitAFriendRewardsVersion:
-  InvalidVersion: 0
-  UnusedVersionOne: 1
-  VersionThree: 3
-  VersionTwo: 2
+  values:
+    InvalidVersion: 0
+    UnusedVersionOne: 1
+    VersionThree: 3
+    VersionTwo: 2
 ReforgeFailedReason:
-  None: 0
-  ReforgeAlreadyHasDstStat: 3
-  ReforgeInsufficientSrcStat: 2
-  ReforgeItemTooLowLevel: 4
-  ReforgeSrcStatNotFound: 1
+  values:
+    None: 0
+    ReforgeAlreadyHasDstStat: 3
+    ReforgeInsufficientSrcStat: 2
+    ReforgeItemTooLowLevel: 4
+    ReforgeSrcStatNotFound: 1
 RegisterAddonMessagePrefixResult:
-  DuplicatePrefix: 1
-  InvalidPrefix: 2
-  MaxPrefixes: 3
-  Success: 0
+  values:
+    DuplicatePrefix: 1
+    InvalidPrefix: 2
+    MaxPrefixes: 3
+    Success: 0
 RelativeContentDifficulty:
-  Difficult: 3
-  Easy: 1
-  Fair: 2
-  Impossible: 4
-  Trivial: 0
+  values:
+    Difficult: 3
+    Easy: 1
+    Fair: 2
+    Impossible: 4
+    Trivial: 0
 ReleaseType:
-  Classic: 2
-  Original: 1
+  values:
+    Classic: 2
+    Original: 1
 RenownRewardDisplayType:
-  Currency: 9
-  GarrFollower: 8
-  Item: 1
-  Mount: 3
-  None: 0
-  Spell: 2
-  Title: 7
-  Transmog: 4
-  TransmogIllusion: 6
-  TransmogSet: 5
+  values:
+    Currency: 9
+    GarrFollower: 8
+    Item: 1
+    Mount: 3
+    None: 0
+    Spell: 2
+    Title: 7
+    Transmog: 4
+    TransmogIllusion: 6
+    TransmogSet: 5
 RenownRewardsFlags:
-  AccountUnlock: 8
-  Capstone: 2
-  Hidden: 4
-  Milestone: 1
+  values:
+    AccountUnlock: 8
+    Capstone: 2
+    Hidden: 4
+    Milestone: 1
 ReportEvidenceType:
-  HouseLayoutJson: 2
-  HouseScreenshot: 1
-  Invalid: 0
+  values:
+    HouseLayoutJson: 2
+    HouseScreenshot: 1
+    Invalid: 0
 ReportMajorCategory:
-  Cheating: 2
-  GameplaySabotage: 1
-  InappropriateCommunication: 0
-  InappropriateDecor: 4
-  InappropriateName: 3
+  values:
+    Cheating: 2
+    GameplaySabotage: 1
+    InappropriateCommunication: 0
+    InappropriateDecor: 4
+    InappropriateName: 3
 ReportMinorCategory:
-  Advertisement: 256
-  Afk: 8
-  BlockingProgress: 32
-  Boosting: 2
-  Botting: 128
-  BTag: 512
-  CharacterName: 2048
-  ChildSexualExploitationAndAbuse: 262144
-  Description: 8192
-  Disruption: 65536
-  GroupName: 1024
-  GuildName: 4096
-  Hacking: 64
-  HarmfulToMinors: 32768
-  IntentionallyFeeding: 16
-  Name: 16384
-  NeighborhoodName: 524288
-  Spam: 4
-  TerroristAndViolentExtremistContent: 131072
-  TextChat: 1
+  values:
+    Advertisement: 256
+    Afk: 8
+    BlockingProgress: 32
+    Boosting: 2
+    Botting: 128
+    BTag: 512
+    CharacterName: 2048
+    ChildSexualExploitationAndAbuse: 262144
+    Description: 8192
+    Disruption: 65536
+    GroupName: 1024
+    GuildName: 4096
+    Hacking: 64
+    HarmfulToMinors: 32768
+    IntentionallyFeeding: 16
+    Name: 16384
+    NeighborhoodName: 524288
+    Spam: 4
+    TerroristAndViolentExtremistContent: 131072
+    TextChat: 1
 ReportSubComplaintTypes:
-  Advertising: 1
-  Inappropriate: 0
+  values:
+    Advertising: 1
+    Inappropriate: 0
 ReportThrottleType:
-  Expensive: 2
-  General: 1
-  Invalid: 0
+  values:
+    Expensive: 2
+    General: 1
+    Invalid: 0
 ReportType:
-  BattlePet: 10
-  Calendar: 11
-  Chat: 0
-  ClubFinderApplicant: 3
-  ClubFinderPosting: 2
-  ClubMember: 6
-  CraftingOrder: 16
-  Friend: 8
-  GroupFinderApplicant: 5
-  GroupFinderPosting: 4
-  GroupMember: 7
-  HousingDecor: 18
-  InWorld: 1
-  Mail: 12
-  Neighborhood: 19
-  NeighborhoodRoster: 20
-  Pet: 9
-  PvP: 13
-  PvPGroupMember: 15
-  PvPScoreboard: 14
-  RecentAlly: 17
+  values:
+    BattlePet: 10
+    Calendar: 11
+    Chat: 0
+    ClubFinderApplicant: 3
+    ClubFinderPosting: 2
+    ClubMember: 6
+    CraftingOrder: 16
+    Friend: 8
+    GroupFinderApplicant: 5
+    GroupFinderPosting: 4
+    GroupMember: 7
+    HousingDecor: 18
+    InWorld: 1
+    Mail: 12
+    Neighborhood: 19
+    NeighborhoodRoster: 20
+    Pet: 9
+    PvP: 13
+    PvPGroupMember: 15
+    PvPScoreboard: 14
+    RecentAlly: 17
 ReservationFlags:
-  Canceled: 2
-  None: 0
-  Plotless: 4
-  Relinquish: 1
+  values:
+    Canceled: 2
+    None: 0
+    Plotless: 4
+    Relinquish: 1
 ResidentType:
-  Manager: 1
-  Owner: 2
-  Resident: 0
+  values:
+    Manager: 1
+    Owner: 2
+    Resident: 0
 RestrictPingsTo:
-  Assist: 2
-  Lead: 1
-  None: 0
-  TankHealer: 3
+  values:
+    Assist: 2
+    Lead: 1
+    None: 0
+    TankHealer: 3
 RetroactiveDecorRewardFlags:
-  AllCriteriaRequired: 1
-  None: 0
+  values:
+    AllCriteriaRequired: 1
+    None: 0
 RolodexContextLevelType:
-  DelveTier: 3
-  Difficulty: 1
-  KeystoneLevel: 2
-  None: 0
+  values:
+    DelveTier: 3
+    Difficulty: 1
+    KeystoneLevel: 2
+    None: 0
 RolodexType:
-  CompleteArena: 16
-  CompleteBg: 17
-  CompleteDelve: 15
-  CompleteDungeon: 12
-  CreatureKill: 11
-  Duel: 18
-  GuildOrderFilledByOther: 9
-  GuildOrderFilledByYou: 10
-  KillLfrBoss: 14
-  KillRaidBoss: 13
-  None: 0
-  PartyMember: 1
-  PersonalOrderFilledByOther: 7
-  PersonalOrderFilledByYou: 8
-  PetBattle: 19
-  PublicOrderFilledByOther: 5
-  PublicOrderFilledByYou: 6
-  PvPKill: 20
-  RaidMember: 2
-  Trade: 3
-  Whisper: 4
+  values:
+    CompleteArena: 16
+    CompleteBg: 17
+    CompleteDelve: 15
+    CompleteDungeon: 12
+    CreatureKill: 11
+    Duel: 18
+    GuildOrderFilledByOther: 9
+    GuildOrderFilledByYou: 10
+    KillLfrBoss: 14
+    KillRaidBoss: 13
+    None: 0
+    PartyMember: 1
+    PersonalOrderFilledByOther: 7
+    PersonalOrderFilledByYou: 8
+    PetBattle: 19
+    PublicOrderFilledByOther: 5
+    PublicOrderFilledByYou: 6
+    PvPKill: 20
+    RaidMember: 2
+    Trade: 3
+    Whisper: 4
 RolodexTypeFlags:
-  HiddenFromHistory: 1
-  None: 0
+  values:
+    HiddenFromHistory: 1
+    None: 0
 RoomConnectionType:
-  All: 1
-  None: 0
+  values:
+    All: 1
+    None: 0
 ScalingArmorType:
-  Cloth: 0
-  Leather: 1
-  Mail: 2
-  Plate: 3
+  values:
+    Cloth: 0
+    Leather: 1
+    Mail: 2
+    Plate: 3
 ScreenLocationType:
-  Bottom: 4
-  Center: 0
-  Left: 1
-  LeftOutside: 7
-  LeftRight: 9
-  LeftRightOutside: 11
-  Right: 2
-  RightOutside: 8
-  Top: 3
-  TopBottom: 10
-  TopLeft: 5
-  TopRight: 6
+  values:
+    Bottom: 4
+    Center: 0
+    Left: 1
+    LeftOutside: 7
+    LeftRight: 9
+    LeftRightOutside: 11
+    Right: 2
+    RightOutside: 8
+    Top: 3
+    TopBottom: 10
+    TopLeft: 5
+    TopRight: 6
 ScreenshotSource:
-  Automatic: 0
-  Cheat: 2
-  PlayerReport: 1
+  values:
+    Automatic: 0
+    Cheat: 2
+    PlayerReport: 1
 ScriptedAnimationBehavior:
-  None: 0
-  SourceCollideWithTarget: 4
-  SourceRecoil: 3
-  TargetKnockBack: 2
-  TargetShake: 1
-  UIParentShake: 5
+  values:
+    None: 0
+    SourceCollideWithTarget: 4
+    SourceRecoil: 3
+    TargetKnockBack: 2
+    TargetShake: 1
+    UIParentShake: 5
 ScriptedAnimationFlags:
-  UseTargetAsSource: 1
+  values:
+    UseTargetAsSource: 1
 ScriptedAnimationTrajectory:
-  AtSource: 0
-  AtTarget: 1
-  CurveLeft: 3
-  CurveRandom: 5
-  CurveRight: 4
-  HalfwayBetween: 6
-  Straight: 2
+  values:
+    AtSource: 0
+    AtTarget: 1
+    CurveLeft: 3
+    CurveRandom: 5
+    CurveRight: 4
+    HalfwayBetween: 6
+    Straight: 2
 ScrubStringFlags:
-  AllowBarCodes: 2
-  None: 0
-  StripControlCodes: 4
-  TruncateNewLines: 1
+  values:
+    AllowBarCodes: 2
+    None: 0
+    StripControlCodes: 4
+    TruncateNewLines: 1
 SeasonID:
-  Fresh: 11
-  FreshHardcore: 12
-  Hardcore: 3
-  NoSeason: 0
-  SeasonOfDiscovery: 2
-  SeasonOfMastery: 1
+  values:
+    Fresh: 11
+    FreshHardcore: 12
+    Hardcore: 3
+    NoSeason: 0
+    SeasonOfDiscovery: 2
+    SeasonOfMastery: 1
 SecondsFormatterAbbreviation:
-  None: 0
-  OneLetter: 2
-  Truncate: 1
+  values:
+    None: 0
+    OneLetter: 2
+    Truncate: 1
 SecondsFormatterInterval:
-  Days: 3
-  Hours: 2
-  Minutes: 1
-  Seconds: 0
+  values:
+    Days: 3
+    Hours: 2
+    Minutes: 1
+    Seconds: 0
 SecondsFormatterIntervalWhitespace:
-  Preserve: 0
-  Strip: 1
-  StripIgnoreLocale: 2
+  values:
+    Preserve: 0
+    Strip: 1
+    StripIgnoreLocale: 2
 SecrecyLevel:
-  AlwaysSecret: 1
-  ContextuallySecret: 2
-  NeverSecret: 0
+  values:
+    AlwaysSecret: 1
+    ContextuallySecret: 2
+    NeverSecret: 0
 SecretAspect:
-  Alpha: 128
-  Attributes: 1
-  BarValue: 16384
-  ButtonState: 2097152
-  Cooldown: 32768
-  CooldownStyle: 524288
-  Cursor: 1024
-  Desaturation: 4096
-  FrameLevel: 256
-  Hierarchy: 1
-  ID: 2
-  MinimumWidth: 131072
-  ObjectDebug: 1
-  ObjectName: 1
-  ObjectSecrets: 1
-  ObjectSecurity: 1
-  ObjectType: 1
-  Padding: 262144
-  Rotation: 65536
-  Scale: 64
-  ScrollOffset: 4194304
-  ScrollRange: 512
-  SecureText: 16
-  Shown: 32
-  TexCoords: 8192
-  Text: 8
-  TooltipTexture: 1048576
-  Toplevel: 4
-  VertexColor: 2048
+  values:
+    Alpha: 128
+    Attributes: 1
+    BarValue: 16384
+    ButtonState: 2097152
+    Cooldown: 32768
+    CooldownStyle: 524288
+    Cursor: 1024
+    Desaturation: 4096
+    FrameLevel: 256
+    Hierarchy: 1
+    ID: 2
+    MinimumWidth: 131072
+    ObjectDebug: 1
+    ObjectName: 1
+    ObjectSecrets: 1
+    ObjectSecurity: 1
+    ObjectType: 1
+    Padding: 262144
+    Rotation: 65536
+    Scale: 64
+    ScrollOffset: 4194304
+    ScrollRange: 512
+    SecureText: 16
+    Shown: 32
+    TexCoords: 8192
+    Text: 8
+    TooltipTexture: 1048576
+    Toplevel: 4
+    VertexColor: 2048
 SelfResurrectOptionType:
-  Item: 1
-  Spell: 0
+  values:
+    Item: 1
+    Spell: 0
 SendAddonMessageResult:
-  AddOnMessageLockdown: 11
-  AddonMessageThrottle: 3
-  ChannelThrottle: 8
-  GeneralError: 9
-  InvalidChannel: 7
-  InvalidChatType: 4
-  InvalidMessage: 2
-  InvalidPrefix: 1
-  NotInGroup: 5
-  NotInGuild: 10
-  Success: 0
-  TargetOffline: 12
-  TargetRequired: 6
+  values:
+    AddOnMessageLockdown: 11
+    AddonMessageThrottle: 3
+    ChannelThrottle: 8
+    GeneralError: 9
+    InvalidChannel: 7
+    InvalidChatType: 4
+    InvalidMessage: 2
+    InvalidPrefix: 1
+    NotInGroup: 5
+    NotInGuild: 10
+    Success: 0
+    TargetOffline: 12
+    TargetRequired: 6
 SendReportResult:
-  GeneralError: 1
-  RequiresChatLine: 3
-  RequiresChatLineOrVoice: 4
-  RequiresScreenshot: 5
-  Success: 0
-  TooManyReports: 2
+  values:
+    GeneralError: 1
+    RequiresChatLine: 3
+    RequiresChatLineOrVoice: 4
+    RequiresScreenshot: 5
+    Success: 0
+    TooManyReports: 2
 SharedStringFlag:
-  InternalOnly: 1
+  values:
+    InternalOnly: 1
 ShutdownSessionReason:
-  AccountLoginCommand: 4
-  Error: 6
-  ForceLogoutCommand: 2
-  LuaScript: 5
-  RealmSelectCommand: 3
-  RestartSessionCommand: 1
-  SessionEnded: 0
+  values:
+    AccountLoginCommand: 4
+    Error: 6
+    ForceLogoutCommand: 2
+    LuaScript: 5
+    RealmSelectCommand: 3
+    RestartSessionCommand: 1
+    SessionEnded: 0
 Siflag:
-  Affectedbyaltitude: 16
-  Affectedbysanity: 2048
-  AutocreatedByBroadcastText: 4
-  CasterOwnsTargetSound: 128
-  Disablepositionallpf: 1
-  Dontplayindoors: 256
-  Dontplayunderwater: 1024
-  Dontstopondeath: 4096
-  Ignoresuppressors: 64
-  Ignorevopriority: 16384
-  Looping: 512
-  Noduplicates: 32
-  None: 0
-  Onlyplayindoors: 32768
-  Onlyplayunderwater: 65536
-  Playonlyforowner: 8192
-  Playsequential: 8
-  UseModCastSpeed: 2
+  values:
+    Affectedbyaltitude: 16
+    Affectedbysanity: 2048
+    AutocreatedByBroadcastText: 4
+    CasterOwnsTargetSound: 128
+    Disablepositionallpf: 1
+    Dontplayindoors: 256
+    Dontplayunderwater: 1024
+    Dontstopondeath: 4096
+    Ignoresuppressors: 64
+    Ignorevopriority: 16384
+    Looping: 512
+    Noduplicates: 32
+    None: 0
+    Onlyplayindoors: 32768
+    Onlyplayunderwater: 65536
+    Playonlyforowner: 8192
+    Playsequential: 8
+    UseModCastSpeed: 2
 SimpleOrderStatus:
-  Creating: 1
-  Failed: 4
-  InProgress: 2
-  Invalid: 0
-  Success: 3
+  values:
+    Creating: 1
+    Failed: 4
+    InProgress: 2
+    Invalid: 0
+    Success: 3
 SleevesGeoRange:
-  Default: 1
-  Flared: 2
-  None: 0
-  PandaCollar: 4
-  Puffy: 3
+  values:
+    Default: 1
+    Flared: 2
+    None: 0
+    PandaCollar: 4
+    Puffy: 3
 SlotRegion:
-  AccountBank: 5
-  CharacterBank: 4
-  Invalid: 0
-  PlayerBags: 2
-  PlayerEquip: 1
-  PlayerInv: 3
+  values:
+    AccountBank: 5
+    CharacterBank: 4
+    Invalid: 0
+    PlayerBags: 2
+    PlayerEquip: 1
+    PlayerInv: 3
 SlotRegionMask:
-  AccountBank: 64
-  CharacterBank: 16
-  Invalid: 1
-  PlayerBags: 4
-  PlayerEquip: 2
-  PlayerInv: 8
+  values:
+    AccountBank: 64
+    CharacterBank: 16
+    Invalid: 1
+    PlayerBags: 4
+    PlayerEquip: 2
+    PlayerInv: 8
 SocialWhoOrigin:
-  Chat: 2
-  Item: 3
-  Social: 1
-  Unknown: 0
+  values:
+    Chat: 2
+    Item: 3
+    Social: 1
+    Unknown: 0
 SoftTargetEnableFlags:
-  Any: 3
-  Gamepad: 1
-  Kbm: 2
-  None: 0
+  values:
+    Any: 3
+    Gamepad: 1
+    Kbm: 2
+    None: 0
 SortPlayersBy:
-  Alphabetical: 2
-  Group: 1
-  Role: 0
+  values:
+    Alphabetical: 2
+    Group: 1
+    Role: 0
 SoundBusFlag:
-  Disablepositionallpf: 1
+  values:
+    Disablepositionallpf: 1
 SpecializationSystem:
-  ChrSpecialization: 1
-  TalentTab: 0
+  values:
+    ChrSpecialization: 1
+    TalentTab: 0
 SpellAuraVisibilityType:
-  EnemyTarget: 2
-  RaidInCombat: 0
-  RaidOutOfCombat: 1
+  values:
+    EnemyTarget: 2
+    RaidInCombat: 0
+    RaidOutOfCombat: 1
 SpellBookItemType:
-  Flyout: 4
-  FutureSpell: 2
-  None: 0
-  PetAction: 3
-  Spell: 1
+  values:
+    Flyout: 4
+    FutureSpell: 2
+    None: 0
+    PetAction: 3
+    Spell: 1
 SpellBookSpellBank:
-  Pet: 1
-  Player: 0
+  values:
+    Pet: 1
+    Player: 0
 SpellDiminishCategory:
-  AoEKnockback: 3
-  Disarm: 7
-  Disorient: 5
-  Incapacitate: 4
-  Root: 0
-  Silence: 6
-  Stun: 2
-  Taunt: 1
+  values:
+    AoEKnockback: 3
+    Disarm: 7
+    Disorient: 5
+    Incapacitate: 4
+    Root: 0
+    Silence: 6
+    Stun: 2
+    Taunt: 1
 SpellDiminishRuleset:
-  None: 0
-  PvE: 1
-  PvP: 2
+  values:
+    None: 0
+    PvE: 1
+    PvP: 2
 SpellDisplayBorderColor:
-  Black: 1
-  Blue: 8
-  Green: 7
-  None: 0
-  Orange: 5
-  Purple: 6
-  Red: 3
-  White: 2
-  Yellow: 4
+  values:
+    Black: 1
+    Blue: 8
+    Green: 7
+    None: 0
+    Orange: 5
+    Purple: 6
+    Red: 3
+    White: 2
+    Yellow: 4
 SpellDisplayIconDisplayType:
-  Buff: 0
-  Circular: 2
-  Debuff: 1
-  NoBorder: 3
+  values:
+    Buff: 0
+    Circular: 2
+    Debuff: 1
+    NoBorder: 3
 SpellDisplayTextShownStateType:
-  Hidden: 1
-  Shown: 0
+  values:
+    Hidden: 1
+    Shown: 0
 SpellDisplayTint:
-  None: 0
-  Red: 1
+  values:
+    None: 0
+    Red: 1
 SplashScreenType:
-  SeasonRollOver: 1
-  WhatsNew: 0
+  values:
+    SeasonRollOver: 1
+    WhatsNew: 0
 StableResult:
-  AlreadyStabled: 5
-  AlreadySummoned: 6
-  BuySlotSuccess: 14
-  CantControlExotic: 11
-  CheckForLuaHack: 13
-  FavoriteToggle: 15
-  InsufficientFunds: 1
-  InternalError: 12
-  InvalidSlot: 3
-  MaxSlots: 0
-  NoPet: 4
-  NotFound: 7
-  NotStableMaster: 2
-  PetRenamed: 16
-  ReviveSuccess: 10
-  StableSuccess: 8
-  UnstableSuccess: 9
+  values:
+    AlreadyStabled: 5
+    AlreadySummoned: 6
+    BuySlotSuccess: 14
+    CantControlExotic: 11
+    CheckForLuaHack: 13
+    FavoriteToggle: 15
+    InsufficientFunds: 1
+    InternalError: 12
+    InvalidSlot: 3
+    MaxSlots: 0
+    NoPet: 4
+    NotFound: 7
+    NotStableMaster: 2
+    PetRenamed: 16
+    ReviveSuccess: 10
+    StableSuccess: 8
+    UnstableSuccess: 9
 StartTimerType:
-  ChallengeModeCountdown: 1
-  PlayerCountdown: 2
-  PlunderstormCountdown: 3
-  PvPBeginTimer: 0
+  values:
+    ChallengeModeCountdown: 1
+    PlayerCountdown: 2
+    PlunderstormCountdown: 3
+    PvPBeginTimer: 0
 StatusBarColorTintValue:
-  Black: 1
-  Blue: 8
-  Green: 7
-  None: 0
-  Orange: 5
-  Purple: 6
-  Red: 3
-  White: 2
-  Yellow: 4
+  values:
+    Black: 1
+    Blue: 8
+    Green: 7
+    None: 0
+    Orange: 5
+    Purple: 6
+    Red: 3
+    White: 2
+    Yellow: 4
 StatusBarFillStyle:
-  Center: 2
-  Reverse: 3
-  Standard: 0
-  StandardNoRangeFill: 1
+  values:
+    Center: 2
+    Reverse: 3
+    Standard: 0
+    StandardNoRangeFill: 1
 StatusBarInterpolation:
-  ExponentialEaseOut: 1
-  Immediate: 0
+  values:
+    ExponentialEaseOut: 1
+    Immediate: 0
 StatusBarOverrideBarTextShownType:
-  Always: 1
-  Never: 0
-  OnlyNotOnMouseover: 3
-  OnlyOnMouseover: 2
+  values:
+    Always: 1
+    Never: 0
+    OnlyNotOnMouseover: 3
+    OnlyOnMouseover: 2
 StatusBarTimerDirection:
-  ElapsedTime: 0
-  RemainingTime: 1
+  values:
+    ElapsedTime: 0
+    RemainingTime: 1
 StatusBarValueTextType:
-  Hidden: 0
-  Percentage: 1
-  Time: 3
-  TimeShowOneLevelOnly: 4
-  Value: 2
-  ValueOverMax: 5
-  ValueOverMaxNormalized: 6
+  values:
+    Hidden: 0
+    Percentage: 1
+    Time: 3
+    TimeShowOneLevelOnly: 4
+    Value: 2
+    ValueOverMax: 5
+    ValueOverMaxNormalized: 6
 StoreDeliveryType:
-  Battlepet: 2
-  Collection: 3
-  Item: 0
-  Mount: 1
+  values:
+    Battlepet: 2
+    Collection: 3
+    Item: 0
+    Mount: 1
 StoreError:
-  AlreadyOwned: 7
-  BattlepayDisabled: 4
-  ClientRestricted: 13
-  ConsumableTokenOwned: 10
-  InsufficientBalance: 5
-  InvalidPaymentMethod: 1
-  ItemUnavailable: 12
-  Other: 6
-  ParentalControlsNoPurchase: 8
-  PaymentFailed: 2
-  PurchaseDenied: 9
-  Success: 0
-  TooManyTokens: 11
-  WrongCurrency: 3
+  values:
+    AlreadyOwned: 7
+    BattlepayDisabled: 4
+    ClientRestricted: 13
+    ConsumableTokenOwned: 10
+    InsufficientBalance: 5
+    InvalidPaymentMethod: 1
+    ItemUnavailable: 12
+    Other: 6
+    ParentalControlsNoPurchase: 8
+    PaymentFailed: 2
+    PurchaseDenied: 9
+    Success: 0
+    TooManyTokens: 11
+    WrongCurrency: 3
 SubcontainerType:
-  AccountBankTabs: 36
-  Auction: 5
-  Bag: 0
-  Bankbag: 3
-  Bankgeneric: 2
-  BuybackSlots: 26
-  CachedReward: 27
-  CharacterBankTabs: 38
-  Childequipmentstorage: 23
-  CraftingOrder: 34
-  CraftingOrderReagents: 35
-  CreatedImmediately: 25
-  CurrencytokenOboslete: 15
-  CurrencyTransfer: 37
-  Equipablespells: 14
-  Equipped: 1
-  EquippedBags: 28
-  EquippedCooking: 31
-  EquippedFishing: 32
-  EquippedProfession1: 29
-  EquippedProfession2: 30
-  EquippedReagentbag: 33
-  GuildBank0: 7
-  GuildBank1: 8
-  GuildBank10: 20
-  GuildBank11: 21
-  GuildBank2: 9
-  GuildBank3: 10
-  GuildBank4: 11
-  GuildBank5: 12
-  GuildBank6: 16
-  GuildBank7: 17
-  GuildBank8: 18
-  GuildBank9: 19
-  GuildOverflow: 13
-  HousingDecorConversion: 39
-  Keyring: 6
-  Mail: 4
-  Quarantine: 24
-  ReagentbankObsolete: 22
+  values:
+    AccountBankTabs: 36
+    Auction: 5
+    Bag: 0
+    Bankbag: 3
+    Bankgeneric: 2
+    BuybackSlots: 26
+    CachedReward: 27
+    CharacterBankTabs: 38
+    Childequipmentstorage: 23
+    CraftingOrder: 34
+    CraftingOrderReagents: 35
+    CreatedImmediately: 25
+    CurrencytokenOboslete: 15
+    CurrencyTransfer: 37
+    Equipablespells: 14
+    Equipped: 1
+    EquippedBags: 28
+    EquippedCooking: 31
+    EquippedFishing: 32
+    EquippedProfession1: 29
+    EquippedProfession2: 30
+    EquippedReagentbag: 33
+    GuildBank0: 7
+    GuildBank1: 8
+    GuildBank10: 20
+    GuildBank11: 21
+    GuildBank2: 9
+    GuildBank3: 10
+    GuildBank4: 11
+    GuildBank5: 12
+    GuildBank6: 16
+    GuildBank7: 17
+    GuildBank8: 18
+    GuildBank9: 19
+    GuildOverflow: 13
+    HousingDecorConversion: 39
+    Keyring: 6
+    Mail: 4
+    Quarantine: 24
+    ReagentbankObsolete: 22
 SummonReason:
-  Scenario: 1
-  Spell: 0
+  values:
+    Scenario: 1
+    Spell: 0
 SummonStatus:
-  Accepted: 2
-  Declined: 3
-  None: 0
-  Pending: 1
+  values:
+    Accepted: 2
+    Declined: 3
+    None: 0
+    Pending: 1
 SurveyDeliveryFlags:
-  EncounterSucccessOnly: 1
-  None: 0
+  values:
+    EncounterSucccessOnly: 1
+    None: 0
 SurveyDeliveryMoment:
-  ChestLooted: 3
-  EncounterEnd: 5
-  Login: 0
-  MythicPlusCompleted: 4
-  ProfessionTable: 1
-  QuestTurnIn: 2
+  values:
+    ChestLooted: 3
+    EncounterEnd: 5
+    Login: 0
+    MythicPlusCompleted: 4
+    ProfessionTable: 1
+    QuestTurnIn: 2
 TableSecurityOption:
-  DisallowSecretKeys: 1
-  DisallowTaintedAccess: 0
-  SecretWrapContents: 2
+  values:
+    DisallowSecretKeys: 1
+    DisallowTaintedAccess: 0
+    SecretWrapContents: 2
 TieredEntranceType:
-  Delve: 1
-  Invalid: 0
-  Sites: 2
-  WorldTier: 3
+  values:
+    Delve: 1
+    Invalid: 0
+    Sites: 2
+    WorldTier: 3
 TimeEventFlag:
-  GlueScreenShortcut: 1
+  values:
+    GlueScreenShortcut: 1
 TitleIconVersion:
-  Large: 2
-  Medium: 1
-  Small: 0
+  values:
+    Large: 2
+    Medium: 1
+    Small: 0
 TooltipComparisonMethod:
-  Single: 0
-  WithBagMainHandItem: 2
-  WithBagOffHandItem: 3
-  WithBothHands: 1
+  values:
+    Single: 0
+    WithBagMainHandItem: 2
+    WithBagOffHandItem: 3
+    WithBothHands: 1
 TooltipDataItemBinding:
-  Account: 1
-  AccountUntilEquipped: 9
-  BindOnEquip: 7
-  BindOnPickup: 6
-  BindOnUse: 8
-  BindToAccount: 4
-  BindToAccountUntilEquipped: 10
-  BindToBnetAccount: 5
-  BnetAccount: 2
-  Quest: 0
-  Soulbound: 3
+  values:
+    Account: 1
+    AccountUntilEquipped: 9
+    BindOnEquip: 7
+    BindOnPickup: 6
+    BindOnUse: 8
+    BindToAccount: 4
+    BindToAccountUntilEquipped: 10
+    BindToBnetAccount: 5
+    BnetAccount: 2
+    Quest: 0
+    Soulbound: 3
 TooltipDataLineType:
-  AzeriteEssencePower: 5
-  AzeriteEssenceSlot: 4
-  AzeriteItemPowerDescription: 9
-  Blank: 1
-  CurrencyTotal: 14
-  DisabledLine: 42
-  EquipSlot: 21
-  ErrorLine: 41
-  FlavorText: 37
-  GemSocket: 3
-  GemSocketEnchantment: 30
-  ItemBinding: 20
-  ItemEnchantmentPermanent: 15
-  ItemLevel: 31
-  ItemName: 22
-  ItemQuality: 35
-  ItemSpellTriggerLearn: 38
-  ItemUpgradeLevel: 32
-  LearnableSpell: 6
-  LearnTransmogIllusion: 40
-  LearnTransmogSet: 39
-  NestedBlock: 19
-  None: 0
-  ProfessionCraftingQuality: 12
-  QuestObjective: 8
-  QuestPlayer: 18
-  QuestTitle: 17
-  RuneforgeLegendaryPowerDescription: 10
-  SellPrice: 11
-  Separator: 23
-  SpellDescription: 34
-  SpellName: 13
-  SpellPassive: 33
-  ToyDescription: 28
-  ToyDuration: 27
-  ToyEffect: 26
-  ToyName: 24
-  ToySource: 29
-  ToyText: 25
-  TradeTimeRemaining: 36
-  UnitName: 2
-  UnitOwner: 16
-  UnitThreat: 7
-  UsageRequirement: 43
+  values:
+    AzeriteEssencePower: 5
+    AzeriteEssenceSlot: 4
+    AzeriteItemPowerDescription: 9
+    Blank: 1
+    CurrencyTotal: 14
+    DisabledLine: 42
+    EquipSlot: 21
+    ErrorLine: 41
+    FlavorText: 37
+    GemSocket: 3
+    GemSocketEnchantment: 30
+    ItemBinding: 20
+    ItemEnchantmentPermanent: 15
+    ItemLevel: 31
+    ItemName: 22
+    ItemQuality: 35
+    ItemSpellTriggerLearn: 38
+    ItemUpgradeLevel: 32
+    LearnableSpell: 6
+    LearnTransmogIllusion: 40
+    LearnTransmogSet: 39
+    NestedBlock: 19
+    None: 0
+    ProfessionCraftingQuality: 12
+    QuestObjective: 8
+    QuestPlayer: 18
+    QuestTitle: 17
+    RuneforgeLegendaryPowerDescription: 10
+    SellPrice: 11
+    Separator: 23
+    SpellDescription: 34
+    SpellName: 13
+    SpellPassive: 33
+    ToyDescription: 28
+    ToyDuration: 27
+    ToyEffect: 26
+    ToyName: 24
+    ToySource: 29
+    ToyText: 25
+    TradeTimeRemaining: 36
+    UnitName: 2
+    UnitOwner: 16
+    UnitThreat: 7
+    UsageRequirement: 43
 TooltipDataType:
-  Achievement: 12
-  AzeriteEssence: 8
-  BattlePet: 6
-  CompanionPet: 9
-  Corpse: 3
-  CorruptionCleanser: 20
-  Currency: 5
-  Debug: 26
-  EnhancedConduit: 13
-  EquipmentSet: 14
-  Flyout: 22
-  InstanceLock: 15
-  Item: 0
-  Macro: 25
-  MinimapMouseover: 21
-  Mount: 10
-  Object: 4
-  Outfit: 27
-  PetAction: 11
-  PvPBrawl: 16
-  Quest: 23
-  QuestPartyProgress: 24
-  RecipeRankInfo: 17
-  Spell: 1
-  Totem: 18
-  Toy: 19
-  Unit: 2
-  UnitAura: 7
+  values:
+    Achievement: 12
+    AzeriteEssence: 8
+    BattlePet: 6
+    CompanionPet: 9
+    Corpse: 3
+    CorruptionCleanser: 20
+    Currency: 5
+    Debug: 26
+    EnhancedConduit: 13
+    EquipmentSet: 14
+    Flyout: 22
+    InstanceLock: 15
+    Item: 0
+    Macro: 25
+    MinimapMouseover: 21
+    Mount: 10
+    Object: 4
+    Outfit: 27
+    PetAction: 11
+    PvPBrawl: 16
+    Quest: 23
+    QuestPartyProgress: 24
+    RecipeRankInfo: 17
+    Spell: 1
+    Totem: 18
+    Toy: 19
+    Unit: 2
+    UnitAura: 7
 TooltipDataUsageRequirementType:
-  Achievement: 7
-  ArenaRating: 11
-  EarnCurrency: 12
-  EquippedItem: 9
-  Faction: 1
-  Guild: 6
-  Level: 5
-  NotAlreadyKnown: 14
-  NotInArena: 15
-  NotInRatedBg: 16
-  PvPMedal: 3
-  PvPRank: 8
-  RaceClass: 0
-  Reputation: 4
-  ShapeshiftForm: 10
-  Skill: 2
-  Specialization: 13
+  values:
+    Achievement: 7
+    ArenaRating: 11
+    EarnCurrency: 12
+    EquippedItem: 9
+    Faction: 1
+    Guild: 6
+    Level: 5
+    NotAlreadyKnown: 14
+    NotInArena: 15
+    NotInRatedBg: 16
+    PvPMedal: 3
+    PvPRank: 8
+    RaceClass: 0
+    Reputation: 4
+    ShapeshiftForm: 10
+    Skill: 2
+    Specialization: 13
 TooltipSide:
-  Bottom: 3
-  Left: 0
-  Right: 1
-  Top: 2
+  values:
+    Bottom: 3
+    Left: 0
+    Right: 1
+    Top: 2
 TooltipTextureAnchor:
-  All: 6
-  LeftBottom: 2
-  LeftCenter: 1
-  LeftTop: 0
-  RightBottom: 5
-  RightCenter: 4
-  RightTop: 3
+  values:
+    All: 6
+    LeftBottom: 2
+    LeftCenter: 1
+    LeftTop: 0
+    RightBottom: 5
+    RightCenter: 4
+    RightTop: 3
 TooltipTextureRelativeRegion:
-  LeftLine: 0
-  RightLine: 1
+  values:
+    LeftLine: 0
+    RightLine: 1
 TrackedSpellCategory:
-  Debuff: 3
-  Defensive: 2
-  None: 0
-  Offensive: 1
-  RacialAbility: 4
+  values:
+    Debuff: 3
+    Defensive: 2
+    None: 0
+    Offensive: 1
+    RacialAbility: 4
 TradeskillRelativeDifficulty:
-  Easy: 2
-  Medium: 1
-  Optimal: 0
-  Trivial: 3
+  values:
+    Easy: 2
+    Medium: 1
+    Optimal: 0
+    Trivial: 3
 TraitCombatConfigFlags:
-  ActiveForSpec: 1
-  SharedActionBars: 4
-  StarterBuild: 2
+  values:
+    ActiveForSpec: 1
+    SharedActionBars: 4
+    StarterBuild: 2
 TraitCondFlag:
-  IsAlwaysMet: 2
-  IsGate: 1
-  IsSufficient: 4
+  values:
+    IsAlwaysMet: 2
+    IsGate: 1
+    IsSufficient: 4
 TraitConditionType:
-  Available: 0
-  DisplayError: 4
-  Granted: 2
-  Increased: 3
-  RanksAllowed: 5
-  Visible: 1
+  values:
+    Available: 0
+    DisplayError: 4
+    Granted: 2
+    Increased: 3
+    RanksAllowed: 5
+    Visible: 1
 TraitConfigDbState:
-  Created: 1
-  Deleted: 3
-  Ready: 0
-  Removed: 2
+  values:
+    Created: 1
+    Deleted: 3
+    Ready: 0
+    Removed: 2
 TraitConfigType:
-  Combat: 1
-  Generic: 3
-  Invalid: 0
-  Profession: 2
+  values:
+    Combat: 1
+    Generic: 3
+    Invalid: 0
+    Profession: 2
 TraitCurrencyFlag:
-  ShowQuantityAsSpent: 1
-  TraitSourcedShowMax: 2
-  UseClassIcon: 4
-  UseSpecIcon: 8
+  values:
+    ShowQuantityAsSpent: 1
+    TraitSourcedShowMax: 2
+    UseClassIcon: 4
+    UseSpecIcon: 8
 TraitCurrencyType:
-  CurrencyTypesBased: 1
-  Gold: 0
-  TraitSourced: 2
-  TraitSourcedPlayerDataElement: 3
+  values:
+    CurrencyTypesBased: 1
+    Gold: 0
+    TraitSourced: 2
+    TraitSourcedPlayerDataElement: 3
 TraitDefinitionSubType:
-  DragonflightBlack: 4
-  DragonflightBlue: 1
-  DragonflightBronze: 3
-  DragonflightGreen: 2
-  DragonflightRed: 0
+  values:
+    DragonflightBlack: 4
+    DragonflightBlue: 1
+    DragonflightBronze: 3
+    DragonflightGreen: 2
+    DragonflightRed: 0
 TraitEdgeType:
-  DeprecatedRankConnection: 1
-  DeprecatedSelectionOption: 5
-  MutuallyExclusive: 4
-  RequiredForAvailability: 3
-  SufficientForAvailability: 2
-  VisualOnly: 0
+  values:
+    DeprecatedRankConnection: 1
+    DeprecatedSelectionOption: 5
+    MutuallyExclusive: 4
+    RequiredForAvailability: 3
+    SufficientForAvailability: 2
+    VisualOnly: 0
 TraitEdgeVisualStyle:
-  None: 0
-  Straight: 1
+  values:
+    None: 0
+    Straight: 1
 TraitNodeEntryType:
-  ArmorSet: 11
-  DeprecatedSelect: 4
-  DragAndDrop: 5
-  ProfPath: 7
-  ProfPathUnlock: 9
-  ProfPerk: 8
-  RedButton: 10
-  SpendCapstoneCircle: 13
-  SpendCapstoneSquare: 14
-  SpendCircle: 2
-  SpendDiamond: 6
-  SpendHex: 0
-  SpendInfinite: 12
-  SpendSmallCircle: 3
-  SpendSquare: 1
+  values:
+    ArmorSet: 11
+    DeprecatedSelect: 4
+    DragAndDrop: 5
+    ProfPath: 7
+    ProfPathUnlock: 9
+    ProfPerk: 8
+    RedButton: 10
+    SpendCapstoneCircle: 13
+    SpendCapstoneSquare: 14
+    SpendCircle: 2
+    SpendDiamond: 6
+    SpendHex: 0
+    SpendInfinite: 12
+    SpendSmallCircle: 3
+    SpendSquare: 1
 TraitNodeFlag:
-  ActiveAtFirstRank: 16
-  HideMaxRank: 64
-  HighestChosenRank: 128
-  NeverPurchasable: 2
-  ShowExpandedSelection: 32
-  ShowMultipleIcons: 1
-  ShowTierTrack: 256
-  TestGridPositioned: 8
-  TestPositionLocked: 4
+  values:
+    ActiveAtFirstRank: 16
+    HideMaxRank: 64
+    HighestChosenRank: 128
+    NeverPurchasable: 2
+    ShowExpandedSelection: 32
+    ShowMultipleIcons: 1
+    ShowTierTrack: 256
+    TestGridPositioned: 8
+    TestPositionLocked: 4
 TraitNodeGroupFlag:
-  AvailableByDefault: 1
+  values:
+    AvailableByDefault: 1
 TraitNodeType:
-  Selection: 2
-  Single: 0
-  SubTreeSelection: 3
-  Tiered: 1
+  values:
+    Selection: 2
+    Single: 0
+    SubTreeSelection: 3
+    Tiered: 1
 TraitPointsOperationType:
-  Multiply: 1
-  None: -1
-  Set: 0
+  values:
+    Multiply: 1
+    None: -1
+    Set: 0
 TraitSystemFlag:
-  AllowEditInChallengeMode: 8
-  AllowEditInCombat: 4
-  AllowMultipleLoadoutsPerTree: 1
-  ShowSpendConfirmation: 2
+  values:
+    AllowEditInChallengeMode: 8
+    AllowEditInCombat: 4
+    AllowMultipleLoadoutsPerTree: 1
+    ShowSpendConfirmation: 2
 TraitSystemVariationType:
-  None: 0
-  Spec: 1
+  values:
+    None: 0
+    Spec: 1
 TraitTreeFlag:
-  CannotRefund: 1
-  HideSingleRankNumbers: 2
+  values:
+    CannotRefund: 1
+    HideSingleRankNumbers: 2
 TransformManipulatorAxis:
-  X: 1
-  Y: 2
-  Z: 4
+  values:
+    X: 1
+    Y: 2
+    Z: 4
 TransformManipulatorControlState:
-  Default: 0
-  Dimmed: 2
-  ExternallyHighlighted: 3
-  Hidden: 1
-  Hovered: 4
-  Moving: 6
-  Selected: 5
+  values:
+    Default: 0
+    Dimmed: 2
+    ExternallyHighlighted: 3
+    Hidden: 1
+    Hovered: 4
+    Moving: 6
+    Selected: 5
 TransformManipulatorDirection:
-  Negative: 1
-  Positive: 0
+  values:
+    Negative: 1
+    Positive: 0
 TransformManipulatorEvent:
-  Cancel: 3
-  Change: 1
-  Complete: 2
-  Hover: 4
-  MouseDown: 5
-  MouseUp: 6
-  Start: 0
+  values:
+    Cancel: 3
+    Change: 1
+    Complete: 2
+    Hover: 4
+    MouseDown: 5
+    MouseUp: 6
+    Start: 0
 TransformManipulatorMode:
-  Rotate: 1
-  Scale: 2
-  Translate: 0
+  values:
+    Rotate: 1
+    Scale: 2
+    Translate: 0
 TransmogCameraVariation:
-  CloakBackpack: 1
-  None: 0
-  RightShoulder: 1
+  values:
+    CloakBackpack: 1
+    None: 0
+    RightShoulder: 1
 TransmogCollectionType:
-  Back: 3
-  Bow: 25
-  Chest: 4
-  Crossbow: 27
-  Dagger: 16
-  Feet: 11
-  Fist: 17
-  Gun: 26
-  Hands: 8
-  Head: 1
-  Holdable: 19
-  Legs: 10
-  None: 0
-  OneHAxe: 13
-  OneHMace: 15
-  OneHSword: 14
-  Paired: 29
-  Polearm: 24
-  Shield: 18
-  Shirt: 5
-  Shoulder: 2
-  Staff: 23
-  Tabard: 6
-  TwoHAxe: 20
-  TwoHMace: 22
-  TwoHSword: 21
-  Waist: 9
-  Wand: 12
-  Warglaives: 28
-  Wrist: 7
+  values:
+    Back: 3
+    Bow: 25
+    Chest: 4
+    Crossbow: 27
+    Dagger: 16
+    Feet: 11
+    Fist: 17
+    Gun: 26
+    Hands: 8
+    Head: 1
+    Holdable: 19
+    Legs: 10
+    None: 0
+    OneHAxe: 13
+    OneHMace: 15
+    OneHSword: 14
+    Paired: 29
+    Polearm: 24
+    Shield: 18
+    Shirt: 5
+    Shoulder: 2
+    Staff: 23
+    Tabard: 6
+    TwoHAxe: 20
+    TwoHMace: 22
+    TwoHSword: 21
+    Waist: 9
+    Wand: 12
+    Warglaives: 28
+    Wrist: 7
 TransmogIllusionFlags:
-  AllowedRangedShieldsHoldables: 4
-  HideUntilCollected: 1
-  PlayerConditionGrantsOnLogin: 2
+  values:
+    AllowedRangedShieldsHoldables: 4
+    HideUntilCollected: 1
+    PlayerConditionGrantsOnLogin: 2
 TransmogModification:
-  Main: 0
-  Secondary: 1
+  values:
+    Main: 0
+    Secondary: 1
 TransmogOutfitCostModifiersApplied:
-  AuraDiscountApplied: 8
-  DebugOnlyFreeDiscountApplied: 1
-  OutfitCostModifierApplied: 4
-  VoidRacialDiscountApplied: 2
+  values:
+    AuraDiscountApplied: 8
+    DebugOnlyFreeDiscountApplied: 1
+    OutfitCostModifierApplied: 4
+    VoidRacialDiscountApplied: 2
 TransmogOutfitDataFlags:
-  IsCachedLocally: 1
+  values:
+    IsCachedLocally: 1
 TransmogOutfitDisplayType:
-  Assigned: 1
-  Disabled: 4
-  Equipped: 2
-  Hidden: 3
-  Unassigned: 0
+  values:
+    Assigned: 1
+    Disabled: 4
+    Equipped: 2
+    Hidden: 3
+    Unassigned: 0
 TransmogOutfitEntryFlags:
-  AutomaticallyAwardedOnLogin: 1
-  IsDefaultEquipped: 32
-  OnlyAvailableDuringEvent: 4
-  SortedToTopOfList: 8
-  UseOverrideCostModifier: 16
-  UseOverrideName: 2
+  values:
+    AutomaticallyAwardedOnLogin: 1
+    IsDefaultEquipped: 32
+    OnlyAvailableDuringEvent: 4
+    SortedToTopOfList: 8
+    UseOverrideCostModifier: 16
+    UseOverrideName: 2
 TransmogOutfitEntrySource:
-  AutomaticallyAwarded: 1
-  PlayerPurchased: 2
-  StampedSource: 0
+  values:
+    AutomaticallyAwarded: 1
+    PlayerPurchased: 2
+    StampedSource: 0
 TransmogOutfitEquipAction:
-  Equip: 0
-  EquipAndLock: 1
-  Lock: 5
-  Remove: 2
-  RemoveAndLock: 3
-  Unlock: 4
+  values:
+    Equip: 0
+    EquipAndLock: 1
+    Lock: 5
+    Remove: 2
+    RemoveAndLock: 3
+    Unlock: 4
 TransmogOutfitSetType:
-  CustomSet: 2
-  Equipped: 0
-  Outfit: 1
+  values:
+    CustomSet: 2
+    Equipped: 0
+    Outfit: 1
 TransmogOutfitSlot:
-  Back: 3
-  Body: 6
-  Chest: 4
-  Feet: 11
-  Hand: 8
-  Head: 0
-  Legs: 10
-  ShoulderLeft: 2
-  ShoulderRight: 1
-  Tabard: 5
-  Waist: 9
-  WeaponMainHand: 12
-  WeaponOffHand: 13
-  WeaponRanged: 14
-  Wrist: 7
+  values:
+    Back: 3
+    Body: 6
+    Chest: 4
+    Feet: 11
+    Hand: 8
+    Head: 0
+    Legs: 10
+    ShoulderLeft: 2
+    ShoulderRight: 1
+    Tabard: 5
+    Waist: 9
+    WeaponMainHand: 12
+    WeaponOffHand: 13
+    WeaponRanged: 14
+    Wrist: 7
 TransmogOutfitSlotError:
-  CannotUseItem: 10
-  IncompatibleWithMainHand: 14
-  InvalidDestination: 5
-  InvalidItemType: 4
-  InvalidSlotForForm: 13
-  InvalidSlotForRace: 11
-  InvalidSource: 8
-  InvalidSourceQuality: 9
-  Legendary: 3
-  Mismatch: 6
-  NoIllusion: 12
-  NoItem: 1
-  NotSoulbound: 2
-  Ok: 0
-  SameItem: 7
+  values:
+    CannotUseItem: 10
+    IncompatibleWithMainHand: 14
+    InvalidDestination: 5
+    InvalidItemType: 4
+    InvalidSlotForForm: 13
+    InvalidSlotForRace: 11
+    InvalidSource: 8
+    InvalidSourceQuality: 9
+    Legendary: 3
+    Mismatch: 6
+    NoIllusion: 12
+    NoItem: 1
+    NotSoulbound: 2
+    Ok: 0
+    SameItem: 7
 TransmogOutfitSlotFlags:
-  CanHaveIllusions: 2
-  CannotBeHidden: 1
-  IsSecondarySlot: 4
+  values:
+    CanHaveIllusions: 2
+    CannotBeHidden: 1
+    IsSecondarySlot: 4
 TransmogOutfitSlotOption:
-  ArtifactSpecFour: 11
-  ArtifactSpecOne: 8
-  ArtifactSpecThree: 10
-  ArtifactSpecTwo: 9
-  DeprecatedReuseMe: 6
-  FuryTwoHandedWeapon: 7
-  None: 0
-  OffHand: 4
-  OneHandedWeapon: 1
-  RangedWeapon: 3
-  Shield: 5
-  TwoHandedWeapon: 2
+  values:
+    ArtifactSpecFour: 11
+    ArtifactSpecOne: 8
+    ArtifactSpecThree: 10
+    ArtifactSpecTwo: 9
+    DeprecatedReuseMe: 6
+    FuryTwoHandedWeapon: 7
+    None: 0
+    OffHand: 4
+    OneHandedWeapon: 1
+    RangedWeapon: 3
+    Shield: 5
+    TwoHandedWeapon: 2
 TransmogOutfitSlotOptionFlags:
-  DisablesOffhandSlot: 4
-  DynamicOptionName: 2
-  IllusionNotAllowed: 1
+  values:
+    DisablesOffhandSlot: 4
+    DynamicOptionName: 2
+    IllusionNotAllowed: 1
 TransmogOutfitSlotOptionSheatheCategory:
-  Back: 1
-  Default: 0
-  Hide: 3
-  Side: 2
+  values:
+    Back: 1
+    Default: 0
+    Hide: 3
+    Side: 2
 TransmogOutfitSlotPosition:
-  Bottom: 2
-  Left: 0
-  Right: 1
+  values:
+    Bottom: 2
+    Left: 0
+    Right: 1
 TransmogOutfitSlotSaveFlags:
-  AppearanceIsNotValid: 1
+  values:
+    AppearanceIsNotValid: 1
 TransmogOutfitSlotWarning:
-  InvalidEquippedDestinationItem: 1
-  NothingEquipped: 5
-  Ok: 0
-  PendingWeaponChanges: 3
-  WeaponDoesNotSupportIllusions: 4
-  WrongWeaponCategoryEquipped: 2
+  values:
+    InvalidEquippedDestinationItem: 1
+    NothingEquipped: 5
+    Ok: 0
+    PendingWeaponChanges: 3
+    WeaponDoesNotSupportIllusions: 4
+    WrongWeaponCategoryEquipped: 2
 TransmogOutfitTransactionFlags:
-  AddNewOutfitMask: 20
-  AddOutfitAndUpdateSlots: 28
-  CreateAndUpdateOutfitInfoMask: 6
-  CreateOutfitInfo: 4
-  FullOutfitUpdateMask: 27
-  UpdateMetadata: 1
-  UpdateOutfitInfo: 2
-  UpdateSituations: 16
-  UpdateSituationsMask: 18
-  UpdateSlots: 8
+  values:
+    AddNewOutfitMask: 20
+    AddOutfitAndUpdateSlots: 28
+    CreateAndUpdateOutfitInfoMask: 6
+    CreateOutfitInfo: 4
+    FullOutfitUpdateMask: 27
+    UpdateMetadata: 1
+    UpdateOutfitInfo: 2
+    UpdateSituations: 16
+    UpdateSituationsMask: 18
+    UpdateSlots: 8
 TransmogOutfitTransactionType:
-  CreateOutfitInfo: 2
-  UpdateMetadata: 0
-  UpdateOutfitInfo: 1
-  UpdateSituations: 4
-  UpdateSlots: 3
+  values:
+    CreateOutfitInfo: 2
+    UpdateMetadata: 0
+    UpdateOutfitInfo: 1
+    UpdateSituations: 4
+    UpdateSlots: 3
 TransmogPendingType:
-  Apply: 0
-  Revert: 1
-  ToggleOff: 3
-  ToggleOn: 2
+  values:
+    Apply: 0
+    Revert: 1
+    ToggleOff: 3
+    ToggleOn: 2
 TransmogSearchType:
-  BaseSets: 2
-  Items: 1
-  UsableSets: 3
+  values:
+    BaseSets: 2
+    Items: 1
+    UsableSets: 3
 TransmogSituation:
-  AllEquipmentSets: 17
-  AllLocations: 2
-  AllMovement: 12
-  AllRacialForms: 19
-  AllSpecs: 0
-  AllTime: 27
-  AllWeather: 22
-  EquipmentSets: 18
-  FormNative: 20
-  FormNonNative: 21
-  LocationArenas: 10
-  LocationBattlegrounds: 11
-  LocationCharacterSelect: 5
-  LocationDelves: 7
-  LocationDungeons: 8
-  LocationHouse: 4
-  LocationRaids: 9
-  LocationRested: 3
-  LocationWorld: 6
-  MovementFlyingMount: 16
-  MovementGroundMount: 15
-  MovementSwimming: 14
-  MovementUnmounted: 13
-  Spec: 1
-  TimeDay: 29
-  TimeEvening: 30
-  TimeMorning: 28
-  TimeNight: 31
-  WeatherClear: 23
-  WeatherRain: 24
-  WeatherSand: 26
-  WeatherSnow: 25
+  values:
+    AllEquipmentSets: 17
+    AllLocations: 2
+    AllMovement: 12
+    AllRacialForms: 19
+    AllSpecs: 0
+    AllTime: 27
+    AllWeather: 22
+    EquipmentSets: 18
+    FormNative: 20
+    FormNonNative: 21
+    LocationArenas: 10
+    LocationBattlegrounds: 11
+    LocationCharacterSelect: 5
+    LocationDelves: 7
+    LocationDungeons: 8
+    LocationHouse: 4
+    LocationRaids: 9
+    LocationRested: 3
+    LocationWorld: 6
+    MovementFlyingMount: 16
+    MovementGroundMount: 15
+    MovementSwimming: 14
+    MovementUnmounted: 13
+    Spec: 1
+    TimeDay: 29
+    TimeEvening: 30
+    TimeMorning: 28
+    TimeNight: 31
+    WeatherClear: 23
+    WeatherRain: 24
+    WeatherSand: 26
+    WeatherSnow: 25
 TransmogSituationFlags:
-  AllSituation: 4
-  DefaultsToOn: 8
-  DisabledSituation: 64
-  DynamicallyNamed: 16
-  IsPlayerFacing: 1
-  NoneSituation: 32
-  SpecUseTalentLoadout: 2
+  values:
+    AllSituation: 4
+    DefaultsToOn: 8
+    DisabledSituation: 64
+    DynamicallyNamed: 16
+    IsPlayerFacing: 1
+    NoneSituation: 32
+    SpecUseTalentLoadout: 2
 TransmogSituationGroupFlags:
-  DynamicallyCreatesGroups: 1
+  values:
+    DynamicallyCreatesGroups: 1
 TransmogSituationTrigger:
-  EquipmentSet: 6
-  EventOutfit: 8
-  Forms: 7
-  Location: 3
-  Manual: 1
-  Movement: 4
-  None: 0
-  Specialization: 5
-  TimeOfDay: 10
-  TransmogUpdate: 2
-  Weather: 9
+  values:
+    EquipmentSet: 6
+    EventOutfit: 8
+    Forms: 7
+    Location: 3
+    Manual: 1
+    Movement: 4
+    None: 0
+    Specialization: 5
+    TimeOfDay: 10
+    TransmogUpdate: 2
+    Weather: 9
 TransmogSituationTriggerFlags:
-  CanChangeLockedOutfit: 2
-  CanLockOutfit: 1
-  DisabledTrigger: 16
-  IsPlayerFacing: 4
-  SituationsAreExclusive: 8
+  values:
+    CanChangeLockedOutfit: 2
+    CanLockOutfit: 1
+    DisabledTrigger: 16
+    IsPlayerFacing: 4
+    SituationsAreExclusive: 8
 TransmogSituationTriggerType:
-  Automatic: 2
-  Manual: 1
-  None: 0
-  TransmogUpdate: 3
+  values:
+    Automatic: 2
+    Manual: 1
+    None: 0
+    TransmogUpdate: 3
 TransmogSlot:
-  Back: 2
-  Body: 4
-  Chest: 3
-  Feet: 10
-  Hand: 7
-  Head: 0
-  Legs: 9
-  Mainhand: 11
-  Offhand: 12
-  Ranged: 13
-  Shoulder: 1
-  Tabard: 5
-  Waist: 8
-  Wrist: 6
+  values:
+    Back: 2
+    Body: 4
+    Chest: 3
+    Feet: 10
+    Hand: 7
+    Head: 0
+    Legs: 9
+    Mainhand: 11
+    Offhand: 12
+    Ranged: 13
+    Shoulder: 1
+    Tabard: 5
+    Waist: 8
+    Wrist: 6
 TransmogSource:
-  Achievement: 7
-  CantCollect: 6
-  HiddenUntilCollected: 5
-  JournalEncounter: 1
-  None: 0
-  NotValidForTransmog: 9
-  Profession: 8
-  Quest: 2
-  TradingPost: 10
-  Vendor: 3
-  WorldDrop: 4
+  values:
+    Achievement: 7
+    CantCollect: 6
+    HiddenUntilCollected: 5
+    JournalEncounter: 1
+    None: 0
+    NotValidForTransmog: 9
+    Profession: 8
+    Quest: 2
+    TradingPost: 10
+    Vendor: 3
+    WorldDrop: 4
 TransmogTimeOfDayCategory:
-  Evening: 2
-  Midday: 1
-  Morning: 0
-  Night: 3
+  values:
+    Evening: 2
+    Midday: 1
+    Morning: 0
+    Night: 3
 TransmogType:
-  Appearance: 0
-  Illusion: 1
+  values:
+    Appearance: 0
+    Illusion: 1
 TransmogUseErrorType:
-  Ability: 3
-  Class: 7
-  Faction: 9
-  Holiday: 5
-  HotRecheckFailed: 6
-  ItemProficiency: 10
-  None: 0
-  PlayerCondition: 1
-  Race: 8
-  Reputation: 4
-  Skill: 2
+  values:
+    Ability: 3
+    Class: 7
+    Faction: 9
+    Holiday: 5
+    HotRecheckFailed: 6
+    ItemProficiency: 10
+    None: 0
+    PlayerCondition: 1
+    Race: 8
+    Reputation: 4
+    Skill: 2
 TtsBoolSetting:
-  AddCharacterNameToSpeech: 1
-  AlternateSystemVoice: 3
-  NarrateMyMessages: 4
-  PlayActivitySoundWhenNotFocused: 2
-  PlaySoundSeparatingChatLineBreaks: 0
+  values:
+    AddCharacterNameToSpeech: 1
+    AlternateSystemVoice: 3
+    NarrateMyMessages: 4
+    PlayActivitySoundWhenNotFocused: 2
+    PlaySoundSeparatingChatLineBreaks: 0
 TtsVoiceType:
-  Alternate: 1
-  Standard: 0
+  values:
+    Alternate: 1
+    Standard: 0
 TugOfWarMarkerArrowShownState:
-  Always: 1
-  FlashOnMove: 2
-  Never: 0
+  values:
+    Always: 1
+    FlashOnMove: 2
+    Never: 0
 TugOfWarStyleValue:
-  ArchaeologyBrown: 1
-  DefaultYellow: 0
+  values:
+    ArchaeologyBrown: 1
+    DefaultYellow: 0
 TurnStrafeStyle:
-  Custom: 2
-  Legacy: 1
-  Modern: 0
+  values:
+    Custom: 2
+    Legacy: 1
+    Modern: 0
 UIActionType:
-  DefaultAction: 0
-  Reserved1: 2
-  UpdateMapSystem: 1
+  values:
+    DefaultAction: 0
+    Reserved1: 2
+    UpdateMapSystem: 1
 UICovenantDisplayInfoFlags:
-  DisplayCovenantAsJourney: 1
-  UseJourneyRewardTrack: 2
-  UseJourneyUnlockToastText: 3
+  values:
+    DisplayCovenantAsJourney: 1
+    UseJourneyRewardTrack: 2
+    UseJourneyUnlockToastText: 3
 UICursorType:
-  ActionBar: 6
-  Ammo: 8
-  BattlePet: 16
-  ConduitCollectionItem: 19
-  Currency: 13
-  Default: 0
-  EquipmentSet: 12
-  Flyout: 14
-  GuildBank: 10
-  GuildBankMoney: 11
-  Item: 1
-  Macro: 7
-  Merchant: 5
-  Money: 2
-  Mount: 17
-  Outfit: 21
-  PerksProgramVendorItem: 20
-  Pet: 9
-  PetAction: 4
-  Spell: 3
-  Toy: 18
-  VoidItem: 15
+  values:
+    ActionBar: 6
+    Ammo: 8
+    BattlePet: 16
+    ConduitCollectionItem: 19
+    Currency: 13
+    Default: 0
+    EquipmentSet: 12
+    Flyout: 14
+    GuildBank: 10
+    GuildBankMoney: 11
+    Item: 1
+    Macro: 7
+    Merchant: 5
+    Money: 2
+    Mount: 17
+    Outfit: 21
+    PerksProgramVendorItem: 20
+    Pet: 9
+    PetAction: 4
+    Spell: 3
+    Toy: 18
+    VoidItem: 15
 UIItemInteractionFlags:
-  AddCurrency: 16
-  ClickShowsFlyout: 8
-  ConfirmationHasDelay: 2
-  ConversionMode: 4
-  DisplayWithInset: 1
-  UsesCharges: 32
+  values:
+    AddCurrency: 16
+    ClickShowsFlyout: 8
+    ConfirmationHasDelay: 2
+    ConversionMode: 4
+    DisplayWithInset: 1
+    UsesCharges: 32
 UIItemInteractionType:
-  CastSpell: 1
-  CleanseCorruption: 2
-  ItemConversion: 4
-  None: 0
-  RunecarverScrapping: 3
+  values:
+    CastSpell: 1
+    CleanseCorruption: 2
+    ItemConversion: 4
+    None: 0
+    RunecarverScrapping: 3
 UIMapFlag:
-  AlwaysAllowTaxiPathing: 131072
-  AlwaysAllowUserWaypoints: 65536
-  DoNotShowOnNavbar: 524288
-  DoNotTranslateBranches: 512
-  FallbackToParentMap: 16
-  FlightMapAutoZoom: 16384
-  FlightMapShowZoomOut: 8192
-  ForceAllOverlayExplored: 4096
-  ForceAllowMapLinks: 262144
-  ForceOnNavbar: 32768
-  GarrisonMap: 8
-  HideArchaeologyDigs: 256
-  HideIcons: 1024
-  HideVignettes: 2048
-  IgnoreInTranslationsToParent: 2097152
-  IsCityMap: 1048576
-  NoHighlight: 1
-  NoHighlightTexture: 32
-  NoWorldPositions: 128
-  ShowOverlays: 2
-  ShowTaskObjectives: 64
-  ShowTaxiNodes: 4
+  values:
+    AlwaysAllowTaxiPathing: 131072
+    AlwaysAllowUserWaypoints: 65536
+    DoNotShowOnNavbar: 524288
+    DoNotTranslateBranches: 512
+    FallbackToParentMap: 16
+    FlightMapAutoZoom: 16384
+    FlightMapShowZoomOut: 8192
+    ForceAllOverlayExplored: 4096
+    ForceAllowMapLinks: 262144
+    ForceOnNavbar: 32768
+    GarrisonMap: 8
+    HideArchaeologyDigs: 256
+    HideIcons: 1024
+    HideVignettes: 2048
+    IgnoreInTranslationsToParent: 2097152
+    IsCityMap: 1048576
+    NoHighlight: 1
+    NoHighlightTexture: 32
+    NoWorldPositions: 128
+    ShowOverlays: 2
+    ShowTaskObjectives: 64
+    ShowTaxiNodes: 4
 UIMapGroupFlag:
-  ShowIconsAcrossFloors: 1
+  values:
+    ShowIconsAcrossFloors: 1
 UIMapSystem:
-  Adventure: 2
-  Minimap: 3
-  Taxi: 1
-  World: 0
+  values:
+    Adventure: 2
+    Minimap: 3
+    Taxi: 1
+    World: 0
 UIMapType:
-  Continent: 2
-  Cosmic: 0
-  Dungeon: 4
-  Micro: 5
-  Orphan: 6
-  World: 1
-  Zone: 3
+  values:
+    Continent: 2
+    Cosmic: 0
+    Dungeon: 4
+    Micro: 5
+    Orphan: 6
+    World: 1
+    Zone: 3
 UIModelSceneActorFlag:
-  Deprecated1: 1
-  UseCenterForOriginX: 2
-  UseCenterForOriginY: 4
-  UseCenterForOriginZ: 8
+  values:
+    Deprecated1: 1
+    UseCenterForOriginX: 2
+    UseCenterForOriginY: 4
+    UseCenterForOriginZ: 8
 UIModelSceneContext:
-  None: -1
-  PerksProgram: 0
+  values:
+    None: -1
+    PerksProgram: 0
 UIModelSceneFlags:
-  Autodress: 4
-  HideWeapon: 2
-  NoCameraSpin: 8
-  SheatheWeapon: 1
+  values:
+    Autodress: 4
+    HideWeapon: 2
+    NoCameraSpin: 8
+    SheatheWeapon: 1
 UISystemType:
-  InGameNavigation: 0
+  values:
+    InGameNavigation: 0
 UITextureSliceMode:
-  Stretched: 0
-  Tiled: 1
+  values:
+    Stretched: 0
+    Tiled: 1
 UIWidgetBlendModeType:
-  Additive: 1
-  Opaque: 0
+  values:
+    Additive: 1
+    Opaque: 0
 UIWidgetButtonEnabledState:
-  Disabled: 0
-  Enabled: 1
+  values:
+    Disabled: 0
+    Enabled: 1
 UIWidgetButtonIconType:
-  Checkmark: 3
-  Exit: 0
-  RedX: 4
-  Speak: 1
-  Undo: 2
+  values:
+    Checkmark: 3
+    Exit: 0
+    RedX: 4
+    Speak: 1
+    Undo: 2
 UIWidgetFlag:
-  UniversalWidget: 1
+  values:
+    UniversalWidget: 1
 UIWidgetFontType:
-  Normal: 0
-  Outline: 2
-  Shadow: 1
+  values:
+    Normal: 0
+    Outline: 2
+    Shadow: 1
 UIWidgetHorizontalDirection:
-  LeftToRight: 0
-  RightToLeft: 1
+  values:
+    LeftToRight: 0
+    RightToLeft: 1
 UIWidgetLayoutDirection:
-  Default: 0
-  Horizontal: 2
-  HorizontalForceNewRow: 4
-  Overlap: 3
-  Vertical: 1
+  values:
+    Default: 0
+    Horizontal: 2
+    HorizontalForceNewRow: 4
+    Overlap: 3
+    Vertical: 1
 UIWidgetModelSceneLayer:
-  Back: 2
-  Front: 1
-  None: 0
+  values:
+    Back: 2
+    Front: 1
+    None: 0
 UIWidgetMotionType:
-  Instant: 0
-  Smooth: 1
+  values:
+    Instant: 0
+    Smooth: 1
 UIWidgetOverrideState:
-  Active: 1
-  Inactive: 0
+  values:
+    Active: 1
+    Inactive: 0
 UIWidgetRewardShownState:
-  Hidden: 0
-  ShownEarned: 1
-  ShownUnearned: 2
+  values:
+    Hidden: 0
+    ShownEarned: 1
+    ShownUnearned: 2
 UIWidgetScale:
-  Eighty: 2
-  Fifty: 5
-  Ninty: 1
-  OneHundred: 0
-  OneHundredEighty: 13
-  OneHundredFifty: 10
-  OneHundredForty: 9
-  OneHundredNinety: 14
-  OneHundredSeventy: 12
-  OneHundredSixty: 11
-  OneHundredTen: 6
-  OneHundredThirty: 8
-  OneHundredTwenty: 7
-  Seventy: 3
-  Sixty: 4
-  TwoHundred: 15
+  values:
+    Eighty: 2
+    Fifty: 5
+    Ninty: 1
+    OneHundred: 0
+    OneHundredEighty: 13
+    OneHundredFifty: 10
+    OneHundredForty: 9
+    OneHundredNinety: 14
+    OneHundredSeventy: 12
+    OneHundredSixty: 11
+    OneHundredTen: 6
+    OneHundredThirty: 8
+    OneHundredTwenty: 7
+    Seventy: 3
+    Sixty: 4
+    TwoHundred: 15
 UIWidgetSetLayoutDirection:
-  Horizontal: 1
-  Overlap: 2
-  Vertical: 0
+  values:
+    Horizontal: 1
+    Overlap: 2
+    Vertical: 0
 UIWidgetSpellButtonCooldownType:
-  HideCooldown: 0
-  ShowCooldown: 1
-  ShowCooldownAndDisableOnCooldown: 2
+  values:
+    HideCooldown: 0
+    ShowCooldown: 1
+    ShowCooldownAndDisableOnCooldown: 2
 UIWidgetTextFormatType:
-  LeadingZeroesWithSixDigits: 3
-  None: 0
-  TimeOneLevel: 1
-  TimeTwoLevel: 2
+  values:
+    LeadingZeroesWithSixDigits: 3
+    None: 0
+    TimeOneLevel: 1
+    TimeTwoLevel: 2
 UIWidgetTextSizeType:
-  Huge27Pt: 3
-  Large20Pt: 8
-  Large24Pt: 2
-  Medium16Pt: 1
-  Medium18Pt: 7
-  Small10Pt: 5
-  Small11Pt: 6
-  Small12Pt: 0
-  Standard14Pt: 4
+  values:
+    Huge27Pt: 3
+    Large20Pt: 8
+    Large24Pt: 2
+    Medium16Pt: 1
+    Medium18Pt: 7
+    Small10Pt: 5
+    Small11Pt: 6
+    Small12Pt: 0
+    Standard14Pt: 4
 UIWidgetTextureAndTextSizeType:
-  Huge: 3
-  Large: 2
-  Medium: 1
-  Medium2: 5
-  Small: 0
-  Standard: 4
+  values:
+    Huge: 3
+    Large: 2
+    Medium: 1
+    Medium2: 5
+    Small: 0
+    Standard: 4
 UIWidgetTooltipLocation:
-  Bottom: 8
-  BottomLeft: 1
-  BottomRight: 7
-  Default: 0
-  Left: 2
-  Right: 6
-  Top: 4
-  TopLeft: 3
-  TopRight: 5
+  values:
+    Bottom: 8
+    BottomLeft: 1
+    BottomRight: 7
+    Default: 0
+    Left: 2
+    Right: 6
+    Top: 4
+    TopLeft: 3
+    TopRight: 5
 UIWidgetUpdateAnimType:
-  Flash: 1
-  FlashAndAnimateNumber: 2
-  None: 0
+  values:
+    Flash: 1
+    FlashAndAnimateNumber: 2
+    None: 0
 UIWidgetVisualizationType:
-  BulletTextList: 10
-  ButtonHeader: 30
-  CaptureBar: 1
-  CaptureZone: 17
-  DiscreteProgressSteps: 19
-  DoubleIconAndText: 5
-  DoubleStateIconRow: 14
-  DoubleStatusBar: 3
-  FillUpFrames: 24
-  HorizontalCurrencies: 9
-  IconAndText: 0
-  IconTextAndBackground: 4
-  IconTextAndCurrencies: 7
-  ItemDisplay: 27
-  MapPinAnimation: 26
-  PreyHuntProgress: 31
-  ScenarioHeaderCurrenciesAndBackground: 11
-  ScenarioHeaderDelves: 29
-  ScenarioHeaderTimer: 20
-  Spacer: 22
-  SpellDisplay: 13
-  StackedResourceTracker: 6
-  StatusBar: 2
-  TextColumnRow: 21
-  TextureAndText: 12
-  TextureAndTextRow: 15
-  TextureWithAnimation: 18
-  TextWithState: 8
-  TextWithSubtext: 25
-  TugOfWar: 28
-  UnitPowerBar: 23
-  ZoneControl: 16
+  values:
+    BulletTextList: 10
+    ButtonHeader: 30
+    CaptureBar: 1
+    CaptureZone: 17
+    DiscreteProgressSteps: 19
+    DoubleIconAndText: 5
+    DoubleStateIconRow: 14
+    DoubleStatusBar: 3
+    FillUpFrames: 24
+    HorizontalCurrencies: 9
+    IconAndText: 0
+    IconTextAndBackground: 4
+    IconTextAndCurrencies: 7
+    ItemDisplay: 27
+    MapPinAnimation: 26
+    PreyHuntProgress: 31
+    ScenarioHeaderCurrenciesAndBackground: 11
+    ScenarioHeaderDelves: 29
+    ScenarioHeaderTimer: 20
+    Spacer: 22
+    SpellDisplay: 13
+    StackedResourceTracker: 6
+    StatusBar: 2
+    TextColumnRow: 21
+    TextureAndText: 12
+    TextureAndTextRow: 15
+    TextureWithAnimation: 18
+    TextWithState: 8
+    TextWithSubtext: 25
+    TugOfWar: 28
+    UnitPowerBar: 23
+    ZoneControl: 16
 UnitAuraSortDirection:
-  Normal: 0
-  Reverse: 1
+  values:
+    Normal: 0
+    Reverse: 1
 UnitAuraSortRule:
-  BigDefensive: 2
-  Default: 1
-  Expiration: 3
-  ExpirationOnly: 4
-  Name: 5
-  NameOnly: 6
-  Unsorted: 0
+  values:
+    BigDefensive: 2
+    Default: 1
+    Expiration: 3
+    ExpirationOnly: 4
+    Name: 5
+    NameOnly: 6
+    Unsorted: 0
 UnitDamageAbsorbClampMode:
-  MaximumHealth: 2
-  MissingHealth: 0
-  MissingHealthWithoutIncomingHeals: 1
+  values:
+    MaximumHealth: 2
+    MissingHealth: 0
+    MissingHealthWithoutIncomingHeals: 1
 UnitHealAbsorbClampMode:
-  CurrentHealth: 0
-  MaximumHealth: 1
+  values:
+    CurrentHealth: 0
+    MaximumHealth: 1
 UnitHealAbsorbMode:
-  ReducedByIncomingHeals: 0
-  Total: 1
+  values:
+    ReducedByIncomingHeals: 0
+    Total: 1
 UnitIncomingHealClampMode:
-  MaximumHealth: 1
-  MissingHealth: 0
+  values:
+    MaximumHealth: 1
+    MissingHealth: 0
 UnitMaximumHealthMode:
-  Default: 0
-  WithAbsorbs: 1
+  values:
+    Default: 0
+    WithAbsorbs: 1
 UnitMirrorPetFlags:
-  Dismissable: 2
-  ExtraPet: 16
-  RecentlyTamed: 4
-  Renameable: 1
-  Stampede: 8
+  values:
+    Dismissable: 2
+    ExtraPet: 16
+    RecentlyTamed: 4
+    Renameable: 1
+    Stampede: 8
 UnitSex:
-  Both: 3
-  Female: 1
-  Male: 0
-  Neutral: 4
-  None: 2
+  values:
+    Both: 3
+    Female: 1
+    Male: 0
+    Neutral: 4
+    None: 2
 UrlTextureResult:
-  Found: 1
-  NotAllowed: 4
-  NotFound: 2
-  Requested: 3
+  values:
+    Found: 1
+    NotAllowed: 4
+    NotFound: 2
+    Requested: 3
 ValidateNameResult:
-  ConsecutiveSpaces: 13
-  DeclensionDoesntMatchBaseName: 16
-  Failure: 1
-  InvalidApostrophe: 9
-  InvalidCharacter: 5
-  InvalidSpace: 12
-  MixedLanguages: 6
-  MultipleApostrophes: 10
-  NoName: 2
-  Profane: 7
-  Reserved: 8
-  RussianConsecutiveSilentCharacters: 14
-  RussianSilentCharacterAtBeginningOrEnd: 15
-  SpacesDisallowed: 17
-  Success: 0
-  ThreeConsecutive: 11
-  TooLong: 4
-  TooShort: 3
+  values:
+    ConsecutiveSpaces: 13
+    DeclensionDoesntMatchBaseName: 16
+    Failure: 1
+    InvalidApostrophe: 9
+    InvalidCharacter: 5
+    InvalidSpace: 12
+    MixedLanguages: 6
+    MultipleApostrophes: 10
+    NoName: 2
+    Profane: 7
+    Reserved: 8
+    RussianConsecutiveSilentCharacters: 14
+    RussianSilentCharacterAtBeginningOrEnd: 15
+    SpacesDisallowed: 17
+    Success: 0
+    ThreeConsecutive: 11
+    TooLong: 4
+    TooShort: 3
 VasPurchaseProgress:
-  ApplyingLicense: 3
-  Complete: 7
-  Invalid: 0
-  PaymentPending: 2
-  PrePurchase: 1
-  ProcessingFactionChange: 6
-  Ready: 5
-  WaitingOnQueue: 4
+  values:
+    ApplyingLicense: 3
+    Complete: 7
+    Invalid: 0
+    PaymentPending: 2
+    PrePurchase: 1
+    ProcessingFactionChange: 6
+    Ready: 5
+    WaitingOnQueue: 4
 VasServiceType:
-  AppearanceChange: 2
-  CharacterClone: 10
-  CharacterTransfer: 4
-  FactionChange: 1
-  FactionTransfer: 5
-  NameChange: 0
-  RaceChange: 3
+  values:
+    AppearanceChange: 2
+    CharacterClone: 10
+    CharacterTransfer: 4
+    FactionChange: 1
+    FactionTransfer: 5
+    NameChange: 0
+    RaceChange: 3
 VasTransactionPurchaseResult:
-  BeginDbErrors: 20010
-  BeginProxyErrors: 17
-  DbAccountDoesNotOwnCharacter: 20017
-  DbAllianceNotEligible: 20027
-  DbAlreadyRenameFlagged: 20055
-  DbAuthenticatorInsufficient: 20073
-  DbBatchProcessingDisabled: 20028
-  DbBatchStateInvalid: 20067
-  DbBnetAccountNotProvided: 20077
-  DbBoostProcessingDisabled: 20095
-  DbBpayDeliveryPending: 20078
-  DbCagedPetInInventory: 20084
-  DbCannotMoveArenaCaptn: 20064
-  DbCannotMoveGuildmaster: 20012
-  DbCharacterDoesNotExist: 20019
-  DbCharacterWithoutGuild: 20070
-  DbCharLocked: 20026
-  DbCharNotLocked: 20025
-  DbCouldNotObtainCharLock: 20041
-  DbCustomizeAlreadyRequested: 20057
-  DbDeletedGuild: 20071
-  DbDuplicateCharacterName: 20015
-  DbDuplicateSupportRequest: 20063
-  DbEventNotActive: 20068
-  DbEventRealmClosed: 20038
-  DbFactionChangeTooSoon: 20061
-  DbGmSenorityInsufficient: 20072
-  DbGuildLevelInsufficient: 20074
-  DbGuildRankInsufficient: 20069
-  DbHasAuctions: 20033
-  DbHasBpayToken: 20079
-  DbHasCraftingOrders: 20092
-  DbHasHeirloomItem: 20080
-  DbHasMail: 20016
-  DbHasNewPlayerExperienceRestriction: 20091
-  DbHasUnclaimedCacheRewards: 20089
-  DbHouseOwnerRestriction: 20096
-  DbIneligibleMapID: 20076
-  DbIneligibleTargetRealm: 20022
-  DbInvalidName: 20094
-  DbInventoryCorrupt: 20040
-  DbLastCustomizeTooSoon: 20058
-  DbLastRenameTooRecent: 20052
-  DbLastRequestTooSoon: 20054
-  DbLastSaveTooDistant: 20083
-  DbLastSaveTooRecent: 20034
-  DbLockAlreadyRequested: 20044
-  DbLockNotAcknowledged: 20043
-  DbMaxCharactersOnServer: 20013
-  DbMoveInProgress: 20018
-  DbMultipleTransferCn: 20056
-  DbNameChangeSkipped: 20093
-  DbNameNotAvailable: 20051
-  DbNeedsEraChoice: 20090
-  DbNeedsLevelSquish: 20088
-  DbNewLeaderInvalid: 20086
-  DbNewNameTooLong: 20024
-  DbNoCopiesAvailable: 20020
-  DbNoCsiFound: 20065
-  DbNoMixedAlliance: 20014
-  DbNoneBatchQueueID: 20029
-  DbNoneLockID: 20042
-  DbNoneRealmForEvent: 20037
-  DbNoneSupportActionID: 20046
-  DbNoneSupportQueueID: 20045
-  DbNoneTemplateForEvent: 20039
-  DbNotMovebackable: 20048
-  DbNotRollbackable: 20047
-  DbOnBoostCooldown: 20085
-  DbPendingItemAudit: 20066
-  DbPvEPvPTransferNotAllowed: 20087
-  DbRaceClassComboIneligible: 20062
-  DbRealmNotEligible: 20011
-  DbRegionalDbNotFound: 20075
-  DbRenameAlreadyRequested: 20049
-  DbReservationDoesNotMatch: 20053
-  DbReservationExpired: 20050
-  DbResultAccountRestricted: 20082
-  DbResultSourceAccountBanned: 20081
-  DbTooMuchMoneyForLevel: 20032
-  DbTransferDateTooSoon: 20023
-  DbTransferNotCancellable: 20031
-  DbTransferNotFinalized: 20030
-  DbTransferNotLockable: 20035
-  DbTransferNotUnlockable: 20036
-  DbUnableToCustomize: 20060
-  DbUnderMinLevelReq: 20021
-  DbWaitingForPayment: 20059
-  DisallowedDestinationAccount: 9
-  DisallowedSourceAccount: 8
-  EndDbErrors: 20097
-  EndProxyErrors: 56
-  EndServerErrors: 16
-  InvalidBpayDeliverableID: 14
-  InvalidBpayProductID: 13
-  InvalidBpayProductType: 15
-  InvalidDestinationAccount: 6
-  InvalidDestinationRealm: 5
-  InvalidDistribution: 12
-  InvalidSourceAccount: 7
-  LowerBoxLevel: 11
-  None: 0
-  NoneCharacter: 2
-  NoneProduct: 3
-  OnlyOneVasAtATime: 4
-  ProxyAccountDataTooBig: 55
-  ProxyBadDbType: 35
-  ProxyBadObjType: 18
-  ProxyBadRequestContained: 33
-  ProxyBindFailed: 51
-  ProxyCannotDeleteArenaCaptain: 31
-  ProxyCannotDeleteGuildLeader: 30
-  ProxyCannotInsertNull: 45
-  ProxyCannotUndeleteTrialBoostCharacter: 46
-  ProxyCharacterHasWoWToken: 53
-  ProxyCharacterLevelTooHigh: 38
-  ProxyCharacterTransferred: 39
-  ProxyCharacterTransferredNoBoostInProgress: 40
-  ProxyDataInvalid: 22
-  ProxyDbError: 21
-  ProxyDeleteNotSupported: 28
-  ProxyExternalUpdateDetected: 37
-  ProxyGenericError: 44
-  ProxyInsertRequestContainedNoData: 49
-  ProxyInvalidKey: 50
-  ProxyIsReadonly: 34
-  ProxyLockedForToken: 42
-  ProxyLockedForTransfer: 26
-  ProxyLockedForUpgrade: 41
-  ProxyLockedForVas: 43
-  ProxyLocksFailed: 24
-  ProxyLostProxyConnection: 23
-  ProxyMissingResultsPtr: 25
-  ProxyMoneyLimitExceeded: 32
-  ProxyNoReturnValue: 27
-  ProxyObjDropped: 29
-  ProxyObjNotInDb: 19
-  ProxyOperationAlreadyInProgress: 36
-  ProxyPredicateFailed: 47
-  ProxyTooBusyBackOff: 54
-  ProxyTooManyRows: 52
-  ProxyUniqueKey: 20
-  ProxyWeeklyRewardNotFound: 48
-  UnknownError: 10
-  VasPurchaseDisabled: 1
+  values:
+    BeginDbErrors: 20010
+    BeginProxyErrors: 17
+    DbAccountDoesNotOwnCharacter: 20017
+    DbAllianceNotEligible: 20027
+    DbAlreadyRenameFlagged: 20055
+    DbAuthenticatorInsufficient: 20073
+    DbBatchProcessingDisabled: 20028
+    DbBatchStateInvalid: 20067
+    DbBnetAccountNotProvided: 20077
+    DbBoostProcessingDisabled: 20095
+    DbBpayDeliveryPending: 20078
+    DbCagedPetInInventory: 20084
+    DbCannotMoveArenaCaptn: 20064
+    DbCannotMoveGuildmaster: 20012
+    DbCharacterDoesNotExist: 20019
+    DbCharacterWithoutGuild: 20070
+    DbCharLocked: 20026
+    DbCharNotLocked: 20025
+    DbCouldNotObtainCharLock: 20041
+    DbCustomizeAlreadyRequested: 20057
+    DbDeletedGuild: 20071
+    DbDuplicateCharacterName: 20015
+    DbDuplicateSupportRequest: 20063
+    DbEventNotActive: 20068
+    DbEventRealmClosed: 20038
+    DbFactionChangeTooSoon: 20061
+    DbGmSenorityInsufficient: 20072
+    DbGuildLevelInsufficient: 20074
+    DbGuildRankInsufficient: 20069
+    DbHasAuctions: 20033
+    DbHasBpayToken: 20079
+    DbHasCraftingOrders: 20092
+    DbHasHeirloomItem: 20080
+    DbHasMail: 20016
+    DbHasNewPlayerExperienceRestriction: 20091
+    DbHasUnclaimedCacheRewards: 20089
+    DbHouseOwnerRestriction: 20096
+    DbIneligibleMapID: 20076
+    DbIneligibleTargetRealm: 20022
+    DbInvalidName: 20094
+    DbInventoryCorrupt: 20040
+    DbLastCustomizeTooSoon: 20058
+    DbLastRenameTooRecent: 20052
+    DbLastRequestTooSoon: 20054
+    DbLastSaveTooDistant: 20083
+    DbLastSaveTooRecent: 20034
+    DbLockAlreadyRequested: 20044
+    DbLockNotAcknowledged: 20043
+    DbMaxCharactersOnServer: 20013
+    DbMoveInProgress: 20018
+    DbMultipleTransferCn: 20056
+    DbNameChangeSkipped: 20093
+    DbNameNotAvailable: 20051
+    DbNeedsEraChoice: 20090
+    DbNeedsLevelSquish: 20088
+    DbNewLeaderInvalid: 20086
+    DbNewNameTooLong: 20024
+    DbNoCopiesAvailable: 20020
+    DbNoCsiFound: 20065
+    DbNoMixedAlliance: 20014
+    DbNoneBatchQueueID: 20029
+    DbNoneLockID: 20042
+    DbNoneRealmForEvent: 20037
+    DbNoneSupportActionID: 20046
+    DbNoneSupportQueueID: 20045
+    DbNoneTemplateForEvent: 20039
+    DbNotMovebackable: 20048
+    DbNotRollbackable: 20047
+    DbOnBoostCooldown: 20085
+    DbPendingItemAudit: 20066
+    DbPvEPvPTransferNotAllowed: 20087
+    DbRaceClassComboIneligible: 20062
+    DbRealmNotEligible: 20011
+    DbRegionalDbNotFound: 20075
+    DbRenameAlreadyRequested: 20049
+    DbReservationDoesNotMatch: 20053
+    DbReservationExpired: 20050
+    DbResultAccountRestricted: 20082
+    DbResultSourceAccountBanned: 20081
+    DbTooMuchMoneyForLevel: 20032
+    DbTransferDateTooSoon: 20023
+    DbTransferNotCancellable: 20031
+    DbTransferNotFinalized: 20030
+    DbTransferNotLockable: 20035
+    DbTransferNotUnlockable: 20036
+    DbUnableToCustomize: 20060
+    DbUnderMinLevelReq: 20021
+    DbWaitingForPayment: 20059
+    DisallowedDestinationAccount: 9
+    DisallowedSourceAccount: 8
+    EndDbErrors: 20097
+    EndProxyErrors: 56
+    EndServerErrors: 16
+    InvalidBpayDeliverableID: 14
+    InvalidBpayProductID: 13
+    InvalidBpayProductType: 15
+    InvalidDestinationAccount: 6
+    InvalidDestinationRealm: 5
+    InvalidDistribution: 12
+    InvalidSourceAccount: 7
+    LowerBoxLevel: 11
+    None: 0
+    NoneCharacter: 2
+    NoneProduct: 3
+    OnlyOneVasAtATime: 4
+    ProxyAccountDataTooBig: 55
+    ProxyBadDbType: 35
+    ProxyBadObjType: 18
+    ProxyBadRequestContained: 33
+    ProxyBindFailed: 51
+    ProxyCannotDeleteArenaCaptain: 31
+    ProxyCannotDeleteGuildLeader: 30
+    ProxyCannotInsertNull: 45
+    ProxyCannotUndeleteTrialBoostCharacter: 46
+    ProxyCharacterHasWoWToken: 53
+    ProxyCharacterLevelTooHigh: 38
+    ProxyCharacterTransferred: 39
+    ProxyCharacterTransferredNoBoostInProgress: 40
+    ProxyDataInvalid: 22
+    ProxyDbError: 21
+    ProxyDeleteNotSupported: 28
+    ProxyExternalUpdateDetected: 37
+    ProxyGenericError: 44
+    ProxyInsertRequestContainedNoData: 49
+    ProxyInvalidKey: 50
+    ProxyIsReadonly: 34
+    ProxyLockedForToken: 42
+    ProxyLockedForTransfer: 26
+    ProxyLockedForUpgrade: 41
+    ProxyLockedForVas: 43
+    ProxyLocksFailed: 24
+    ProxyLostProxyConnection: 23
+    ProxyMissingResultsPtr: 25
+    ProxyMoneyLimitExceeded: 32
+    ProxyNoReturnValue: 27
+    ProxyObjDropped: 29
+    ProxyObjNotInDb: 19
+    ProxyOperationAlreadyInProgress: 36
+    ProxyPredicateFailed: 47
+    ProxyTooBusyBackOff: 54
+    ProxyTooManyRows: 52
+    ProxyUniqueKey: 20
+    ProxyWeeklyRewardNotFound: 48
+    UnknownError: 10
+    VasPurchaseDisabled: 1
 ViewArenaSize:
-  Three: 1
-  Two: 0
+  values:
+    Three: 1
+    Two: 0
 ViewRaidSize:
-  Forty: 2
-  Ten: 0
-  TwentyFive: 1
+  values:
+    Forty: 2
+    Ten: 0
+    TwentyFive: 1
 VignetteObjectiveType:
-  Defeat: 1
-  DefeatShowRemainingHealth: 2
-  None: 0
+  values:
+    Defeat: 1
+    DefeatShowRemainingHealth: 2
+    None: 0
 VignetteType:
-  FyrakkFlight: 4
-  Normal: 0
-  PvPBounty: 1
-  Torghast: 2
-  Treasure: 3
+  values:
+    FyrakkFlight: 4
+    Normal: 0
+    PvPBounty: 1
+    Torghast: 2
+    Treasure: 3
 Vocalerrorsounds:
-  Abilitycooling: 50
-  Alreadyingroup: 20
-  Alreadyinguild: 21
-  Ammoonlyinbag: 28
-  Bagfull: 29
-  BoundNodrop: 4
-  Cantaffordbankslot: 22
-  CantattackNotarget: 38
-  CantattackNotstandingObsolete: 37
-  Cantattackrongdirection: 36
-  CantcastOutofrange: 46
-  Cantcreate: 18
-  Cantdrinkmore: 6
-  Canteatmore: 7
-  CanteatMoving: 24
-  Cantequip2Hequipped: 42
-  Cantequip2HNoskill: 43
-  Cantequip2HSkill: 41
-  Cantflyhere: 60
-  Cantinvite: 8
-  CantlearnLevel: 13
-  Cantloot: 17
-  CantlootDidntkill: 31
-  CantlootLocked: 33
-  CantlootNotstandingObsolete: 34
-  CantlootToofar: 35
-  CantlootWrongfacing: 32
-  Cantputbag: 26
-  Cantswap: 58
-  CanttaxiNomoney: 54
-  CanttradeSoulbound: 59
-  Cantuseitem: 51
-  Cantuselocked: 55
-  Cantusetoofar: 57
-  Chestinuse: 52
-  Declinegroup: 19
-  ExhaustedObsolete: 67
-  FoodcoolingObsolete: 53
-  Genericnotarget: 45
-  Guildpermissions: 62
-  Invaliditemtarget: 66
-  Invalidtarget: 11
-  Inventoryfull: 0
-  Inviteebusy: 9
-  Itemcooling: 5
-  Itemlocked: 61
-  Itemmaxcount: 30
-  Locked: 14
-  Mustequippitem: 49
-  Noenergy: 64
-  NoequipEver: 3
-  NoequipLevel: 2
-  Noequipslotavailable: 56
-  Noessence: 65
-  Nomana: 15
-  Norage: 63
-  Notabag: 25
-  Notenoughgold: 39
-  Notenoughmoney: 40
-  Notequippable: 44
-  Notwhiledead: 16
-  Outofammo: 1
-  Potioncooling: 47
-  Proficiencyneeded: 48
-  Spellcooling: 12
-  Targettoofar: 10
-  Toomanybankslots: 23
-  Wrongslot: 27
+  values:
+    Abilitycooling: 50
+    Alreadyingroup: 20
+    Alreadyinguild: 21
+    Ammoonlyinbag: 28
+    Bagfull: 29
+    BoundNodrop: 4
+    Cantaffordbankslot: 22
+    CantattackNotarget: 38
+    CantattackNotstandingObsolete: 37
+    Cantattackrongdirection: 36
+    CantcastOutofrange: 46
+    Cantcreate: 18
+    Cantdrinkmore: 6
+    Canteatmore: 7
+    CanteatMoving: 24
+    Cantequip2Hequipped: 42
+    Cantequip2HNoskill: 43
+    Cantequip2HSkill: 41
+    Cantflyhere: 60
+    Cantinvite: 8
+    CantlearnLevel: 13
+    Cantloot: 17
+    CantlootDidntkill: 31
+    CantlootLocked: 33
+    CantlootNotstandingObsolete: 34
+    CantlootToofar: 35
+    CantlootWrongfacing: 32
+    Cantputbag: 26
+    Cantswap: 58
+    CanttaxiNomoney: 54
+    CanttradeSoulbound: 59
+    Cantuseitem: 51
+    Cantuselocked: 55
+    Cantusetoofar: 57
+    Chestinuse: 52
+    Declinegroup: 19
+    ExhaustedObsolete: 67
+    FoodcoolingObsolete: 53
+    Genericnotarget: 45
+    Guildpermissions: 62
+    Invaliditemtarget: 66
+    Invalidtarget: 11
+    Inventoryfull: 0
+    Inviteebusy: 9
+    Itemcooling: 5
+    Itemlocked: 61
+    Itemmaxcount: 30
+    Locked: 14
+    Mustequippitem: 49
+    Noenergy: 64
+    NoequipEver: 3
+    NoequipLevel: 2
+    Noequipslotavailable: 56
+    Noessence: 65
+    Nomana: 15
+    Norage: 63
+    Notabag: 25
+    Notenoughgold: 39
+    Notenoughmoney: 40
+    Notequippable: 44
+    Notwhiledead: 16
+    Outofammo: 1
+    Potioncooling: 47
+    Proficiencyneeded: 48
+    Spellcooling: 12
+    Targettoofar: 10
+    Toomanybankslots: 23
+    Wrongslot: 27
 VoiceChatStatusCode:
-  AlreadyInChannel: 10
-  ChannelAlreadyExists: 9
-  ChannelNameTooLong: 8
-  ChannelNameTooShort: 7
-  ClientAlreadyLoggedIn: 6
-  ClientNotInitialized: 4
-  ClientNotLoggedIn: 5
-  Disabled: 18
-  Failure: 12
-  InvalidCommunityStream: 20
-  InvalidInputDevice: 23
-  InvalidOutputDevice: 24
-  LoginProhibited: 3
-  OperationPending: 1
-  PlayerSilenced: 21
-  PlayerVoiceChatParentalDisabled: 22
-  ProxyConnectionTimeOut: 15
-  ProxyConnectionUnableToConnect: 16
-  ProxyConnectionUnexpectedDisconnect: 17
-  ServiceLost: 13
-  Success: 0
-  TargetNotFound: 11
-  TooManyRequests: 2
-  UnableToLaunchProxy: 14
-  UnsupportedChatChannelType: 19
+  values:
+    AlreadyInChannel: 10
+    ChannelAlreadyExists: 9
+    ChannelNameTooLong: 8
+    ChannelNameTooShort: 7
+    ClientAlreadyLoggedIn: 6
+    ClientNotInitialized: 4
+    ClientNotLoggedIn: 5
+    Disabled: 18
+    Failure: 12
+    InvalidCommunityStream: 20
+    InvalidInputDevice: 23
+    InvalidOutputDevice: 24
+    LoginProhibited: 3
+    OperationPending: 1
+    PlayerSilenced: 21
+    PlayerVoiceChatParentalDisabled: 22
+    ProxyConnectionTimeOut: 15
+    ProxyConnectionUnableToConnect: 16
+    ProxyConnectionUnexpectedDisconnect: 17
+    ServiceLost: 13
+    Success: 0
+    TargetNotFound: 11
+    TooManyRequests: 2
+    UnableToLaunchProxy: 14
+    UnsupportedChatChannelType: 19
 VoiceTtsStatusCode:
-  DestinationQueueFull: 8
-  EngineAllocationFailed: 2
-  EnqueueNotNecessary: 9
-  InputTextEnqueued: 6
-  InternalError: 13
-  InvalidArgument: 12
-  InvalidEngineType: 1
-  ManagerNotFound: 11
-  MaxCharactersExceeded: 4
-  NotSupported: 3
-  SdkNotInitialized: 7
-  Success: 0
-  UtteranceBelowMinimumDuration: 5
-  UtteranceNotFound: 10
+  values:
+    DestinationQueueFull: 8
+    EngineAllocationFailed: 2
+    EnqueueNotNecessary: 9
+    InputTextEnqueued: 6
+    InternalError: 13
+    InvalidArgument: 12
+    InvalidEngineType: 1
+    ManagerNotFound: 11
+    MaxCharactersExceeded: 4
+    NotSupported: 3
+    SdkNotInitialized: 7
+    Success: 0
+    UtteranceBelowMinimumDuration: 5
+    UtteranceNotFound: 10
 WarbandSceneFlags:
-  AwardedAutomatically: 8
-  CannotBeSaved: 4
-  DoNotInclude: 1
-  HiddenUntilCollected: 2
-  IsDefault: 16
+  values:
+    AwardedAutomatically: 8
+    CannotBeSaved: 4
+    DoNotInclude: 1
+    HiddenUntilCollected: 2
+    IsDefault: 16
 WeaponSlot:
-  MainHand: 0
-  OffHand: 1
+  values:
+    MainHand: 0
+    OffHand: 1
 WeeklyRewardChestActivityType:
-  LFGDungeons: 1
-  Scenario: 0
-  World: 2
+  values:
+    LFGDungeons: 1
+    Scenario: 0
+    World: 2
 WeeklyRewardChestClaimRewardResult:
-  CountExceeded: 7
-  DbError: 5
-  InvalidSlot: 3
-  InvalidThreshold: 1
-  LockFailure: 6
-  PlayerNotFound: 2
-  Success: 0
-  TooManyItems: 4
+  values:
+    CountExceeded: 7
+    DbError: 5
+    InvalidSlot: 3
+    InvalidThreshold: 1
+    LockFailure: 6
+    PlayerNotFound: 2
+    Success: 0
+    TooManyItems: 4
 WeeklyRewardChestThresholdType:
-  Activities: 1
-  AlsoReceive: 4
-  Concession: 5
-  None: 0
-  Raid: 3
-  RankedPvP: 2
-  World: 6
+  values:
+    Activities: 1
+    AlsoReceive: 4
+    Concession: 5
+    None: 0
+    Raid: 3
+    RankedPvP: 2
+    World: 6
 WeeklyRewardProgressResult:
-  DbError: 3
-  NoPlayer: 4
-  NoSeason: 1
-  Success: 0
-  TimedOut: 2
+  values:
+    DbError: 3
+    NoPlayer: 4
+    NoSeason: 1
+    Success: 0
+    TimedOut: 2
 WidgetAnimationType:
-  Fade: 1
-  None: 0
+  values:
+    Fade: 1
+    None: 0
 WidgetCurrencyClass:
-  Currency: 0
-  Item: 1
+  values:
+    Currency: 0
+    Item: 1
 WidgetEnabledState:
-  Artifact: 5
-  Black: 6
-  BrightBlue: 7
-  Disabled: 0
-  Green: 4
-  Red: 2
-  White: 3
-  Yellow: 1
+  values:
+    Artifact: 5
+    Black: 6
+    BrightBlue: 7
+    Disabled: 0
+    Green: 4
+    Red: 2
+    White: 3
+    Yellow: 1
 WidgetGlowAnimType:
-  None: 0
-  Pulse: 1
+  values:
+    None: 0
+    Pulse: 1
 WidgetIconSizeType:
-  Large: 2
-  Medium: 1
-  Small: 0
-  Standard: 3
+  values:
+    Large: 2
+    Medium: 1
+    Small: 0
+    Standard: 3
 WidgetIconSourceType:
-  Item: 1
-  Spell: 0
+  values:
+    Item: 1
+    Spell: 0
 WidgetOpacityType:
-  Eighty: 2
-  Fifty: 5
-  Forty: 6
-  Ninety: 1
-  OneHundred: 0
-  Seventy: 3
-  Sixty: 4
-  Ten: 9
-  Thirty: 7
-  Twenty: 8
-  Zero: 10
+  values:
+    Eighty: 2
+    Fifty: 5
+    Forty: 6
+    Ninety: 1
+    OneHundred: 0
+    Seventy: 3
+    Sixty: 4
+    Ten: 9
+    Thirty: 7
+    Twenty: 8
+    Zero: 10
 WidgetShowGlowState:
-  HideGlow: 0
-  ShowGlow: 1
+  values:
+    HideGlow: 0
+    ShowGlow: 1
 WidgetShownState:
-  Hidden: 0
-  Shown: 1
+  values:
+    Hidden: 0
+    Shown: 1
 WidgetTextHorizontalAlignmentType:
-  Center: 1
-  Left: 0
-  Right: 2
+  values:
+    Center: 1
+    Left: 0
+    Right: 2
 WidgetUnitPowerBarFlashMomentType:
-  FlashWhenMax: 0
-  FlashWhenMin: 1
-  NeverFlash: 2
+  values:
+    FlashWhenMax: 0
+    FlashWhenMin: 1
+    NeverFlash: 2
 WorldCursorAnchorType:
-  Cursor: 2
-  Default: 1
-  Nameplate: 3
-  None: 0
+  values:
+    Cursor: 2
+    Default: 1
+    Nameplate: 3
+    None: 0
 WorldElapsedTimerTypes:
-  ChallengeMode: 1
-  None: 0
-  ProvingGround: 2
+  values:
+    ChallengeMode: 1
+    None: 0
+    ProvingGround: 2
 WorldTierDifficulty:
-  Heroic: 2
-  Mythic: 3
-  Normal: 1
+  values:
+    Heroic: 2
+    Mythic: 3
+    Normal: 1
 WoWClientCursorSize:
-  ExtraLarge: 3
-  Large: 2
-  Massive: 4
-  Medium: 1
-  Standard: 0
+  values:
+    ExtraLarge: 3
+    Large: 2
+    Massive: 4
+    Medium: 1
+    Standard: 0
 WoWEntitlementType:
-  Appearance: 4
-  AppearanceSet: 5
-  Battlepet: 2
-  GameTime: 6
-  Illusion: 8
-  Invalid: 9
-  Item: 0
-  Mount: 1
-  Title: 7
-  Toy: 3
+  values:
+    Appearance: 4
+    AppearanceSet: 5
+    Battlepet: 2
+    GameTime: 6
+    Illusion: 8
+    Invalid: 9
+    Item: 0
+    Mount: 1
+    Title: 7
+    Toy: 3
 WoWLabsAreaType:
-  PlunderstormDropDense: 2
-  PlunderstormDropMedium: 1
-  PlunderstormDropSparse: 0
+  values:
+    PlunderstormDropDense: 2
+    PlunderstormDropMedium: 1
+    PlunderstormDropSparse: 0
 ZoneControlActiveState:
-  Active: 1
-  Inactive: 0
+  values:
+    Active: 1
+    Inactive: 0
 ZoneControlDangerFlashType:
-  ShowOnBadStates: 1
-  ShowOnBoth: 2
-  ShowOnGoodStates: 0
-  ShowOnNeither: 3
+  values:
+    ShowOnBadStates: 1
+    ShowOnBoth: 2
+    ShowOnGoodStates: 0
+    ShowOnNeither: 3
 ZoneControlFillType:
-  DoubleFillClockwise: 2
-  DoubleFillCounterClockwise: 3
-  SingleFillClockwise: 0
-  SingleFillCounterClockwise: 1
+  values:
+    DoubleFillClockwise: 2
+    DoubleFillCounterClockwise: 3
+    SingleFillClockwise: 0
+    SingleFillCounterClockwise: 1
 ZoneControlLeadingEdgeType:
-  NoLeadingEdge: 0
-  UseLeadingEdge: 1
+  values:
+    NoLeadingEdge: 0
+    UseLeadingEdge: 1
 ZoneControlMode:
-  BothStatesAreGood: 0
-  NeitherStateIsGood: 3
-  State1IsGood: 1
-  State2IsGood: 2
+  values:
+    BothStatesAreGood: 0
+    NeitherStateIsGood: 3
+    State1IsGood: 1
+    State2IsGood: 2
 ZoneControlState:
-  State1: 0
-  State2: 1
+  values:
+    State1: 0
+    State2: 1

--- a/data/products/wow_classic/enums.yaml
+++ b/data/products/wow_classic/enums.yaml
@@ -1,7222 +1,8017 @@
 AbbreviationDataError:
-  InvalidBreakpoint: 1
-  InvalidFractionDivisor: 4
-  InvalidSignificandDivisor: 2
-  NotMultipleOfTen: 8
+  values:
+    InvalidBreakpoint: 1
+    InvalidFractionDivisor: 4
+    InvalidSignificandDivisor: 2
+    NotMultipleOfTen: 8
 AccountCurrencyTransferResult:
-  CannotUseCurrency: 8
-  CharacterLoggedIn: 2
-  CurrencyTransferDisabled: 10
-  InsufficientCurrency: 3
-  InvalidCharacter: 1
-  InvalidCurrency: 5
-  MaxQuantity: 4
-  NoValidSourceCharacter: 6
-  ServerError: 7
-  Success: 0
-  TransactionInProgress: 9
+  values:
+    CannotUseCurrency: 8
+    CharacterLoggedIn: 2
+    CurrencyTransferDisabled: 10
+    InsufficientCurrency: 3
+    InvalidCharacter: 1
+    InvalidCurrency: 5
+    MaxQuantity: 4
+    NoValidSourceCharacter: 6
+    ServerError: 7
+    Success: 0
+    TransactionInProgress: 9
 AccountData:
-  Bindings: 2
-  Bindings2: 3
-  CharacterListOrder: 16
-  ChatSettings: 7
-  ClickBindings: 12
-  Config: 0
-  Config2: 1
-  CooldownManager: 17
-  CooldownManager2: 18
-  FlaggedIDs: 10
-  FlaggedIDs2: 11
-  FrontendChatSettings: 15
-  Macros: 4
-  Macros2: 5
-  Shop2PendingOrders: 19
-  TtsSettings: 8
-  TtsSettings2: 9
-  UIEditModeAccount: 13
-  UIEditModeChar: 14
-  UILayout: 6
+  values:
+    Bindings: 2
+    Bindings2: 3
+    CharacterListOrder: 16
+    ChatSettings: 7
+    ClickBindings: 12
+    Config: 0
+    Config2: 1
+    CooldownManager: 17
+    CooldownManager2: 18
+    FlaggedIDs: 10
+    FlaggedIDs2: 11
+    FrontendChatSettings: 15
+    Macros: 4
+    Macros2: 5
+    Shop2PendingOrders: 19
+    TtsSettings: 8
+    TtsSettings2: 9
+    UIEditModeAccount: 13
+    UIEditModeChar: 14
+    UILayout: 6
 AccountDataUpdateStatus:
-  Corrupt: 2
-  Failed: 1
-  Success: 0
-  Toobig: 3
+  values:
+    Corrupt: 2
+    Failed: 1
+    Success: 0
+    Toobig: 3
 AccountExportResult:
-  AlreadyInProgress: 11
-  Cancelled: 2
-  FailedToGenerateFile: 13
-  FailedToLockAccount: 12
-  FileInvalid: 8
-  FileWriteFailed: 9
-  NoAccountFound: 5
-  RequestedInvalidCharacter: 6
-  RpcError: 7
-  ShuttingDown: 3
-  Success: 0
-  TimedOut: 4
-  Unavailable: 10
-  UnknownError: 1
+  values:
+    AlreadyInProgress: 11
+    Cancelled: 2
+    FailedToGenerateFile: 13
+    FailedToLockAccount: 12
+    FileInvalid: 8
+    FileWriteFailed: 9
+    NoAccountFound: 5
+    RequestedInvalidCharacter: 6
+    RpcError: 7
+    ShuttingDown: 3
+    Success: 0
+    TimedOut: 4
+    Unavailable: 10
+    UnknownError: 1
 AccountSequenceCacheType:
-  HouseDecor: 2
-  Invalid: 0
-  Local: 1
+  values:
+    HouseDecor: 2
+    Invalid: 0
+    Local: 1
 AccountStateFlags:
-  AccountUpgradeComplete: 4
-  InPetCombat: 2
-  LoadFailed: 1
-  None: 0
-  TokenEligCheckComplete: 8
+  values:
+    AccountUpgradeComplete: 4
+    InPetCombat: 2
+    LoadFailed: 1
+    None: 0
+    TokenEligCheckComplete: 8
 AccountStateLoadedFlags:
-  AccountCurrenciesLoaded: '0x0000000000200000'
-  AccountFactionsLoaded: '0x0000000200000000'
-  AccountItemsLoaded: '0x0000000400000000'
-  AccountMappingLoaded: '0x0000008000000000'
-  AccountNotificationsLoaded: '0x0000000008000000'
-  AccountWowlabsLoaded: '0x0000000020000000'
-  AchievementsLoaded: '0x0000000000000001'
-  ArchivedPurchasesLoaded: '0x0000000000000200'
-  AuctionableTokensLoaded: '0x0000000000002000'
-  BanktabSettingsLoaded: '0x0000004000000000'
-  BattleNetAccountLoaded: '0x0000000000100000'
-  BitVectorsLoaded: '0x0000000100000000'
-  BpayAddLicenseObjectsLoaded: '0x0000000000000800'
-  BpayDistributionObjectsLoaded: '0x0000000000000100'
-  BpayProductitemObjectsLoaded: '0x0000000000020000'
-  CharacterItemsLoaded: '0x0000010000000000'
-  CharactersLoaded: '0x0000000000000040'
-  CombinedQuestLogLoaded: '0x0000000800000000'
-  ConsumableTokensLoaded: '0x0000000000004000'
-  CriteriaLoaded: '0x0000000000000002'
-  CurrencyCapsLoaded: '0x0000000000000010'
-  CurrencyTransferLogLoaded: '0x0000020000000000'
-  DataElementsLoaded: '0x0000001000000000'
-  DynamicCriteriaLoaded: '0x0000000001000000'
-  EventRecordsLoaded: '0x0000200000000000'
-  HousingDataLoaded: '0x0000080000000000'
-  ItemCollectionsLoaded: '0x0000000000001000'
-  LgVendorPurchaseLoaded: '0x0000040000000000'
-  LoadedNone: '0x0000000000000000'
-  MountsLoaded: '0x0000000000000004'
-  PerksHeldItemLoaded: '0x0000000040000000'
-  PerksPastRewardsLoaded: '0x0000000000008000'
-  PerksPendingPurchaseLoaded: '0x0000000010000000'
-  PerksPendingRewardsLoaded: '0x0000000080000000'
-  PetjournalInitialized: '0x0000000000000008'
-  PurchasesLoaded: '0x0000000000000080'
-  QuestCriteriaLoaded: '0x0000000000080000'
-  QuestLogLoaded: '0x0000000000000020'
-  RafActivityLoaded: '0x0000000002000000'
-  RafBalanceLoaded: '0x0000000000400000'
-  RafRewardsLoaded: '0x0000000000800000'
-  RevokedRafRewardsLoaded: '0x0000000004000000'
-  SettingsLoaded: '0x0000000000000400'
-  TransmogOutfitsLoaded: '0x0000400000000000'
-  TrialBoostHistoryLoaded: '0x0000000000040000'
-  VasTransactionsLoaded: '0x0000000000010000'
-  WarbandScenesLoaded: '0x0000100000000000'
-  WarbandsLoaded: '0x0000002000000000'
+  values:
+    AccountCurrenciesLoaded: '0x0000000000200000'
+    AccountFactionsLoaded: '0x0000000200000000'
+    AccountItemsLoaded: '0x0000000400000000'
+    AccountMappingLoaded: '0x0000008000000000'
+    AccountNotificationsLoaded: '0x0000000008000000'
+    AccountWowlabsLoaded: '0x0000000020000000'
+    AchievementsLoaded: '0x0000000000000001'
+    ArchivedPurchasesLoaded: '0x0000000000000200'
+    AuctionableTokensLoaded: '0x0000000000002000'
+    BanktabSettingsLoaded: '0x0000004000000000'
+    BattleNetAccountLoaded: '0x0000000000100000'
+    BitVectorsLoaded: '0x0000000100000000'
+    BpayAddLicenseObjectsLoaded: '0x0000000000000800'
+    BpayDistributionObjectsLoaded: '0x0000000000000100'
+    BpayProductitemObjectsLoaded: '0x0000000000020000'
+    CharacterItemsLoaded: '0x0000010000000000'
+    CharactersLoaded: '0x0000000000000040'
+    CombinedQuestLogLoaded: '0x0000000800000000'
+    ConsumableTokensLoaded: '0x0000000000004000'
+    CriteriaLoaded: '0x0000000000000002'
+    CurrencyCapsLoaded: '0x0000000000000010'
+    CurrencyTransferLogLoaded: '0x0000020000000000'
+    DataElementsLoaded: '0x0000001000000000'
+    DynamicCriteriaLoaded: '0x0000000001000000'
+    EventRecordsLoaded: '0x0000200000000000'
+    HousingDataLoaded: '0x0000080000000000'
+    ItemCollectionsLoaded: '0x0000000000001000'
+    LgVendorPurchaseLoaded: '0x0000040000000000'
+    LoadedNone: '0x0000000000000000'
+    MountsLoaded: '0x0000000000000004'
+    PerksHeldItemLoaded: '0x0000000040000000'
+    PerksPastRewardsLoaded: '0x0000000000008000'
+    PerksPendingPurchaseLoaded: '0x0000000010000000'
+    PerksPendingRewardsLoaded: '0x0000000080000000'
+    PetjournalInitialized: '0x0000000000000008'
+    PurchasesLoaded: '0x0000000000000080'
+    QuestCriteriaLoaded: '0x0000000000080000'
+    QuestLogLoaded: '0x0000000000000020'
+    RafActivityLoaded: '0x0000000002000000'
+    RafBalanceLoaded: '0x0000000000400000'
+    RafRewardsLoaded: '0x0000000000800000'
+    RevokedRafRewardsLoaded: '0x0000000004000000'
+    SettingsLoaded: '0x0000000000000400'
+    TransmogOutfitsLoaded: '0x0000400000000000'
+    TrialBoostHistoryLoaded: '0x0000000000040000'
+    VasTransactionsLoaded: '0x0000000000010000'
+    WarbandScenesLoaded: '0x0000100000000000'
+    WarbandsLoaded: '0x0000002000000000'
 AccountStoreCategoryType:
-  Creature: 1
-  Icon: 4
-  Mount: 3
-  TransmogSet: 2
+  values:
+    Creature: 1
+    Icon: 4
+    Mount: 3
+    TransmogSet: 2
 AccountStoreFrontFlag:
-  Enabled: 1
-  PurchaseEnabled: 2
-  RefundEnabled: 4
+  values:
+    Enabled: 1
+    PurchaseEnabled: 2
+    RefundEnabled: 4
 AccountStoreItemFlag:
-  DisplayAsNew: 4
-  DisplayDefaultArmor: 1
-  DisplayOnly: 8
-  NotInGameReward: 2
+  values:
+    DisplayAsNew: 4
+    DisplayDefaultArmor: 1
+    DisplayOnly: 8
+    NotInGameReward: 2
 AccountStoreItemMode:
-  Hidden: 2
-  Locked: 3
-  Normal: 1
+  values:
+    Hidden: 2
+    Locked: 3
+    Normal: 1
 AccountStoreItemRewardType:
-  Illusion: 7
-  Misc: 10
-  Mount: 2
-  Pet: 3
-  Tender: 9
-  Toy: 5
-  Transmog: 1
-  TransmogSet: 8
-  WarbandScene: 11
+  values:
+    Illusion: 7
+    Misc: 10
+    Mount: 2
+    Pet: 3
+    Tender: 9
+    Toy: 5
+    Transmog: 1
+    TransmogSet: 8
+    WarbandScene: 11
 AccountStoreItemStatus:
-  Owned: 3
-  Refundable: 2
-  Unowned: 1
+  values:
+    Owned: 3
+    Refundable: 2
+    Unowned: 1
 AccountStoreSettlementAction:
-  Give: 1
-  NotSet: 0
-  Remove: 2
+  values:
+    Give: 1
+    NotSet: 0
+    Remove: 2
 AccountStoreState:
-  Available: 0
-  Unavailable: 2
-  Unknown: 1
+  values:
+    Available: 0
+    Unavailable: 2
+    Unknown: 1
 AccountStoreTransactionResult:
-  Incomplete: 1
-  InsufficientFunds: 4
-  InvalidCurrencyType: 8
-  ItemAlreadyOwned: 6
-  ItemNotOwned: 7
-  ItemUnknown: 5
-  NotSupported: 10
-  OwnedButRefundTimeExpired: 9
-  ProxyError: 12
-  Success: 0
-  TransactionInProgress: 3
-  Unavailable: 11
-  UnknownError: 2
+  values:
+    Incomplete: 1
+    InsufficientFunds: 4
+    InvalidCurrencyType: 8
+    ItemAlreadyOwned: 6
+    ItemNotOwned: 7
+    ItemUnknown: 5
+    NotSupported: 10
+    OwnedButRefundTimeExpired: 9
+    ProxyError: 12
+    Success: 0
+    TransactionInProgress: 3
+    Unavailable: 11
+    UnknownError: 2
 AccountStoreTransactionType:
-  DebugRemoveItem: 4
-  DebugResetHistory: 3
-  Purchase: 1
-  Refund: 2
-  Undefined: 0
+  values:
+    DebugRemoveItem: 4
+    DebugResetHistory: 3
+    Purchase: 1
+    Refund: 2
+    Undefined: 0
 AccountTransType:
-  AccountCurrencies: 26
-  AccountNotifications: 38
-  AccountStore: 54
-  Achievements: 4
-  AddLicense: 16
-  ArchivedPurchases: 9
-  AuctionableToken: 18
-  BankTab: 48
-  BattlenetAccount: 25
-  Battlepet: 3
-  BitVectors: 50
-  CharacterDataMerge: 53
-  CharacterItems: 57
-  Characters: 7
-  CombinedQuestLog: 51
-  ConsumableToken: 19
-  CreateOrderInfo: 32
-  Criteria: 5
-  CriteriaNotif: 13
-  CurrencyCaps: 11
-  CurrencyTransferLog: 58
-  Distribution: 2
-  Distributions: 10
-  DynamicCriteria: 30
-  EventRecords: 63
-  Factions: 49
-  FixedLicense: 15
-  GetOrderStatusByPurchaseID: 46
-  HouseInitiativeFavor: 66
-  HousingItem: 64
-  ItemCollections: 17
-  Items: 47
-  LgVendorPurchase: 59
-  LoadWowlabs: 44
-  Mapping: 56
-  Mounts: 6
-  OutstandingRpc: 43
-  PerkItemHold: 39
-  PerkPastRewards: 41
-  PerkPendingRewards: 40
-  PerkTransaction: 42
-  PlayerDataElements: 52
-  Productitem: 21
-  Profile: 61
-  ProxyCreateAccountHonor: 34
-  ProxyForwarder: 0
-  ProxyGenerateBpayID: 37
-  ProxyGmSetHonor: 36
-  ProxyHonorInitialConversion: 33
-  ProxyValidateAccountHonor: 35
-  Purchase: 1
-  Purchases: 8
-  QuestCriteria: 24
-  QuestLog: 12
-  RafActivity: 31
-  RafFriendMonth: 28
-  RafRecruiterAcceptances: 27
-  RafReward: 29
-  SaveWarbandGroups: 60
-  Settings: 14
-  TransmogOutfitCollection: 65
-  TrialBoostHistories: 23
-  TrialBoostHistory: 22
-  UpgradeAccount: 45
-  VasTransaction: 20
-  WarbandGroups: 55
-  WarbandSceneCollection: 62
+  values:
+    AccountCurrencies: 26
+    AccountNotifications: 38
+    AccountStore: 54
+    Achievements: 4
+    AddLicense: 16
+    ArchivedPurchases: 9
+    AuctionableToken: 18
+    BankTab: 48
+    BattlenetAccount: 25
+    Battlepet: 3
+    BitVectors: 50
+    CharacterDataMerge: 53
+    CharacterItems: 57
+    Characters: 7
+    CombinedQuestLog: 51
+    ConsumableToken: 19
+    CreateOrderInfo: 32
+    Criteria: 5
+    CriteriaNotif: 13
+    CurrencyCaps: 11
+    CurrencyTransferLog: 58
+    Distribution: 2
+    Distributions: 10
+    DynamicCriteria: 30
+    EventRecords: 63
+    Factions: 49
+    FixedLicense: 15
+    GetOrderStatusByPurchaseID: 46
+    HouseInitiativeFavor: 66
+    HousingItem: 64
+    ItemCollections: 17
+    Items: 47
+    LgVendorPurchase: 59
+    LoadWowlabs: 44
+    Mapping: 56
+    Mounts: 6
+    OutstandingRpc: 43
+    PerkItemHold: 39
+    PerkPastRewards: 41
+    PerkPendingRewards: 40
+    PerkTransaction: 42
+    PlayerDataElements: 52
+    Productitem: 21
+    Profile: 61
+    ProxyCreateAccountHonor: 34
+    ProxyForwarder: 0
+    ProxyGenerateBpayID: 37
+    ProxyGmSetHonor: 36
+    ProxyHonorInitialConversion: 33
+    ProxyValidateAccountHonor: 35
+    Purchase: 1
+    Purchases: 8
+    QuestCriteria: 24
+    QuestLog: 12
+    RafActivity: 31
+    RafFriendMonth: 28
+    RafRecruiterAcceptances: 27
+    RafReward: 29
+    SaveWarbandGroups: 60
+    Settings: 14
+    TransmogOutfitCollection: 65
+    TrialBoostHistories: 23
+    TrialBoostHistory: 22
+    UpgradeAccount: 45
+    VasTransaction: 20
+    WarbandGroups: 55
+    WarbandSceneCollection: 62
 ActionBarOrientation:
-  Horizontal: 0
-  Vertical: 1
+  values:
+    Horizontal: 0
+    Vertical: 1
 ActionBarVisibleSetting:
-  Always: 0
-  Hidden: 3
-  InCombat: 1
-  OutOfCombat: 2
+  values:
+    Always: 0
+    Hidden: 3
+    InCombat: 1
+    OutOfCombat: 2
 AddOnEnableState:
-  All: 2
-  None: 0
-  Some: 1
+  values:
+    All: 2
+    None: 0
+    Some: 1
 AddOnPerformanceMessageType:
-  OverallAddOnErrorDialog: 2
-  SpecificAddOnChatWarning: 0
-  SpecificAddOnErrorDialog: 1
+  values:
+    OverallAddOnErrorDialog: 2
+    SpecificAddOnChatWarning: 0
+    SpecificAddOnErrorDialog: 1
 AddOnProfilerMetric:
-  CountTimeOver1000Ms: 11
-  CountTimeOver100Ms: 9
-  CountTimeOver10Ms: 7
-  CountTimeOver1Ms: 5
-  CountTimeOver500Ms: 10
-  CountTimeOver50Ms: 8
-  CountTimeOver5Ms: 6
-  EncounterAverageTime: 2
-  LastTime: 3
-  PeakTime: 4
-  RecentAverageTime: 1
-  SessionAverageTime: 0
+  values:
+    CountTimeOver1000Ms: 11
+    CountTimeOver100Ms: 9
+    CountTimeOver10Ms: 7
+    CountTimeOver1Ms: 5
+    CountTimeOver500Ms: 10
+    CountTimeOver50Ms: 8
+    CountTimeOver5Ms: 6
+    EncounterAverageTime: 2
+    LastTime: 3
+    PeakTime: 4
+    RecentAverageTime: 1
+    SessionAverageTime: 0
 AddOnRestrictionState:
-  Activating: 1
-  Active: 2
-  Inactive: 0
+  values:
+    Activating: 1
+    Active: 2
+    Inactive: 0
 AddOnRestrictionType:
-  ChallengeMode: 2
-  Chat: 5
-  Combat: 0
-  Encounter: 1
-  Map: 4
-  PvPMatch: 3
+  values:
+    ChallengeMode: 2
+    Chat: 5
+    Combat: 0
+    Encounter: 1
+    Map: 4
+    PvPMatch: 3
 AddOnSecurityStatus:
-  Banned: 2
-  Insecure: 1
-  NotAvailable: 3
-  Secure: 0
+  values:
+    Banned: 2
+    Insecure: 1
+    NotAvailable: 3
+    Secure: 0
 ArrowCalloutDirection:
-  Down: 1
-  Left: 2
-  Right: 3
-  Up: 0
+  values:
+    Down: 1
+    Left: 2
+    Right: 3
+    Up: 0
 ArrowCalloutType:
-  Generic: 1
-  None: 0
-  Tutorial: 3
-  WidgetContainerNoBorder: 4
-  WorldLootObject: 2
+  values:
+    Generic: 1
+    None: 0
+    Tutorial: 3
+    WidgetContainerNoBorder: 4
+    WorldLootObject: 2
 AssistActionType:
-  CapturedBuff: 6
-  GraveMarker: 2
-  LoungingPlayer: 1
-  None: 0
-  PlacedVo: 3
-  PlayerGuardian: 4
-  PlayerSlayer: 5
+  values:
+    CapturedBuff: 6
+    GraveMarker: 2
+    LoungingPlayer: 1
+    None: 0
+    PlacedVo: 3
+    PlayerGuardian: 4
+    PlayerSlayer: 5
 AuctionHouseCommoditySortOrder:
-  Quantity: 1
-  UnitPrice: 0
+  values:
+    Quantity: 1
+    UnitPrice: 0
 AuctionHouseError:
-  BidIncrement: 2
-  BidOwn: 3
-  BoundItem: 16
-  ConjuredItem: 17
-  DatabaseError: 10
-  DoubleBid: 23
-  EquippedBag: 20
-  FavoritesMaxed: 24
-  HasRestriction: 6
-  HigherBid: 1
-  IsBag: 19
-  IsBusy: 7
-  ItemBoundToAccountUntilEquip: 26
-  ItemHasQuote: 9
-  ItemNotAvailable: 25
-  ItemNotFound: 4
-  LimitedDurationItem: 18
-  LootItem: 22
-  MinBid: 11
-  NotEnoughItems: 12
-  NotEnoughMoney: 0
-  QuestItem: 15
-  RepairItem: 13
-  RestrictedAccountTrial: 5
-  Unavailable: 8
-  UsedCharges: 14
-  WrappedItem: 21
+  values:
+    BidIncrement: 2
+    BidOwn: 3
+    BoundItem: 16
+    ConjuredItem: 17
+    DatabaseError: 10
+    DoubleBid: 23
+    EquippedBag: 20
+    FavoritesMaxed: 24
+    HasRestriction: 6
+    HigherBid: 1
+    IsBag: 19
+    IsBusy: 7
+    ItemBoundToAccountUntilEquip: 26
+    ItemHasQuote: 9
+    ItemNotAvailable: 25
+    ItemNotFound: 4
+    LimitedDurationItem: 18
+    LootItem: 22
+    MinBid: 11
+    NotEnoughItems: 12
+    NotEnoughMoney: 0
+    QuestItem: 15
+    RepairItem: 13
+    RestrictedAccountTrial: 5
+    Unavailable: 8
+    UsedCharges: 14
+    WrappedItem: 21
 AuctionHouseFilter:
-  ArtifactQuality: 12
-  CommonQuality: 7
-  CurrentExpansionOnly: 3
-  EpicQuality: 10
-  ExactMatch: 5
-  LegendaryCraftedItemOnly: 13
-  LegendaryQuality: 11
-  None: 0
-  PoorQuality: 6
-  RareQuality: 9
-  UncollectedOnly: 1
-  UncommonQuality: 8
-  UpgradesOnly: 4
-  UsableOnly: 2
+  values:
+    ArtifactQuality: 12
+    CommonQuality: 7
+    CurrentExpansionOnly: 3
+    EpicQuality: 10
+    ExactMatch: 5
+    LegendaryCraftedItemOnly: 13
+    LegendaryQuality: 11
+    None: 0
+    PoorQuality: 6
+    RareQuality: 9
+    UncollectedOnly: 1
+    UncommonQuality: 8
+    UpgradesOnly: 4
+    UsableOnly: 2
 AuctionHouseFilterCategory:
-  Equipment: 1
-  Rarity: 2
-  Uncategorized: 0
+  values:
+    Equipment: 1
+    Rarity: 2
+    Uncategorized: 0
 AuctionHouseItemSortOrder:
-  Bid: 0
-  Buyout: 1
+  values:
+    Bid: 0
+    Buyout: 1
 AuctionHouseNotification:
-  AuctionExpired: 5
-  AuctionOutbid: 3
-  AuctionRemoved: 1
-  AuctionSold: 4
-  AuctionWon: 2
-  BidPlaced: 0
+  values:
+    AuctionExpired: 5
+    AuctionOutbid: 3
+    AuctionRemoved: 1
+    AuctionSold: 4
+    AuctionWon: 2
+    BidPlaced: 0
 AuctionHouseSortOrder:
-  Bid: 3
-  Buyout: 4
-  Level: 2
-  Name: 1
-  Price: 0
-  TimeRemaining: 5
+  values:
+    Bid: 3
+    Buyout: 4
+    Level: 2
+    Name: 1
+    Price: 0
+    TimeRemaining: 5
 AuctionHouseTimeLeftBand:
-  Long: 2
-  Medium: 1
-  Short: 0
-  VeryLong: 3
+  values:
+    Long: 2
+    Medium: 1
+    Short: 0
+    VeryLong: 3
 AuctionStatus:
-  Active: 0
-  Sold: 1
+  values:
+    Active: 0
+    Sold: 1
 AuraFrameIconDirection:
-  Down: 0
-  Left: 0
-  Right: 1
-  Up: 1
+  values:
+    Down: 0
+    Left: 0
+    Right: 1
+    Up: 1
 AuraFrameIconWrap:
-  Down: 0
-  Left: 0
-  Right: 1
-  Up: 1
+  values:
+    Down: 0
+    Left: 0
+    Right: 1
+    Up: 1
 AuraFrameOrientation:
-  Horizontal: 0
-  Vertical: 1
+  values:
+    Horizontal: 0
+    Vertical: 1
 AuraFrameVisibleSetting:
-  Always: 0
-  Hidden: 2
-  InCombat: 1
+  values:
+    Always: 0
+    Hidden: 2
+    InCombat: 1
 AutoCompleteEntryFlag:
-  AccountCharacter: 128
-  Bnet: 8
-  Friend: 4
-  InAOI: 64
-  InGroup: 1
-  InGuild: 2
-  InteractedWith: 16
-  Online: 32
-  RecentPlayer: 256
+  values:
+    AccountCharacter: 128
+    Bnet: 8
+    Friend: 4
+    InAOI: 64
+    InGroup: 1
+    InGuild: 2
+    InteractedWith: 16
+    Online: 32
+    RecentPlayer: 256
 AutoCompletePriority:
-  AccountCharacter: 5
-  AccountCharacterSameRealm: 6
-  Friend: 4
-  Guild: 3
-  InGroup: 2
-  Interacted: 1
-  Other: 0
+  values:
+    AccountCharacter: 5
+    AccountCharacterSameRealm: 6
+    Friend: 4
+    Guild: 3
+    InGroup: 2
+    Interacted: 1
+    Other: 0
 AvgItemLevelCategories:
-  Base: 0
-  EquippedBase: 1
-  EquippedEffective: 2
-  EquippedEffectiveWeighted: 5
-  PvP: 3
-  PvPWeighted: 4
+  values:
+    Base: 0
+    EquippedBase: 1
+    EquippedEffective: 2
+    EquippedEffectiveWeighted: 5
+    PvP: 3
+    PvPWeighted: 4
 AzeriteEssenceSlot:
-  MainSlot: 0
-  PassiveOneSlot: 1
-  PassiveThreeSlot: 3
-  PassiveTwoSlot: 2
+  values:
+    MainSlot: 0
+    PassiveOneSlot: 1
+    PassiveThreeSlot: 3
+    PassiveTwoSlot: 2
 AzeritePowerLevel:
-  Base: 0
-  Downgraded: 2
-  Upgraded: 1
+  values:
+    Base: 0
+    Downgraded: 2
+    Upgraded: 1
 BagFlag:
-  AllowBagsInNonBagSlots: 1024
-  AllowBuyback: 65536
-  AllowPartialStack: 16384
-  AllowSoulboundItemInAccountBank: 134217728
-  AlreadyBound: 4
-  AlreadyOwner: 2
-  AsymmetricSwap: 1048576
-  BagIsEmpty: 16
-  DontFindStack: 1
-  HasRefund: 33554432
-  IgnoreBankcheck: 512
-  IgnoreBoundItemCheck: 64
-  IgnoreExisting: 8192
-  IgnorePetBankcheck: 131072
-  IgnoreReagentBags: 8388608
-  IgnoreSoulbound: 4194304
-  LookInAccountBankOnly: 16777216
-  LookInBankOnly: 32768
-  LookInInventory: 32
-  PreferNeutralPriorityBags: 524288
-  PreferPriorityBags: 262144
-  PreferQuivers: 2048
-  PreferReagentBags: 2097152
-  RecurseQuivers: 256
-  SkipValidCountCheck: 67108864
-  StackOnly: 128
-  Swap: 8
-  SwapBags: 4096
+  values:
+    AllowBagsInNonBagSlots: 1024
+    AllowBuyback: 65536
+    AllowPartialStack: 16384
+    AllowSoulboundItemInAccountBank: 134217728
+    AlreadyBound: 4
+    AlreadyOwner: 2
+    AsymmetricSwap: 1048576
+    BagIsEmpty: 16
+    DontFindStack: 1
+    HasRefund: 33554432
+    IgnoreBankcheck: 512
+    IgnoreBoundItemCheck: 64
+    IgnoreExisting: 8192
+    IgnorePetBankcheck: 131072
+    IgnoreReagentBags: 8388608
+    IgnoreSoulbound: 4194304
+    LookInAccountBankOnly: 16777216
+    LookInBankOnly: 32768
+    LookInInventory: 32
+    PreferNeutralPriorityBags: 524288
+    PreferPriorityBags: 262144
+    PreferQuivers: 2048
+    PreferReagentBags: 2097152
+    RecurseQuivers: 256
+    SkipValidCountCheck: 67108864
+    StackOnly: 128
+    Swap: 8
+    SwapBags: 4096
 BagIndex:
-  Accountbanktab: -5
-  AccountBankTab_1: 13
-  AccountBankTab_2: 14
-  AccountBankTab_3: 15
-  AccountBankTab_4: 16
-  AccountBankTab_5: 17
-  Backpack: 0
-  Bag_1: 1
-  Bag_2: 2
-  Bag_3: 3
-  Bag_4: 4
-  Bank: -1
-  Bankbag: -4
-  BankBag_1: 6
-  BankBag_2: 7
-  BankBag_3: 8
-  BankBag_4: 9
-  BankBag_5: 10
-  BankBag_6: 11
-  BankBag_7: 12
-  Keyring: -2
-  ReagentBag: 5
-  Reagentbank: -3
+  values:
+    Accountbanktab: -5
+    AccountBankTab_1: 13
+    AccountBankTab_2: 14
+    AccountBankTab_3: 15
+    AccountBankTab_4: 16
+    AccountBankTab_5: 17
+    Backpack: 0
+    Bag_1: 1
+    Bag_2: 2
+    Bag_3: 3
+    Bag_4: 4
+    Bank: -1
+    Bankbag: -4
+    BankBag_1: 6
+    BankBag_2: 7
+    BankBag_3: 8
+    BankBag_4: 9
+    BankBag_5: 10
+    BankBag_6: 11
+    BankBag_7: 12
+    Keyring: -2
+    ReagentBag: 5
+    Reagentbank: -3
 BagsDirection:
-  Down: 1
-  Left: 0
-  Right: 1
-  Up: 0
+  values:
+    Down: 1
+    Left: 0
+    Right: 1
+    Up: 0
 BagSlotFlags:
-  ClassConsumables: 4
-  ClassEquipment: 2
-  ClassJunk: 16
-  ClassProfessionGoods: 8
-  ClassQuestItems: 32
-  ClassReagents: 128
-  DisableAutoSort: 1
-  ExcludeJunkSell: 64
-  ExpansionCurrent: 256
-  ExpansionLegacy: 512
+  values:
+    ClassConsumables: 4
+    ClassEquipment: 2
+    ClassJunk: 16
+    ClassProfessionGoods: 8
+    ClassQuestItems: 32
+    ClassReagents: 128
+    DisableAutoSort: 1
+    ExcludeJunkSell: 64
+    ExpansionCurrent: 256
+    ExpansionLegacy: 512
 BagsOrientation:
-  Horizontal: 0
-  Vertical: 1
+  values:
+    Horizontal: 0
+    Vertical: 1
 BalanceType:
-  Eclipse: 0
-  None: -1
+  values:
+    Eclipse: 0
+    None: -1
 BankLockedReason:
-  BankConversionFailed: 3
-  BankDisabled: 2
-  NoAccountInventoryLock: 1
-  None: 0
+  values:
+    BankConversionFailed: 3
+    BankDisabled: 2
+    NoAccountInventoryLock: 1
+    None: 0
 BankType:
-  Account: 2
-  Character: 0
-  Guild: 1
+  values:
+    Account: 2
+    Character: 0
+    Guild: 1
 Base64Variant:
-  Standard: 0
-  StandardUrlSafe: 1
+  values:
+    Standard: 0
+    StandardUrlSafe: 1
 BattlepayBannerType:
-  Discount: 1
-  Featured: 2
-  New: 3
-  None: 0
+  values:
+    Discount: 1
+    Featured: 2
+    New: 3
+    None: 0
 BattlepayDisplayFlags:
-  CardAlwaysShowsTexture: 4
-  CardDoesNotShowModel: 2
-  Deprecated1: 32
-  Deprecated2: 64
-  Expansion: 1
-  HiddenPrice: 8
-  HideWhenOwned: 256
-  RafReward: 512
-  ShowFancyToast: 1024
-  UseHorizontalLayoutForFullCard: 16
-  UseIconBorderWithOverrideTexture: 2048
-  UseSquareIconBorder: 128
+  values:
+    CardAlwaysShowsTexture: 4
+    CardDoesNotShowModel: 2
+    Deprecated1: 32
+    Deprecated2: 64
+    Expansion: 1
+    HiddenPrice: 8
+    HideWhenOwned: 256
+    RafReward: 512
+    ShowFancyToast: 1024
+    UseHorizontalLayoutForFullCard: 16
+    UseIconBorderWithOverrideTexture: 2048
+    UseSquareIconBorder: 128
 BattlepayGroupDisplayType:
-  ActiveTimeOnly: 2
-  Everyone: 0
-  TrialAndVeteranOnly: 1
+  values:
+    ActiveTimeOnly: 2
+    Everyone: 0
+    TrialAndVeteranOnly: 1
 BattlepayLicenseSynthesisFlags:
-  ForceToGameAccount: 1
+  values:
+    ForceToGameAccount: 1
 BattlepayProductChoiceType:
-  ChoiceNone: 0
-  ChoiceOne: 1
-  SpecAndFaction: 2
-  VasCharacter: 3
-  VasCharacterAndName: 4
+  values:
+    ChoiceNone: 0
+    ChoiceOne: 1
+    SpecAndFaction: 2
+    VasCharacter: 3
+    VasCharacterAndName: 4
 BattlepayProductDecorator:
-  Boost: 0
-  Expansion: 1
-  VasService: 3
-  WoWToken: 2
+  values:
+    Boost: 0
+    Expansion: 1
+    VasService: 3
+    WoWToken: 2
 BattlepayProductGroupFlags:
-  DisableOwnedProducts: 4
-  EnabledForTrial: 2
-  EnabledForVeteran: 8
-  HideOwnedProducts: 1
-  None: 0
-  TrialAndVeteranOnly: 16
+  values:
+    DisableOwnedProducts: 4
+    EnabledForTrial: 2
+    EnabledForVeteran: 8
+    HideOwnedProducts: 1
+    None: 0
+    TrialAndVeteranOnly: 16
 BattlepayShopEntryBannerType:
-  Discount: 1
-  Featured: 0
-  New: 2
+  values:
+    Discount: 1
+    Featured: 0
+    New: 2
 BattlepayShopEntryFlags:
-  None: 0
+  values:
+    None: 0
 BattlePetAction:
-  Ability: 1
-  None: 0
-  Skip: 4
-  SwitchPet: 2
-  Trap: 3
+  values:
+    Ability: 1
+    None: 0
+    Skip: 4
+    SwitchPet: 2
+    Trap: 3
 BattlePetBreedQuality:
-  Common: 1
-  Epic: 4
-  Legendary: 5
-  Poor: 0
-  Rare: 3
-  Uncommon: 2
+  values:
+    Common: 1
+    Epic: 4
+    Legendary: 5
+    Poor: 0
+    Rare: 3
+    Uncommon: 2
 BattlePetOwner:
-  Ally: 1
-  Enemy: 2
-  Weather: 0
+  values:
+    Ally: 1
+    Enemy: 2
+    Weather: 0
 BattlePetSources:
-  Achievement: 5
-  Discovery: 10
-  Drop: 0
-  PetStore: 9
-  Profession: 3
-  Promotion: 7
-  Quest: 1
-  Tcg: 8
-  TradingPost: 11
-  Vendor: 2
-  WildPet: 4
-  WorldEvent: 6
+  values:
+    Achievement: 5
+    Discovery: 10
+    Drop: 0
+    PetStore: 9
+    Profession: 3
+    Promotion: 7
+    Quest: 1
+    Tcg: 8
+    TradingPost: 11
+    Vendor: 2
+    WildPet: 4
+    WorldEvent: 6
 BindingContext:
-  HousingEditor: 1
-  HousingEditorBasicAndExpertDecorMode: 7
-  HousingEditorBasicDecorMode: 2
-  HousingEditorCleanupMode: 5
-  HousingEditorCustomizeMode: 4
-  HousingEditorExpertDecorMode: 3
-  HousingEditorExteriorCustomizationMode: 8
-  HousingEditorLayoutMode: 6
-  None: 0
-  ReservedFutureFeatureBinding01: 9
+  values:
+    HousingEditor: 1
+    HousingEditorBasicAndExpertDecorMode: 7
+    HousingEditorBasicDecorMode: 2
+    HousingEditorCleanupMode: 5
+    HousingEditorCustomizeMode: 4
+    HousingEditorExpertDecorMode: 3
+    HousingEditorExteriorCustomizationMode: 8
+    HousingEditorLayoutMode: 6
+    None: 0
+    ReservedFutureFeatureBinding01: 9
 BindingSet:
-  Account: 1
-  Character: 2
-  Current: 3
-  Default: 0
+  values:
+    Account: 1
+    Character: 2
+    Current: 3
+    Default: 0
 BnetAccountFlag:
-  AccountQuestBitFixUp: 64
-  AchievementsToBi: 128
-  BattlePetTrainer: 1
-  CanBuyAhGameTimeTokens: 32768
-  CataLegendaryMountChecked: 262144
-  CataLegendaryMountObtained: 524288
-  DarkRealmLightCopy: 2048
-  Employee: 16
-  EmployeeFlagIsManual: 32
-  GdprErased: 1024
-  InvalidTransmogsFixUp: 256
-  InvalidTransmogsFixUp2: 512
-  IsLegacy: 131072
-  LockedForExport: 16384
-  MopQuestLogFlagsFixUp: 1048576
-  None: 0
-  PetAchievementFixUp: 65536
-  QuestLogFlagsFixUp: 4096
-  RafVeteranNotified: 2
-  TwitterHasTempSecret: 8
-  TwitterLinked: 4
-  WasSecured: 8192
+  values:
+    AccountQuestBitFixUp: 64
+    AchievementsToBi: 128
+    BattlePetTrainer: 1
+    CanBuyAhGameTimeTokens: 32768
+    CataLegendaryMountChecked: 262144
+    CataLegendaryMountObtained: 524288
+    DarkRealmLightCopy: 2048
+    Employee: 16
+    EmployeeFlagIsManual: 32
+    GdprErased: 1024
+    InvalidTransmogsFixUp: 256
+    InvalidTransmogsFixUp2: 512
+    IsLegacy: 131072
+    LockedForExport: 16384
+    MopQuestLogFlagsFixUp: 1048576
+    None: 0
+    PetAchievementFixUp: 65536
+    QuestLogFlagsFixUp: 4096
+    RafVeteranNotified: 2
+    TwitterHasTempSecret: 8
+    TwitterLinked: 4
+    WasSecured: 8192
 BonusStatIndex:
-  Agility: 3
-  AgilityOrIntellect: 73
-  AgilityOrStrength: 72
-  AgilityOrStrengthOrIntellect: 71
-  ArcaneResistance: 56
-  ArmorPenetrationRating: 44
-  AttackPower: 38
-  BlockRating: 15
-  BlockValue: 48
-  CombatRatingAvoidance: 63
-  CombatRatingLifesteal: 62
-  CombatRatingSpeed: 61
-  CombatRatingSturdiness: 64
-  CombatRatingUnused_0: 58
-  CombatRatingUnused_10: 68
-  CombatRatingUnused_11: 69
-  CombatRatingUnused_12: 70
-  CombatRatingUnused_2: 59
-  CombatRatingUnused_27: 66
-  CombatRatingUnused_3: 60
-  CombatRatingUnused_7: 65
-  CombatRatingUnused_9: 67
-  CritMeleeRating: 19
-  CritRangedRating: 20
-  CritRating: 32
-  CritSpellRating: 21
-  CritTakenMeleeRatingObsolete: 25
-  CritTakenRangedRatingObsolete: 26
-  CritTakenRatingObsolete: 34
-  CritTakenSpellRatingObsolete: 27
-  DefenseSkillRating: 12
-  DodgeRating: 13
-  Endurance: 2
-  Energy: 8
-  ExpertiseRating: 37
-  ExtraArmor: 50
-  FireResistance: 51
-  Focus: 10
-  FrostResistance: 52
-  HasteMeleeRatingObsolete: 28
-  HasteRangedRatingObsolete: 29
-  HasteRating: 36
-  HasteSpellRatingObsolete: 30
-  Health: 1
-  HealthRegen: 46
-  HitMeleeRating: 16
-  HitRangedRating: 17
-  HitRating: 31
-  HitSpellRating: 18
-  HitTakenMeleeRatingObsolete: 22
-  HitTakenRangedRatingObsolete: 23
-  HitTakenRatingObsolete: 33
-  HitTakenSpellRatingObsolete: 24
-  HolyResistance: 53
-  Intellect: 5
-  Mana: 0
-  ManaRegeneration: 43
-  MasteryRating: 49
-  NatureResistance: 55
-  ParryRating: 14
-  ProfessionCraftingSpeed: 80
-  ProfessionDeftness: 78
-  ProfessionFinesse: 77
-  ProfessionIngenuity: 82
-  ProfessionInspiration: 75
-  ProfessionMulticraft: 81
-  ProfessionPerception: 79
-  ProfessionResourcefulness: 76
-  PvPPower: 57
-  Rage: 9
-  RangedAttackPower: 39
-  ResilienceRating: 35
-  ShadowResistance: 54
-  SpellDamageDone: 42
-  SpellHealingDone: 41
-  SpellPenetration: 47
-  SpellPower: 45
-  Spirit: 6
-  Stamina: 7
-  Strength: 4
-  StrengthOrIntellect: 74
-  Versatility: 40
-  WeaponSkillRating: 11
+  values:
+    Agility: 3
+    AgilityOrIntellect: 73
+    AgilityOrStrength: 72
+    AgilityOrStrengthOrIntellect: 71
+    ArcaneResistance: 56
+    ArmorPenetrationRating: 44
+    AttackPower: 38
+    BlockRating: 15
+    BlockValue: 48
+    CombatRatingAvoidance: 63
+    CombatRatingLifesteal: 62
+    CombatRatingSpeed: 61
+    CombatRatingSturdiness: 64
+    CombatRatingUnused_0: 58
+    CombatRatingUnused_10: 68
+    CombatRatingUnused_11: 69
+    CombatRatingUnused_12: 70
+    CombatRatingUnused_2: 59
+    CombatRatingUnused_27: 66
+    CombatRatingUnused_3: 60
+    CombatRatingUnused_7: 65
+    CombatRatingUnused_9: 67
+    CritMeleeRating: 19
+    CritRangedRating: 20
+    CritRating: 32
+    CritSpellRating: 21
+    CritTakenMeleeRatingObsolete: 25
+    CritTakenRangedRatingObsolete: 26
+    CritTakenRatingObsolete: 34
+    CritTakenSpellRatingObsolete: 27
+    DefenseSkillRating: 12
+    DodgeRating: 13
+    Endurance: 2
+    Energy: 8
+    ExpertiseRating: 37
+    ExtraArmor: 50
+    FireResistance: 51
+    Focus: 10
+    FrostResistance: 52
+    HasteMeleeRatingObsolete: 28
+    HasteRangedRatingObsolete: 29
+    HasteRating: 36
+    HasteSpellRatingObsolete: 30
+    Health: 1
+    HealthRegen: 46
+    HitMeleeRating: 16
+    HitRangedRating: 17
+    HitRating: 31
+    HitSpellRating: 18
+    HitTakenMeleeRatingObsolete: 22
+    HitTakenRangedRatingObsolete: 23
+    HitTakenRatingObsolete: 33
+    HitTakenSpellRatingObsolete: 24
+    HolyResistance: 53
+    Intellect: 5
+    Mana: 0
+    ManaRegeneration: 43
+    MasteryRating: 49
+    NatureResistance: 55
+    ParryRating: 14
+    ProfessionCraftingSpeed: 80
+    ProfessionDeftness: 78
+    ProfessionFinesse: 77
+    ProfessionIngenuity: 82
+    ProfessionInspiration: 75
+    ProfessionMulticraft: 81
+    ProfessionPerception: 79
+    ProfessionResourcefulness: 76
+    PvPPower: 57
+    Rage: 9
+    RangedAttackPower: 39
+    ResilienceRating: 35
+    ShadowResistance: 54
+    SpellDamageDone: 42
+    SpellHealingDone: 41
+    SpellPenetration: 47
+    SpellPower: 45
+    Spirit: 6
+    Stamina: 7
+    Strength: 4
+    StrengthOrIntellect: 74
+    Versatility: 40
+    WeaponSkillRating: 11
 BrawlType:
-  Arena: 2
-  Battleground: 1
-  LFG: 3
-  None: 0
-  SoloRbg: 5
-  SoloShuffle: 4
+  values:
+    Arena: 2
+    Battleground: 1
+    LFG: 3
+    None: 0
+    SoloRbg: 5
+    SoloShuffle: 4
 BulkPurchaseResult:
-  ResultFailed: 3
-  ResultInProgress: 1
-  ResultInsufficientFunds: 6
-  ResultOk: 0
-  ResultPartialSuccess: 2
-  ResultPurchaseTimeout: 7
-  ResultSystemDisabled: 5
-  ResultTooManyProducts: 4
+  values:
+    ResultFailed: 3
+    ResultInProgress: 1
+    ResultInsufficientFunds: 6
+    ResultOk: 0
+    ResultPartialSuccess: 2
+    ResultPurchaseTimeout: 7
+    ResultSystemDisabled: 5
+    ResultTooManyProducts: 4
 BulkPurchaseStatus:
-  Done: 3
-  Failed: 4
-  FetchEntitlements: 2
-  PlacingOrders: 0
-  PurchasesPending: 1
+  values:
+    Done: 3
+    Failed: 4
+    FetchEntitlements: 2
+    PlacingOrders: 0
+    PurchasesPending: 1
 BulkRefundResult:
-  ResultFailed: 1
-  ResultInvalidRequest: 2
-  ResultOk: 0
-  ResultRefundWindowExpired: 3
-  ResultSystemDisabled: 4
-  ResultTimeout: 5
+  values:
+    ResultFailed: 1
+    ResultInvalidRequest: 2
+    ResultOk: 0
+    ResultRefundWindowExpired: 3
+    ResultSystemDisabled: 4
+    ResultTimeout: 5
 CachedRewardType:
-  Currency: 2
-  Item: 1
-  None: 0
-  Quest: 3
+  values:
+    Currency: 2
+    Item: 1
+    None: 0
+    Quest: 3
 CalendarCommandType:
-  Complain: 10
-  Create: 0
-  GetCalendar: 7
-  GetEvent: 8
-  Invite: 1
-  ModeratorStatus: 6
-  Notes: 11
-  RemoveEvent: 4
-  RemoveInvite: 3
-  Rsvp: 2
-  Status: 5
-  UpdateEvent: 9
+  values:
+    Complain: 10
+    Create: 0
+    GetCalendar: 7
+    GetEvent: 8
+    Invite: 1
+    ModeratorStatus: 6
+    Notes: 11
+    RemoveEvent: 4
+    RemoveInvite: 3
+    Rsvp: 2
+    Status: 5
+    UpdateEvent: 9
 CalendarErrorType:
-  ArenaEventsExceeded: 27
-  CalendarDisabled: 25
-  CommunityEventsExceeded: 1
-  ComplaintAdded: 50
-  ComplaintDisabled: 31
-  ComplaintGm: 34
-  ComplaintLimit: 35
-  ComplaintNotFound: 36
-  ComplaintSameGuild: 33
-  ComplaintSelf: 32
-  CreatorNotFound: 46
-  DataAlreadySet: 24
-  DeleteCreatorFailed: 23
-  EventInvalid: 6
-  EventLocked: 22
-  EventPassed: 21
-  EventsExceeded: 2
-  EventThrottled: 47
-  EventWrongServer: 37
-  Ignored: 14
-  Internal: 49
-  InvalidClub: 45
-  InvalidDate: 17
-  InvalidDescription: 44
-  InvalidMaxSize: 16
-  InvalidNotes: 42
-  InvalidSignup: 39
-  InvalidTime: 18
-  InvalidTitle: 43
-  InvitesExceeded: 15
-  InviteThrottled: 48
-  ModeratorRestricted: 41
-  NameNotFound: 12
-  NeedsTitle: 20
-  NoCommunityInvites: 38
-  NoInvite: 30
-  NoInvites: 19
-  NoModerator: 40
-  NoPermission: 5
-  NotInCommunity: 10
-  NotInGuild: 9
-  NotInvited: 7
-  OtherInvitesExceeded: 4
-  RestrictedAccount: 26
-  RestrictedLevel: 28
-  SelfInvitesExceeded: 3
-  Squelched: 29
-  Success: 0
-  TargetAlreadyInvited: 11
-  UnknownError: 8
-  WrongFaction: 13
+  values:
+    ArenaEventsExceeded: 27
+    CalendarDisabled: 25
+    CommunityEventsExceeded: 1
+    ComplaintAdded: 50
+    ComplaintDisabled: 31
+    ComplaintGm: 34
+    ComplaintLimit: 35
+    ComplaintNotFound: 36
+    ComplaintSameGuild: 33
+    ComplaintSelf: 32
+    CreatorNotFound: 46
+    DataAlreadySet: 24
+    DeleteCreatorFailed: 23
+    EventInvalid: 6
+    EventLocked: 22
+    EventPassed: 21
+    EventsExceeded: 2
+    EventThrottled: 47
+    EventWrongServer: 37
+    Ignored: 14
+    Internal: 49
+    InvalidClub: 45
+    InvalidDate: 17
+    InvalidDescription: 44
+    InvalidMaxSize: 16
+    InvalidNotes: 42
+    InvalidSignup: 39
+    InvalidTime: 18
+    InvalidTitle: 43
+    InvitesExceeded: 15
+    InviteThrottled: 48
+    ModeratorRestricted: 41
+    NameNotFound: 12
+    NeedsTitle: 20
+    NoCommunityInvites: 38
+    NoInvite: 30
+    NoInvites: 19
+    NoModerator: 40
+    NoPermission: 5
+    NotInCommunity: 10
+    NotInGuild: 9
+    NotInvited: 7
+    OtherInvitesExceeded: 4
+    RestrictedAccount: 26
+    RestrictedLevel: 28
+    SelfInvitesExceeded: 3
+    Squelched: 29
+    Success: 0
+    TargetAlreadyInvited: 11
+    UnknownError: 8
+    WrongFaction: 13
 CalendarEventBits:
-  ArenaDeprecated: 256
-  AutoApprove: 32
-  CantComplain: 3788
-  CommunityAnnouncement: 64
-  CommunitySignup: 1024
-  CommunityWide: 3136
-  GuildDeprecated: 2
-  GuildSignup: 2048
-  Holiday: 8
-  Locked: 16
-  Player: 1
-  PlayerCreated: 3395
-  RaidLockout: 128
-  RaidReset: 512
-  System: 4
+  values:
+    ArenaDeprecated: 256
+    AutoApprove: 32
+    CantComplain: 3788
+    CommunityAnnouncement: 64
+    CommunitySignup: 1024
+    CommunityWide: 3136
+    GuildDeprecated: 2
+    GuildSignup: 2048
+    Holiday: 8
+    Locked: 16
+    Player: 1
+    PlayerCreated: 3395
+    RaidLockout: 128
+    RaidReset: 512
+    System: 4
 CalendarEventRepeatOptions:
-  Biweekly: 2
-  Monthly: 3
-  Never: 0
-  Weekly: 1
+  values:
+    Biweekly: 2
+    Monthly: 3
+    Never: 0
+    Weekly: 1
 CalendarEventType:
-  Dungeon: 1
-  HeroicDeprecated: 5
-  Meeting: 3
-  Other: 4
-  PvP: 2
-  Raid: 0
+  values:
+    Dungeon: 1
+    HeroicDeprecated: 5
+    Meeting: 3
+    Other: 4
+    PvP: 2
+    Raid: 0
 CalendarFilterFlags:
-  Battleground: 4
-  Darkmoon: 2
-  RaidLockout: 8
-  RaidReset: 16
-  WeeklyHoliday: 1
+  values:
+    Battleground: 4
+    Darkmoon: 2
+    RaidLockout: 8
+    RaidReset: 16
+    WeeklyHoliday: 1
 CalendarGetEventType:
-  Add: 1
-  Copy: 2
-  Get: 0
+  values:
+    Add: 1
+    Copy: 2
+    Get: 0
 CalendarHolidayFilterType:
-  Battleground: 2
-  Darkmoon: 1
-  Weekly: 0
+  values:
+    Battleground: 2
+    Darkmoon: 1
+    Weekly: 0
 CalendarInviteBits:
-  Creator: 4
-  Moderator: 2
-  None: 0
-  PendingInvite: 1
-  Signup: 8
+  values:
+    Creator: 4
+    Moderator: 2
+    None: 0
+    PendingInvite: 1
+    Signup: 8
 CalendarInviteSortType:
-  Class: 2
-  Level: 1
-  Name: 0
-  Notes: 5
-  Party: 4
-  Status: 3
+  values:
+    Class: 2
+    Level: 1
+    Name: 0
+    Notes: 5
+    Party: 4
+    Status: 3
 CalendarInviteType:
-  Normal: 0
-  Signup: 1
+  values:
+    Normal: 0
+    Signup: 1
 CalendarModeratorStatus:
-  Creator: 2
-  Moderator: 1
-  None: 0
+  values:
+    Creator: 2
+    Moderator: 1
+    None: 0
 CalendarStatus:
-  Available: 1
-  Confirmed: 3
-  Declined: 2
-  Invited: 0
-  NotSignedup: 7
-  Out: 4
-  Signedup: 6
-  Standby: 5
-  Tentative: 8
+  values:
+    Available: 1
+    Confirmed: 3
+    Declined: 2
+    Invited: 0
+    NotSignedup: 7
+    Out: 4
+    Signedup: 6
+    Standby: 5
+    Tentative: 8
 CalendarTexturesType:
-  Dungeons: 0
-  Raid: 1
+  values:
+    Dungeons: 0
+    Raid: 1
 CalendarType:
-  Community: 1
-  Holiday: 4
-  HolidayBattleground: 7
-  HolidayDarkmoon: 6
-  HolidayWeekly: 5
-  Player: 0
-  RaidLockout: 2
-  RaidReset: 3
+  values:
+    Community: 1
+    Holiday: 4
+    HolidayBattleground: 7
+    HolidayDarkmoon: 6
+    HolidayWeekly: 5
+    Player: 0
+    RaidLockout: 2
+    RaidReset: 3
 CalendarWebActionType:
-  Accept: 0
-  Decline: 1
-  Remove: 2
-  ReportSpam: 3
-  Signup: 4
-  Tentative: 5
-  TentativeSignup: 6
+  values:
+    Accept: 0
+    Decline: 1
+    Remove: 2
+    ReportSpam: 3
+    Signup: 4
+    Tentative: 5
+    TentativeSignup: 6
 CameraModeAspectRatio:
-  Cinemascope_2_Dot_4_X_1: 3
-  Default: 0
-  HighDefinition_16_X_9: 2
-  LegacyLetterbox: 1
+  values:
+    Cinemascope_2_Dot_4_X_1: 3
+    Default: 0
+    HighDefinition_16_X_9: 2
+    LegacyLetterbox: 1
 CanRedeemTokenForBalanceResult:
-  FailureCap: 1
-  Ok: 0
+  values:
+    FailureCap: 1
+    Ok: 0
 CaptureBarWidgetFillDirectionType:
-  LeftToRight: 1
-  RightToLeft: 0
+  values:
+    LeftToRight: 1
+    RightToLeft: 0
 Causeofdeath:
-  Creature: 3
-  Drowning: 5
-  Falling: 4
-  Fatigue: 6
-  Fire: 9
-  Lava: 8
-  None: 0
-  PlayerDuel: 2
-  PlayerPvP: 1
-  Slime: 7
+  values:
+    Creature: 3
+    Drowning: 5
+    Falling: 4
+    Fatigue: 6
+    Fire: 9
+    Lava: 8
+    None: 0
+    PlayerDuel: 2
+    PlayerPvP: 1
+    Slime: 7
 CauseofdeathFlags:
-  CreatureNameNeeded: 2
-  NoneNeeded: 0
-  PlayerNameNeeded: 1
-  ZoneNameNeeded: 4
+  values:
+    CreatureNameNeeded: 2
+    NoneNeeded: 0
+    PlayerNameNeeded: 1
+    ZoneNameNeeded: 4
 ChallengeModeHistoryFlags:
-  ConfirmedLeaver: 1
-  None: 0
+  values:
+    ConfirmedLeaver: 1
+    None: 0
 ChallengeModeHistoryResult:
-  Leaver: 1
-  Successful: 0
+  values:
+    Leaver: 1
+    Successful: 0
 ChallengeModeHistoryStatus:
-  Leaver: 1
-  Normal: 0
+  values:
+    Leaver: 1
+    Normal: 0
 ChannelPlayerFlags:
-  ChannelPlayerHidden: 8
-  ChannelPlayerModerator: 2
-  ChannelPlayerNone: 0
-  ChannelPlayerOwner: 1
-  ChannelPlayerTextAllow: 4
+  values:
+    ChannelPlayerHidden: 8
+    ChannelPlayerModerator: 2
+    ChannelPlayerNone: 0
+    ChannelPlayerOwner: 1
+    ChannelPlayerTextAllow: 4
 CharacterServiceInfoFlag:
-  AllowMaxLevelBoost: 2
-  RestrictToRecommendedSpecs: 1
+  values:
+    AllowMaxLevelBoost: 2
+    RestrictToRecommendedSpecs: 1
 CharCustomizationType:
-  CustomOptionFacewear: 7
-  CustomOptionHorn: 6
-  CustomOptionTattoo: 5
-  CustomOptionTattooColor: 8
-  Face: 1
-  FacialHair: 4
-  Hair: 2
-  HairColor: 3
-  Skin: 0
+  values:
+    CustomOptionFacewear: 7
+    CustomOptionHorn: 6
+    CustomOptionTattoo: 5
+    CustomOptionTattooColor: 8
+    Face: 1
+    FacialHair: 4
+    Hair: 2
+    HairColor: 3
+    Skin: 0
 ChatChannelRuleset:
-  ChromieTimeBuringCrusade: 4
-  ChromieTimeCataclysm: 3
-  ChromieTimeLegion: 8
-  ChromieTimeMists: 6
-  ChromieTimeWoD: 7
-  ChromieTimeWrath: 5
-  Disabled: 2
-  Mentor: 1
-  None: 0
+  values:
+    ChromieTimeBuringCrusade: 4
+    ChromieTimeCataclysm: 3
+    ChromieTimeLegion: 8
+    ChromieTimeMists: 6
+    ChromieTimeWoD: 7
+    ChromieTimeWrath: 5
+    Disabled: 2
+    Mentor: 1
+    None: 0
 ChatChannelType:
-  Communities: 4
-  Custom: 1
-  None: 0
-  PrivateParty: 2
-  PublicParty: 3
+  values:
+    Communities: 4
+    Custom: 1
+    None: 0
+    PrivateParty: 2
+    PublicParty: 3
 ChatToxityFilterOptOut:
-  ExcludeFilterAll: 4294967295
-  ExcludeFilterFriend: 1
-  ExcludeFilterGuild: 2
-  FilterAll: 0
+  values:
+    ExcludeFilterAll: 4294967295
+    ExcludeFilterFriend: 1
+    ExcludeFilterGuild: 2
+    FilterAll: 0
 ChatWhisperTargetStatus:
-  CanWhisper: 0
-  CanWhisperGuild: 1
-  Offline: 2
-  WrongFaction: 3
+  values:
+    CanWhisper: 0
+    CanWhisperGuild: 1
+    Offline: 2
+    WrongFaction: 3
 ChrCustomizationCategoryFlag:
-  Subcategory: 2
-  UndressModel: 1
+  values:
+    Subcategory: 2
+    UndressModel: 1
 ChrCustomizationOptionType:
-  Checkbox: 1
-  Dropdown: 0
-  Slider: 2
+  values:
+    Checkbox: 1
+    Dropdown: 0
+    Slider: 2
 ChrModelFeatureFlags:
-  Deprecated0: 8
-  Forms: 2
-  HunterPets: 32
-  Identity: 4
-  Mounts: 16
-  None: 0
-  Players: 64
-  Summons: 1
+  values:
+    Deprecated0: 8
+    Forms: 2
+    HunterPets: 32
+    Identity: 4
+    Mounts: 16
+    None: 0
+    Players: 64
+    Summons: 1
 ChrRacesAllianceType:
-  Alliance: 0
-  Horde: 1
-  NeutralOrNpc: 2
+  values:
+    Alliance: 0
+    Horde: 1
+    NeutralOrNpc: 2
 CinematicType:
-  GameCinematicSequence: 3
-  GameClientScene: 2
-  GameMovie: 1
-  GlueMovie: 0
+  values:
+    GameCinematicSequence: 3
+    GameClientScene: 2
+    GameMovie: 1
+    GlueMovie: 0
 ClientPlatformType:
-  Macintosh: 1
-  Windows: 0
+  values:
+    Macintosh: 1
+    Windows: 0
 ClientSceneType:
-  DefaultSceneType: 0
-  MinigameSceneType: 1
+  values:
+    DefaultSceneType: 0
+    MinigameSceneType: 1
 ClientSettingsConfigFlag:
-  ClientSettingsConfigBeta: 64
-  ClientSettingsConfigBetaRetail: 128
-  ClientSettingsConfigDebug: 1
-  ClientSettingsConfigGm: 8
-  ClientSettingsConfigInternal: 2
-  ClientSettingsConfigPerf: 4
-  ClientSettingsConfigRetail: 256
-  ClientSettingsConfigTest: 16
-  ClientSettingsConfigTestRetail: 32
+  values:
+    ClientSettingsConfigBeta: 64
+    ClientSettingsConfigBetaRetail: 128
+    ClientSettingsConfigDebug: 1
+    ClientSettingsConfigGm: 8
+    ClientSettingsConfigInternal: 2
+    ClientSettingsConfigPerf: 4
+    ClientSettingsConfigRetail: 256
+    ClientSettingsConfigTest: 16
+    ClientSettingsConfigTestRetail: 32
 ClubActionType:
-  ErrorClubActionAcceptInvitation: 13
-  ErrorClubActionAddBan: 22
-  ErrorClubActionCreate: 1
-  ErrorClubActionCreateMessage: 24
-  ErrorClubActionCreateStream: 15
-  ErrorClubActionCreateTicket: 5
-  ErrorClubActionDeclineInvitation: 14
-  ErrorClubActionDestroy: 3
-  ErrorClubActionDestroyMessage: 26
-  ErrorClubActionDestroyStream: 17
-  ErrorClubActionDestroyTicket: 6
-  ErrorClubActionEdit: 2
-  ErrorClubActionEditMember: 19
-  ErrorClubActionEditMemberNote: 20
-  ErrorClubActionEditMessage: 25
-  ErrorClubActionEditStream: 16
-  ErrorClubActionGetBans: 10
-  ErrorClubActionGetInvitations: 11
-  ErrorClubActionGetTicket: 8
-  ErrorClubActionGetTickets: 9
-  ErrorClubActionInviteMember: 18
-  ErrorClubActionKickMember: 21
-  ErrorClubActionLeave: 4
-  ErrorClubActionRedeemTicket: 7
-  ErrorClubActionRemoveBan: 23
-  ErrorClubActionRevokeInvitation: 12
-  ErrorClubActionSubscribe: 0
+  values:
+    ErrorClubActionAcceptInvitation: 13
+    ErrorClubActionAddBan: 22
+    ErrorClubActionCreate: 1
+    ErrorClubActionCreateMessage: 24
+    ErrorClubActionCreateStream: 15
+    ErrorClubActionCreateTicket: 5
+    ErrorClubActionDeclineInvitation: 14
+    ErrorClubActionDestroy: 3
+    ErrorClubActionDestroyMessage: 26
+    ErrorClubActionDestroyStream: 17
+    ErrorClubActionDestroyTicket: 6
+    ErrorClubActionEdit: 2
+    ErrorClubActionEditMember: 19
+    ErrorClubActionEditMemberNote: 20
+    ErrorClubActionEditMessage: 25
+    ErrorClubActionEditStream: 16
+    ErrorClubActionGetBans: 10
+    ErrorClubActionGetInvitations: 11
+    ErrorClubActionGetTicket: 8
+    ErrorClubActionGetTickets: 9
+    ErrorClubActionInviteMember: 18
+    ErrorClubActionKickMember: 21
+    ErrorClubActionLeave: 4
+    ErrorClubActionRedeemTicket: 7
+    ErrorClubActionRemoveBan: 23
+    ErrorClubActionRevokeInvitation: 12
+    ErrorClubActionSubscribe: 0
 ClubErrorType:
-  ErrorClubAlreadyMember: 19
-  ErrorClubBanAlreadyExists: 35
-  ErrorClubBanCountAtMax: 36
-  ErrorClubDoesntAllowCrossFaction: 40
-  ErrorClubEditHasCrossFactionMembers: 41
-  ErrorClubFull: 16
-  ErrorClubInsufficientPrivileges: 24
-  ErrorClubInvalidRoleID: 23
-  ErrorClubInvitationAlreadyExists: 22
-  ErrorClubMemberHasRequiredRole: 31
-  ErrorClubNoClub: 17
-  ErrorClubNoSuchInvitation: 21
-  ErrorClubNoSuchMember: 20
-  ErrorClubNotMember: 18
-  ErrorClubReceivedInvitationCountAtMax: 33
-  ErrorClubSentInvitationCountAtMax: 32
-  ErrorClubStreamCountAtMax: 30
-  ErrorClubStreamCountAtMin: 29
-  ErrorClubStreamInvalidName: 28
-  ErrorClubStreamNoStream: 27
-  ErrorClubTargetIsBanned: 34
-  ErrorClubTicketCountAtMax: 37
-  ErrorClubTicketHasConsumedAllowedRedeemCount: 39
-  ErrorClubTicketNoSuchTicket: 38
-  ErrorClubTooManyClubsJoined: 25
-  ErrorClubVoiceFull: 26
-  ErrorCommunitiesBadTarget: 4
-  ErrorCommunitiesChatMute: 15
-  ErrorCommunitiesGuild: 8
-  ErrorCommunitiesIgnored: 7
-  ErrorCommunitiesMissingShortName: 11
-  ErrorCommunitiesNeutralFaction: 2
-  ErrorCommunitiesNone: 0
-  ErrorCommunitiesProfanity: 12
-  ErrorCommunitiesRestricted: 6
-  ErrorCommunitiesTrial: 13
-  ErrorCommunitiesUnknown: 1
-  ErrorCommunitiesUnknownRealm: 3
-  ErrorCommunitiesUnknownTicket: 10
-  ErrorCommunitiesVeteranTrial: 14
-  ErrorCommunitiesWrongFaction: 5
-  ErrorCommunitiesWrongRegion: 9
+  values:
+    ErrorClubAlreadyMember: 19
+    ErrorClubBanAlreadyExists: 35
+    ErrorClubBanCountAtMax: 36
+    ErrorClubDoesntAllowCrossFaction: 40
+    ErrorClubEditHasCrossFactionMembers: 41
+    ErrorClubFull: 16
+    ErrorClubInsufficientPrivileges: 24
+    ErrorClubInvalidRoleID: 23
+    ErrorClubInvitationAlreadyExists: 22
+    ErrorClubMemberHasRequiredRole: 31
+    ErrorClubNoClub: 17
+    ErrorClubNoSuchInvitation: 21
+    ErrorClubNoSuchMember: 20
+    ErrorClubNotMember: 18
+    ErrorClubReceivedInvitationCountAtMax: 33
+    ErrorClubSentInvitationCountAtMax: 32
+    ErrorClubStreamCountAtMax: 30
+    ErrorClubStreamCountAtMin: 29
+    ErrorClubStreamInvalidName: 28
+    ErrorClubStreamNoStream: 27
+    ErrorClubTargetIsBanned: 34
+    ErrorClubTicketCountAtMax: 37
+    ErrorClubTicketHasConsumedAllowedRedeemCount: 39
+    ErrorClubTicketNoSuchTicket: 38
+    ErrorClubTooManyClubsJoined: 25
+    ErrorClubVoiceFull: 26
+    ErrorCommunitiesBadTarget: 4
+    ErrorCommunitiesChatMute: 15
+    ErrorCommunitiesGuild: 8
+    ErrorCommunitiesIgnored: 7
+    ErrorCommunitiesMissingShortName: 11
+    ErrorCommunitiesNeutralFaction: 2
+    ErrorCommunitiesNone: 0
+    ErrorCommunitiesProfanity: 12
+    ErrorCommunitiesRestricted: 6
+    ErrorCommunitiesTrial: 13
+    ErrorCommunitiesUnknown: 1
+    ErrorCommunitiesUnknownRealm: 3
+    ErrorCommunitiesUnknownTicket: 10
+    ErrorCommunitiesVeteranTrial: 14
+    ErrorCommunitiesWrongFaction: 5
+    ErrorCommunitiesWrongRegion: 9
 ClubFieldType:
-  ClubBroadcast: 3
-  ClubDescription: 2
-  ClubName: 0
-  ClubShortName: 1
-  ClubStreamName: 4
-  ClubStreamSubject: 5
-  NumTypes: 6
+  values:
+    ClubBroadcast: 3
+    ClubDescription: 2
+    ClubName: 0
+    ClubShortName: 1
+    ClubStreamName: 4
+    ClubStreamSubject: 5
+    NumTypes: 6
 ClubFinderApplicationUpdateType:
-  AcceptInvite: 1
-  Cancel: 3
-  DeclineInvite: 2
-  None: 0
+  values:
+    AcceptInvite: 1
+    Cancel: 3
+    DeclineInvite: 2
+    None: 0
 ClubFinderClubPostingStatusFlags:
-  Banned: 5
-  FakePost: 6
-  ForceDescriptionChange: 2
-  ForceNameChange: 3
-  NeedsCacheUpdate: 1
-  None: 0
-  PendingDelete: 7
-  PostDelisted: 8
-  UnderReview: 4
+  values:
+    Banned: 5
+    FakePost: 6
+    ForceDescriptionChange: 2
+    ForceNameChange: 3
+    NeedsCacheUpdate: 1
+    None: 0
+    PendingDelete: 7
+    PostDelisted: 8
+    UnderReview: 4
 ClubFinderDisableReason:
-  Muted: 0
-  Silenced: 1
-  VeteranTrial: 2
+  values:
+    Muted: 0
+    Silenced: 1
+    VeteranTrial: 2
 ClubFinderPostingReportType:
-  ApplicantsName: 3
-  ClubName: 1
-  JoinNote: 4
-  PostersName: 0
-  PostingDescription: 2
+  values:
+    ApplicantsName: 3
+    ClubName: 1
+    JoinNote: 4
+    PostersName: 0
+    PostingDescription: 2
 ClubFinderRequestType:
-  All: 3
-  Community: 2
-  Guild: 1
-  None: 0
+  values:
+    All: 3
+    Community: 2
+    Guild: 1
+    None: 0
 ClubFinderSettingFlags:
-  AutoAccept: 14
-  Damage: 11
-  Dungeons: 1
-  EnableListing: 12
-  FactionAlliance: 16
-  FactionHorde: 15
-  FactionNeutral: 17
-  Healer: 10
-  LanguageReserved1: 21
-  LanguageReserved2: 22
-  LanguageReserved3: 23
-  LanguageReserved4: 24
-  LanguageReserved5: 25
-  Large: 8
-  MaxLevelOnly: 13
-  Medium: 7
-  None: 0
-  PvP: 3
-  Raids: 2
-  RP: 4
-  Small: 6
-  Social: 5
-  SortMemberCount: 19
-  SortNewest: 20
-  SortRelevance: 18
-  Tank: 9
+  values:
+    AutoAccept: 14
+    Damage: 11
+    Dungeons: 1
+    EnableListing: 12
+    FactionAlliance: 16
+    FactionHorde: 15
+    FactionNeutral: 17
+    Healer: 10
+    LanguageReserved1: 21
+    LanguageReserved2: 22
+    LanguageReserved3: 23
+    LanguageReserved4: 24
+    LanguageReserved5: 25
+    Large: 8
+    MaxLevelOnly: 13
+    Medium: 7
+    None: 0
+    PvP: 3
+    Raids: 2
+    RP: 4
+    Small: 6
+    Social: 5
+    SortMemberCount: 19
+    SortNewest: 20
+    SortRelevance: 18
+    Tank: 9
 ClubInvitationCandidateStatus:
-  AlreadyMember: 2
-  Available: 0
-  InvitePending: 1
+  values:
+    AlreadyMember: 2
+    Available: 0
+    InvitePending: 1
 ClubMemberPresence:
-  Away: 4
-  Busy: 5
-  Offline: 3
-  Online: 1
-  OnlineMobile: 2
-  Unknown: 0
+  values:
+    Away: 4
+    Busy: 5
+    Offline: 3
+    Online: 1
+    OnlineMobile: 2
+    Unknown: 0
 ClubRemovedReason:
-  Banned: 1
-  ClubDestroyed: 3
-  None: 0
-  Removed: 2
+  values:
+    Banned: 1
+    ClubDestroyed: 3
+    None: 0
+    Removed: 2
 ClubRestrictionReason:
-  None: 0
-  Unavailable: 1
+  values:
+    None: 0
+    Unavailable: 1
 ClubRoleIdentifier:
-  Leader: 2
-  Member: 4
-  Moderator: 3
-  Owner: 1
+  values:
+    Leader: 2
+    Member: 4
+    Moderator: 3
+    Owner: 1
 ClubStreamNotificationFilter:
-  All: 2
-  Mention: 1
-  None: 0
+  values:
+    All: 2
+    Mention: 1
+    None: 0
 ClubStreamType:
-  General: 0
-  Guild: 1
-  Officer: 2
-  Other: 3
+  values:
+    General: 0
+    Guild: 1
+    Officer: 2
+    Other: 3
 ClubType:
-  BattleNet: 0
-  Character: 1
-  Guild: 2
-  Other: 3
+  values:
+    BattleNet: 0
+    Character: 1
+    Guild: 2
+    Other: 3
 ColorOverride:
-  ItemQualityAccount: 7
-  ItemQualityArtifact: 6
-  ItemQualityCommon: 1
-  ItemQualityEpic: 4
-  ItemQualityLegendary: 5
-  ItemQualityPoor: 0
-  ItemQualityRare: 3
-  ItemQualityUncommon: 2
+  values:
+    ItemQualityAccount: 7
+    ItemQualityArtifact: 6
+    ItemQualityCommon: 1
+    ItemQualityEpic: 4
+    ItemQualityLegendary: 5
+    ItemQualityPoor: 0
+    ItemQualityRare: 3
+    ItemQualityUncommon: 2
 CombatAudioAlertCastState:
-  Off: 0
-  OnCastEnd: 2
-  OnCastStart: 1
+  values:
+    Off: 0
+    OnCastEnd: 2
+    OnCastStart: 1
 CombatAudioAlertCategory:
-  General: 0
-  PartyHealth: 7
-  PlayerCast: 3
-  PlayerDebuffs: 8
-  PlayerHealth: 1
-  PlayerResource1: 5
-  PlayerResource2: 6
-  TargetCast: 4
-  TargetHealth: 2
+  values:
+    General: 0
+    PartyHealth: 7
+    PlayerCast: 3
+    PlayerDebuffs: 8
+    PlayerHealth: 1
+    PlayerResource1: 5
+    PlayerResource2: 6
+    TargetCast: 4
+    TargetHealth: 2
 CombatAudioAlertDebuffSelfAlertValues:
-  DispelType: 1
-  Off: 0
+  values:
+    DispelType: 1
+    Off: 0
 CombatAudioAlertPartyPercentValues:
-  Off: 0
-  Under100Percent: 1
-  Under10Percent: 10
-  Under20Percent: 9
-  Under30Percent: 8
-  Under40Percent: 7
-  Under50Percent: 6
-  Under60Percent: 5
-  Under70Percent: 4
-  Under80Percent: 3
-  Under90Percent: 2
+  values:
+    Off: 0
+    Under100Percent: 1
+    Under10Percent: 10
+    Under20Percent: 9
+    Under30Percent: 8
+    Under40Percent: 7
+    Under50Percent: 6
+    Under60Percent: 5
+    Under70Percent: 4
+    Under80Percent: 3
+    Under90Percent: 2
 CombatAudioAlertPercentValues:
-  Every10Percent: 1
-  Every20Percent: 2
-  Every30Percent: 3
-  Every40Percent: 4
-  Every50Percent: 5
-  Off: 0
+  values:
+    Every10Percent: 1
+    Every20Percent: 2
+    Every30Percent: 3
+    Every40Percent: 4
+    Every50Percent: 5
+    Off: 0
 CombatAudioAlertPlayerCastFormatValues:
-  Cast: 3
-  Casting: 2
-  CastingSpellname: 0
-  CastSpellname: 1
-  Spellname: 4
+  values:
+    Cast: 3
+    Casting: 2
+    CastingSpellname: 0
+    CastSpellname: 1
+    Spellname: 4
 CombatAudioAlertPlayerDebuffFormatValues:
-  Full: 0
-  NoSpellname: 1
+  values:
+    Full: 0
+    NoSpellname: 1
 CombatAudioAlertPlayerHealthFormatValues:
-  HealthFull: 0
-  HealthNoPercent: 1
-  HealthNoPercentDiv10: 2
-  NoHealthFull: 3
-  NoHealthNoPercent: 4
-  NoHealthNoPercentDiv10: 5
+  values:
+    HealthFull: 0
+    HealthNoPercent: 1
+    HealthNoPercentDiv10: 2
+    NoHealthFull: 3
+    NoHealthNoPercent: 4
+    NoHealthNoPercentDiv10: 5
 CombatAudioAlertPlayerResourceFormatValues:
-  NoResourceFull: 3
-  NoResourceNoPercent: 4
-  NoResourceNoPercentDiv10: 5
-  ResourceFull: 0
-  ResourceNoPercent: 1
-  ResourceNoPercentDiv10: 2
+  values:
+    NoResourceFull: 3
+    NoResourceNoPercent: 4
+    NoResourceNoPercentDiv10: 5
+    ResourceFull: 0
+    ResourceNoPercent: 1
+    ResourceNoPercentDiv10: 2
 CombatAudioAlertSayIfTargetedType:
-  Aggro: 1
-  None: 0
-  Targeted: 2
-  TargetedBy: 3
+  values:
+    Aggro: 1
+    None: 0
+    Targeted: 2
+    TargetedBy: 3
 CombatAudioAlertSpecSetting:
-  Resource1Format: 1
-  Resource1Percent: 0
-  Resource1Voice: 2
-  Resource1Volume: 3
-  Resource2Format: 5
-  Resource2Percent: 4
-  Resource2Voice: 6
-  Resource2Volume: 7
-  SayIfTargeted: 8
+  values:
+    Resource1Format: 1
+    Resource1Percent: 0
+    Resource1Voice: 2
+    Resource1Volume: 3
+    Resource2Format: 5
+    Resource2Percent: 4
+    Resource2Voice: 6
+    Resource2Volume: 7
+    SayIfTargeted: 8
 CombatAudioAlertTargetCastFormatValues:
-  Cast: 5
-  Casting: 4
-  CastingSpellname: 2
-  CastSpellname: 3
-  Spellname: 6
-  TargetCastingSpellname: 0
-  TargetCastSpellname: 1
+  values:
+    Cast: 5
+    Casting: 4
+    CastingSpellname: 2
+    CastSpellname: 3
+    Spellname: 6
+    TargetCastingSpellname: 0
+    TargetCastSpellname: 1
 CombatAudioAlertTargetDeathBehavior:
-  Default: 0
-  SayTargetDead: 1
+  values:
+    Default: 0
+    SayTargetDead: 1
 CombatAudioAlertTargetHealthFormatValues:
-  HealthFull: 3
-  HealthNoPercent: 4
-  HealthNoPercentDiv10: 5
-  NoHealthFull: 0
-  NoHealthNoPercent: 1
-  NoHealthNoPercentDiv10: 2
-  TargetFull: 6
-  TargetNoPercent: 7
-  TargetNoPercentDiv10: 8
+  values:
+    HealthFull: 3
+    HealthNoPercent: 4
+    HealthNoPercentDiv10: 5
+    NoHealthFull: 0
+    NoHealthNoPercent: 1
+    NoHealthNoPercentDiv10: 2
+    TargetFull: 6
+    TargetNoPercent: 7
+    TargetNoPercentDiv10: 8
 CombatAudioAlertThrottle:
-  PlayerCast: 3
-  PlayerHealth: 1
-  PlayerHealthSamePercent: 7
-  PlayerResource1: 5
-  PlayerResource1SamePercent: 9
-  PlayerResource2: 6
-  PlayerResource2SamePercent: 10
-  Sample: 0
-  TargetCast: 4
-  TargetHealth: 2
-  TargetHealthSamePercent: 8
+  values:
+    PlayerCast: 3
+    PlayerHealth: 1
+    PlayerHealthSamePercent: 7
+    PlayerResource1: 5
+    PlayerResource1SamePercent: 9
+    PlayerResource2: 6
+    PlayerResource2SamePercent: 10
+    Sample: 0
+    TargetCast: 4
+    TargetHealth: 2
+    TargetHealthSamePercent: 8
 CombatAudioAlertType:
-  Cast: 1
-  Health: 0
+  values:
+    Cast: 1
+    Health: 0
 CombatAudioAlertUnit:
-  Player: 0
-  Target: 1
+  values:
+    Player: 0
+    Target: 1
 CombatLogMessageOrder:
-  Newest: 0
-  Oldest: 1
+  values:
+    Newest: 0
+    Oldest: 1
 CombatLogObject:
-  AffiliationMine: 1
-  AffiliationOutsider: 8
-  AffiliationParty: 2
-  AffiliationRaid: 4
-  ControlNpc: 512
-  ControlPlayer: 256
-  Empty: 0
-  Focus: 131072
-  Mainassist: 524288
-  Maintank: 262144
-  None: 2147483648
-  ReactionFriendly: 16
-  ReactionHostile: 64
-  ReactionNeutral: 32
-  Target: 65536
-  TypeGuardian: 8192
-  TypeNpc: 2048
-  TypeObject: 16384
-  TypePet: 4096
-  TypePlayer: 1024
+  values:
+    AffiliationMine: 1
+    AffiliationOutsider: 8
+    AffiliationParty: 2
+    AffiliationRaid: 4
+    ControlNpc: 512
+    ControlPlayer: 256
+    Empty: 0
+    Focus: 131072
+    Mainassist: 524288
+    Maintank: 262144
+    None: 2147483648
+    ReactionFriendly: 16
+    ReactionHostile: 64
+    ReactionNeutral: 32
+    Target: 65536
+    TypeGuardian: 8192
+    TypeNpc: 2048
+    TypeObject: 16384
+    TypePet: 4096
+    TypePlayer: 1024
 CombatLogObjectTarget:
-  RaidNone: 2147483648
-  Raidtarget1: 1
-  Raidtarget2: 2
-  Raidtarget3: 4
-  Raidtarget4: 8
-  Raidtarget5: 16
-  Raidtarget6: 32
-  Raidtarget7: 64
-  Raidtarget8: 128
+  values:
+    RaidNone: 2147483648
+    Raidtarget1: 1
+    Raidtarget2: 2
+    Raidtarget3: 4
+    Raidtarget4: 8
+    Raidtarget5: 16
+    Raidtarget6: 32
+    Raidtarget7: 64
+    Raidtarget8: 128
 CombinedQuestLogStatus:
-  Available: 0
-  Complete: 1
-  CompleteDaily: 2
-  CompleteGameReset: 6
-  CompleteMonthly: 4
-  CompleteWeekly: 3
-  CompleteYearly: 5
-  Reset: 7
+  values:
+    Available: 0
+    Complete: 1
+    CompleteDaily: 2
+    CompleteGameReset: 6
+    CompleteMonthly: 4
+    CompleteWeekly: 3
+    CompleteYearly: 5
+    Reset: 7
 CombinedQuestStatus:
-  Completed: 1
-  Invalid: 0
-  NotCompleted: 2
+  values:
+    Completed: 1
+    Invalid: 0
+    NotCompleted: 2
 CommunicationMode:
-  OpenMic: 1
-  PushToTalk: 0
+  values:
+    OpenMic: 1
+    PushToTalk: 0
 CompanionConfigSlotTypes:
-  Combat: 2
-  Role: 0
-  Utility: 1
+  values:
+    Combat: 2
+    Role: 0
+    Utility: 1
 CompressionLevel:
-  Default: 0
-  OptimizeForSize: 2
-  OptimizeForSpeed: 1
+  values:
+    Default: 0
+    OptimizeForSize: 2
+    OptimizeForSpeed: 1
 CompressionMethod:
-  Deflate: 0
-  Gzip: 2
-  Zlib: 1
+  values:
+    Deflate: 0
+    Gzip: 2
+    Zlib: 1
 ConfirmationPromptUIType:
-  BonusRoll: 1
-  SimpleWarning: 2
-  SimpleWarningAlert: 4
-  StaticText: 0
-  StaticTextAlert: 3
+  values:
+    BonusRoll: 1
+    SimpleWarning: 2
+    SimpleWarningAlert: 4
+    StaticText: 0
+    StaticTextAlert: 3
 ConsoleCategory:
-  Combat: 3
-  Console: 2
-  Debug: 0
-  Default: 5
-  Game: 4
-  Gm: 8
-  Graphics: 1
-  Net: 6
-  None: 10
-  Reveal: 9
-  Sound: 7
+  values:
+    Combat: 3
+    Console: 2
+    Debug: 0
+    Default: 5
+    Game: 4
+    Gm: 8
+    Graphics: 1
+    Net: 6
+    None: 10
+    Reveal: 9
+    Sound: 7
 ConsoleColorType:
-  AdminColor: 6
-  BackgroundColor: 8
-  ClickbufferColor: 9
-  DefaultColor: 0
-  DefaultGreen: 11
-  EchoColor: 2
-  ErrorColor: 3
-  GlobalColor: 5
-  HighlightColor: 7
-  InputColor: 1
-  PrivateColor: 10
-  WarningColor: 4
+  values:
+    AdminColor: 6
+    BackgroundColor: 8
+    ClickbufferColor: 9
+    DefaultColor: 0
+    DefaultGreen: 11
+    EchoColor: 2
+    ErrorColor: 3
+    GlobalColor: 5
+    HighlightColor: 7
+    InputColor: 1
+    PrivateColor: 10
+    WarningColor: 4
 ConsoleCommandType:
-  Command: 1
-  Cvar: 0
-  Macro: 2
-  Script: 3
+  values:
+    Command: 1
+    Cvar: 0
+    Macro: 2
+    Script: 3
 ContentTrackingError:
-  AlreadyTracked: 2
-  MaxTracked: 1
-  Untrackable: 0
+  values:
+    AlreadyTracked: 2
+    MaxTracked: 1
+    Untrackable: 0
 ContentTrackingResult:
-  DataPending: 1
-  Failure: 2
-  Success: 0
+  values:
+    DataPending: 1
+    Failure: 2
+    Success: 0
 ContentTrackingStopType:
-  Collected: 1
-  Invalidated: 0
-  Manual: 2
+  values:
+    Collected: 1
+    Invalidated: 0
+    Manual: 2
 ContentTrackingTargetType:
-  Achievement: 2
-  JournalEncounter: 0
-  Profession: 3
-  Quest: 4
-  Vendor: 1
+  values:
+    Achievement: 2
+    JournalEncounter: 0
+    Profession: 3
+    Quest: 4
+    Vendor: 1
 ContentTrackingType:
-  Achievement: 2
-  Appearance: 0
-  Decor: 3
-  Mount: 1
+  values:
+    Achievement: 2
+    Appearance: 0
+    Decor: 3
+    Mount: 1
 ContributionAppearanceFlags:
-  TooltipUseTimeRemaining: 0
+  values:
+    TooltipUseTimeRemaining: 0
 ContributionResult:
-  FailedConditionCheck: 5
-  IncorrectState: 2
-  InternalError: 7
-  InvalidID: 3
-  MustBeNearNpc: 1
-  QuestDataMissing: 4
-  Success: 0
-  UnableToCompleteTurnIn: 6
+  values:
+    FailedConditionCheck: 5
+    IncorrectState: 2
+    InternalError: 7
+    InvalidID: 3
+    MustBeNearNpc: 1
+    QuestDataMissing: 4
+    Success: 0
+    UnableToCompleteTurnIn: 6
 ContributionState:
-  Active: 2
-  Building: 1
-  Destroyed: 4
-  None: 0
-  UnderAttack: 3
+  values:
+    Active: 2
+    Building: 1
+    Destroyed: 4
+    None: 0
+    UnderAttack: 3
 CooldownSetLinkedSpellFlags:
-  UseAsTooltip: 1
+  values:
+    UseAsTooltip: 1
 CooldownSetSpellFlags:
-  HideAura: 1
-  HideByDefault: 2
+  values:
+    HideAura: 1
+    HideByDefault: 2
 CooldownViewerAddAlertStatus:
-  DuplicateAlert: 3
-  InvalidAlertType: 1
-  InvalidEventType: 2
-  Success: 0
+  values:
+    DuplicateAlert: 3
+    InvalidAlertType: 1
+    InvalidEventType: 2
+    Success: 0
 CooldownViewerAlertEventType:
-  Available: 1
-  ChargeGained: 4
-  OnAuraApplied: 5
-  OnAuraRemoved: 6
-  OnCooldown: 3
-  PandemicTime: 2
+  values:
+    Available: 1
+    ChargeGained: 4
+    OnAuraApplied: 5
+    OnAuraRemoved: 6
+    OnCooldown: 3
+    PandemicTime: 2
 CooldownViewerAlertType:
-  Sound: 1
-  Visual: 2
+  values:
+    Sound: 1
+    Visual: 2
 CooldownViewerBarContent:
-  IconAndName: 0
-  IconOnly: 1
-  NameOnly: 2
+  values:
+    IconAndName: 0
+    IconOnly: 1
+    NameOnly: 2
 CooldownViewerCategory:
-  Essential: 0
-  TrackedBar: 3
-  TrackedBuff: 2
-  Utility: 1
+  values:
+    Essential: 0
+    TrackedBar: 3
+    TrackedBuff: 2
+    Utility: 1
 CooldownViewerIconDirection:
-  Left: 0
-  Right: 1
+  values:
+    Left: 0
+    Right: 1
 CooldownViewerOrientation:
-  Horizontal: 0
-  Vertical: 1
+  values:
+    Horizontal: 0
+    Vertical: 1
 CooldownViewerVisibleSetting:
-  Always: 0
-  Hidden: 2
-  InCombat: 1
+  values:
+    Always: 0
+    Hidden: 2
+    InCombat: 1
 CornerstonePurchaseMode:
-  Basic: 0
-  Import: 1
-  Move: 2
+  values:
+    Basic: 0
+    Import: 1
+    Move: 2
 CovenantSkill:
-  Kyrian: 2730
-  Necrolord: 2733
-  NightFae: 2732
-  Venthyr: 2731
+  values:
+    Kyrian: 2730
+    Necrolord: 2733
+    NightFae: 2732
+    Venthyr: 2731
 CovenantType:
-  Kyrian: 1
-  Necrolord: 4
-  NightFae: 3
-  None: 0
-  Venthyr: 2
+  values:
+    Kyrian: 1
+    Necrolord: 4
+    NightFae: 3
+    None: 0
+    Venthyr: 2
 CraftingOrderDuration:
-  Long: 2
-  Medium: 1
-  Short: 0
+  values:
+    Long: 2
+    Medium: 1
+    Short: 0
 CraftingOrderFlags:
-  HasAllReagents: 8
-  HasNoneReagents: 2
-  HasSomeReagents: 4
-  IsFulfillable: 16
-  IsRecraft: 1
-  None: 0
+  values:
+    HasAllReagents: 8
+    HasNoneReagents: 2
+    HasSomeReagents: 4
+    IsFulfillable: 16
+    IsRecraft: 1
+    None: 0
 CraftingOrderItemFlags:
-  HasEnchantmentData: 2
-  None: 0
-  NpcProvided: 1
+  values:
+    HasEnchantmentData: 2
+    None: 0
+    NpcProvided: 1
 CraftingOrderItemType:
-  CraftedResult: 2
-  Currency: 5
-  Deprecated: 4
-  Item: 0
-  Recraft: 1
-  RemoveReagent: 3
+  values:
+    CraftedResult: 2
+    Currency: 5
+    Deprecated: 4
+    Item: 0
+    Recraft: 1
+    RemoveReagent: 3
 CraftingOrderReagentSource:
-  Any: 0
-  Crafter: 2
-  Customer: 1
-  None: 3
+  values:
+    Any: 0
+    Crafter: 2
+    Customer: 1
+    None: 3
 CraftingOrderResult:
-  Aborted: 1
-  AlreadyClaimed: 2
-  AlreadyCrafted: 3
-  CannotBeOrdered: 4
-  CannotCancel: 5
-  CannotClaim: 6
-  CannotClaimOwnOrder: 7
-  CannotCraft: 8
-  CannotCreate: 9
-  CannotFulfill: 10
-  CannotRecraft: 11
-  CannotReject: 12
-  CannotRelease: 13
-  CrafterIsIgnored: 14
-  DatabaseError: 15
-  Expired: 16
-  InvalidDuration: 18
-  InvalidMinQuality: 19
-  InvalidNotes: 20
-  InvalidReagent: 21
-  InvalidRealm: 22
-  InvalidRecipe: 23
-  InvalidRecraftItem: 24
-  InvalidSort: 25
-  InvalidTarget: 26
-  InvalidType: 27
-  Locked: 17
-  MaxOrdersReached: 28
-  MissingCraftingTable: 29
-  MissingCurrency: 30
-  MissingItem: 31
-  MissingNpc: 32
-  MissingOrder: 33
-  MissingRecraftItem: 34
-  NoAccountItems: 35
-  NotClaimed: 36
-  NotCrafted: 37
-  NotInGuild: 38
-  NotYetImplemented: 39
-  Ok: 0
-  OutOfPublicOrderCapacity: 40
-  ServerIsNotAvailable: 41
-  TargetCannotCraft: 43
-  TargetLocked: 44
-  ThrottleViolation: 42
-  Timeout: 45
-  TooManyCurrencies: 46
-  TooManyItems: 47
-  WrongVersion: 48
+  values:
+    Aborted: 1
+    AlreadyClaimed: 2
+    AlreadyCrafted: 3
+    CannotBeOrdered: 4
+    CannotCancel: 5
+    CannotClaim: 6
+    CannotClaimOwnOrder: 7
+    CannotCraft: 8
+    CannotCreate: 9
+    CannotFulfill: 10
+    CannotRecraft: 11
+    CannotReject: 12
+    CannotRelease: 13
+    CrafterIsIgnored: 14
+    DatabaseError: 15
+    Expired: 16
+    InvalidDuration: 18
+    InvalidMinQuality: 19
+    InvalidNotes: 20
+    InvalidReagent: 21
+    InvalidRealm: 22
+    InvalidRecipe: 23
+    InvalidRecraftItem: 24
+    InvalidSort: 25
+    InvalidTarget: 26
+    InvalidType: 27
+    Locked: 17
+    MaxOrdersReached: 28
+    MissingCraftingTable: 29
+    MissingCurrency: 30
+    MissingItem: 31
+    MissingNpc: 32
+    MissingOrder: 33
+    MissingRecraftItem: 34
+    NoAccountItems: 35
+    NotClaimed: 36
+    NotCrafted: 37
+    NotInGuild: 38
+    NotYetImplemented: 39
+    Ok: 0
+    OutOfPublicOrderCapacity: 40
+    ServerIsNotAvailable: 41
+    TargetCannotCraft: 43
+    TargetLocked: 44
+    ThrottleViolation: 42
+    Timeout: 45
+    TooManyCurrencies: 46
+    TooManyItems: 47
+    WrongVersion: 48
 CraftingOrderSortType:
-  AveTip: 1
-  ItemName: 0
-  MaxTip: 2
-  Quantity: 3
-  Reagents: 4
-  Status: 7
-  TimeRemaining: 6
-  Tip: 5
+  values:
+    AveTip: 1
+    ItemName: 0
+    MaxTip: 2
+    Quantity: 3
+    Reagents: 4
+    Status: 7
+    TimeRemaining: 6
+    Tip: 5
 CraftingOrderState:
-  Canceled: 13
-  Canceling: 12
-  Claimed: 4
-  Claiming: 3
-  Crafting: 8
-  Created: 2
-  Creating: 1
-  Expired: 15
-  Expiring: 14
-  Fulfilled: 11
-  Fulfilling: 10
-  None: 0
-  Recrafting: 9
-  Rejected: 6
-  Rejecting: 5
-  Releasing: 7
+  values:
+    Canceled: 13
+    Canceling: 12
+    Claimed: 4
+    Claiming: 3
+    Crafting: 8
+    Created: 2
+    Creating: 1
+    Expired: 15
+    Expiring: 14
+    Fulfilled: 11
+    Fulfilling: 10
+    None: 0
+    Recrafting: 9
+    Rejected: 6
+    Rejecting: 5
+    Releasing: 7
 CraftingOrderType:
-  Guild: 1
-  Npc: 3
-  Personal: 2
-  Public: 0
+  values:
+    Guild: 1
+    Npc: 3
+    Personal: 2
+    Public: 0
 CraftingReagentItemFlag:
-  TooltipShowsAsStatModifications: 1
+  values:
+    TooltipShowsAsStatModifications: 1
 CraftingReagentType:
-  Automatic: 3
-  Basic: 1
-  Finishing: 2
-  Modifying: 0
+  values:
+    Automatic: 3
+    Basic: 1
+    Finishing: 2
+    Modifying: 0
 CreateAllAccountData:
-  AccountCurrenciesDone: '0x0000000000200000'
-  AccountDynamicCriteriaDone: '0x0000000001000000'
-  AccountFactionsDone: '0x0000000200000000'
-  AccountItemsDone: '0x0000000400000000'
-  AccountMappingDone: '0x0000008000000000'
-  AccountNotificationsDone: '0x0000000008000000'
-  AccountStateHousingData: '0x0000080000000000'
-  AchievementsDone: '0x0000000000000001'
-  ArchivedPurchasesDone: '0x0000000000000200'
-  AuctionableTokensDone: '0x0000000000002000'
-  BanktabSettingsDone: '0x0000004000000000'
-  BattlepetsDone: '0x0000000000000008'
-  BitVectorsDone: '0x0000000100000000'
-  BpayAddLicenseObjectsDone: '0x0000000000000800'
-  BpayDistributionObjectsDone: '0x0000000000000100'
-  BpayProductitemObjectsDone: '0x0000000000020000'
-  CharacterItemsDone: '0x0000010000000000'
-  CharactersDone: '0x0000000000000040'
-  CombinedQuestLogEntriesDone: '0x0000000800000000'
-  ConsumableTokensDone: '0x0000000000004000'
-  CriteriaDone: '0x0000000000000002'
-  CurrencycapsDone: '0x0000000000000010'
-  CurrencyTransferLogDone: '0x0000020000000000'
-  DataElementsDone: '0x0000001000000000'
-  EventRecordsDone: '0x0000200000000000'
-  ItemCollectionItemsDone: '0x0000000000001000'
-  LgVendorPurchaseDone: '0x0000040000000000'
-  MountsDone: '0x0000000000000004'
-  None: '0x0000000000000000'
-  Object: '0x0000000000100000'
-  PerkHeldItemsDone: '0x0000000040000000'
-  PerkPastRewardsDone: '0x0000000000008000'
-  PerkPendingPurchasesDone: '0x0000000010000000'
-  PerkPendingRewardsDone: '0x0000000080000000'
-  PurchasesDone: '0x0000000000000080'
-  QuestCriteriaDone: '0x0000000000080000'
-  QuestLogDone: '0x0000000000000020'
-  RafActivitiesDone: '0x0000000002000000'
-  RafBalanceDone: '0x0000000000400000'
-  RafRewardsDone: '0x0000000000800000'
-  RevokedRafRewardsDone: '0x0000000004000000'
-  SettingsDone: '0x0000000000000400'
-  TransmogOutfitsLoadedDone: '0x0000400000000000'
-  TrialBoostHistoryDone: '0x0000000000040000'
-  VasTransactionsDone: '0x0000000000010000'
-  WarbandGroupsDone: '0x0000002000000000'
-  WarbandScenesLoadedDone: '0x0000100000000000'
-  WowlabsDataDone: '0x0000000020000000'
+  values:
+    AccountCurrenciesDone: '0x0000000000200000'
+    AccountDynamicCriteriaDone: '0x0000000001000000'
+    AccountFactionsDone: '0x0000000200000000'
+    AccountItemsDone: '0x0000000400000000'
+    AccountMappingDone: '0x0000008000000000'
+    AccountNotificationsDone: '0x0000000008000000'
+    AccountStateHousingData: '0x0000080000000000'
+    AchievementsDone: '0x0000000000000001'
+    ArchivedPurchasesDone: '0x0000000000000200'
+    AuctionableTokensDone: '0x0000000000002000'
+    BanktabSettingsDone: '0x0000004000000000'
+    BattlepetsDone: '0x0000000000000008'
+    BitVectorsDone: '0x0000000100000000'
+    BpayAddLicenseObjectsDone: '0x0000000000000800'
+    BpayDistributionObjectsDone: '0x0000000000000100'
+    BpayProductitemObjectsDone: '0x0000000000020000'
+    CharacterItemsDone: '0x0000010000000000'
+    CharactersDone: '0x0000000000000040'
+    CombinedQuestLogEntriesDone: '0x0000000800000000'
+    ConsumableTokensDone: '0x0000000000004000'
+    CriteriaDone: '0x0000000000000002'
+    CurrencycapsDone: '0x0000000000000010'
+    CurrencyTransferLogDone: '0x0000020000000000'
+    DataElementsDone: '0x0000001000000000'
+    EventRecordsDone: '0x0000200000000000'
+    ItemCollectionItemsDone: '0x0000000000001000'
+    LgVendorPurchaseDone: '0x0000040000000000'
+    MountsDone: '0x0000000000000004'
+    None: '0x0000000000000000'
+    Object: '0x0000000000100000'
+    PerkHeldItemsDone: '0x0000000040000000'
+    PerkPastRewardsDone: '0x0000000000008000'
+    PerkPendingPurchasesDone: '0x0000000010000000'
+    PerkPendingRewardsDone: '0x0000000080000000'
+    PurchasesDone: '0x0000000000000080'
+    QuestCriteriaDone: '0x0000000000080000'
+    QuestLogDone: '0x0000000000000020'
+    RafActivitiesDone: '0x0000000002000000'
+    RafBalanceDone: '0x0000000000400000'
+    RafRewardsDone: '0x0000000000800000'
+    RevokedRafRewardsDone: '0x0000000004000000'
+    SettingsDone: '0x0000000000000400'
+    TransmogOutfitsLoadedDone: '0x0000400000000000'
+    TrialBoostHistoryDone: '0x0000000000040000'
+    VasTransactionsDone: '0x0000000000010000'
+    WarbandGroupsDone: '0x0000002000000000'
+    WarbandScenesLoadedDone: '0x0000100000000000'
+    WowlabsDataDone: '0x0000000020000000'
 CreateNeighborhoodErrorType:
-  None: 0
-  OversizedGuild: 3
-  Profanity: 1
-  UndersizedGuild: 2
+  values:
+    None: 0
+    OversizedGuild: 3
+    Profanity: 1
+    UndersizedGuild: 2
 CurioRarity:
-  Common: 1
-  Epic: 4
-  Rare: 3
-  Uncommon: 2
+  values:
+    Common: 1
+    Epic: 4
+    Rare: 3
+    Uncommon: 2
 CurrencyConversionResult:
-  Conversion: 1
-  NoConversion: 0
-  SkippedAccountCurrency: 2
+  values:
+    Conversion: 1
+    NoConversion: 0
+    SkippedAccountCurrency: 2
 CurrencyDestroyReason:
-  BonusRoll: 9
-  Capped: 6
-  Cheat: 0
-  DroppedToCorpse: 8
-  Garrison: 7
-  LegacyConversion: 10
-  QuestTurnin: 3
-  Spell: 1
-  Trade: 5
-  Vendor: 4
-  VersionUpdate: 2
+  values:
+    BonusRoll: 9
+    Capped: 6
+    Cheat: 0
+    DroppedToCorpse: 8
+    Garrison: 7
+    LegacyConversion: 10
+    QuestTurnin: 3
+    Spell: 1
+    Trade: 5
+    Vendor: 4
+    VersionUpdate: 2
 CurrencyFlags:
-  Currency_100_Scaler: 8
-  CurrencyAccountWide: 16777216
-  CurrencyAllowOverflowMailer: 33554432
-  CurrencyAppearsInLootWindow: 2
-  CurrencyComputedWeeklyMaximum: 4
-  CurrencyDeprecated: 131072
-  CurrencyDestroyExtraOnLoot: 2097152
-  CurrencyDoNotCompressChat: 8192
-  CurrencyDoNotLogAcquisitionToBi: 16384
-  CurrencyDoNotToast: 1048576
-  CurrencyDontCoalesceInLootWindow: 8388608
-  CurrencyDontShowTotalInTooltip: 4194304
-  CurrencyDynamicMaximum: 262144
-  CurrencyHasWarmodeBonus: 134217728
-  CurrencyHasWeeklyCatchup: 4096
-  CurrencyHideAsReward: 67108864
-  CurrencyIgnoreMaxQtyOnLoad: 32
-  CurrencyIsAllianceOnly: 268435456
-  CurrencyIsHordeOnly: 536870912
-  CurrencyLimitWarmodeBonusOncePerTooltip: 1073741824
-  CurrencyLogOnWorldChange: 64
-  CurrencyNoLowLevelDrop: 16
-  CurrencyNoRaidDrop: 32768
-  CurrencyNotPersistent: 65536
-  CurrencyResetTrackedQuantity: 256
-  CurrencySingleDropInLoot: 2048
-  CurrencySuppressChatMessageOnVersionChange: 1024
-  CurrencySuppressChatMessages: 524288
-  CurrencyTrackQuantity: 128
-  CurrencyTradable: 1
-  CurrencyUpdateVersionIgnoreMax: 512
-  CurrencyUsesLedgerBalance: 2147483648
+  values:
+    Currency_100_Scaler: 8
+    CurrencyAccountWide: 16777216
+    CurrencyAllowOverflowMailer: 33554432
+    CurrencyAppearsInLootWindow: 2
+    CurrencyComputedWeeklyMaximum: 4
+    CurrencyDeprecated: 131072
+    CurrencyDestroyExtraOnLoot: 2097152
+    CurrencyDoNotCompressChat: 8192
+    CurrencyDoNotLogAcquisitionToBi: 16384
+    CurrencyDoNotToast: 1048576
+    CurrencyDontCoalesceInLootWindow: 8388608
+    CurrencyDontShowTotalInTooltip: 4194304
+    CurrencyDynamicMaximum: 262144
+    CurrencyHasWarmodeBonus: 134217728
+    CurrencyHasWeeklyCatchup: 4096
+    CurrencyHideAsReward: 67108864
+    CurrencyIgnoreMaxQtyOnLoad: 32
+    CurrencyIsAllianceOnly: 268435456
+    CurrencyIsHordeOnly: 536870912
+    CurrencyLimitWarmodeBonusOncePerTooltip: 1073741824
+    CurrencyLogOnWorldChange: 64
+    CurrencyNoLowLevelDrop: 16
+    CurrencyNoRaidDrop: 32768
+    CurrencyNotPersistent: 65536
+    CurrencyResetTrackedQuantity: 256
+    CurrencySingleDropInLoot: 2048
+    CurrencySuppressChatMessageOnVersionChange: 1024
+    CurrencySuppressChatMessages: 524288
+    CurrencyTrackQuantity: 128
+    CurrencyTradable: 1
+    CurrencyUpdateVersionIgnoreMax: 512
+    CurrencyUsesLedgerBalance: 2147483648
 CurrencyFlagsB:
-  CurrencyBAllowReductionByResourcefulness: 1024
-  CurrencyBBattlenetVirtualCurrency: 8
-  CurrencyBDontDisplayIfZero: 32
-  CurrencyBForceMaxQuantityOnConversion: 256
-  CurrencyBNoBonusXP: 2048
-  CurrencyBNoNotificationMailOnOfflineProgress: 4
-  CurrencyBScaleMaxQuantityBySeasonWeeks: 64
-  CurrencyBScaleMaxQuantityByWeeksSinceStart: 128
-  CurrencyBShowQuestXPGainInTooltip: 2
-  CurrencyBUnearnableBeforeMaxQuantityStart: 512
-  CurrencyBUseTotalEarnedForEarned: 1
-  FutureCurrencyFlag: 16
+  values:
+    CurrencyBAllowReductionByResourcefulness: 1024
+    CurrencyBBattlenetVirtualCurrency: 8
+    CurrencyBDontDisplayIfZero: 32
+    CurrencyBForceMaxQuantityOnConversion: 256
+    CurrencyBNoBonusXP: 2048
+    CurrencyBNoNotificationMailOnOfflineProgress: 4
+    CurrencyBScaleMaxQuantityBySeasonWeeks: 64
+    CurrencyBScaleMaxQuantityByWeeksSinceStart: 128
+    CurrencyBShowQuestXPGainInTooltip: 2
+    CurrencyBUnearnableBeforeMaxQuantityStart: 512
+    CurrencyBUseTotalEarnedForEarned: 1
+    FutureCurrencyFlag: 16
 CurrencyGainFlags:
-  Autotracking: 8
-  BonusAward: 1
-  DroppedFromDeath: 2
-  FromAccountServer: 4
-  None: 0
+  values:
+    Autotracking: 8
+    BonusAward: 1
+    DroppedFromDeath: 2
+    FromAccountServer: 4
+    None: 0
 CurrencySource:
-  AccountCopy: 37
-  AccountServerConversion: 46
-  Arena: 17
-  ArenaPoints: 38
-  AuctionDeposit: 41
-  AzeriteRespec: 34
-  Barbershop: 42
-  BonusRoll: 33
-  ChallengeModeDungeon: 44
-  Cheat: 4
-  ConvertOldItem: 0
-  ConvertOldPvPCurrency: 1
-  ExceededMaxQty: 18
-  GarrisonBuilding: 23
-  GarrisonBuildingRefund: 26
-  GarrisonFollowerActivation: 25
-  GarrisonMissionReward: 27
-  GarrisonResourceOverTime: 28
-  GarrisonTalent: 30
-  GarrisonWorldQuestBonus: 31
-  GuildBankWithdrawal: 21
-  InitiativeReward: 45
-  ItemDeletion: 14
-  ItemRefund: 2
-  LFGReward: 11
-  Loot: 9
-  Pushloot: 22
-  PvPCompletionBonus: 19
-  PvPDrop: 24
-  PvPHonorQuestReward: 40
-  PvPHonorReward: 32
-  PvPKillCredit: 6
-  PvPMetaCredit: 7
-  PvPScriptedAward: 8
-  PvPTeamContribution: 39
-  QuestReward: 3
-  QuestRewardIgnoreCaps: 29
-  RandomBattleground: 16
-  RatedBattleground: 15
-  Script: 20
-  SimulateLoot: 43
-  Spell: 13
-  Trade: 12
-  UpdatingVersion: 10
-  Vendor: 5
-  WorldQuestReward: 35
-  WorldQuestRewardIgnoreCaps: 36
+  values:
+    AccountCopy: 37
+    AccountServerConversion: 46
+    Arena: 17
+    ArenaPoints: 38
+    AuctionDeposit: 41
+    AzeriteRespec: 34
+    Barbershop: 42
+    BonusRoll: 33
+    ChallengeModeDungeon: 44
+    Cheat: 4
+    ConvertOldItem: 0
+    ConvertOldPvPCurrency: 1
+    ExceededMaxQty: 18
+    GarrisonBuilding: 23
+    GarrisonBuildingRefund: 26
+    GarrisonFollowerActivation: 25
+    GarrisonMissionReward: 27
+    GarrisonResourceOverTime: 28
+    GarrisonTalent: 30
+    GarrisonWorldQuestBonus: 31
+    GuildBankWithdrawal: 21
+    InitiativeReward: 45
+    ItemDeletion: 14
+    ItemRefund: 2
+    LFGReward: 11
+    Loot: 9
+    Pushloot: 22
+    PvPCompletionBonus: 19
+    PvPDrop: 24
+    PvPHonorQuestReward: 40
+    PvPHonorReward: 32
+    PvPKillCredit: 6
+    PvPMetaCredit: 7
+    PvPScriptedAward: 8
+    PvPTeamContribution: 39
+    QuestReward: 3
+    QuestRewardIgnoreCaps: 29
+    RandomBattleground: 16
+    RatedBattleground: 15
+    Script: 20
+    SimulateLoot: 43
+    Spell: 13
+    Trade: 12
+    UpdatingVersion: 10
+    Vendor: 5
+    WorldQuestReward: 35
+    WorldQuestRewardIgnoreCaps: 36
 CurrencyTokenCategoryFlags:
-  FlagPlayerItemAssignment: 2
-  FlagSortLast: 1
-  Hidden: 4
-  StartsCollapsed: 16
-  Virtual: 8
+  values:
+    FlagPlayerItemAssignment: 2
+    FlagSortLast: 1
+    Hidden: 4
+    StartsCollapsed: 16
+    Virtual: 8
 CurrencyType:
-  Copper: 0
-  Gold: 2
-  Silver: 1
+  values:
+    Copper: 0
+    Gold: 2
+    Silver: 1
 Cursormode:
-  AttackCursor: 4
-  AttackErrorCursor: 50
-  BroomCursor: 42
-  BroomErrorCursor: 88
-  BuyCursor: 3
-  BuyErrorCursor: 49
-  CampaignQuestCursor: 23
-  CampaignQuestErrorCursor: 69
-  CampaignQuestTurninCursor: 24
-  CampaignQuestTurninErrorCursor: 70
-  CastCursor: 2
-  CastErrorCursor: 48
-  CustomCursor: 91
-  EnchantCursor: 39
-  EnchantErrorCursor: 85
-  GatherCursor: 13
-  GatherErrorCursor: 59
-  GrabbingHandCursor: 44
-  GrabbingHandErrorCursor: 90
-  HoldingHandCursor: 43
-  HoldingHandErrorCursor: 89
-  InnkeeperCursor: 22
-  InnkeeperErrorCursor: 68
-  InspectCursor: 7
-  InspectErrorCursor: 53
-  InteractCursor: 5
-  InteractErrorCursor: 51
-  ItemCursor: 19
-  ItemErrorCursor: 65
-  LockCursor: 14
-  LockErrorCursor: 60
-  LootAllCursor: 16
-  LootAllErrorCursor: 62
-  MailCursor: 15
-  MailErrorCursor: 61
-  MapPinCursor: 37
-  MapPinErrorCursor: 83
-  MineCursor: 11
-  MineErrorCursor: 57
-  NoCursor: 0
-  PaletteCursor: 41
-  PaletteErrorCursor: 87
-  PickupCursor: 8
-  PickupErrorCursor: 54
-  PingCursor: 38
-  PingErrorCursor: 84
-  PointCursor: 1
-  PointErrorCursor: 47
-  QuestCursor: 25
-  QuestErrorCursor: 71
-  QuestImportantCursor: 30
-  QuestImportantErrorCursor: 76
-  QuestImportantTurninCursor: 31
-  QuestImportantTurninErrorCursor: 77
-  QuestLegendaryCursor: 28
-  QuestLegendaryErrorCursor: 74
-  QuestLegendaryTurninCursor: 29
-  QuestLegendaryTurninErrorCursor: 75
-  QuestMetaCursor: 32
-  QuestMetaErrorCursor: 78
-  QuestMetaTurninCursor: 33
-  QuestMetaTurninErrorCursor: 79
-  QuestRecurringCursor: 34
-  QuestRecurringErrorCursor: 80
-  QuestRecurringTurninCursor: 35
-  QuestRecurringTurninErrorCursor: 81
-  QuestRepeatableCursor: 26
-  QuestRepeatableErrorCursor: 72
-  QuestTurninCursor: 27
-  QuestTurninErrorCursor: 73
-  RepairCursor: 17
-  RepairErrorCursor: 63
-  RepairnpcCursor: 18
-  RepairnpcErrorCursor: 64
-  SkinAllianceCursor: 21
-  SkinAllianceErrorCursor: 67
-  SkinCursor: 12
-  SkinErrorCursor: 58
-  SkinHordeCursor: 20
-  SkinHordeErrorCursor: 66
-  SpeakCursor: 6
-  SpeakErrorCursor: 52
-  StablemasterCursor: 40
-  StablemasterErrorCursor: 86
-  TaxiCursor: 9
-  TaxiErrorCursor: 55
-  TrainerCursor: 10
-  TrainerErrorCursor: 56
-  UIMoveCursor: 45
-  UIResizeCursor: 46
-  VehicleCursor: 36
-  VehicleErrorCursor: 82
+  values:
+    AttackCursor: 4
+    AttackErrorCursor: 50
+    BroomCursor: 42
+    BroomErrorCursor: 88
+    BuyCursor: 3
+    BuyErrorCursor: 49
+    CampaignQuestCursor: 23
+    CampaignQuestErrorCursor: 69
+    CampaignQuestTurninCursor: 24
+    CampaignQuestTurninErrorCursor: 70
+    CastCursor: 2
+    CastErrorCursor: 48
+    CustomCursor: 91
+    EnchantCursor: 39
+    EnchantErrorCursor: 85
+    GatherCursor: 13
+    GatherErrorCursor: 59
+    GrabbingHandCursor: 44
+    GrabbingHandErrorCursor: 90
+    HoldingHandCursor: 43
+    HoldingHandErrorCursor: 89
+    InnkeeperCursor: 22
+    InnkeeperErrorCursor: 68
+    InspectCursor: 7
+    InspectErrorCursor: 53
+    InteractCursor: 5
+    InteractErrorCursor: 51
+    ItemCursor: 19
+    ItemErrorCursor: 65
+    LockCursor: 14
+    LockErrorCursor: 60
+    LootAllCursor: 16
+    LootAllErrorCursor: 62
+    MailCursor: 15
+    MailErrorCursor: 61
+    MapPinCursor: 37
+    MapPinErrorCursor: 83
+    MineCursor: 11
+    MineErrorCursor: 57
+    NoCursor: 0
+    PaletteCursor: 41
+    PaletteErrorCursor: 87
+    PickupCursor: 8
+    PickupErrorCursor: 54
+    PingCursor: 38
+    PingErrorCursor: 84
+    PointCursor: 1
+    PointErrorCursor: 47
+    QuestCursor: 25
+    QuestErrorCursor: 71
+    QuestImportantCursor: 30
+    QuestImportantErrorCursor: 76
+    QuestImportantTurninCursor: 31
+    QuestImportantTurninErrorCursor: 77
+    QuestLegendaryCursor: 28
+    QuestLegendaryErrorCursor: 74
+    QuestLegendaryTurninCursor: 29
+    QuestLegendaryTurninErrorCursor: 75
+    QuestMetaCursor: 32
+    QuestMetaErrorCursor: 78
+    QuestMetaTurninCursor: 33
+    QuestMetaTurninErrorCursor: 79
+    QuestRecurringCursor: 34
+    QuestRecurringErrorCursor: 80
+    QuestRecurringTurninCursor: 35
+    QuestRecurringTurninErrorCursor: 81
+    QuestRepeatableCursor: 26
+    QuestRepeatableErrorCursor: 72
+    QuestTurninCursor: 27
+    QuestTurninErrorCursor: 73
+    RepairCursor: 17
+    RepairErrorCursor: 63
+    RepairnpcCursor: 18
+    RepairnpcErrorCursor: 64
+    SkinAllianceCursor: 21
+    SkinAllianceErrorCursor: 67
+    SkinCursor: 12
+    SkinErrorCursor: 58
+    SkinHordeCursor: 20
+    SkinHordeErrorCursor: 66
+    SpeakCursor: 6
+    SpeakErrorCursor: 52
+    StablemasterCursor: 40
+    StablemasterErrorCursor: 86
+    TaxiCursor: 9
+    TaxiErrorCursor: 55
+    TrainerCursor: 10
+    TrainerErrorCursor: 56
+    UIMoveCursor: 45
+    UIResizeCursor: 46
+    VehicleCursor: 36
+    VehicleErrorCursor: 82
 CursorStyle:
-  Crosshair: 1
-  Mouse: 0
+  values:
+    Crosshair: 1
+    Mouse: 0
 CustomBindingType:
-  VoicePushToTalk: 0
+  values:
+    VoicePushToTalk: 0
 Damageclass:
-  All: 127
-  AllMagical: 126
-  AllPhysical: 1
-  Arcane: 6
-  Fire: 2
-  FirstResist: 2
-  Frost: 4
-  Holy: 1
-  LastResist: 6
-  MaskArcane: 64
-  MaskChaos: 124
-  MaskChromatic: 62
-  MaskCosmic: 106
-  MaskDivine: 66
-  MaskElemental: 28
-  MaskFire: 4
-  MaskFirestorm: 12
-  MaskFlamestrike: 5
-  MaskFrost: 16
-  MaskFrostfire: 20
-  MaskFroststorm: 24
-  MaskFroststrike: 17
-  MaskHoly: 2
-  MaskHolyfire: 6
-  MaskHolyfrost: 18
-  MaskHolystorm: 10
-  MaskHolystrike: 3
-  MaskMagical: 126
-  MaskNature: 8
-  MaskNone: 0
-  MaskPhysical: 1
-  MaskShadow: 32
-  MaskShadowflame: 36
-  MaskShadowfrost: 48
-  MaskShadowstorm: 40
-  MaskShadowstrike: 33
-  MaskSpellfire: 68
-  MaskSpellfrost: 80
-  MaskSpellshadow: 96
-  MaskSpellstorm: 72
-  MaskSpellstrike: 65
-  MaskStormstrike: 9
-  MaskTwilight: 34
-  Nature: 3
-  Physical: 0
-  Shadow: 5
+  values:
+    All: 127
+    AllMagical: 126
+    AllPhysical: 1
+    Arcane: 6
+    Fire: 2
+    FirstResist: 2
+    Frost: 4
+    Holy: 1
+    LastResist: 6
+    MaskArcane: 64
+    MaskChaos: 124
+    MaskChromatic: 62
+    MaskCosmic: 106
+    MaskDivine: 66
+    MaskElemental: 28
+    MaskFire: 4
+    MaskFirestorm: 12
+    MaskFlamestrike: 5
+    MaskFrost: 16
+    MaskFrostfire: 20
+    MaskFroststorm: 24
+    MaskFroststrike: 17
+    MaskHoly: 2
+    MaskHolyfire: 6
+    MaskHolyfrost: 18
+    MaskHolystorm: 10
+    MaskHolystrike: 3
+    MaskMagical: 126
+    MaskNature: 8
+    MaskNone: 0
+    MaskPhysical: 1
+    MaskShadow: 32
+    MaskShadowflame: 36
+    MaskShadowfrost: 48
+    MaskShadowstorm: 40
+    MaskShadowstrike: 33
+    MaskSpellfire: 68
+    MaskSpellfrost: 80
+    MaskSpellshadow: 96
+    MaskSpellstorm: 72
+    MaskSpellstrike: 65
+    MaskStormstrike: 9
+    MaskTwilight: 34
+    Nature: 3
+    Physical: 0
+    Shadow: 5
 DamageclassType:
-  Magical: 1
-  Physical: 0
+  values:
+    Magical: 1
+    Physical: 0
 DamageMeterCombineSessionType:
-  Arena: 2
-  ArenaMultiRound: 3
-  ChallengeMode: 1
-  None: 0
+  values:
+    Arena: 2
+    ArenaMultiRound: 3
+    ChallengeMode: 1
+    None: 0
 DamageMeterNumbers:
-  Compact: 1
-  Complete: 2
-  Minimal: 0
+  values:
+    Compact: 1
+    Complete: 2
+    Minimal: 0
 DamageMeterOverrideType:
-  AllowFriendlyFire: 1
-  Ignore: 0
-  IgnoreForAbsorbSpell: 4
-  RedirectSourceToAuraCaster: 3
-  RedirectSourceToOwner: 2
+  values:
+    AllowFriendlyFire: 1
+    Ignore: 0
+    IgnoreForAbsorbSpell: 4
+    RedirectSourceToAuraCaster: 3
+    RedirectSourceToOwner: 2
 DamageMeterSessionType:
-  Current: 1
-  Expired: 2
-  Overall: 0
+  values:
+    Current: 1
+    Expired: 2
+    Overall: 0
 DamageMeterSourceDisplayType:
-  Ally: 1
-  Enemy: 2
-  None: 0
+  values:
+    Ally: 1
+    Enemy: 2
+    None: 0
 DamageMeterSpellDetailsDisplayType:
-  Deaths: 3
-  EnemyDamageTaken: 4
-  SpellAffected: 2
-  SpellCasted: 0
-  UnitSpecificSpellCasted: 1
+  values:
+    Deaths: 3
+    EnemyDamageTaken: 4
+    SpellAffected: 2
+    SpellCasted: 0
+    UnitSpecificSpellCasted: 1
 DamageMeterStorageType:
-  Absorbs: 2
-  AvoidableDamageTaken: 6
-  Damage: 0
-  DamageTaken: 5
-  Deaths: 7
-  Dispels: 4
-  EnemyDamageTaken: 8
-  HealingAndAbsorbs: 1
-  Interrupts: 3
+  values:
+    Absorbs: 2
+    AvoidableDamageTaken: 6
+    Damage: 0
+    DamageTaken: 5
+    Deaths: 7
+    Dispels: 4
+    EnemyDamageTaken: 8
+    HealingAndAbsorbs: 1
+    Interrupts: 3
 DamageMeterStyle:
-  Bordered: 2
-  Default: 0
-  FullBackground: 3
-  Thin: 1
+  values:
+    Bordered: 2
+    Default: 0
+    FullBackground: 3
+    Thin: 1
 DamageMeterType:
-  Absorbs: 4
-  AvoidableDamageTaken: 8
-  DamageDone: 0
-  DamageTaken: 7
-  Deaths: 9
-  Dispels: 6
-  Dps: 1
-  EnemyDamageTaken: 10
-  HealingDone: 2
-  Hps: 3
-  Interrupts: 5
+  values:
+    Absorbs: 4
+    AvoidableDamageTaken: 8
+    DamageDone: 0
+    DamageTaken: 7
+    Deaths: 9
+    Dispels: 6
+    Dps: 1
+    EnemyDamageTaken: 10
+    HealingDone: 2
+    Hps: 3
+    Interrupts: 5
 DamageMeterVisibility:
-  Always: 0
-  Hidden: 2
-  InCombat: 1
-  InGroup: 3
+  values:
+    Always: 0
+    Hidden: 2
+    InCombat: 1
+    InGroup: 3
 DeveloperLogAssertDomain:
-  Art: 1
-  Design: 2
-  Engineering: 4
-  LiveOperations: 64
-  Performance: 32
-  Sound: 8
-  Tools: 16
+  values:
+    Art: 1
+    Design: 2
+    Engineering: 4
+    LiveOperations: 64
+    Performance: 32
+    Sound: 8
+    Tools: 16
 DeveloperLogErrorDomain:
-  Assert: 0
-  AssertData: 1
-  Frame: 2
-  TestSuite: 3
+  values:
+    Assert: 0
+    AssertData: 1
+    Frame: 2
+    TestSuite: 3
 DeveloperLogTrafficType:
-  ClientToServer: 1
-  GameEvent: 2
-  LuaToClient: 3
-  ServerToClient: 0
+  values:
+    ClientToServer: 1
+    GameEvent: 2
+    LuaToClient: 3
+    ServerToClient: 0
 DisableAccountProfilesFlags:
-  DecorsCollections: 32
-  Document: 1
-  ItemsCollections: 16
-  MountsCollections: 4
-  None: 0
-  PetsCollections: 8
-  SharedCollections: 2
+  values:
+    DecorsCollections: 32
+    Document: 1
+    ItemsCollections: 16
+    MountsCollections: 4
+    None: 0
+    PetsCollections: 8
+    SharedCollections: 2
 DurationTextBindingProperty:
-  ElapsedDuration: 2
-  ElapsedPercent: 3
-  EndTime: 6
-  RemainingDuration: 0
-  RemainingPercent: 1
-  StartTime: 5
-  TotalDuration: 4
+  values:
+    ElapsedDuration: 2
+    ElapsedPercent: 3
+    EndTime: 6
+    RemainingDuration: 0
+    RemainingPercent: 1
+    StartTime: 5
+    TotalDuration: 4
 DurationTimeModifier:
-  BaseTime: 1
-  RealTime: 0
+  values:
+    BaseTime: 1
+    RealTime: 0
 EditModeAccountSetting:
-  DeprecatedShowDebuffFrame: 11
-  EnableAdvancedOptions: 23
-  EnableSnap: 22
-  GridSpacing: 1
-  SettingsExpanded: 2
-  ShowArchaeologyBar: 27
-  ShowArenaFrames: 17
-  ShowBossFrames: 16
-  ShowBuffsAndDebuffs: 10
-  ShowCastBar: 7
-  ShowCooldownViewer: 28
-  ShowDamageMeter: 31
-  ShowDurabilityFrame: 21
-  ShowEncounterBar: 8
-  ShowEncounterEvents: 30
-  ShowExternalDefensives: 32
-  ShowExtraAbilities: 9
-  ShowGrid: 0
-  ShowHudTooltip: 19
-  ShowLootFrame: 18
-  ShowPartyFrames: 12
-  ShowPersonalResourceDisplay: 29
-  ShowPetActionBar: 5
-  ShowPetFrame: 24
-  ShowPossessActionBar: 6
-  ShowRaidFrames: 13
-  ShowStanceBar: 4
-  ShowStatusTrackingBar2: 20
-  ShowTalkingHeadFrame: 14
-  ShowTargetAndFocus: 3
-  ShowTimerBars: 25
-  ShowTotemActionBar: 33
-  ShowVehicleLeaveButton: 15
-  ShowVehicleSeatIndicator: 26
+  values:
+    DeprecatedShowDebuffFrame: 11
+    EnableAdvancedOptions: 23
+    EnableSnap: 22
+    GridSpacing: 1
+    SettingsExpanded: 2
+    ShowArchaeologyBar: 27
+    ShowArenaFrames: 17
+    ShowBossFrames: 16
+    ShowBuffsAndDebuffs: 10
+    ShowCastBar: 7
+    ShowCooldownViewer: 28
+    ShowDamageMeter: 31
+    ShowDurabilityFrame: 21
+    ShowEncounterBar: 8
+    ShowEncounterEvents: 30
+    ShowExternalDefensives: 32
+    ShowExtraAbilities: 9
+    ShowGrid: 0
+    ShowHudTooltip: 19
+    ShowLootFrame: 18
+    ShowPartyFrames: 12
+    ShowPersonalResourceDisplay: 29
+    ShowPetActionBar: 5
+    ShowPetFrame: 24
+    ShowPossessActionBar: 6
+    ShowRaidFrames: 13
+    ShowStanceBar: 4
+    ShowStatusTrackingBar2: 20
+    ShowTalkingHeadFrame: 14
+    ShowTargetAndFocus: 3
+    ShowTimerBars: 25
+    ShowTotemActionBar: 33
+    ShowVehicleLeaveButton: 15
+    ShowVehicleSeatIndicator: 26
 EditModeActionBarSetting:
-  AlwaysShowButtons: 9
-  DeprecatedSnapToSide: 7
-  HideBarArt: 6
-  HideBarScrolling: 8
-  IconPadding: 4
-  IconSize: 3
-  NumIcons: 2
-  NumRows: 1
-  Orientation: 0
-  VisibleSetting: 5
+  values:
+    AlwaysShowButtons: 9
+    DeprecatedSnapToSide: 7
+    HideBarArt: 6
+    HideBarScrolling: 8
+    IconPadding: 4
+    IconSize: 3
+    NumIcons: 2
+    NumRows: 1
+    Orientation: 0
+    VisibleSetting: 5
 EditModeActionBarSystemIndices:
-  Bar2: 2
-  Bar3: 3
-  ExtraBar1: 6
-  ExtraBar2: 7
-  ExtraBar3: 8
-  MainBar: 1
-  PetActionBar: 12
-  PossessActionBar: 13
-  RightBar1: 4
-  RightBar2: 5
-  StanceBar: 11
+  values:
+    Bar2: 2
+    Bar3: 3
+    ExtraBar1: 6
+    ExtraBar2: 7
+    ExtraBar3: 8
+    MainBar: 1
+    PetActionBar: 12
+    PossessActionBar: 13
+    RightBar1: 4
+    RightBar2: 5
+    StanceBar: 11
 EditModeArchaeologyBarSetting:
-  Size: 0
+  values:
+    Size: 0
 EditModeAuraFrameSetting:
-  DeprecatedShowFull: 7
-  IconDirection: 2
-  IconLimitBuffFrame: 3
-  IconLimitDebuffFrame: 4
-  IconPadding: 6
-  IconSize: 5
-  IconWrap: 1
-  Opacity: 9
-  Orientation: 0
-  ShowDispelType: 10
-  VisibleSetting: 8
+  values:
+    DeprecatedShowFull: 7
+    IconDirection: 2
+    IconLimitBuffFrame: 3
+    IconLimitDebuffFrame: 4
+    IconPadding: 6
+    IconSize: 5
+    IconWrap: 1
+    Opacity: 9
+    Orientation: 0
+    ShowDispelType: 10
+    VisibleSetting: 8
 EditModeAuraFrameSystemIndices:
-  BuffFrame: 1
-  DebuffFrame: 2
-  ExternalDefensivesFrame: 3
+  values:
+    BuffFrame: 1
+    DebuffFrame: 2
+    ExternalDefensivesFrame: 3
 EditModeBagsSetting:
-  BagSlotPadding: 3
-  Direction: 1
-  Orientation: 0
-  Size: 2
+  values:
+    BagSlotPadding: 3
+    Direction: 1
+    Orientation: 0
+    Size: 2
 EditModeCastBarSetting:
-  BarSize: 0
-  LockToPlayerFrame: 1
-  ShowCastTime: 2
+  values:
+    BarSize: 0
+    LockToPlayerFrame: 1
+    ShowCastTime: 2
 EditModeChatFrameSetting:
-  HeightHundreds: 2
-  HeightTensAndOnes: 3
-  WidthHundreds: 0
-  WidthTensAndOnes: 1
+  values:
+    HeightHundreds: 2
+    HeightTensAndOnes: 3
+    WidthHundreds: 0
+    WidthTensAndOnes: 1
 EditModeCooldownViewerSetting:
-  BarContent: 7
-  BarWidthScale: 11
-  HideWhenInactive: 8
-  IconDirection: 2
-  IconLimit: 1
-  IconPadding: 4
-  IconSize: 3
-  Opacity: 5
-  Orientation: 0
-  ShowTimer: 9
-  ShowTooltips: 10
-  VisibleSetting: 6
+  values:
+    BarContent: 7
+    BarWidthScale: 11
+    HideWhenInactive: 8
+    IconDirection: 2
+    IconLimit: 1
+    IconPadding: 4
+    IconSize: 3
+    Opacity: 5
+    Orientation: 0
+    ShowTimer: 9
+    ShowTooltips: 10
+    VisibleSetting: 6
 EditModeCooldownViewerSystemIndices:
-  BuffBar: 4
-  BuffIcon: 3
-  Essential: 1
-  Utility: 2
+  values:
+    BuffBar: 4
+    BuffIcon: 3
+    Essential: 1
+    Utility: 2
 EditModeDamageMeterSetting:
-  BackgroundTransparency: 12
-  BarHeight: 10
-  FrameHeight: 4
-  FrameWidth: 3
-  Numbers: 2
-  ObsoleteReuse1: 7
-  Padding: 5
-  ShowClassColor: 9
-  ShowSpecIcon: 8
-  Style: 1
-  TextSize: 11
-  Transparency: 6
-  Visibility: 0
+  values:
+    BackgroundTransparency: 12
+    BarHeight: 10
+    FrameHeight: 4
+    FrameWidth: 3
+    Numbers: 2
+    ObsoleteReuse1: 7
+    Padding: 5
+    ShowClassColor: 9
+    ShowSpecIcon: 8
+    Style: 1
+    TextSize: 11
+    Transparency: 6
+    Visibility: 0
 EditModeDurabilityFrameSetting:
-  Size: 0
+  values:
+    Size: 0
 EditModeEncounterEventsSetting:
-  BackgroundTransparency: 5
-  BarWidth: 12
-  FlipHorizontally: 11
-  IconDirection: 1
-  IconSize: 3
-  Orientation: 0
-  OverallSize: 4
-  Padding: 13
-  ShowSpellName: 2
-  ShowTimer: 9
-  TooltipAnchor: 8
-  Transparency: 6
-  ViewType: 10
-  Visibility: 7
+  values:
+    BackgroundTransparency: 5
+    BarWidth: 12
+    FlipHorizontally: 11
+    IconDirection: 1
+    IconSize: 3
+    Orientation: 0
+    OverallSize: 4
+    Padding: 13
+    ShowSpellName: 2
+    ShowTimer: 9
+    TooltipAnchor: 8
+    Transparency: 6
+    ViewType: 10
+    Visibility: 7
 EditModeEncounterEventsSystemIndices:
-  CriticalWarnings: 2
-  MediumWarnings: 3
-  NormalWarnings: 4
-  Timeline: 1
+  values:
+    CriticalWarnings: 2
+    MediumWarnings: 3
+    NormalWarnings: 4
+    Timeline: 1
 EditModeLayoutType:
-  Account: 1
-  Character: 2
-  Override: 3
-  Preset: 0
+  values:
+    Account: 1
+    Character: 2
+    Override: 3
+    Preset: 0
 EditModeMicroMenuSetting:
-  EyeSize: 3
-  Order: 1
-  Orientation: 0
-  Size: 2
+  values:
+    EyeSize: 3
+    Order: 1
+    Orientation: 0
+    Size: 2
 EditModeMinimapSetting:
-  HeaderUnderneath: 0
-  RotateMinimap: 1
-  Size: 2
+  values:
+    HeaderUnderneath: 0
+    RotateMinimap: 1
+    Size: 2
 EditModeObjectiveTrackerSetting:
-  Height: 0
-  Opacity: 1
-  TextSize: 2
+  values:
+    Height: 0
+    Opacity: 1
+    TextSize: 2
 EditModePersonalResourceDisplaySetting:
-  BarWidth: 12
-  DeprecatedOnlyShowInCombat: 1
-  HealthBarHeight: 4
-  HideAltPower: 14
-  HideClassInfo: 3
-  HideClassInfoOnPlayerFrame: 10
-  HideHealth: 0
-  HidePower: 2
-  Opacity: 7
-  Padding: 6
-  PowerBarHeight: 5
-  ShowBarText: 13
-  ShowClassColor: 11
-  Size: 9
-  VisibleSetting: 8
+  values:
+    BarWidth: 12
+    DeprecatedOnlyShowInCombat: 1
+    HealthBarHeight: 4
+    HideAltPower: 14
+    HideClassInfo: 3
+    HideClassInfoOnPlayerFrame: 10
+    HideHealth: 0
+    HidePower: 2
+    Opacity: 7
+    Padding: 6
+    PowerBarHeight: 5
+    ShowBarText: 13
+    ShowClassColor: 11
+    Size: 9
+    VisibleSetting: 8
 EditModePresetLayouts:
-  Classic: 1
-  Modern: 0
+  values:
+    Classic: 1
+    Modern: 0
 EditModeSettingDisplayType:
-  Checkbox: 1
-  Dropdown: 0
-  Slider: 2
+  values:
+    Checkbox: 1
+    Dropdown: 0
+    Slider: 2
 EditModeStatusTrackingBarSetting:
-  Height: 0
-  Size: 3
-  TextSize: 2
-  Width: 1
+  values:
+    Height: 0
+    Size: 3
+    TextSize: 2
+    Width: 1
 EditModeStatusTrackingBarSystemIndices:
-  StatusTrackingBar1: 1
-  StatusTrackingBar2: 2
+  values:
+    StatusTrackingBar1: 1
+    StatusTrackingBar2: 2
 EditModeSystem:
-  ActionBar: 0
-  ArchaeologyBar: 19
-  AuraFrame: 6
-  Bags: 14
-  CastBar: 1
-  ChatFrame: 8
-  CooldownViewer: 20
-  DamageMeter: 23
-  DurabilityFrame: 16
-  EncounterBar: 4
-  EncounterEvents: 22
-  ExtraAbilities: 5
-  HudTooltip: 11
-  LootFrame: 10
-  MicroMenu: 13
-  Minimap: 2
-  ObjectiveTracker: 12
-  PersonalResourceDisplay: 21
-  StatusTrackingBar: 15
-  TalkingHeadFrame: 7
-  TimerBars: 17
-  TotemActionBar: 24
-  UnitFrame: 3
-  VehicleLeaveButton: 9
-  VehicleSeatIndicator: 18
+  values:
+    ActionBar: 0
+    ArchaeologyBar: 19
+    AuraFrame: 6
+    Bags: 14
+    CastBar: 1
+    ChatFrame: 8
+    CooldownViewer: 20
+    DamageMeter: 23
+    DurabilityFrame: 16
+    EncounterBar: 4
+    EncounterEvents: 22
+    ExtraAbilities: 5
+    HudTooltip: 11
+    LootFrame: 10
+    MicroMenu: 13
+    Minimap: 2
+    ObjectiveTracker: 12
+    PersonalResourceDisplay: 21
+    StatusTrackingBar: 15
+    TalkingHeadFrame: 7
+    TimerBars: 17
+    TotemActionBar: 24
+    UnitFrame: 3
+    VehicleLeaveButton: 9
+    VehicleSeatIndicator: 18
 EditModeTimerBarsSetting:
-  Size: 0
+  values:
+    Size: 0
 EditModeUnitFrameSetting:
-  AuraOrganizationType: 18
-  BigDefensiveIconSize: 21
-  BuffsOnTop: 2
-  CastBarOnSide: 7
-  CastBarUnderneath: 1
-  DisplayBorder: 12
-  FrameHeight: 11
-  FrameSize: 16
-  FrameWidth: 10
-  HidePortrait: 0
-  IconSize: 19
-  Opacity: 20
-  RaidGroupDisplayType: 13
-  RowSize: 15
-  ShowCastTime: 8
-  ShowPartyFrameBackground: 5
-  SortPlayersBy: 14
-  UseHorizontalGroups: 6
-  UseLargerFrame: 3
-  UseRaidStylePartyFrames: 4
-  ViewArenaSize: 17
-  ViewRaidSize: 9
+  values:
+    AuraOrganizationType: 18
+    BigDefensiveIconSize: 21
+    BuffsOnTop: 2
+    CastBarOnSide: 7
+    CastBarUnderneath: 1
+    DisplayBorder: 12
+    FrameHeight: 11
+    FrameSize: 16
+    FrameWidth: 10
+    HidePortrait: 0
+    IconSize: 19
+    Opacity: 20
+    RaidGroupDisplayType: 13
+    RowSize: 15
+    ShowCastTime: 8
+    ShowPartyFrameBackground: 5
+    SortPlayersBy: 14
+    UseHorizontalGroups: 6
+    UseLargerFrame: 3
+    UseRaidStylePartyFrames: 4
+    ViewArenaSize: 17
+    ViewRaidSize: 9
 EditModeUnitFrameSystemIndices:
-  Arena: 7
-  Boss: 6
-  Focus: 3
-  Party: 4
-  Pet: 8
-  Player: 1
-  Raid: 5
-  Target: 2
+  values:
+    Arena: 7
+    Boss: 6
+    Focus: 3
+    Party: 4
+    Pet: 8
+    Player: 1
+    Raid: 5
+    Target: 2
 EditModeVehicleSeatIndicatorSetting:
-  Size: 0
+  values:
+    Size: 0
 EncounterEventCastState:
-  Casting: 1
-  Expired: 3
-  NotCasting: 2
+  values:
+    Casting: 1
+    Expired: 3
+    NotCasting: 2
 EncounterEventColorTrigger:
-  TextWarning: 0
-  TimelineEvent: 1
-  TimelineEventHighlight: 2
+  values:
+    TextWarning: 0
+    TimelineEvent: 1
+    TimelineEventHighlight: 2
 EncounterEventIconmask:
-  BleedEffect: 4
-  CurseEffect: 32
-  DeadlyEffect: 1
-  DiseaseEffect: 16
-  DpsRole: 512
-  EnrageEffect: 2
-  HealerRole: 256
-  MagicEffect: 8
-  PoisonEffect: 64
-  TankRole: 128
+  values:
+    BleedEffect: 4
+    CurseEffect: 32
+    DeadlyEffect: 1
+    DiseaseEffect: 16
+    DpsRole: 512
+    EnrageEffect: 2
+    HealerRole: 256
+    MagicEffect: 8
+    PoisonEffect: 64
+    TankRole: 128
 EncounterEventSeverity:
-  High: 2
-  Low: 0
-  Medium: 1
+  values:
+    High: 2
+    Low: 0
+    Medium: 1
 EncounterEventsIconDirection:
-  Bottom: 1
-  Left: 0
-  Right: 1
-  Top: 0
+  values:
+    Bottom: 1
+    Left: 0
+    Right: 1
+    Top: 0
 EncounterEventsOrientation:
-  Horizontal: 0
-  Vertical: 1
+  values:
+    Horizontal: 0
+    Vertical: 1
 EncounterEventSoundTrigger:
-  OnTextWarningShown: 0
-  OnTimelineEventFinished: 1
-  OnTimelineEventHighlight: 2
+  values:
+    OnTextWarningShown: 0
+    OnTimelineEventFinished: 1
+    OnTimelineEventHighlight: 2
 EncounterEventsTooltipAnchor:
-  Cursor: 2
-  Default: 1
-  Hidden: 0
+  values:
+    Cursor: 2
+    Default: 1
+    Hidden: 0
 EncounterEventsViewType:
-  Bars: 1
-  Timeline: 0
+  values:
+    Bars: 1
+    Timeline: 0
 EncounterEventsVisibility:
-  Always: 0
-  DeprecatedHidden: 2
-  InEncounter: 1
+  values:
+    Always: 0
+    DeprecatedHidden: 2
+    InEncounter: 1
 EncounterTimelineEventSortDirection:
-  Ascending: 1
-  Descending: 0
+  values:
+    Ascending: 1
+    Descending: 0
 EncounterTimelineEventSource:
-  EditMode: 2
-  Encounter: 0
-  Script: 1
+  values:
+    EditMode: 2
+    Encounter: 0
+    Script: 1
 EncounterTimelineEventState:
-  Active: 0
-  Canceled: 3
-  Finished: 2
-  Paused: 1
+  values:
+    Active: 0
+    Canceled: 3
+    Finished: 2
+    Paused: 1
 EncounterTimelineIconSet:
-  DamageAlert: 3
-  Deadly: 4
-  Dispel: 5
-  Enrage: 6
-  HealerAlert: 2
-  TankAlert: 1
+  values:
+    DamageAlert: 3
+    Deadly: 4
+    Dispel: 5
+    Enrage: 6
+    HealerAlert: 2
+    TankAlert: 1
 EncounterTimelineTrack:
-  Indeterminate: 4
-  Long: 3
-  Medium: 2
-  Queued: 0
-  Short: 1
+  values:
+    Indeterminate: 4
+    Long: 3
+    Medium: 2
+    Queued: 0
+    Short: 1
 EncounterTimelineTrackType:
-  Hidden: 0
-  Linear: 2
-  Sorted: 1
+  values:
+    Hidden: 0
+    Linear: 2
+    Sorted: 1
 EncounterTimelineViewType:
-  Bars: 2
-  None: 0
-  Timeline: 1
+  values:
+    Bars: 2
+    None: 0
+    Timeline: 1
 EndOfMatchType:
-  None: 0
-  Plunderstorm: 1
+  values:
+    None: 0
+    Plunderstorm: 1
 EnvironmentalDamageFlags:
-  DmgIsPct: 2
-  OneTime: 1
+  values:
+    DmgIsPct: 2
+    OneTime: 1
 Environmentaldamagetype:
-  Drowning: 1
-  Falling: 2
-  Fatigue: 0
-  Fire: 5
-  Lava: 3
-  Slime: 4
+  values:
+    Drowning: 1
+    Falling: 2
+    Fatigue: 0
+    Fire: 5
+    Lava: 3
+    Slime: 4
 EventRealmQueues:
-  None: 0
-  PlunderstormDuo: 2
-  PlunderstormSolo: 1
-  PlunderstormTraining: 8
-  PlunderstormTrio: 4
+  values:
+    None: 0
+    PlunderstormDuo: 2
+    PlunderstormSolo: 1
+    PlunderstormTraining: 8
+    PlunderstormTrio: 4
 EventToastDisplayType:
-  CapstoneUnlocked: 12
-  ChallengeMode: 7
-  FlightpointDiscovered: 11
-  HouseUpgradeAvailable: 15
-  LargeTextWithIcon: 4
-  NormalBlockText: 1
-  NormalSingleLine: 0
-  NormalTextWithIcon: 3
-  NormalTextWithIconAndRarity: 5
-  NormalTitleAndSubTitle: 2
-  Scenario: 6
-  ScenarioClickExpand: 8
-  Scoreboard: 14
-  SingleLineWithIcon: 13
-  WeeklyRewardUnlock: 9
-  WeeklyRewardUpgrade: 10
+  values:
+    CapstoneUnlocked: 12
+    ChallengeMode: 7
+    FlightpointDiscovered: 11
+    HouseUpgradeAvailable: 15
+    LargeTextWithIcon: 4
+    NormalBlockText: 1
+    NormalSingleLine: 0
+    NormalTextWithIcon: 3
+    NormalTextWithIconAndRarity: 5
+    NormalTitleAndSubTitle: 2
+    Scenario: 6
+    ScenarioClickExpand: 8
+    Scoreboard: 14
+    SingleLineWithIcon: 13
+    WeeklyRewardUnlock: 9
+    WeeklyRewardUpgrade: 10
 EventToastEventType:
-  BattlePetLevelChanged: 8
-  BattlePetLevelUpAbility: 9
-  CriteriaUpdated: 19
-  FlightpointDiscovered: 25
-  HouseUpgradeAvailable: 26
-  LevelUp: 0
-  LevelUpDungeon: 2
-  LevelUpOther: 15
-  LevelUpPvP: 4
-  LevelUpRaid: 3
-  LevelUpSpell: 1
-  MythicPlusWeeklyRecord: 11
-  PetBattleCapture: 7
-  PetBattleFinalRound: 6
-  PetBattleNewAbility: 5
-  PlayerAuraAdded: 16
-  PlayerAuraRemoved: 17
-  PvPTierUpdate: 20
-  QuestBossEmote: 10
-  QuestTurnedIn: 12
-  Scenario: 14
-  SpellLearned: 21
-  SpellScript: 18
-  TreasureItem: 22
-  WeeklyRewardUnlock: 23
-  WeeklyRewardUpgrade: 24
-  WorldStateChange: 13
+  values:
+    BattlePetLevelChanged: 8
+    BattlePetLevelUpAbility: 9
+    CriteriaUpdated: 19
+    FlightpointDiscovered: 25
+    HouseUpgradeAvailable: 26
+    LevelUp: 0
+    LevelUpDungeon: 2
+    LevelUpOther: 15
+    LevelUpPvP: 4
+    LevelUpRaid: 3
+    LevelUpSpell: 1
+    MythicPlusWeeklyRecord: 11
+    PetBattleCapture: 7
+    PetBattleFinalRound: 6
+    PetBattleNewAbility: 5
+    PlayerAuraAdded: 16
+    PlayerAuraRemoved: 17
+    PvPTierUpdate: 20
+    QuestBossEmote: 10
+    QuestTurnedIn: 12
+    Scenario: 14
+    SpellLearned: 21
+    SpellScript: 18
+    TreasureItem: 22
+    WeeklyRewardUnlock: 23
+    WeeklyRewardUpgrade: 24
+    WorldStateChange: 13
 EventToastFlags:
-  DisableRightClickDismiss: 1
+  values:
+    DisableRightClickDismiss: 1
 ExcludedCensorSources:
-  All: 255
-  Friends: 1
-  Guild: 2
-  None: 0
-  Reserve1: 4
-  Reserve2: 8
-  Reserve3: 16
-  Reserve4: 32
-  Reserve5: 64
-  Reserve6: 128
+  values:
+    All: 255
+    Friends: 1
+    Guild: 2
+    None: 0
+    Reserve1: 4
+    Reserve2: 8
+    Reserve3: 16
+    Reserve4: 32
+    Reserve5: 64
+    Reserve6: 128
 ExpansionLandingPageType:
-  Midnight: 1
-  None: 0
+  values:
+    Midnight: 1
+    None: 0
 ExpansionLevel:
-  BattleForAzeroth: 7
-  BurningCrusade: 1
-  Cataclysm: 3
-  Draenor: 5
-  Dragonflight: 9
-  LastTitan: 12
-  Legion: 6
-  Midnight: 11
-  MistsOfPandaria: 4
-  None: 0
-  Northrend: 2
-  Shadowlands: 8
-  WarWithin: 10
+  values:
+    BattleForAzeroth: 7
+    BurningCrusade: 1
+    Cataclysm: 3
+    Draenor: 5
+    Dragonflight: 9
+    LastTitan: 12
+    Legion: 6
+    Midnight: 11
+    MistsOfPandaria: 4
+    None: 0
+    Northrend: 2
+    Shadowlands: 8
+    WarWithin: 10
 FlightPathFaction:
-  Alliance: 2
-  Horde: 1
-  Neutral: 0
+  values:
+    Alliance: 2
+    Horde: 1
+    Neutral: 0
 FlightPathState:
-  Current: 0
-  Reachable: 1
-  Unreachable: 2
+  values:
+    Current: 0
+    Reachable: 1
+    Unreachable: 2
 FollowerAbilityCastResult:
-  AlreadyAtMaxDurability: 13
-  CannotTargetLimitedUseFollower: 11
-  CannotTargetNonAutoMissionFollower: 14
-  Failure: 1
-  InvalidFollowerSpell: 4
-  InvalidFollowerType: 9
-  InvalidTarget: 3
-  MustBeUnique: 10
-  MustTargetFollower: 7
-  MustTargetLimitedUseFollower: 12
-  MustTargetTrait: 8
-  NoPendingCast: 2
-  RerollNotAllowed: 5
-  SingleMissionDuration: 6
-  Success: 0
+  values:
+    AlreadyAtMaxDurability: 13
+    CannotTargetLimitedUseFollower: 11
+    CannotTargetNonAutoMissionFollower: 14
+    Failure: 1
+    InvalidFollowerSpell: 4
+    InvalidFollowerType: 9
+    InvalidTarget: 3
+    MustBeUnique: 10
+    MustTargetFollower: 7
+    MustTargetLimitedUseFollower: 12
+    MustTargetTrait: 8
+    NoPendingCast: 2
+    RerollNotAllowed: 5
+    SingleMissionDuration: 6
+    Success: 0
 FontStringScaleAnimationMode:
-  FontSize: 0
-  Vertex: 1
+  values:
+    FontSize: 0
+    Vertex: 1
 FragmentID:
-  Actor: 15
-  CgObject: 2
-  ClientObservablesData: 6
-  DeferredMessages: 9
-  EntityPosition: 1
-  FHousingDecor: 20
-  FHousingDecorActor: 28
-  FHousingDecorProxy: 26
-  FHousingFixture: 34
-  FHousingHouseDecorSet: 24
-  FHousingHouseFixtureSet: 35
-  FHousingHouseRoomSet: 25
-  FHousingPlayerHouse: 23
-  FHousingPlotAreaTrigger: 29
-  FHousingRoom: 21
-  FHousingRoomComponentMesh: 22
-  FHousingStorageMirrorData: 33
-  FJamHousingCornerstone: 27
-  FLootObjectList: 12
-  FMeshObjectData: 19
-  FMirroredPositionData: 31
-  FNeighborhoodMirrorData: 30
-  FNeighborhoodStateData: 38
-  FPathingDoor: 41
-  FPathingDynamicLinks: 40
-  FPersistableJamServers: 10
-  FPhaseShiftData: 16
-  FPlayerHouseInfo: 32
-  FPlayerInitiativeInfo: 37
-  FPlayerJamServers: 11
-  FPlayerOwnershipLink: 13
-  FTransportLink: 5
-  FUnitAIGroupLink: 39
-  FUnitAreaTriggerLink: 14
-  FVendor: 17
-  HeartbeatData: 4
-  JamDispatcher: 3
-  MirroredObjectC: 18
-  MirrorState: 0
-  ReservedArchetypeSeparator: 255
-  TagActiveClientS: 216
-  TagActiveObjectC: 217
-  TagActivePlayer: 215
-  TagAIGroup: 212
-  TagAreaTrigger: 209
-  TagAzeriteEmpoweredItem: 202
-  TagAzeriteItem: 203
-  TagContainer: 201
-  TagConversation: 211
-  TagCorpse: 208
-  TagDynamicObject: 207
-  TagGameObject: 206
-  TagHouseExteriorPiece: 224
-  TagHouseExteriorRoot: 225
-  TagHousingDecorProxyGameObject: 226
-  TagHousingPoolObject: 223
-  TagHousingRoom: 220
-  TagHousingSubdivisionObject: 222
-  TagItem: 200
-  TagLootObject: 214
-  TagMeshObject: 221
-  TagPlayer: 205
-  TagScenario: 213
-  TagSceneObject: 210
-  TagUnit: 204
-  TagUnitVehicle: 219
-  TagVisibleObjectC: 218
-  TestFragment_1: 250
-  TestFragment_2: 251
-  TestFragment_3: 252
-  TestFragment_4: 253
-  TestFragment_5: 254
-  Timer: 36
-  TimerQueues: 7
-  TransferSuspensionData: 8
+  values:
+    Actor: 15
+    CgObject: 2
+    ClientObservablesData: 6
+    DeferredMessages: 9
+    EntityPosition: 1
+    FHousingDecor: 20
+    FHousingDecorActor: 28
+    FHousingDecorProxy: 26
+    FHousingFixture: 34
+    FHousingHouseDecorSet: 24
+    FHousingHouseFixtureSet: 35
+    FHousingHouseRoomSet: 25
+    FHousingPlayerHouse: 23
+    FHousingPlotAreaTrigger: 29
+    FHousingRoom: 21
+    FHousingRoomComponentMesh: 22
+    FHousingStorageMirrorData: 33
+    FJamHousingCornerstone: 27
+    FLootObjectList: 12
+    FMeshObjectData: 19
+    FMirroredPositionData: 31
+    FNeighborhoodMirrorData: 30
+    FNeighborhoodStateData: 38
+    FPathingDoor: 41
+    FPathingDynamicLinks: 40
+    FPersistableJamServers: 10
+    FPhaseShiftData: 16
+    FPlayerHouseInfo: 32
+    FPlayerInitiativeInfo: 37
+    FPlayerJamServers: 11
+    FPlayerOwnershipLink: 13
+    FTransportLink: 5
+    FUnitAIGroupLink: 39
+    FUnitAreaTriggerLink: 14
+    FVendor: 17
+    HeartbeatData: 4
+    JamDispatcher: 3
+    MirroredObjectC: 18
+    MirrorState: 0
+    ReservedArchetypeSeparator: 255
+    TagActiveClientS: 216
+    TagActiveObjectC: 217
+    TagActivePlayer: 215
+    TagAIGroup: 212
+    TagAreaTrigger: 209
+    TagAzeriteEmpoweredItem: 202
+    TagAzeriteItem: 203
+    TagContainer: 201
+    TagConversation: 211
+    TagCorpse: 208
+    TagDynamicObject: 207
+    TagGameObject: 206
+    TagHouseExteriorPiece: 224
+    TagHouseExteriorRoot: 225
+    TagHousingDecorProxyGameObject: 226
+    TagHousingPoolObject: 223
+    TagHousingRoom: 220
+    TagHousingSubdivisionObject: 222
+    TagItem: 200
+    TagLootObject: 214
+    TagMeshObject: 221
+    TagPlayer: 205
+    TagScenario: 213
+    TagSceneObject: 210
+    TagUnit: 204
+    TagUnitVehicle: 219
+    TagVisibleObjectC: 218
+    TestFragment_1: 250
+    TestFragment_2: 251
+    TestFragment_3: 252
+    TestFragment_4: 253
+    TestFragment_5: 254
+    Timer: 36
+    TimerQueues: 7
+    TransferSuspensionData: 8
 FrameTutorialAccount:
-  AccountWideReputation: 9
-  AssistedCombatRotationActionButton: 22
-  AssistedCombatRotationDragSpell: 21
-  BindToAccountUntilEquip: 11
-  CompletedQuestsFilter: 12
-  CompletedQuestsFilterSeen: 13
-  ConcentrationCurrency: 14
-  EditModeManager: 3
-  EnconterJournalTutorialsTabSeen: 33
-  EventSchedulerTabSeen: 20
-  HeirloomJournalLevel: 7
-  HousingCleanupMode: 40
-  HousingDecorCleanup: 23
-  HousingDecorClippingGrid: 25
-  HousingDecorCustomization: 26
-  HousingDecorLayout: 27
-  HousingDecorPlace: 24
-  HousingEndeavorsTabSeen: 48
-  HousingExpertMode: 39
-  HousingHouseFinderMap: 28
-  HousingHouseFinderVisitHouse: 29
-  HousingInvalidCollision: 37
-  HousingItemAcquisition: 30
-  HousingMarketTab: 34
-  HousingModesUnlocked: 38
-  HousingNewPip: 31
-  HousingTeleportButton: 35
-  HudRevampBagChanges: 1
-  LFGList: 6
-  LocalStoriesFilterSeen: 19
-  MapLegendOpened: 15
-  MountCollectionDragonriding: 5
-  NpcCraftingOrderCreateButton: 17
-  NpcCraftingOrders: 16
-  NpcCraftingOrderTabNew: 18
-  PerksProgramActivitiesIntro: 2
-  PerksProgramActivitiesOpen: 32
-  RPETalentStarterBuild: 36
-  RunesOfPower: 49
-  TimerunnersAdvantage: 8
-  TransferableCurrencies: 10
-  TransmogCustomSets: 43
-  TransmogCustomSetsMigration: 47
-  TransmogOutfits: 41
-  TransmogSets: 42
-  TransmogSetsTab: 4
-  TransmogSituations: 44
-  TransmogTrialOfStyle: 46
-  TransmogWeaponOptions: 45
+  values:
+    AccountWideReputation: 9
+    AssistedCombatRotationActionButton: 22
+    AssistedCombatRotationDragSpell: 21
+    BindToAccountUntilEquip: 11
+    CompletedQuestsFilter: 12
+    CompletedQuestsFilterSeen: 13
+    ConcentrationCurrency: 14
+    EditModeManager: 3
+    EnconterJournalTutorialsTabSeen: 33
+    EventSchedulerTabSeen: 20
+    HeirloomJournalLevel: 7
+    HousingCleanupMode: 40
+    HousingDecorCleanup: 23
+    HousingDecorClippingGrid: 25
+    HousingDecorCustomization: 26
+    HousingDecorLayout: 27
+    HousingDecorPlace: 24
+    HousingEndeavorsTabSeen: 48
+    HousingExpertMode: 39
+    HousingHouseFinderMap: 28
+    HousingHouseFinderVisitHouse: 29
+    HousingInvalidCollision: 37
+    HousingItemAcquisition: 30
+    HousingMarketTab: 34
+    HousingModesUnlocked: 38
+    HousingNewPip: 31
+    HousingTeleportButton: 35
+    HudRevampBagChanges: 1
+    LFGList: 6
+    LocalStoriesFilterSeen: 19
+    MapLegendOpened: 15
+    MountCollectionDragonriding: 5
+    NpcCraftingOrderCreateButton: 17
+    NpcCraftingOrders: 16
+    NpcCraftingOrderTabNew: 18
+    PerksProgramActivitiesIntro: 2
+    PerksProgramActivitiesOpen: 32
+    RPETalentStarterBuild: 36
+    RunesOfPower: 49
+    TimerunnersAdvantage: 8
+    TransferableCurrencies: 10
+    TransmogCustomSets: 43
+    TransmogCustomSetsMigration: 47
+    TransmogOutfits: 41
+    TransmogSets: 42
+    TransmogSetsTab: 4
+    TransmogSituations: 44
+    TransmogTrialOfStyle: 46
+    TransmogWeaponOptions: 45
 GameMode:
-  Plunderstorm: 2
-  Standard: 1
-  WoWHack: 3
+  values:
+    Plunderstorm: 2
+    Standard: 1
+    WoWHack: 3
 GamePadPowerLevel:
-  Critical: 0
-  High: 3
-  Low: 1
-  Medium: 2
-  Unknown: 5
-  Wired: 4
+  values:
+    Critical: 0
+    High: 3
+    Low: 1
+    Medium: 2
+    Unknown: 5
+    Wired: 4
 GameRule:
-  AchievementsPanelDisabled: 40
-  ActionbarIconIntroDisabled: 60
-  ActionButtonTypeOverlayStrategy: 165
-  ActionCombatTargetLockEnabled: 87
-  AfterDeathSpectatingUI: 49
-  AllPlayersAreFastMovers: 53
-  AlwaysAllowAlliedRaces: 59
-  AutoAttacksDisabled: 103
-  BagSpaceOverride: 172
-  BagsUIDisabled: 64
-  BlockWhileSheathedAllowed: 88
-  CharacterCreateUseFixedBackgroundModel: 55
-  CharacterlessLogin: 14
-  CharacterPanelDisabled: 37
-  CharNameReservationEnabled: 2
-  CharReservationsPerRealmReopenThreshold: 8
-  ChatLinkLevelToastsDisabled: 63
-  ClearMailOnRealmTransfer: 92
-  CollectionsPanelDisabled: 36
-  CommunitiesPanelDisabled: 41
-  CompactRaidFrameManagerDisabled: 81
-  CustomActionbarOverlayHeightOffset: 33
-  DeleteItemConfirmationDisabled: 62
-  DisableCampsites: 114
-  DisableHonorDecay: 23
-  DisablePct: 9
-  DisableQuickJoin: 162
-  DisableRaidGroups: 163
-  DisableRealmSelection: 113
-  DisableVas: 119
-  DoesNotCountTowardAccountCharacterMax: 142
-  EditModeDisabled: 82
-  EjDungeonsDisabled: 149
-  EjItemSetsDisabled: 151
-  EjJourneysDisabled: 156
-  EjRaidsDisabled: 150
-  EjSuggestedContentDisabled: 148
-  EncounterJournalDisabled: 42
-  EtaRealmLaunchTime: 5
-  ExperienceBarDisabled: 159
-  FastAreaTriggerTick: 52
-  FinderPanelDisabled: 43
-  ForceAlteredFormsOn: 56
-  ForcedChatLanguage: 34
-  ForcedMultiActionBarSetting: 133
-  ForcedPartyFrameScale: 32
-  FrontEndChat: 50
-  FullCharacterCreateDisabled: 84
-  GameMode: 13
-  GdapiCharacterProfileDisabled: 153
-  GroupFinderCapabilities: 98
-  GuildsDisabled: 46
-  HardcoreRuleset: 10
-  HelpPanelDisabled: 45
-  HideAllMultiActionBars: 135
-  HideFaction: 116
-  HideTransmogZeroCost: 161
-  HideUnavailableTransmogSlots: 160
-  HousingDashboardDisabled: 102
-  HousingEnabled: 154
-  IgnoreChrclassDisabledFlag: 54
-  IngameCalendarDisabled: 75
-  IngameFriendsListDisabled: 79
-  IngameMailNotificationDisabled: 74
-  IngameTrackingDisabled: 76
-  IngameWhoListDisabled: 77
-  InstanceDifficultyBannerDisabled: 83
-  LandingPageFactionID: 35
-  LootMethodStyle: 157
-  MacrosDisabled: 80
-  MailGameRule: 132
-  MapPlunderstormCircle: 48
-  MaxAccountCharReservationsPerContentset: 4
-  MaxCharactersPerContentSet: 139
-  MaxCharReservationsPerRealm: 3
-  MaximizeWorldMapDisabled: 67
-  MaxLootDropLevel: 25
-  MaxNameplateDistance: 28
-  MaxUnitNameDistance: 27
-  MerchantFilterDisabled: 101
-  MicrobarScale: 26
-  MinimapDisabled: 146
-  MinUndeleteLevelRequired: 140
-  NameplateCastBarDisabled: 107
-  NoDebuffLimit: 1
-  NonPlayerNameplateScale: 31
-  ObjectiveTrackerDisabled: 104
-  PerksProgramActivityTrackingDisabled: 66
-  PersonalResourceDisplayDisabled: 129
-  PetBattlesDisabled: 65
-  PlayerCastBarDisabled: 105
-  PlayerFrameDisabled: 131
-  PlayerNameplateAlternateHealthColor: 58
-  PlayerNameplateDifficultyIcon: 57
-  PlunderstormAreaSelection: 94
-  PremadeGroupFinderStyle: 93
-  PvPInitialRatingOverride: 190
-  QuestLogMicrobuttonDisabled: 47
-  QuestLogPanelDisabled: 71
-  QuestLogSuperTrackingDisabled: 72
-  RaceAlteredFormsDisabled: 78
-  RecommendLeastPopulatedRealm: 169
-  ReleaseSpiritGhostDisabled: 61
-  RepairArmorDisabled: 147
-  ReplaceAbsentGmSeconds: 11
-  ReplaceGmRankLastOnlineSeconds: 12
-  RestrictedAchievementCategoryID: 155
-  Runecarving: 17
-  SelfFoundAllowed: 22
-  SpellbookPanelDisabled: 38
-  StoreDisabled: 44
-  SummoningStones: 108
-  TalentRespecCostMax: 19
-  TalentRespecCostMin: 18
-  TalentRespecCostStep: 20
-  TalentsPanelDisabled: 39
-  TargetCastBarDisabled: 106
-  TargetFrameBuffsDisabled: 85
-  TargetFrameDisabled: 130
-  TimerunningAllowed: 137
-  TransmogEnabled: 109
-  TrivialGroupXPPercent: 7
-  TutorialFrameDisabled: 73
-  UnflaggedPlayersCanAttackPvPFlaggedPlayers: 173
-  UnitFramePvPContextualDisabled: 86
-  UniversalNameplateOcclusion: 51
-  UseGameTableVariation: 164
-  UserAddonsDisabled: 29
-  UserScriptsDisabled: 30
-  UseSimpleCharacterSelectList: 115
-  VanillaAccountMailInstant: 91
-  VanillaNpcKnockback: 16
-  VanillaRageGenerationModifier: 21
-  WorldMapDisabled: 145
-  WorldMapFrameStrata: 100
-  WorldMapHelpPlateDisabled: 70
-  WorldMapLegendDisabled: 99
-  WorldMapTrackingOptionsDisabled: 68
-  WorldMapTrackingPinDisabled: 69
+  values:
+    AchievementsPanelDisabled: 40
+    ActionbarIconIntroDisabled: 60
+    ActionButtonTypeOverlayStrategy: 165
+    ActionCombatTargetLockEnabled: 87
+    AfterDeathSpectatingUI: 49
+    AllPlayersAreFastMovers: 53
+    AlwaysAllowAlliedRaces: 59
+    AutoAttacksDisabled: 103
+    BagSpaceOverride: 172
+    BagsUIDisabled: 64
+    BlockWhileSheathedAllowed: 88
+    CharacterCreateUseFixedBackgroundModel: 55
+    CharacterlessLogin: 14
+    CharacterPanelDisabled: 37
+    CharNameReservationEnabled: 2
+    CharReservationsPerRealmReopenThreshold: 8
+    ChatLinkLevelToastsDisabled: 63
+    ClearMailOnRealmTransfer: 92
+    CollectionsPanelDisabled: 36
+    CommunitiesPanelDisabled: 41
+    CompactRaidFrameManagerDisabled: 81
+    CustomActionbarOverlayHeightOffset: 33
+    DeleteItemConfirmationDisabled: 62
+    DisableCampsites: 114
+    DisableHonorDecay: 23
+    DisablePct: 9
+    DisableQuickJoin: 162
+    DisableRaidGroups: 163
+    DisableRealmSelection: 113
+    DisableVas: 119
+    DoesNotCountTowardAccountCharacterMax: 142
+    EditModeDisabled: 82
+    EjDungeonsDisabled: 149
+    EjItemSetsDisabled: 151
+    EjJourneysDisabled: 156
+    EjRaidsDisabled: 150
+    EjSuggestedContentDisabled: 148
+    EncounterJournalDisabled: 42
+    EtaRealmLaunchTime: 5
+    ExperienceBarDisabled: 159
+    FastAreaTriggerTick: 52
+    FinderPanelDisabled: 43
+    ForceAlteredFormsOn: 56
+    ForcedChatLanguage: 34
+    ForcedMultiActionBarSetting: 133
+    ForcedPartyFrameScale: 32
+    FrontEndChat: 50
+    FullCharacterCreateDisabled: 84
+    GameMode: 13
+    GdapiCharacterProfileDisabled: 153
+    GroupFinderCapabilities: 98
+    GuildsDisabled: 46
+    HardcoreRuleset: 10
+    HelpPanelDisabled: 45
+    HideAllMultiActionBars: 135
+    HideFaction: 116
+    HideTransmogZeroCost: 161
+    HideUnavailableTransmogSlots: 160
+    HousingDashboardDisabled: 102
+    HousingEnabled: 154
+    IgnoreChrclassDisabledFlag: 54
+    IngameCalendarDisabled: 75
+    IngameFriendsListDisabled: 79
+    IngameMailNotificationDisabled: 74
+    IngameTrackingDisabled: 76
+    IngameWhoListDisabled: 77
+    InstanceDifficultyBannerDisabled: 83
+    LandingPageFactionID: 35
+    LootMethodStyle: 157
+    MacrosDisabled: 80
+    MailGameRule: 132
+    MapPlunderstormCircle: 48
+    MaxAccountCharReservationsPerContentset: 4
+    MaxCharactersPerContentSet: 139
+    MaxCharReservationsPerRealm: 3
+    MaximizeWorldMapDisabled: 67
+    MaxLootDropLevel: 25
+    MaxNameplateDistance: 28
+    MaxUnitNameDistance: 27
+    MerchantFilterDisabled: 101
+    MicrobarScale: 26
+    MinimapDisabled: 146
+    MinUndeleteLevelRequired: 140
+    NameplateCastBarDisabled: 107
+    NoDebuffLimit: 1
+    NonPlayerNameplateScale: 31
+    ObjectiveTrackerDisabled: 104
+    PerksProgramActivityTrackingDisabled: 66
+    PersonalResourceDisplayDisabled: 129
+    PetBattlesDisabled: 65
+    PlayerCastBarDisabled: 105
+    PlayerFrameDisabled: 131
+    PlayerNameplateAlternateHealthColor: 58
+    PlayerNameplateDifficultyIcon: 57
+    PlunderstormAreaSelection: 94
+    PremadeGroupFinderStyle: 93
+    PvPInitialRatingOverride: 190
+    QuestLogMicrobuttonDisabled: 47
+    QuestLogPanelDisabled: 71
+    QuestLogSuperTrackingDisabled: 72
+    RaceAlteredFormsDisabled: 78
+    RecommendLeastPopulatedRealm: 169
+    ReleaseSpiritGhostDisabled: 61
+    RepairArmorDisabled: 147
+    ReplaceAbsentGmSeconds: 11
+    ReplaceGmRankLastOnlineSeconds: 12
+    RestrictedAchievementCategoryID: 155
+    Runecarving: 17
+    SelfFoundAllowed: 22
+    SpellbookPanelDisabled: 38
+    StoreDisabled: 44
+    SummoningStones: 108
+    TalentRespecCostMax: 19
+    TalentRespecCostMin: 18
+    TalentRespecCostStep: 20
+    TalentsPanelDisabled: 39
+    TargetCastBarDisabled: 106
+    TargetFrameBuffsDisabled: 85
+    TargetFrameDisabled: 130
+    TimerunningAllowed: 137
+    TransmogEnabled: 109
+    TrivialGroupXPPercent: 7
+    TutorialFrameDisabled: 73
+    UnflaggedPlayersCanAttackPvPFlaggedPlayers: 173
+    UnitFramePvPContextualDisabled: 86
+    UniversalNameplateOcclusion: 51
+    UseGameTableVariation: 164
+    UserAddonsDisabled: 29
+    UserScriptsDisabled: 30
+    UseSimpleCharacterSelectList: 115
+    VanillaAccountMailInstant: 91
+    VanillaNpcKnockback: 16
+    VanillaRageGenerationModifier: 21
+    WorldMapDisabled: 145
+    WorldMapFrameStrata: 100
+    WorldMapHelpPlateDisabled: 70
+    WorldMapLegendDisabled: 99
+    WorldMapTrackingOptionsDisabled: 68
+    WorldMapTrackingPinDisabled: 69
 GameRuleFlags:
-  AllowClient: 1
-  None: 0
-  RequiresDefault: 2
+  values:
+    AllowClient: 1
+    None: 0
+    RequiresDefault: 2
 GameRuleType:
-  Bool: 2
-  Float: 1
-  Int: 0
+  values:
+    Bool: 2
+    Float: 1
+    Int: 0
 GarrAutoBoardIndex:
-  AllyCenterFront: 3
-  AllyLeftBack: 0
-  AllyLeftFront: 2
-  AllyRightBack: 1
-  AllyRightFront: 4
-  EnemyCenterLeftBack: 10
-  EnemyCenterLeftFront: 6
-  EnemyCenterRightBack: 11
-  EnemyCenterRightFront: 7
-  EnemyLeftBack: 9
-  EnemyLeftFront: 5
-  EnemyRightBack: 12
-  EnemyRightFront: 8
-  None: -1
+  values:
+    AllyCenterFront: 3
+    AllyLeftBack: 0
+    AllyLeftFront: 2
+    AllyRightBack: 1
+    AllyRightFront: 4
+    EnemyCenterLeftBack: 10
+    EnemyCenterLeftFront: 6
+    EnemyCenterRightBack: 11
+    EnemyCenterRightFront: 7
+    EnemyLeftBack: 9
+    EnemyLeftFront: 5
+    EnemyRightBack: 12
+    EnemyRightFront: 8
+    None: -1
 GarrAutoCombatantRole:
-  HealSupport: 4
-  Melee: 1
-  None: 0
-  RangedMagic: 3
-  RangedPhysical: 2
-  Tank: 5
+  values:
+    HealSupport: 4
+    Melee: 1
+    None: 0
+    RangedMagic: 3
+    RangedPhysical: 2
+    Tank: 5
 GarrAutoCombatSpellTutorialFlag:
-  All: 4
-  Column: 2
-  None: 0
-  Row: 3
-  Single: 1
+  values:
+    All: 4
+    Column: 2
+    None: 0
+    Row: 3
+    Single: 1
 GarrAutoCombatTutorial:
-  AttackAll: 256
-  AttackColumn: 64
-  AttackRow: 128
-  AttackSingle: 32
-  BeneficialEffect: 16
-  EnvironmentalEffect: 1024
-  HealCompanion: 4
-  LevelHeal: 8
-  PlaceCompanion: 2
-  SelectMission: 1
-  TroopTutorial: 512
+  values:
+    AttackAll: 256
+    AttackColumn: 64
+    AttackRow: 128
+    AttackSingle: 32
+    BeneficialEffect: 16
+    EnvironmentalEffect: 1024
+    HealCompanion: 4
+    LevelHeal: 8
+    PlaceCompanion: 2
+    SelectMission: 1
+    TroopTutorial: 512
 GarrAutoEventFlags:
-  AutoAttack: 1
-  Environment: 4
-  None: 0
-  Passive: 2
+  values:
+    AutoAttack: 1
+    Environment: 4
+    None: 0
+    Passive: 2
 GarrAutoMissionEventType:
-  ApplyAura: 7
-  Died: 9
-  Heal: 4
-  MeleeDamage: 0
-  PeriodicDamage: 5
-  PeriodicHeal: 6
-  RangeDamage: 1
-  RemoveAura: 8
-  SpellMeleeDamage: 2
-  SpellRangeDamage: 3
+  values:
+    ApplyAura: 7
+    Died: 9
+    Heal: 4
+    MeleeDamage: 0
+    PeriodicDamage: 5
+    PeriodicHeal: 6
+    RangeDamage: 1
+    RemoveAura: 8
+    SpellMeleeDamage: 2
+    SpellRangeDamage: 3
 GarrAutoPreviewTargetType:
-  Buff: 4
-  Damage: 1
-  Debuff: 8
-  Heal: 2
-  None: 0
+  values:
+    Buff: 4
+    Damage: 1
+    Debuff: 8
+    Heal: 2
+    None: 0
 GarrFollowerMissionCompleteState:
-  Alive: 0
-  KilledByMissionFailure: 1
-  OutOfDurability: 3
-  SavedByPreventDeath: 2
+  values:
+    Alive: 0
+    KilledByMissionFailure: 1
+    OutOfDurability: 3
+    SavedByPreventDeath: 2
 GarrFollowerQuality:
-  Common: 1
-  Epic: 4
-  Legendary: 5
-  None: 0
-  Rare: 3
-  Title: 6
-  Uncommon: 2
+  values:
+    Common: 1
+    Epic: 4
+    Legendary: 5
+    None: 0
+    Rare: 3
+    Title: 6
+    Uncommon: 2
 GarrisonFollowerType:
-  FollowerType_6_0_Boat: 2
-  FollowerType_6_0_GarrisonFollower: 1
-  FollowerType_7_0_GarrisonFollower: 4
-  FollowerType_8_0_GarrisonFollower: 22
-  FollowerType_9_0_GarrisonFollower: 123
+  values:
+    FollowerType_6_0_Boat: 2
+    FollowerType_6_0_GarrisonFollower: 1
+    FollowerType_7_0_GarrisonFollower: 4
+    FollowerType_8_0_GarrisonFollower: 22
+    FollowerType_9_0_GarrisonFollower: 123
 GarrisonTalentAvailability:
-  Available: 0
-  Unavailable: 1
-  UnavailableAlreadyHave: 7
-  UnavailableAnotherIsResearching: 2
-  UnavailableNotEnoughGold: 4
-  UnavailableNotEnoughResources: 3
-  UnavailablePlayerCondition: 6
-  UnavailableRequiresPrerequisiteTalent: 8
-  UnavailableTierUnavailable: 5
+  values:
+    Available: 0
+    Unavailable: 1
+    UnavailableAlreadyHave: 7
+    UnavailableAnotherIsResearching: 2
+    UnavailableNotEnoughGold: 4
+    UnavailableNotEnoughResources: 3
+    UnavailablePlayerCondition: 6
+    UnavailableRequiresPrerequisiteTalent: 8
+    UnavailableTierUnavailable: 5
 GarrisonType:
-  Type_6_0_Garrison: 2
-  Type_7_0_Garrison: 3
-  Type_8_0_Garrison: 9
-  Type_9_0_Garrison: 111
+  values:
+    Type_6_0_Garrison: 2
+    Type_7_0_Garrison: 3
+    Type_8_0_Garrison: 9
+    Type_9_0_Garrison: 111
 GarrTalentCostType:
-  Initial: 0
-  MakePermanent: 2
-  Respec: 1
-  TreeReset: 3
+  values:
+    Initial: 0
+    MakePermanent: 2
+    Respec: 1
+    TreeReset: 3
 GarrTalentFeatureSubtype:
-  Ardenweald: 3
-  Bastion: 1
-  Generic: 0
-  Maldraxxus: 4
-  Revendreth: 2
+  values:
+    Ardenweald: 3
+    Bastion: 1
+    Generic: 0
+    Maldraxxus: 4
+    Revendreth: 2
 GarrTalentFeatureType:
-  Adventures: 3
-  AnimaDiversion: 1
-  AnimaDiversionMap: 7
-  Cyphers: 8
-  Generic: 0
-  ReservoirUpgrades: 4
-  SanctumUnique: 5
-  SoulBinds: 6
-  TravelPortals: 2
+  values:
+    Adventures: 3
+    AnimaDiversion: 1
+    AnimaDiversionMap: 7
+    Cyphers: 8
+    Generic: 0
+    ReservoirUpgrades: 4
+    SanctumUnique: 5
+    SoulBinds: 6
+    TravelPortals: 2
 GarrTalentResearchCostSource:
-  Talent: 0
-  Tree: 1
+  values:
+    Talent: 0
+    Tree: 1
 GarrTalentSocketType:
-  Conduit: 2
-  None: 0
-  Spell: 1
+  values:
+    Conduit: 2
+    None: 0
+    Spell: 1
 GarrTalentTreeType:
-  Classic: 1
-  Tiers: 0
+  values:
+    Classic: 1
+    Tiers: 0
 GarrTalentType:
-  Major: 2
-  Minor: 1
-  Socket: 3
-  Standard: 0
+  values:
+    Major: 2
+    Minor: 1
+    Socket: 3
+    Standard: 0
 GarrTalentUI:
-  AnimaDiversionMap: 3
-  CovenantSanctum: 1
-  Generic: 0
-  SoulBinds: 2
+  values:
+    AnimaDiversionMap: 3
+    CovenantSanctum: 1
+    Generic: 0
+    SoulBinds: 2
 GossipNpcOption:
-  AccountBanker: 57
-  AdventureMap: 31
-  ArtifactRespec: 21
-  Auctioneer: 10
-  AzeriteRespec: 35
-  Banker: 6
-  BarbersChoice: 52
-  Battlemaster: 9
-  Binder: 5
-  BlackMarketAuctionHouse: 46
-  CemeterySelect: 22
-  CharacterBanker: 56
-  ChromieTimeNpc: 40
-  ContributionCollector: 33
-  CovenantPreviewNpc: 41
-  CovenantRenownNpc: 45
-  DisableXPGain: 16
-  EnableXPGain: 17
-  ForgeMaster: 55
-  GarrisonArchitect: 26
-  GarrisonMissionNpc: 27
-  GarrisonRecruitment: 30
-  GarrisonTalent: 32
-  GarrisonTradeskillNpc: 29
-  GlyphMaster: 24
-  GuildBanker: 14
-  GuildRename: 62
-  GuildTabardVendor: 8
-  HouseFinder: 65
-  HousingCreateGuildNeighborhood: 60
-  HousingGetNeighborhoodCharter: 61
-  HousingOpenCharterConfirmation: 63
-  IslandsMissionNpc: 36
-  ItemUpgrade: 64
-  LFGDungeon: 20
-  Mailbox: 18
-  MajorFactionRenown: 53
-  NewPlayerGuide: 43
-  None: 0
-  PerksProgramVendor: 47
-  PersonalTabardVendor: 54
-  PetitionVendor: 7
-  PetUntrainer: 13
-  ProfessionRespec: 58
-  ProfessionsCraftingOrder: 48
-  ProfessionsCustomerOrder: 50
-  ProfessionsOpen: 49
-  QueueScenario: 25
-  RenameNeighborhood: 59
-  RuneforgeLegendaryCrafting: 42
-  RuneforgeLegendaryUpgrade: 44
-  ShipmentCrafter: 28
-  Soulbind: 39
-  SpecializationMaster: 23
-  Spellclick: 15
-  SpiritHealer: 4
-  Stablemaster: 12
-  TalentMaster: 11
-  Taxinode: 2
-  TieredEntrance: 66
-  Trainer: 3
-  TraitSystem: 51
-  Transmogrify: 34
-  UIItemInteraction: 37
-  Vendor: 1
-  WorldMap: 38
-  WorldPvPQueue: 19
+  values:
+    AccountBanker: 57
+    AdventureMap: 31
+    ArtifactRespec: 21
+    Auctioneer: 10
+    AzeriteRespec: 35
+    Banker: 6
+    BarbersChoice: 52
+    Battlemaster: 9
+    Binder: 5
+    BlackMarketAuctionHouse: 46
+    CemeterySelect: 22
+    CharacterBanker: 56
+    ChromieTimeNpc: 40
+    ContributionCollector: 33
+    CovenantPreviewNpc: 41
+    CovenantRenownNpc: 45
+    DisableXPGain: 16
+    EnableXPGain: 17
+    ForgeMaster: 55
+    GarrisonArchitect: 26
+    GarrisonMissionNpc: 27
+    GarrisonRecruitment: 30
+    GarrisonTalent: 32
+    GarrisonTradeskillNpc: 29
+    GlyphMaster: 24
+    GuildBanker: 14
+    GuildRename: 62
+    GuildTabardVendor: 8
+    HouseFinder: 65
+    HousingCreateGuildNeighborhood: 60
+    HousingGetNeighborhoodCharter: 61
+    HousingOpenCharterConfirmation: 63
+    IslandsMissionNpc: 36
+    ItemUpgrade: 64
+    LFGDungeon: 20
+    Mailbox: 18
+    MajorFactionRenown: 53
+    NewPlayerGuide: 43
+    None: 0
+    PerksProgramVendor: 47
+    PersonalTabardVendor: 54
+    PetitionVendor: 7
+    PetUntrainer: 13
+    ProfessionRespec: 58
+    ProfessionsCraftingOrder: 48
+    ProfessionsCustomerOrder: 50
+    ProfessionsOpen: 49
+    QueueScenario: 25
+    RenameNeighborhood: 59
+    RuneforgeLegendaryCrafting: 42
+    RuneforgeLegendaryUpgrade: 44
+    ShipmentCrafter: 28
+    Soulbind: 39
+    SpecializationMaster: 23
+    Spellclick: 15
+    SpiritHealer: 4
+    Stablemaster: 12
+    TalentMaster: 11
+    Taxinode: 2
+    TieredEntrance: 66
+    Trainer: 3
+    TraitSystem: 51
+    Transmogrify: 34
+    UIItemInteraction: 37
+    Vendor: 1
+    WorldMap: 38
+    WorldPvPQueue: 19
 GossipNpcOptionDisplayFlags:
-  ForceInteractionOnSingleChoice: 1
+  values:
+    ForceInteractionOnSingleChoice: 1
 GossipOptionRecFlags:
-  HideOptionIDFromClient: 2
-  PlayMovieLabelPrepend: 4
-  QuestLabelPrepend: 1
+  values:
+    HideOptionIDFromClient: 2
+    PlayMovieLabelPrepend: 4
+    QuestLabelPrepend: 1
 GossipOptionStatus:
-  AlreadyComplete: 3
-  Available: 0
-  Locked: 2
-  Unavailable: 1
+  values:
+    AlreadyComplete: 3
+    Available: 0
+    Locked: 2
+    Unavailable: 1
 GraphicsValidationResult:
-  AmdGpuUnsupported: 36
-  AppleGpuUnsupported: 35
-  CompatMode: 41
-  CpuMem_2: 6
-  CpuMem_4: 7
-  CpuMem_8: 8
-  DualCore: 4
-  Dx11Unsupported: 30
-  Dx12Win7Unsupported: 31
-  GpuDriver: 40
-  Graphics: 3
-  Illegal: 1
-  IntelGpuUnsupported: 37
-  LegacyUnsupported: 29
-  MacOsUnsupported: 27
-  Needs_5_0: 9
-  Needs_6_0: 10
-  NeedsAmdGpu: 15
-  NeedsAppleGpu: 14
-  NeedsDx12: 12
-  NeedsDx12Vrs2: 13
-  NeedsIntelGpu: 16
-  NeedsMacOs_10_13: 19
-  NeedsMacOs_10_14: 20
-  NeedsMacOs_10_15: 21
-  NeedsMacOs_11_0: 22
-  NeedsMacOs_12_0: 23
-  NeedsMacOs_13_0: 24
-  NeedsNvidiaGpu: 17
-  NeedsQualcommGpu: 18
-  NeedsRt: 11
-  NeedsWindows_10: 25
-  NeedsWindows_11: 26
-  NvapiWineUnsupported: 34
-  NvidiaGpuUnsupported: 38
-  QuadCore: 5
-  QualcommGpuUnsupported: 39
-  RemoteDesktopUnsupported: 32
-  Supported: 0
-  Unknown: 42
-  Unsupported: 2
-  WindowsUnsupported: 28
-  WineUnsupported: 33
+  values:
+    AmdGpuUnsupported: 36
+    AppleGpuUnsupported: 35
+    CompatMode: 41
+    CpuMem_2: 6
+    CpuMem_4: 7
+    CpuMem_8: 8
+    DualCore: 4
+    Dx11Unsupported: 30
+    Dx12Win7Unsupported: 31
+    GpuDriver: 40
+    Graphics: 3
+    Illegal: 1
+    IntelGpuUnsupported: 37
+    LegacyUnsupported: 29
+    MacOsUnsupported: 27
+    Needs_5_0: 9
+    Needs_6_0: 10
+    NeedsAmdGpu: 15
+    NeedsAppleGpu: 14
+    NeedsDx12: 12
+    NeedsDx12Vrs2: 13
+    NeedsIntelGpu: 16
+    NeedsMacOs_10_13: 19
+    NeedsMacOs_10_14: 20
+    NeedsMacOs_10_15: 21
+    NeedsMacOs_11_0: 22
+    NeedsMacOs_12_0: 23
+    NeedsMacOs_13_0: 24
+    NeedsNvidiaGpu: 17
+    NeedsQualcommGpu: 18
+    NeedsRt: 11
+    NeedsWindows_10: 25
+    NeedsWindows_11: 26
+    NvapiWineUnsupported: 34
+    NvidiaGpuUnsupported: 38
+    QuadCore: 5
+    QualcommGpuUnsupported: 39
+    RemoteDesktopUnsupported: 32
+    Supported: 0
+    Unknown: 42
+    Unsupported: 2
+    WindowsUnsupported: 28
+    WineUnsupported: 33
 GuildErrorType:
-  AlreadyInGuild: 2
-  BadItem: 29
-  BankNotFound: 43
-  BankTabFull: 28
-  BankTabLocked: 35
-  Busy: 20
-  CantInviteSelf: 41
-  DeleteNoAppropriateLeader: 47
-  GuildBankNotAvailable: 45
-  GuildRepTooLow: 40
-  HasRestriction: 42
-  HousingEvictError: 51
-  Ignored: 19
-  InCooldown: 49
-  InvalidBankTab: 24
-  InvitedToGuild: 4
-  LockedForMove: 39
-  NameAlreadyExists: 7
-  NameInvalid: 6
-  NewLeaderWrongFaction: 44
-  NewLeaderWrongRealm: 46
-  NoPermisson: 8
-  NotEnoughMoney: 26
-  NotInGuild: 9
-  PlayerNotFound: 11
-  RankInUse: 18
-  RankRequiresAuthenticator: 34
-  RanksLocked: 17
-  RealmMismatch: 48
-  ReservationExpired: 50
-  Success: 0
-  TargetAlreadyInGuild: 3
-  TargetInvitedToGuild: 5
-  TargetLevelTooHigh: 22
-  TargetLevelTooLow: 21
-  TargetNotInGuild: 10
-  TargetTooHigh: 13
-  TargetTooLow: 14
-  TeamNotFound: 27
-  TeamsLocked: 30
-  Throttled: 52
-  TooFewRanks: 16
-  TooManyCreate: 33
-  TooManyMembers: 23
-  TooManyRanks: 15
-  TooMuchMoney: 31
-  TrialAccount: 36
-  UndeletableDueToLevel: 38
-  UnknownError: 1
-  VeteranAccount: 37
-  WithdrawLimit: 25
-  WrongBankTab: 32
-  WrongFaction: 12
+  values:
+    AlreadyInGuild: 2
+    BadItem: 29
+    BankNotFound: 43
+    BankTabFull: 28
+    BankTabLocked: 35
+    Busy: 20
+    CantInviteSelf: 41
+    DeleteNoAppropriateLeader: 47
+    GuildBankNotAvailable: 45
+    GuildRepTooLow: 40
+    HasRestriction: 42
+    HousingEvictError: 51
+    Ignored: 19
+    InCooldown: 49
+    InvalidBankTab: 24
+    InvitedToGuild: 4
+    LockedForMove: 39
+    NameAlreadyExists: 7
+    NameInvalid: 6
+    NewLeaderWrongFaction: 44
+    NewLeaderWrongRealm: 46
+    NoPermisson: 8
+    NotEnoughMoney: 26
+    NotInGuild: 9
+    PlayerNotFound: 11
+    RankInUse: 18
+    RankRequiresAuthenticator: 34
+    RanksLocked: 17
+    RealmMismatch: 48
+    ReservationExpired: 50
+    Success: 0
+    TargetAlreadyInGuild: 3
+    TargetInvitedToGuild: 5
+    TargetLevelTooHigh: 22
+    TargetLevelTooLow: 21
+    TargetNotInGuild: 10
+    TargetTooHigh: 13
+    TargetTooLow: 14
+    TeamNotFound: 27
+    TeamsLocked: 30
+    Throttled: 52
+    TooFewRanks: 16
+    TooManyCreate: 33
+    TooManyMembers: 23
+    TooManyRanks: 15
+    TooMuchMoney: 31
+    TrialAccount: 36
+    UndeletableDueToLevel: 38
+    UnknownError: 1
+    VeteranAccount: 37
+    WithdrawLimit: 25
+    WrongBankTab: 32
+    WrongFaction: 12
 HolidayCalendarFlags:
-  Alliance: 1
-  Horde: 2
+  values:
+    Alliance: 1
+    Horde: 2
 HolidayFlags:
-  BeginEventOnlyOnStageChange: 64
-  DontDisplayBanner: 8
-  DontDisplayEnd: 4
-  DontShowInCalendar: 2
-  DurationUseMinutes: 32
-  IsRegionwide: 1
-  NotAvailableClientSide: 16
+  values:
+    BeginEventOnlyOnStageChange: 64
+    DontDisplayBanner: 8
+    DontDisplayEnd: 4
+    DontShowInCalendar: 2
+    DurationUseMinutes: 32
+    IsRegionwide: 1
+    NotAvailableClientSide: 16
 HouseEditingContext:
-  Decor: 1
-  Fixture: 3
-  None: 0
-  Room: 2
+  values:
+    Decor: 1
+    Fixture: 3
+    None: 0
+    Room: 2
 HouseEditorMode:
-  BasicDecor: 1
-  Cleanup: 5
-  Customize: 4
-  ExpertDecor: 2
-  ExteriorCustomization: 6
-  Layout: 3
-  None: 0
+  values:
+    BasicDecor: 1
+    Cleanup: 5
+    Customize: 4
+    ExpertDecor: 2
+    ExteriorCustomization: 6
+    Layout: 3
+    None: 0
 HouseExteriorWMODataFlags:
-  AllowedInAllianceNeighborhoods: 4
-  AllowedInHordeNeighborhoods: 2
-  HiddenUnlessOwned: 8
-  None: 0
-  UnlockedByDefault: 1
+  values:
+    AllowedInAllianceNeighborhoods: 4
+    AllowedInHordeNeighborhoods: 2
+    HiddenUnlessOwned: 8
+    None: 0
+    UnlockedByDefault: 1
 HouseFinderSuggestionReason:
-  BNetFriends: 8
-  CharterInvite: 2
-  Guild: 4
-  HomeOwner: 64
-  None: 0
-  Owner: 1
-  PartySync: 16
-  Random: 32
+  values:
+    BNetFriends: 8
+    CharterInvite: 2
+    Guild: 4
+    HomeOwner: 64
+    None: 0
+    Owner: 1
+    PartySync: 16
+    Random: 32
 HouseLevelRewardType:
-  Object: 1
-  Value: 0
+  values:
+    Object: 1
+    Value: 0
 HouseLevelRewardValueType:
-  ExteriorDecor: 0
-  Fixtures: 3
-  InteriorDecor: 1
-  Rooms: 2
+  values:
+    ExteriorDecor: 0
+    Fixtures: 3
+    InteriorDecor: 1
+    Rooms: 2
 HouseOwnerError:
-  Faction: 1
-  GenericPermission: 3
-  Guild: 2
-  None: 0
+  values:
+    Faction: 1
+    GenericPermission: 3
+    Guild: 2
+    None: 0
 HouseSettingFlags:
-  HouseAccessAnyone: 1
-  HouseAccessFriends: 8
-  HouseAccessGuild: 4
-  HouseAccessNeighbors: 2
-  HouseAccessParty: 16
-  None: 0
-  PlotAccessAnyone: 32
-  PlotAccessFriends: 256
-  PlotAccessGuild: 128
-  PlotAccessNeighbors: 64
-  PlotAccessParty: 512
+  values:
+    HouseAccessAnyone: 1
+    HouseAccessFriends: 8
+    HouseAccessGuild: 4
+    HouseAccessNeighbors: 2
+    HouseAccessParty: 16
+    None: 0
+    PlotAccessAnyone: 32
+    PlotAccessFriends: 256
+    PlotAccessGuild: 128
+    PlotAccessNeighbors: 64
+    PlotAccessParty: 512
 HouseVisitType:
-  Friend: 1
-  Guild: 2
-  Party: 3
-  Unknown: 0
+  values:
+    Friend: 1
+    Guild: 2
+    Party: 3
+    Unknown: 0
 HousingBasicModeTargetType:
-  Decor: 1
-  House: 2
-  None: 0
+  values:
+    Decor: 1
+    House: 2
+    None: 0
 HousingCatalogEntryModelScenePresets:
-  DecorCeiling: 1338
-  DecorDefault: 1317
-  DecorFlat: 1318
-  DecorHorizontalSurface: 1452
-  DecorHuge: 1337
-  DecorLarge: 1336
-  DecorMedium: 1335
-  DecorSmall: 1334
-  DecorTiny: 1333
-  DecorWall: 1339
+  values:
+    DecorCeiling: 1338
+    DecorDefault: 1317
+    DecorFlat: 1318
+    DecorHorizontalSurface: 1452
+    DecorHuge: 1337
+    DecorLarge: 1336
+    DecorMedium: 1335
+    DecorSmall: 1334
+    DecorTiny: 1333
+    DecorWall: 1339
 HousingCatalogEntrySize:
-  Huge: 69
-  Large: 68
-  Medium: 67
-  None: 0
-  Small: 66
-  Tiny: 65
+  values:
+    Huge: 69
+    Large: 68
+    Medium: 67
+    None: 0
+    Small: 66
+    Tiny: 65
 HousingCatalogEntryType:
-  Decor: 1
-  Invalid: 0
-  Room: 2
+  values:
+    Decor: 1
+    Invalid: 0
+    Room: 2
 HousingCatalogSortType:
-  Alphabetical: 1
-  DateAdded: 0
+  values:
+    Alphabetical: 1
+    DateAdded: 0
 HousingCleanupModeTargetType:
-  Decor: 1
-  HouseExterior: 2
-  None: 0
+  values:
+    Decor: 1
+    HouseExterior: 2
+    None: 0
 HousingCustomizeModeTargetType:
-  Decor: 1
-  ExteriorHouse: 3
-  None: 0
-  RoomComponent: 2
+  values:
+    Decor: 1
+    ExteriorHouse: 3
+    None: 0
+    RoomComponent: 2
 HousingDecorActionFlags:
-  Add: 1
-  ClickTarget: 16
-  DragMove: 4
-  HoverTarget: 32
-  IncludeTargetChildren: 512
-  MaintainLastTarget: 256
-  None: 0
-  PrecisionMove: 8
-  PreviewDecor: 2048
-  Remove: 2
-  TargetHouseExterior: 128
-  TargetRoomComponents: 64
-  UsePlacedDecorList: 1024
+  values:
+    Add: 1
+    ClickTarget: 16
+    DragMove: 4
+    HoverTarget: 32
+    IncludeTargetChildren: 512
+    MaintainLastTarget: 256
+    None: 0
+    PrecisionMove: 8
+    PreviewDecor: 2048
+    Remove: 2
+    TargetHouseExterior: 128
+    TargetRoomComponents: 64
+    UsePlacedDecorList: 1024
 HousingDecorModelType:
-  M2: 1
-  None: 0
-  WMO: 2
+  values:
+    M2: 1
+    None: 0
+    WMO: 2
 HousingDecorPlacementRestriction:
-  ChildOutsideBounds: 8
-  InvalidCollision: 32
-  InvalidLightOverlap: 64
-  InvalidTarget: 16
-  OutsidePlotBounds: 4
-  OutsideRoomBounds: 2
-  TooFarAway: 1
+  values:
+    ChildOutsideBounds: 8
+    InvalidCollision: 32
+    InvalidLightOverlap: 64
+    InvalidTarget: 16
+    OutsidePlotBounds: 4
+    OutsideRoomBounds: 2
+    TooFarAway: 1
 HousingDecorTheme:
-  BloodElf: 5
-  Folk: 1
-  Generic: 3
-  NightElf: 4
-  None: 0
-  Rugged: 2
+  values:
+    BloodElf: 5
+    Folk: 1
+    Generic: 3
+    NightElf: 4
+    None: 0
+    Rugged: 2
 HousingDecorType:
-  Ceiling: 3
-  Floor: 1
-  Flooring: 4
-  None: 0
-  Wall: 2
+  values:
+    Ceiling: 3
+    Floor: 1
+    Flooring: 4
+    None: 0
+    Wall: 2
 HousingExpertModeTargetType:
-  Decor: 1
-  House: 2
-  None: 0
+  values:
+    Decor: 1
+    House: 2
+    None: 0
 HousingExpertSubmodeRestriction:
-  NoHouseExteriorScale: 2
-  None: 0
-  NotInExpertMode: 1
-  NoWMOScale: 3
+  values:
+    NoHouseExteriorScale: 2
+    None: 0
+    NotInExpertMode: 1
+    NoWMOScale: 3
 HousingFavorUpdateSource:
-  DecorCollection: 1
-  DeferredRewards: 2
-  InitiativeChest: 6
-  InitiativeTask: 5
-  NewHouseDecorFavor: 4
-  Quest: 7
-  RetroactiveDecor: 3
-  Unknown: 0
+  values:
+    DecorCollection: 1
+    DeferredRewards: 2
+    InitiativeChest: 6
+    InitiativeTask: 5
+    NewHouseDecorFavor: 4
+    Quest: 7
+    RetroactiveDecor: 3
+    Unknown: 0
 HousingFavorUpdateType:
-  Add: 0
-  InitiativeAdd: 1
-  Set: 2
+  values:
+    Add: 0
+    InitiativeAdd: 1
+    Set: 2
 HousingFixtureDecorAction:
-  Detach: 1
-  Store: 0
+  values:
+    Detach: 1
+    Store: 0
 HousingFixtureFlags:
-  IsDefaultFixture: 1
-  None: 0
-  UnlockedByDefault: 2
+  values:
+    IsDefaultFixture: 1
+    None: 0
+    UnlockedByDefault: 2
 HousingFixtureSize:
-  Any: 1
-  Large: 4
-  Medium: 3
-  None: 0
-  Small: 2
+  values:
+    Any: 1
+    Large: 4
+    Medium: 3
+    None: 0
+    Small: 2
 HousingFixtureType:
-  Base: 9
-  Chimney: 16
-  Door: 11
-  None: 0
-  Roof: 10
-  RoofDetail: 13
-  RoofWindow: 14
-  Tower: 15
-  Window: 12
+  values:
+    Base: 9
+    Chimney: 16
+    Door: 11
+    None: 0
+    Roof: 10
+    RoofDetail: 13
+    RoofWindow: 14
+    Tower: 15
+    Window: 12
 HousingIncrementType:
-  Back: 8
-  Down: 32
-  Forward: 4
-  Left: 1
-  Right: 2
-  RotateLeft: 64
-  RotateRight: 128
-  ScaleDown: 512
-  ScaleUp: 256
-  Up: 16
+  values:
+    Back: 8
+    Down: 32
+    Forward: 4
+    Left: 1
+    Right: 2
+    RotateLeft: 64
+    RotateRight: 128
+    ScaleDown: 512
+    ScaleUp: 256
+    Up: 16
 HousingItemToastType:
-  Customization: 2
-  Decor: 3
-  Fixture: 1
-  HouseType: 4
-  Room: 0
+  values:
+    Customization: 2
+    Decor: 3
+    Fixture: 1
+    HouseType: 4
+    Room: 0
 HousingLayoutCameraDirection:
-  Down: 2
-  Left: 4
-  None: 0
-  Right: 8
-  Up: 1
+  values:
+    Down: 2
+    Left: 4
+    None: 0
+    Right: 8
+    Up: 1
 HousingLayoutPinType:
-  Door: 0
-  Room: 1
+  values:
+    Door: 0
+    Room: 1
 HousingLayoutRestriction:
-  IsBaseRoom: 4
-  LastRoom: 7
-  None: 0
-  NotHouseOwner: 3
-  NotInsideHouse: 2
-  RoomNotFound: 1
-  RoomNotLeaf: 5
-  SingleDoor: 9
-  StairwellConnection: 6
-  UnreachableRoom: 8
+  values:
+    IsBaseRoom: 4
+    LastRoom: 7
+    None: 0
+    NotHouseOwner: 3
+    NotInsideHouse: 2
+    RoomNotFound: 1
+    RoomNotLeaf: 5
+    SingleDoor: 9
+    StairwellConnection: 6
+    UnreachableRoom: 8
 HousingLayoutStairDirection:
-  Down: 1
-  Up: 0
+  values:
+    Down: 1
+    Up: 0
 HousingPlotOwnerType:
-  Friend: 2
-  None: 0
-  Self: 3
-  Stranger: 1
+  values:
+    Friend: 2
+    None: 0
+    Self: 3
+    Stranger: 1
 HousingPrecisionSubmode:
-  Rotate: 1
-  Scale: 2
-  Translate: 0
+  values:
+    Rotate: 1
+    Scale: 2
+    Translate: 0
 HousingResult:
-  ActionLockedByCombat: 1
-  BoundsFailureChildren: 2
-  BoundsFailurePlot: 3
-  BoundsFailureRoom: 4
-  BoundToStartingArea: 5
-  CannotAfford: 6
-  CharterComplete: 7
-  CollisionInvalid: 8
-  DbError: 9
-  DecorCannotBeRedeemed: 10
-  DecorItemNotDestroyable: 11
-  DecorNotFound: 12
-  DecorNotFoundInStorage: 13
-  DuplicateCharterSignature: 14
-  FilterRejected: 15
-  FixtureCantDeleteDoor: 16
-  FixtureHookEmpty: 17
-  FixtureHookOccupied: 18
-  FixtureHouseTypeMismatch: 19
-  FixtureNotFound: 20
-  FixtureSizeMismatch: 21
-  FixtureTypeMismatch: 22
-  GenericFailure: 23
-  GuildMoreAccountsNeeded: 24
-  GuildMoreActivePlayersNeeded: 25
-  GuildNotLoaded: 26
-  HookNotChildOfFixture: 35
-  HouseEditLockFailed: 27
-  HouseExteriorAlreadyThatSize: 28
-  HouseExteriorAlreadyThatType: 29
-  HouseExteriorRootNotFound: 30
-  HouseExteriorSizeNotAvailable: 34
-  HouseExteriorTypeNeighborhoodMismatch: 31
-  HouseExteriorTypeNotFound: 32
-  HouseExteriorTypeSizeMismatch: 33
-  HouseNotFound: 36
-  IncorrectFaction: 37
-  InvalidDecorItem: 38
-  InvalidDistance: 39
-  InvalidGuild: 40
-  InvalidHouse: 41
-  InvalidInstance: 42
-  InvalidInteraction: 43
-  InvalidLightOverlap: 44
-  InvalidMap: 45
-  InvalidNeighborhoodName: 46
-  InvalidRoomLayout: 47
-  LockedByOtherPlayer: 48
-  LockOperationFailed: 49
-  MaxDecorReached: 50
-  MaxPreviewDecorReached: 51
-  MissingCoreFixture: 52
-  MissingDye: 53
-  MissingExpansionAccess: 54
-  MissingFactionMap: 55
-  MissingPrivateNeighborhoodInvite: 56
-  MoreHouseSlotsNeeded: 57
-  MoreSignaturesNeeded: 58
-  NeighborhoodNotFound: 59
-  NoNeighborhoodOwnershipRequests: 60
-  NotInDecorEditMode: 61
-  NotInFixtureEditMode: 62
-  NotInLayoutEditMode: 63
-  NotInsideHouse: 64
-  NotOnOwnedPlot: 65
-  OperationAborted: 66
-  OwnerNotInGuild: 67
-  PermissionDenied: 68
-  PlacementTargetInvalid: 69
-  PlayerNotFound: 70
-  PlayerNotInInstance: 71
-  PlotNotFound: 72
-  PlotNotVacant: 73
-  PlotReservationCooldown: 74
-  PlotReserved: 75
-  RoomNotFound: 76
-  RoomUpdateFailed: 77
-  RpcFailure: 78
-  ServiceNotAvailable: 79
-  StaticDataNotFound: 80
-  Success: 0
-  TimeoutLimit: 81
-  TimerunningNotAllowed: 82
-  TokenRequired: 83
-  TooManyRequests: 84
-  TransactionFailure: 85
-  UncollectedExteriorFixture: 86
-  UncollectedHouseType: 87
-  UncollectedRoom: 88
-  UncollectedRoomMaterial: 89
-  UncollectedRoomTheme: 90
-  UnlockOperationFailed: 91
+  values:
+    ActionLockedByCombat: 1
+    BoundsFailureChildren: 2
+    BoundsFailurePlot: 3
+    BoundsFailureRoom: 4
+    BoundToStartingArea: 5
+    CannotAfford: 6
+    CharterComplete: 7
+    CollisionInvalid: 8
+    DbError: 9
+    DecorCannotBeRedeemed: 10
+    DecorItemNotDestroyable: 11
+    DecorNotFound: 12
+    DecorNotFoundInStorage: 13
+    DuplicateCharterSignature: 14
+    FilterRejected: 15
+    FixtureCantDeleteDoor: 16
+    FixtureHookEmpty: 17
+    FixtureHookOccupied: 18
+    FixtureHouseTypeMismatch: 19
+    FixtureNotFound: 20
+    FixtureSizeMismatch: 21
+    FixtureTypeMismatch: 22
+    GenericFailure: 23
+    GuildMoreAccountsNeeded: 24
+    GuildMoreActivePlayersNeeded: 25
+    GuildNotLoaded: 26
+    HookNotChildOfFixture: 35
+    HouseEditLockFailed: 27
+    HouseExteriorAlreadyThatSize: 28
+    HouseExteriorAlreadyThatType: 29
+    HouseExteriorRootNotFound: 30
+    HouseExteriorSizeNotAvailable: 34
+    HouseExteriorTypeNeighborhoodMismatch: 31
+    HouseExteriorTypeNotFound: 32
+    HouseExteriorTypeSizeMismatch: 33
+    HouseNotFound: 36
+    IncorrectFaction: 37
+    InvalidDecorItem: 38
+    InvalidDistance: 39
+    InvalidGuild: 40
+    InvalidHouse: 41
+    InvalidInstance: 42
+    InvalidInteraction: 43
+    InvalidLightOverlap: 44
+    InvalidMap: 45
+    InvalidNeighborhoodName: 46
+    InvalidRoomLayout: 47
+    LockedByOtherPlayer: 48
+    LockOperationFailed: 49
+    MaxDecorReached: 50
+    MaxPreviewDecorReached: 51
+    MissingCoreFixture: 52
+    MissingDye: 53
+    MissingExpansionAccess: 54
+    MissingFactionMap: 55
+    MissingPrivateNeighborhoodInvite: 56
+    MoreHouseSlotsNeeded: 57
+    MoreSignaturesNeeded: 58
+    NeighborhoodNotFound: 59
+    NoNeighborhoodOwnershipRequests: 60
+    NotInDecorEditMode: 61
+    NotInFixtureEditMode: 62
+    NotInLayoutEditMode: 63
+    NotInsideHouse: 64
+    NotOnOwnedPlot: 65
+    OperationAborted: 66
+    OwnerNotInGuild: 67
+    PermissionDenied: 68
+    PlacementTargetInvalid: 69
+    PlayerNotFound: 70
+    PlayerNotInInstance: 71
+    PlotNotFound: 72
+    PlotNotVacant: 73
+    PlotReservationCooldown: 74
+    PlotReserved: 75
+    RoomNotFound: 76
+    RoomUpdateFailed: 77
+    RpcFailure: 78
+    ServiceNotAvailable: 79
+    StaticDataNotFound: 80
+    Success: 0
+    TimeoutLimit: 81
+    TimerunningNotAllowed: 82
+    TokenRequired: 83
+    TooManyRequests: 84
+    TransactionFailure: 85
+    UncollectedExteriorFixture: 86
+    UncollectedHouseType: 87
+    UncollectedRoom: 88
+    UncollectedRoomMaterial: 89
+    UncollectedRoomTheme: 90
+    UnlockOperationFailed: 91
 HousingRoomComponentCeilingType:
-  Flat: 0
-  Vaulted: 1
+  values:
+    Flat: 0
+    Vaulted: 1
 HousingRoomComponentDoorType:
-  Doorway: 1
-  None: 0
-  Threshold: 2
+  values:
+    Doorway: 1
+    None: 0
+    Threshold: 2
 HousingRoomComponentFlags:
-  HiddenInLayoutMode: 1
-  None: 0
+  values:
+    HiddenInLayoutMode: 1
+    None: 0
 HousingRoomComponentFloorType:
-  Floor: 0
+  values:
+    Floor: 0
 HousingRoomComponentOptionFlags:
-  IsDefault: 1
-  None: 0
+  values:
+    IsDefault: 1
+    None: 0
 HousingRoomComponentOptionType:
-  Cosmetic: 0
-  Doorway: 2
-  DoorwayWall: 1
+  values:
+    Cosmetic: 0
+    Doorway: 2
+    DoorwayWall: 1
 HousingRoomComponentStairType:
-  MiddleToEnd: 4
-  MiddleToMiddle: 3
-  None: 0
-  StartToEnd: 1
-  StartToMiddle: 2
+  values:
+    MiddleToEnd: 4
+    MiddleToMiddle: 3
+    None: 0
+    StartToEnd: 1
+    StartToMiddle: 2
 HousingRoomComponentTextureFlags:
-  None: 0
-  UnlockedByDefault: 1
+  values:
+    None: 0
+    UnlockedByDefault: 1
 HousingRoomComponentType:
-  Ceiling: 3
-  Doorway: 7
-  DoorwayWall: 6
-  Floor: 2
-  None: 0
-  Pillar: 5
-  Stairs: 4
-  Wall: 1
+  values:
+    Ceiling: 3
+    Doorway: 7
+    DoorwayWall: 6
+    Floor: 2
+    None: 0
+    Pillar: 5
+    Stairs: 4
+    Wall: 1
 HousingRoomFlags:
-  BaseRoom: 1
-  HasCustomGeometry: 8
-  HasStairs: 2
-  None: 0
-  UnlockedByDefault: 4
+  values:
+    BaseRoom: 1
+    HasCustomGeometry: 8
+    HasStairs: 2
+    None: 0
+    UnlockedByDefault: 4
 HousingTeleportReason:
-  Booted: 3
-  Cheat: 1
-  ExitingHouse: 9
-  Friend: 6
-  GuildMember: 7
-  Homestone: 4
-  None: 0
-  PartyMember: 8
-  Portal: 10
-  Tutorial: 11
-  UnspecifiedSpellcast: 2
-  Visit: 5
+  values:
+    Booted: 3
+    Cheat: 1
+    ExitingHouse: 9
+    Friend: 6
+    GuildMember: 7
+    Homestone: 4
+    None: 0
+    PartyMember: 8
+    Portal: 10
+    Tutorial: 11
+    UnspecifiedSpellcast: 2
+    Visit: 5
 HousingThemeFlags:
-  None: 0
-  ShowInStyleSelector: 2
-  UnlockedByDefault: 1
+  values:
+    None: 0
+    ShowInStyleSelector: 2
+    UnlockedByDefault: 1
 HousingThrottleType:
-  Decoration: 1
-  General: 0
+  values:
+    Decoration: 1
+    General: 0
 IconAndTextShiftTextType:
-  None: 0
-  ShiftText: 1
+  values:
+    None: 0
+    ShiftText: 1
 IconAndTextWidgetState:
-  Hidden: 0
-  Shown: 1
-  ShownWithDynamicIconFlashing: 2
-  ShownWithDynamicIconNotFlashing: 3
+  values:
+    Hidden: 0
+    Shown: 1
+    ShownWithDynamicIconFlashing: 2
+    ShownWithDynamicIconNotFlashing: 3
 IconState:
-  Hidden: 0
-  ShowState1: 1
-  ShowState2: 2
+  values:
+    Hidden: 0
+    ShowState1: 1
+    ShowState2: 2
 ImageSharingResult:
-  AccountDataRequestFailure: 6
-  EncryptionFailure: 11
-  EncryptionSecretNotSet: 14
-  FailedToCreateHeader: 10
-  Failure: 0
-  GetAccountDataRequestFailure: 7
-  InvalidOAuthExpiration: 12
-  InvalidRefreshExpiration: 13
-  MissingFieldApiError: 5
-  NotConfigured: 2
-  PlatformApiError: 4
-  RefreshTokenExpired: 9
-  RetrievedExisting: 3
-  SetAccountDataRequestFailure: 8
-  Success: 1
+  values:
+    AccountDataRequestFailure: 6
+    EncryptionFailure: 11
+    EncryptionSecretNotSet: 14
+    FailedToCreateHeader: 10
+    Failure: 0
+    GetAccountDataRequestFailure: 7
+    InvalidOAuthExpiration: 12
+    InvalidRefreshExpiration: 13
+    MissingFieldApiError: 5
+    NotConfigured: 2
+    PlatformApiError: 4
+    RefreshTokenExpired: 9
+    RetrievedExisting: 3
+    SetAccountDataRequestFailure: 8
+    Success: 1
 InitiativeMilestoneFlags:
-  FinalMilestone: 1
+  values:
+    FinalMilestone: 1
 InitiativeRewardFlags:
-  PermanentWorldState: 1
+  values:
+    PermanentWorldState: 1
 InputContext:
-  GamePad: 3
-  Keyboard: 1
-  Mouse: 2
-  None: 0
+  values:
+    GamePad: 3
+    Keyboard: 1
+    Mouse: 2
+    None: 0
 InvalidPlotScreenshotReason:
-  Facing: 2
-  NoActivePlayer: 4
-  None: 0
-  NoNeighborhoodFound: 3
-  OutOfBounds: 1
+  values:
+    Facing: 2
+    NoActivePlayer: 4
+    None: 0
+    NoNeighborhoodFound: 3
+    OutOfBounds: 1
 InventoryType:
-  Index2HweaponType: 17
-  IndexAmmoType: 24
-  IndexBagType: 18
-  IndexBodyType: 4
-  IndexChestType: 5
-  IndexCloakType: 16
-  IndexEquipablespellDefensiveType: 33
-  IndexEquipablespellOffensiveType: 31
-  IndexEquipablespellUtilityType: 32
-  IndexEquipablespellWeaponType: 34
-  IndexFeetType: 8
-  IndexFingerType: 11
-  IndexHandType: 10
-  IndexHeadType: 1
-  IndexHoldableType: 23
-  IndexLegsType: 7
-  IndexNeckType: 2
-  IndexNonEquipType: 0
-  IndexProfessionGearType: 30
-  IndexProfessionToolType: 29
-  IndexQuiverType: 27
-  IndexRangedrightType: 26
-  IndexRangedType: 15
-  IndexRelicType: 28
-  IndexRobeType: 20
-  IndexShieldType: 14
-  IndexShoulderType: 3
-  IndexTabardType: 19
-  IndexThrownType: 25
-  IndexTrinketType: 12
-  IndexWaistType: 6
-  IndexWeaponmainhandType: 21
-  IndexWeaponoffhandType: 22
-  IndexWeaponType: 13
-  IndexWristType: 9
+  values:
+    Index2HweaponType: 17
+    IndexAmmoType: 24
+    IndexBagType: 18
+    IndexBodyType: 4
+    IndexChestType: 5
+    IndexCloakType: 16
+    IndexEquipablespellDefensiveType: 33
+    IndexEquipablespellOffensiveType: 31
+    IndexEquipablespellUtilityType: 32
+    IndexEquipablespellWeaponType: 34
+    IndexFeetType: 8
+    IndexFingerType: 11
+    IndexHandType: 10
+    IndexHeadType: 1
+    IndexHoldableType: 23
+    IndexLegsType: 7
+    IndexNeckType: 2
+    IndexNonEquipType: 0
+    IndexProfessionGearType: 30
+    IndexProfessionToolType: 29
+    IndexQuiverType: 27
+    IndexRangedrightType: 26
+    IndexRangedType: 15
+    IndexRelicType: 28
+    IndexRobeType: 20
+    IndexShieldType: 14
+    IndexShoulderType: 3
+    IndexTabardType: 19
+    IndexThrownType: 25
+    IndexTrinketType: 12
+    IndexWaistType: 6
+    IndexWeaponmainhandType: 21
+    IndexWeaponoffhandType: 22
+    IndexWeaponType: 13
+    IndexWristType: 9
 ItemArmorSubclass:
-  Cloth: 1
-  Cosmetic: 5
-  Generic: 0
-  Idol: 8
-  Leather: 2
-  Libram: 7
-  Mail: 3
-  Plate: 4
-  Relic: 11
-  Shield: 6
-  Sigil: 10
-  Totem: 9
+  values:
+    Cloth: 1
+    Cosmetic: 5
+    Generic: 0
+    Idol: 8
+    Leather: 2
+    Libram: 7
+    Mail: 3
+    Plate: 4
+    Relic: 11
+    Shield: 6
+    Sigil: 10
+    Totem: 9
 ItemBind:
-  Multi: 6
-  None: 0
-  OnAcquire: 1
-  OnEquip: 2
-  OnUse: 3
-  Quest: 4
-  QuestMulti: 5
-  ToBnetAccount: 8
-  ToBnetAccountUntilEquipped: 9
-  ToWoWAccount: 7
+  values:
+    Multi: 6
+    None: 0
+    OnAcquire: 1
+    OnEquip: 2
+    OnUse: 3
+    Quest: 4
+    QuestMulti: 5
+    ToBnetAccount: 8
+    ToBnetAccountUntilEquipped: 9
+    ToWoWAccount: 7
 ItemClass:
-  Armor: 4
-  Battlepet: 17
-  Consumable: 0
-  Container: 1
-  CurrencyTokenObsolete: 10
-  Gem: 3
-  Glyph: 16
-  Housing: 20
-  ItemEnhancement: 8
-  Key: 13
-  Miscellaneous: 15
-  PermanentObsolete: 14
-  Profession: 19
-  Projectile: 6
-  Questitem: 12
-  Quiver: 11
-  Reagent: 5
-  Recipe: 9
-  Tradegoods: 7
-  Weapon: 2
-  WoWToken: 18
+  values:
+    Armor: 4
+    Battlepet: 17
+    Consumable: 0
+    Container: 1
+    CurrencyTokenObsolete: 10
+    Gem: 3
+    Glyph: 16
+    Housing: 20
+    ItemEnhancement: 8
+    Key: 13
+    Miscellaneous: 15
+    PermanentObsolete: 14
+    Profession: 19
+    Projectile: 6
+    Questitem: 12
+    Quiver: 11
+    Reagent: 5
+    Recipe: 9
+    Tradegoods: 7
+    Weapon: 2
+    WoWToken: 18
 Itemclassfilterflags:
-  Armor: 16
-  Battlepet: 131072
-  Consumable: 1
-  Container: 2
-  CurrencyTokenObsolete: 1024
-  Gem: 8
-  Glyph: 65536
-  ItemEnhancement: 256
-  Key: 8192
-  Miscellaneous: 32768
-  PermanentObsolete: 16384
-  Projectile: 64
-  Questitemclassfilterflags: 4096
-  Quiver: 2048
-  Reagent: 32
-  Recipe: 512
-  Tradegoods: 128
-  Weapon: 4
+  values:
+    Armor: 16
+    Battlepet: 131072
+    Consumable: 1
+    Container: 2
+    CurrencyTokenObsolete: 1024
+    Gem: 8
+    Glyph: 65536
+    ItemEnhancement: 256
+    Key: 8192
+    Miscellaneous: 32768
+    PermanentObsolete: 16384
+    Projectile: 64
+    Questitemclassfilterflags: 4096
+    Quiver: 2048
+    Reagent: 32
+    Recipe: 512
+    Tradegoods: 128
+    Weapon: 4
 ItemCollectionType:
-  ExteriorFixture: 9
-  Heirloom: 2
-  HouseType: 13
-  None: 0
-  Room: 8
-  RoomMaterial: 11
-  RoomTheme: 10
-  RuneforgeLegendaryAbility: 5
-  Toy: 1
-  Transmog: 3
-  TransmogIllusion: 6
-  TransmogOutfit: 12
-  TransmogSetFavorite: 4
-  WarbandScene: 7
+  values:
+    ExteriorFixture: 9
+    Heirloom: 2
+    HouseType: 13
+    None: 0
+    Room: 8
+    RoomMaterial: 11
+    RoomTheme: 10
+    RuneforgeLegendaryAbility: 5
+    Toy: 1
+    Transmog: 3
+    TransmogIllusion: 6
+    TransmogOutfit: 12
+    TransmogSetFavorite: 4
+    WarbandScene: 7
 ItemCommodityStatus:
-  Commodity: 2
-  Item: 1
-  Unknown: 0
+  values:
+    Commodity: 2
+    Item: 1
+    Unknown: 0
 ItemConsumableSubclass:
-  Bandage: 7
-  CombatCurio: 11
-  Elixir: 2
-  Flasksphials: 3
-  Fooddrink: 5
-  Generic: 0
-  Itemenhancement: 6
-  Other: 8
-  Potion: 1
-  Relic: 12
-  Scroll: 4
-  UtilityCurio: 10
-  VantusRune: 9
+  values:
+    Bandage: 7
+    CombatCurio: 11
+    Elixir: 2
+    Flasksphials: 3
+    Fooddrink: 5
+    Generic: 0
+    Itemenhancement: 6
+    Other: 8
+    Potion: 1
+    Relic: 12
+    Scroll: 4
+    UtilityCurio: 10
+    VantusRune: 9
 ItemCreationContext:
-  BlackMarket: 15
-  ChallengeMode_1: 16
-  ChallengeMode_2: 33
-  ChallengeMode_3: 34
-  ChallengeMode_4: 87
-  ChallengeModeJackpot: 35
-  CharacterBoost_1: 61
-  CharacterBoost_2: 62
-  CharacterBoost_3: 86
-  CorpseRecovery: 80
-  Delves_1: 104
-  Delves_2: 106
-  Delves_3: 107
-  DelvesBonus_1: 129
-  DelvesBonus_10: 138
-  DelvesBonus_2: 130
-  DelvesBonus_3: 131
-  DelvesBonus_4: 132
-  DelvesBonus_5: 133
-  DelvesBonus_6: 134
-  DelvesBonus_7: 135
-  DelvesBonus_8: 136
-  DelvesBonus_9: 137
-  DelvesBounty_1: 117
-  DelvesBounty_2: 118
-  DelvesBounty_3: 119
-  DelvesBounty_4: 120
-  DelvesBounty_5: 121
-  DelvesBounty_6: 122
-  DelvesBounty_7: 123
-  DelvesBounty_8: 124
-  DelvesJackpot: 108
-  DelvesKey_1: 109
-  DelvesKey_2: 110
-  DelvesKey_3: 111
-  DelvesKey_4: 112
-  DelvesKey_5: 113
-  DelvesKey_6: 114
-  DelvesKey_7: 115
-  DelvesKey_8: 116
-  DelvesLevelUp_1: 125
-  DelvesLevelUp_2: 126
-  DelvesLevelUp_3: 127
-  DelvesLevelUp_4: 128
-  DungeonBonus_1: 139
-  DungeonBonus_10: 148
-  DungeonBonus_2: 140
-  DungeonBonus_3: 141
-  DungeonBonus_4: 142
-  DungeonBonus_5: 143
-  DungeonBonus_6: 144
-  DungeonBonus_7: 145
-  DungeonBonus_8: 146
-  DungeonBonus_9: 147
-  DungeonHardMode_1: 159
-  DungeonHardMode_2: 160
-  DungeonHardMode_3: 161
-  DungeonHeroic: 2
-  DungeonHeroicJackpot: 102
-  DungeonLevelUp_1: 17
-  DungeonLevelUp_2: 18
-  DungeonLevelUp_3: 19
-  DungeonLevelUp_4: 20
-  DungeonMythic: 23
-  DungeonMythicJackpot: 103
-  DungeonNormal: 1
-  DungeonNormalJackpot: 101
-  Endeavors: 185
-  ForceNone: 21
-  LegendaryCrafting_1: 63
-  LegendaryCrafting_2: 64
-  LegendaryCrafting_3: 65
-  LegendaryCrafting_4: 66
-  LegendaryCrafting_5: 67
-  LegendaryCrafting_6: 68
-  LegendaryCrafting_7: 69
-  LegendaryCrafting_8: 70
-  LegendaryCrafting_9: 71
-  LegendaryForge: 59
-  MissionReward_1: 31
-  MissionReward_2: 32
-  NewCharacter: 75
-  None: 0
-  PvPBrawl_1: 77
-  PvPBrawl_2: 78
-  PvPHonorReward: 24
-  PvPRanked_1: 8
-  PvPRanked_2: 38
-  PvPRanked_3: 39
-  PvPRanked_4: 40
-  PvPRanked_5: 44
-  PvPRanked_6: 45
-  PvPRanked_7: 46
-  PvPRanked_8: 52
-  PvPRanked_9: 88
-  PvPRankedJackpot: 56
-  PvPUnranked_1: 7
-  PvPUnranked_2: 41
-  PvPUnranked_3: 47
-  PvPUnranked_4: 48
-  PvPUnranked_5: 49
-  PvPUnranked_6: 50
-  PvPUnranked_7: 51
-  QuestBonusLoot: 60
-  QuestReward: 11
-  RaidBonus_1: 149
-  RaidBonus_10: 158
-  RaidBonus_2: 150
-  RaidBonus_3: 151
-  RaidBonus_4: 152
-  RaidBonus_5: 153
-  RaidBonus_6: 154
-  RaidBonus_7: 155
-  RaidBonus_8: 156
-  RaidBonus_9: 157
-  RaidFinder: 4
-  RaidFinderExtended: 83
-  RaidFinderExtended_2: 90
-  RaidFinderExtended_3: 94
-  RaidHeroic: 5
-  RaidHeroicExtended: 84
-  RaidHeroicExtended_2: 91
-  RaidHeroicExtended_3: 95
-  RaidMythic: 6
-  RaidMythicExtended: 85
-  RaidMythicExtended_2: 92
-  RaidMythicExtended_3: 96
-  RaidNormal: 3
-  RaidNormalExtended: 82
-  RaidNormalExtended_2: 89
-  RaidNormalExtended_3: 93
-  Relinquished: 58
-  ScenarioHeroic: 10
-  ScenarioNormal: 9
-  Store: 12
-  TemplateCharacter_1: 97
-  TemplateCharacter_2: 98
-  TemplateCharacter_3: 99
-  TemplateCharacter_4: 100
-  Timerunning: 105
-  TimewalkerLevelUp: 22
-  TimewalkerMaxLevel: 186
-  Torghast: 79
-  TournamentRealm_1: 57
-  TournamentRealm_2: 162
-  TournamentRealm_3: 163
-  TournamentRealm_4: 164
-  TradeSkill: 13
-  Vendor: 14
-  Warbound_1: 165
-  Warbound_10: 174
-  Warbound_11: 175
-  Warbound_12: 176
-  Warbound_13: 177
-  Warbound_14: 178
-  Warbound_15: 179
-  Warbound_16: 180
-  Warbound_17: 181
-  Warbound_18: 182
-  Warbound_19: 183
-  Warbound_2: 166
-  Warbound_20: 184
-  Warbound_3: 167
-  Warbound_4: 168
-  Warbound_5: 169
-  Warbound_6: 170
-  Warbound_7: 171
-  Warbound_8: 172
-  Warbound_9: 173
-  WarMode: 76
-  WeeklyRewardsAdditional: 72
-  WeeklyRewardsConcession: 73
-  WorldBoss: 81
-  WorldQuest_1: 25
-  WorldQuest_10: 43
-  WorldQuest_11: 53
-  WorldQuest_12: 54
-  WorldQuest_13: 55
-  WorldQuest_2: 26
-  WorldQuest_3: 27
-  WorldQuest_4: 28
-  WorldQuest_5: 29
-  WorldQuest_6: 30
-  WorldQuest_7: 36
-  WorldQuest_8: 37
-  WorldQuest_9: 42
-  WorldQuestJackpot: 74
+  values:
+    BlackMarket: 15
+    ChallengeMode_1: 16
+    ChallengeMode_2: 33
+    ChallengeMode_3: 34
+    ChallengeMode_4: 87
+    ChallengeModeJackpot: 35
+    CharacterBoost_1: 61
+    CharacterBoost_2: 62
+    CharacterBoost_3: 86
+    CorpseRecovery: 80
+    Delves_1: 104
+    Delves_2: 106
+    Delves_3: 107
+    DelvesBonus_1: 129
+    DelvesBonus_10: 138
+    DelvesBonus_2: 130
+    DelvesBonus_3: 131
+    DelvesBonus_4: 132
+    DelvesBonus_5: 133
+    DelvesBonus_6: 134
+    DelvesBonus_7: 135
+    DelvesBonus_8: 136
+    DelvesBonus_9: 137
+    DelvesBounty_1: 117
+    DelvesBounty_2: 118
+    DelvesBounty_3: 119
+    DelvesBounty_4: 120
+    DelvesBounty_5: 121
+    DelvesBounty_6: 122
+    DelvesBounty_7: 123
+    DelvesBounty_8: 124
+    DelvesJackpot: 108
+    DelvesKey_1: 109
+    DelvesKey_2: 110
+    DelvesKey_3: 111
+    DelvesKey_4: 112
+    DelvesKey_5: 113
+    DelvesKey_6: 114
+    DelvesKey_7: 115
+    DelvesKey_8: 116
+    DelvesLevelUp_1: 125
+    DelvesLevelUp_2: 126
+    DelvesLevelUp_3: 127
+    DelvesLevelUp_4: 128
+    DungeonBonus_1: 139
+    DungeonBonus_10: 148
+    DungeonBonus_2: 140
+    DungeonBonus_3: 141
+    DungeonBonus_4: 142
+    DungeonBonus_5: 143
+    DungeonBonus_6: 144
+    DungeonBonus_7: 145
+    DungeonBonus_8: 146
+    DungeonBonus_9: 147
+    DungeonHardMode_1: 159
+    DungeonHardMode_2: 160
+    DungeonHardMode_3: 161
+    DungeonHeroic: 2
+    DungeonHeroicJackpot: 102
+    DungeonLevelUp_1: 17
+    DungeonLevelUp_2: 18
+    DungeonLevelUp_3: 19
+    DungeonLevelUp_4: 20
+    DungeonMythic: 23
+    DungeonMythicJackpot: 103
+    DungeonNormal: 1
+    DungeonNormalJackpot: 101
+    Endeavors: 185
+    ForceNone: 21
+    LegendaryCrafting_1: 63
+    LegendaryCrafting_2: 64
+    LegendaryCrafting_3: 65
+    LegendaryCrafting_4: 66
+    LegendaryCrafting_5: 67
+    LegendaryCrafting_6: 68
+    LegendaryCrafting_7: 69
+    LegendaryCrafting_8: 70
+    LegendaryCrafting_9: 71
+    LegendaryForge: 59
+    MissionReward_1: 31
+    MissionReward_2: 32
+    NewCharacter: 75
+    None: 0
+    PvPBrawl_1: 77
+    PvPBrawl_2: 78
+    PvPHonorReward: 24
+    PvPRanked_1: 8
+    PvPRanked_2: 38
+    PvPRanked_3: 39
+    PvPRanked_4: 40
+    PvPRanked_5: 44
+    PvPRanked_6: 45
+    PvPRanked_7: 46
+    PvPRanked_8: 52
+    PvPRanked_9: 88
+    PvPRankedJackpot: 56
+    PvPUnranked_1: 7
+    PvPUnranked_2: 41
+    PvPUnranked_3: 47
+    PvPUnranked_4: 48
+    PvPUnranked_5: 49
+    PvPUnranked_6: 50
+    PvPUnranked_7: 51
+    QuestBonusLoot: 60
+    QuestReward: 11
+    RaidBonus_1: 149
+    RaidBonus_10: 158
+    RaidBonus_2: 150
+    RaidBonus_3: 151
+    RaidBonus_4: 152
+    RaidBonus_5: 153
+    RaidBonus_6: 154
+    RaidBonus_7: 155
+    RaidBonus_8: 156
+    RaidBonus_9: 157
+    RaidFinder: 4
+    RaidFinderExtended: 83
+    RaidFinderExtended_2: 90
+    RaidFinderExtended_3: 94
+    RaidHeroic: 5
+    RaidHeroicExtended: 84
+    RaidHeroicExtended_2: 91
+    RaidHeroicExtended_3: 95
+    RaidMythic: 6
+    RaidMythicExtended: 85
+    RaidMythicExtended_2: 92
+    RaidMythicExtended_3: 96
+    RaidNormal: 3
+    RaidNormalExtended: 82
+    RaidNormalExtended_2: 89
+    RaidNormalExtended_3: 93
+    Relinquished: 58
+    ScenarioHeroic: 10
+    ScenarioNormal: 9
+    Store: 12
+    TemplateCharacter_1: 97
+    TemplateCharacter_2: 98
+    TemplateCharacter_3: 99
+    TemplateCharacter_4: 100
+    Timerunning: 105
+    TimewalkerLevelUp: 22
+    TimewalkerMaxLevel: 186
+    Torghast: 79
+    TournamentRealm_1: 57
+    TournamentRealm_2: 162
+    TournamentRealm_3: 163
+    TournamentRealm_4: 164
+    TradeSkill: 13
+    Vendor: 14
+    Warbound_1: 165
+    Warbound_10: 174
+    Warbound_11: 175
+    Warbound_12: 176
+    Warbound_13: 177
+    Warbound_14: 178
+    Warbound_15: 179
+    Warbound_16: 180
+    Warbound_17: 181
+    Warbound_18: 182
+    Warbound_19: 183
+    Warbound_2: 166
+    Warbound_20: 184
+    Warbound_3: 167
+    Warbound_4: 168
+    Warbound_5: 169
+    Warbound_6: 170
+    Warbound_7: 171
+    Warbound_8: 172
+    Warbound_9: 173
+    WarMode: 76
+    WeeklyRewardsAdditional: 72
+    WeeklyRewardsConcession: 73
+    WorldBoss: 81
+    WorldQuest_1: 25
+    WorldQuest_10: 43
+    WorldQuest_11: 53
+    WorldQuest_12: 54
+    WorldQuest_13: 55
+    WorldQuest_2: 26
+    WorldQuest_3: 27
+    WorldQuest_4: 28
+    WorldQuest_5: 29
+    WorldQuest_6: 30
+    WorldQuest_7: 36
+    WorldQuest_8: 37
+    WorldQuest_9: 42
+    WorldQuestJackpot: 74
 ItemDisplayTextDisplayStyle:
-  ItemNameAndInfoText: 1
-  ItemNameOnlyCentered: 2
-  PlayerChoiceReward: 3
-  WorldQuestReward: 0
+  values:
+    ItemNameAndInfoText: 1
+    ItemNameOnlyCentered: 2
+    PlayerChoiceReward: 3
+    WorldQuestReward: 0
 ItemDisplayTooltipEnabledType:
-  Disabled: 1
-  Enabled: 0
+  values:
+    Disabled: 1
+    Enabled: 0
 ItemGemColor:
-  Arcane: 1024
-  Blood: 128
-  Blue: 8
-  Cogwheel: 32
-  Cypher: 8388608
-  DominationBlood: 1048576
-  DominationFrost: 2097152
-  DominationUnholy: 4194304
-  Fel: 512
-  Fiber: 1073741824
-  Fire: 4096
-  Fragrance: 67108864
-  Frost: 2048
-  Holy: 65536
-  Hydraulic: 16
-  Iron: 64
-  Life: 16384
-  Meta: 1
-  Primordial: 33554432
-  PunchcardBlue: 524288
-  PunchcardRed: 131072
-  PunchcardYellow: 262144
-  Red: 2
-  Shadow: 256
-  SingingSea: 268435456
-  SingingThunder: 134217728
-  SingingWind: 536870912
-  Tinker: 16777216
-  Water: 8192
-  Wind: 32768
-  Yellow: 4
+  values:
+    Arcane: 1024
+    Blood: 128
+    Blue: 8
+    Cogwheel: 32
+    Cypher: 8388608
+    DominationBlood: 1048576
+    DominationFrost: 2097152
+    DominationUnholy: 4194304
+    Fel: 512
+    Fiber: 1073741824
+    Fire: 4096
+    Fragrance: 67108864
+    Frost: 2048
+    Holy: 65536
+    Hydraulic: 16
+    Iron: 64
+    Life: 16384
+    Meta: 1
+    Primordial: 33554432
+    PunchcardBlue: 524288
+    PunchcardRed: 131072
+    PunchcardYellow: 262144
+    Red: 2
+    Shadow: 256
+    SingingSea: 268435456
+    SingingThunder: 134217728
+    SingingWind: 536870912
+    Tinker: 16777216
+    Water: 8192
+    Wind: 32768
+    Yellow: 4
 ItemGemSubclass:
-  Blue: 1
-  Green: 4
-  Meta: 6
-  Orange: 5
-  Prismatic: 8
-  Purple: 3
-  Red: 0
-  Simple: 7
-  Yellow: 2
+  values:
+    Blue: 1
+    Green: 4
+    Meta: 6
+    Orange: 5
+    Prismatic: 8
+    Purple: 3
+    Red: 0
+    Simple: 7
+    Yellow: 2
 ItemHousingSubclass:
-  Decor: 0
-  Dye: 1
-  ExteriorCustomization: 4
-  Room: 2
-  RoomCustomization: 3
-  ServiceItem: 5
+  values:
+    Decor: 0
+    Dye: 1
+    ExteriorCustomization: 4
+    Room: 2
+    RoomCustomization: 3
+    ServiceItem: 5
 ItemMiscellaneousSubclass:
-  CompanionPet: 2
-  Holiday: 3
-  Junk: 0
-  Mount: 5
-  MountEquipment: 6
-  Other: 4
-  Reagent: 1
+  values:
+    CompanionPet: 2
+    Holiday: 3
+    Junk: 0
+    Mount: 5
+    MountEquipment: 6
+    Other: 4
+    Reagent: 1
 ItemModification:
-  ArtifactAppearanceID: 8
-  ArtifactTier: 24
-  BattlePetBreed: 4
-  BattlePetCreaturedisplayid: 6
-  BattlePetLevel: 5
-  BattlePetSpecies: 3
-  ChangeModifiedCraftingStat_1: 29
-  ChangeModifiedCraftingStat_2: 30
-  ContentTuningID: 28
-  CraftingDataID: 40
-  CraftingQualityID: 38
-  CraftingReagentSlot_0: 43
-  CraftingReagentSlot_1: 44
-  CraftingReagentSlot_10: 53
-  CraftingReagentSlot_11: 54
-  CraftingReagentSlot_12: 55
-  CraftingReagentSlot_13: 56
-  CraftingReagentSlot_14: 57
-  CraftingReagentSlot_2: 45
-  CraftingReagentSlot_3: 46
-  CraftingReagentSlot_4: 47
-  CraftingReagentSlot_5: 48
-  CraftingReagentSlot_6: 49
-  CraftingReagentSlot_7: 50
-  CraftingReagentSlot_8: 51
-  CraftingReagentSlot_9: 52
-  CraftingSkillLineAbilityID: 39
-  CraftingSkillReagents: 41
-  CraftingSkillWatermark: 42
-  CurrencyWalletID: 61
-  CurrencyWalletQuantity: 62
-  CurrencyWalletVersion: 63
-  DbidHigh: 59
-  DbidLow: 60
-  IncrementLevel: 2
-  KeystoneAffix0: 19
-  KeystoneAffix01: 20
-  KeystoneAffix02: 21
-  KeystoneAffix03: 22
-  KeystoneMapChallengeModeID: 17
-  KeystonePowerLevel: 18
-  LegionArtifactKnowledgeObsolete: 23
-  PvPRating: 26
-  RedirectedBaseStats: 64
-  Reforge: 58
-  SoulbindConduitRank: 37
-  TimewalkerLevel: 9
-  TransmogrifyItemModifiedAppearanceIDSpec_0: 1
-  TransmogrifyItemModifiedAppearanceIDSpec_1: 11
-  TransmogrifyItemModifiedAppearanceIDSpec_2: 13
-  TransmogrifyItemModifiedAppearanceIDSpec_3: 15
-  TransmogrifyItemModifiedAppearanceIDSpec_4: 25
-  TransmogrifyItemModifiedAppearanceIDSpecAll: 0
-  TransmogrifyOverrideEnchantVisualIDSpec_0: 10
-  TransmogrifyOverrideEnchantVisualIDSpec_1: 12
-  TransmogrifyOverrideEnchantVisualIDSpec_2: 14
-  TransmogrifyOverrideEnchantVisualIDSpec_3: 16
-  TransmogrifyOverrideEnchantVisualIDSpec_4: 27
-  TransmogrifyOverrideEnchantVisualIDSpecAll: 7
-  TransmogrifySecondaryItemModifiedAppearanceIDSpec_0: 32
-  TransmogrifySecondaryItemModifiedAppearanceIDSpec_1: 33
-  TransmogrifySecondaryItemModifiedAppearanceIDSpec_2: 34
-  TransmogrifySecondaryItemModifiedAppearanceIDSpec_3: 35
-  TransmogrifySecondaryItemModifiedAppearanceIDSpec_4: 36
-  TransmogrifySecondaryItemModifiedAppearanceIDSpecAll: 31
+  values:
+    ArtifactAppearanceID: 8
+    ArtifactTier: 24
+    BattlePetBreed: 4
+    BattlePetCreaturedisplayid: 6
+    BattlePetLevel: 5
+    BattlePetSpecies: 3
+    ChangeModifiedCraftingStat_1: 29
+    ChangeModifiedCraftingStat_2: 30
+    ContentTuningID: 28
+    CraftingDataID: 40
+    CraftingQualityID: 38
+    CraftingReagentSlot_0: 43
+    CraftingReagentSlot_1: 44
+    CraftingReagentSlot_10: 53
+    CraftingReagentSlot_11: 54
+    CraftingReagentSlot_12: 55
+    CraftingReagentSlot_13: 56
+    CraftingReagentSlot_14: 57
+    CraftingReagentSlot_2: 45
+    CraftingReagentSlot_3: 46
+    CraftingReagentSlot_4: 47
+    CraftingReagentSlot_5: 48
+    CraftingReagentSlot_6: 49
+    CraftingReagentSlot_7: 50
+    CraftingReagentSlot_8: 51
+    CraftingReagentSlot_9: 52
+    CraftingSkillLineAbilityID: 39
+    CraftingSkillReagents: 41
+    CraftingSkillWatermark: 42
+    CurrencyWalletID: 61
+    CurrencyWalletQuantity: 62
+    CurrencyWalletVersion: 63
+    DbidHigh: 59
+    DbidLow: 60
+    IncrementLevel: 2
+    KeystoneAffix0: 19
+    KeystoneAffix01: 20
+    KeystoneAffix02: 21
+    KeystoneAffix03: 22
+    KeystoneMapChallengeModeID: 17
+    KeystonePowerLevel: 18
+    LegionArtifactKnowledgeObsolete: 23
+    PvPRating: 26
+    RedirectedBaseStats: 64
+    Reforge: 58
+    SoulbindConduitRank: 37
+    TimewalkerLevel: 9
+    TransmogrifyItemModifiedAppearanceIDSpec_0: 1
+    TransmogrifyItemModifiedAppearanceIDSpec_1: 11
+    TransmogrifyItemModifiedAppearanceIDSpec_2: 13
+    TransmogrifyItemModifiedAppearanceIDSpec_3: 15
+    TransmogrifyItemModifiedAppearanceIDSpec_4: 25
+    TransmogrifyItemModifiedAppearanceIDSpecAll: 0
+    TransmogrifyOverrideEnchantVisualIDSpec_0: 10
+    TransmogrifyOverrideEnchantVisualIDSpec_1: 12
+    TransmogrifyOverrideEnchantVisualIDSpec_2: 14
+    TransmogrifyOverrideEnchantVisualIDSpec_3: 16
+    TransmogrifyOverrideEnchantVisualIDSpec_4: 27
+    TransmogrifyOverrideEnchantVisualIDSpecAll: 7
+    TransmogrifySecondaryItemModifiedAppearanceIDSpec_0: 32
+    TransmogrifySecondaryItemModifiedAppearanceIDSpec_1: 33
+    TransmogrifySecondaryItemModifiedAppearanceIDSpec_2: 34
+    TransmogrifySecondaryItemModifiedAppearanceIDSpec_3: 35
+    TransmogrifySecondaryItemModifiedAppearanceIDSpec_4: 36
+    TransmogrifySecondaryItemModifiedAppearanceIDSpecAll: 31
 ItemProfessionSubclass:
-  Alchemy: 2
-  Archaeology: 13
-  Blacksmithing: 0
-  Cooking: 4
-  Enchanting: 8
-  Engineering: 7
-  Fishing: 9
-  Herbalism: 3
-  Inscription: 12
-  Jewelcrafting: 11
-  Leatherworking: 1
-  Mining: 5
-  Skinning: 10
-  Tailoring: 6
+  values:
+    Alchemy: 2
+    Archaeology: 13
+    Blacksmithing: 0
+    Cooking: 4
+    Enchanting: 8
+    Engineering: 7
+    Fishing: 9
+    Herbalism: 3
+    Inscription: 12
+    Jewelcrafting: 11
+    Leatherworking: 1
+    Mining: 5
+    Skinning: 10
+    Tailoring: 6
 ItemQuality:
-  Artifact: 6
-  Epic: 4
-  Good: 2
-  Heirloom: 7
-  Legendary: 5
-  Poor: 0
-  Rare: 3
-  Standard: 1
-  WoWToken: 8
+  values:
+    Artifact: 6
+    Epic: 4
+    Good: 2
+    Heirloom: 7
+    Legendary: 5
+    Poor: 0
+    Rare: 3
+    Standard: 1
+    WoWToken: 8
 ItemReagentSubclass:
-  ContextToken: 2
-  Keystone: 1
-  Reagent: 0
+  values:
+    ContextToken: 2
+    Keystone: 1
+    Reagent: 0
 ItemRecipeSubclass:
-  Alchemy: 6
-  Blacksmithing: 4
-  Book: 0
-  Cooking: 5
-  Enchanting: 8
-  Engineering: 3
-  FirstAid: 7
-  Fishing: 9
-  Inscription: 11
-  Jewelcrafting: 10
-  Leatherworking: 1
-  Tailoring: 2
+  values:
+    Alchemy: 6
+    Blacksmithing: 4
+    Book: 0
+    Cooking: 5
+    Enchanting: 8
+    Engineering: 3
+    FirstAid: 7
+    Fishing: 9
+    Inscription: 11
+    Jewelcrafting: 10
+    Leatherworking: 1
+    Tailoring: 2
 ItemRecraftFlags:
-  Invalid: 1
+  values:
+    Invalid: 1
 Itemsetflags:
-  Legacy: 1
-  RequiresPvPTalentsActive: 4
-  UseItemHistorySetSlots: 2
+  values:
+    Legacy: 1
+    RequiresPvPTalentsActive: 4
+    UseItemHistorySetSlots: 2
 ItemSlotFilterType:
-  Chest: 4
-  Cloak: 3
-  Feet: 9
-  Finger: 12
-  Hand: 6
-  Head: 0
-  Legs: 8
-  MainHand: 10
-  Neck: 1
-  NoFilter: 15
-  OffHand: 11
-  Other: 14
-  Shoulder: 2
-  Trinket: 13
-  Waist: 7
-  Wrist: 5
+  values:
+    Chest: 4
+    Cloak: 3
+    Feet: 9
+    Finger: 12
+    Hand: 6
+    Head: 0
+    Legs: 8
+    MainHand: 10
+    Neck: 1
+    NoFilter: 15
+    OffHand: 11
+    Other: 14
+    Shoulder: 2
+    Trinket: 13
+    Waist: 7
+    Wrist: 5
 ItemSocketInfoUIType:
-  Default: 0
+  values:
+    Default: 0
 ItemSocketType:
-  Arcane: 12
-  Blood: 9
-  Blue: 4
-  Cogwheel: 6
-  Cypher: 23
-  Domination: 22
-  Fel: 11
-  Fiber: 30
-  Fire: 14
-  Fragrance: 26
-  Frost: 13
-  Holy: 18
-  Hydraulic: 5
-  Iron: 8
-  Life: 16
-  Meta: 1
-  None: 0
-  Primordial: 25
-  Prismatic: 7
-  PunchcardBlue: 21
-  PunchcardRed: 19
-  PunchcardYellow: 20
-  Red: 2
-  Shadow: 10
-  SingingSea: 28
-  SingingThunder: 27
-  SingingWind: 29
-  Tinker: 24
-  Water: 15
-  Wind: 17
-  Yellow: 3
+  values:
+    Arcane: 12
+    Blood: 9
+    Blue: 4
+    Cogwheel: 6
+    Cypher: 23
+    Domination: 22
+    Fel: 11
+    Fiber: 30
+    Fire: 14
+    Fragrance: 26
+    Frost: 13
+    Holy: 18
+    Hydraulic: 5
+    Iron: 8
+    Life: 16
+    Meta: 1
+    None: 0
+    Primordial: 25
+    Prismatic: 7
+    PunchcardBlue: 21
+    PunchcardRed: 19
+    PunchcardYellow: 20
+    Red: 2
+    Shadow: 10
+    SingingSea: 28
+    SingingThunder: 27
+    SingingWind: 29
+    Tinker: 24
+    Water: 15
+    Wind: 17
+    Yellow: 3
 ItemSoundType:
-  Close: 3
-  Drop: 1
-  Pickup: 0
-  Use: 2
+  values:
+    Close: 3
+    Drop: 1
+    Pickup: 0
+    Use: 2
 ItemSubclassDisplay:
-  HideSubclassInAuction: 2
-  HideSubclassInTooltips: 1
-  ShowItemCount: 4
+  values:
+    HideSubclassInAuction: 2
+    HideSubclassInTooltips: 1
+    ShowItemCount: 4
 ItemSubclassFlag:
-  ArmorsubclassLfgscalingarmor: 1024
-  ItemsubclassQuivernotrequired: 64
-  ItemsubclassUsesInvtype: 512
-  WeaponsubclassCanparry: 1
-  WeaponsubclassDeprecatedReuseMe: 256
-  WeaponsubclassIsrifle: 8
-  WeaponsubclassIsthrown: 16
-  WeaponsubclassIsunarmed: 4
-  WeaponsubclassRanged: 128
-  WeaponsubclassRighthandRanged: 32
-  WeaponsubclassSetfingerseq: 2
+  values:
+    ArmorsubclassLfgscalingarmor: 1024
+    ItemsubclassQuivernotrequired: 64
+    ItemsubclassUsesInvtype: 512
+    WeaponsubclassCanparry: 1
+    WeaponsubclassDeprecatedReuseMe: 256
+    WeaponsubclassIsrifle: 8
+    WeaponsubclassIsthrown: 16
+    WeaponsubclassIsunarmed: 4
+    WeaponsubclassRanged: 128
+    WeaponsubclassRighthandRanged: 32
+    WeaponsubclassSetfingerseq: 2
 ItemTryOnReason:
-  DataPending: 3
-  NotEquippable: 2
-  Success: 0
-  WrongRace: 1
+  values:
+    DataPending: 3
+    NotEquippable: 2
+    Success: 0
+    WrongRace: 1
 ItemWeaponSubclass:
-  Axe1H: 0
-  Axe2H: 1
-  Bearclaw: 11
-  Bows: 2
-  Catclaw: 12
-  Crossbow: 18
-  Dagger: 15
-  Fishingpole: 20
-  Generic: 14
-  Guns: 3
-  Mace1H: 4
-  Mace2H: 5
-  Obsolete3: 17
-  Polearm: 6
-  Staff: 10
-  Sword1H: 7
-  Sword2H: 8
-  Thrown: 16
-  Unarmed: 13
-  Wand: 19
-  Warglaive: 9
+  values:
+    Axe1H: 0
+    Axe2H: 1
+    Bearclaw: 11
+    Bows: 2
+    Catclaw: 12
+    Crossbow: 18
+    Dagger: 15
+    Fishingpole: 20
+    Generic: 14
+    Guns: 3
+    Mace1H: 4
+    Mace2H: 5
+    Obsolete3: 17
+    Polearm: 6
+    Staff: 10
+    Sword1H: 7
+    Sword2H: 8
+    Thrown: 16
+    Unarmed: 13
+    Wand: 19
+    Warglaive: 9
 JailersTowerType:
-  AdamantVaults: 11
-  ArkobanHall: 7
-  BossRush: 14
-  Coldheart: 4
-  ForgottenCatacombs: 12
-  FractureChambers: 2
-  Mortregar: 5
-  Ossuary: 13
-  SkoldusHalls: 1
-  Soulforges: 3
-  TormentChamberAnduin: 10
-  TormentChamberJaina: 8
-  TormentChamberThrall: 9
-  TwistingCorridors: 0
-  UpperReaches: 6
+  values:
+    AdamantVaults: 11
+    ArkobanHall: 7
+    BossRush: 14
+    Coldheart: 4
+    ForgottenCatacombs: 12
+    FractureChambers: 2
+    Mortregar: 5
+    Ossuary: 13
+    SkoldusHalls: 1
+    Soulforges: 3
+    TormentChamberAnduin: 10
+    TormentChamberJaina: 8
+    TormentChamberThrall: 9
+    TwistingCorridors: 0
+    UpperReaches: 6
 JournalEncounterFlags:
-  AllianceOnly: 4
-  DoNotDisplayEncounter: 64
-  HordeOnly: 8
-  InternalOnly: 32
-  LimitDifficulties: 2
-  NoMap: 16
-  Obsolete: 1
+  values:
+    AllianceOnly: 4
+    DoNotDisplayEncounter: 64
+    HordeOnly: 8
+    InternalOnly: 32
+    LimitDifficulties: 2
+    NoMap: 16
+    Obsolete: 1
 JournalEncounterIconFlags:
-  Bleed: 8192
-  Curse: 256
-  Deadly: 16
-  Disease: 1024
-  Dps: 2
-  Enrage: 2048
-  Healer: 4
-  Heroic: 8
-  Important: 32
-  Interruptible: 64
-  Magic: 128
-  Mythic: 4096
-  Poison: 512
-  Tank: 1
+  values:
+    Bleed: 8192
+    Curse: 256
+    Deadly: 16
+    Disease: 1024
+    Dps: 2
+    Enrage: 2048
+    Healer: 4
+    Heroic: 8
+    Important: 32
+    Interruptible: 64
+    Magic: 128
+    Mythic: 4096
+    Poison: 512
+    Tank: 1
 JournalEncounterItemFlags:
-  DisplayAsExtremelyRare: 16
-  DisplayAsPerPlayerLoot: 4
-  DisplayAsVeryRare: 8
-  LimitDifficulties: 2
-  Obsolete: 1
+  values:
+    DisplayAsExtremelyRare: 16
+    DisplayAsPerPlayerLoot: 4
+    DisplayAsVeryRare: 8
+    LimitDifficulties: 2
+    Obsolete: 1
 JournalEncounterLocFlags:
-  Primary: 1
+  values:
+    Primary: 1
 JournalEncounterSectionFlags:
-  LimitDifficulties: 2
-  StartExpanded: 1
+  values:
+    LimitDifficulties: 2
+    StartExpanded: 1
 JournalEncounterSecTypes:
-  Ability: 2
-  Creature: 1
-  Generic: 0
-  Overview: 3
+  values:
+    Ability: 2
+    Creature: 1
+    Generic: 0
+    Overview: 3
 JournalInstanceFlags:
-  DoNotDisplayInstance: 4
-  HideUserSelectableDifficulty: 2
-  Timewalker: 1
+  values:
+    DoNotDisplayInstance: 4
+    HideUserSelectableDifficulty: 2
+    Timewalker: 1
 JournalLinkTypes:
-  Encounter: 1
-  Instance: 0
-  Section: 2
-  Tier: 3
+  values:
+    Encounter: 1
+    Instance: 0
+    Section: 2
+    Tier: 3
 LanguageFlag:
-  HiddenFromPlayer: 2
-  HideLanguageNameInChat: 4
-  IsExotic: 1
+  values:
+    HiddenFromPlayer: 2
+    HideLanguageNameInChat: 4
+    IsExotic: 1
 LeavePartyConfirmReason:
-  QuestSync: 0
-  RestrictedChallengeMode: 1
+  values:
+    QuestSync: 0
+    RestrictedChallengeMode: 1
 LFGEntryGeneralPlaystyle:
-  Expert: 4
-  FunRelaxed: 2
-  FunSerious: 3
-  Learning: 1
-  None: 0
+  values:
+    Expert: 4
+    FunRelaxed: 2
+    FunSerious: 3
+    Learning: 1
+    None: 0
 LFGEntryPlaystyle:
-  Casual: 2
-  Hardcore: 3
-  None: 0
-  Standard: 1
+  values:
+    Casual: 2
+    Hardcore: 3
+    None: 0
+    Standard: 1
 LFGListDisplayType:
-  ClassEnumerate: 2
-  Comment: 5
-  HideAll: 3
-  PlayerCount: 4
-  RoleCount: 0
-  RoleEnumerate: 1
+  values:
+    ClassEnumerate: 2
+    Comment: 5
+    HideAll: 3
+    PlayerCount: 4
+    RoleCount: 0
+    RoleEnumerate: 1
 LFGListFilter:
-  CurrentExpansion: 32
-  CurrentSeason: 64
-  NotCurrentSeason: 128
-  NotRecommended: 2
-  PvE: 4
-  PvP: 8
-  Recommended: 1
-  Timerunning: 16
+  values:
+    CurrentExpansion: 32
+    CurrentSeason: 64
+    NotCurrentSeason: 128
+    NotRecommended: 2
+    PvE: 4
+    PvP: 8
+    Recommended: 1
+    Timerunning: 16
 LFGRole:
-  Damage: 2
-  Healer: 1
-  Tank: 0
+  values:
+    Damage: 2
+    Healer: 1
+    Tank: 0
 LFGSlotInvalidReason:
-  AreaNotExplored: 9
-  CannotRunAnyChildDungeon: 14
-  ChromieTime: 16
-  EngagedInPvP: 12
-  ExpansionTooLow: 1
-  GearTooHigh: 5
-  GearTooLow: 4
-  LevelTargetTooHigh: 8
-  LevelTargetTooLow: 7
-  LevelTooHigh: 3
-  LevelTooLow: 2
-  None: 0
-  NoSpec: 13
-  NoValidRoles: 11
-  Npe: 17
-  PlayerConditionFailed: 19
-  RaidLocked: 6
-  Restricted: 15
-  Timerunning: 18
-  WrongFaction: 10
+  values:
+    AreaNotExplored: 9
+    CannotRunAnyChildDungeon: 14
+    ChromieTime: 16
+    EngagedInPvP: 12
+    ExpansionTooLow: 1
+    GearTooHigh: 5
+    GearTooLow: 4
+    LevelTargetTooHigh: 8
+    LevelTargetTooLow: 7
+    LevelTooHigh: 3
+    LevelTooLow: 2
+    None: 0
+    NoSpec: 13
+    NoValidRoles: 11
+    Npe: 17
+    PlayerConditionFailed: 19
+    RaidLocked: 6
+    Restricted: 15
+    Timerunning: 18
+    WrongFaction: 10
 LgVendorPurchaseSettlementState:
-  NotSettled: 1
-  Settled: 0
+  values:
+    NotSettled: 1
+    Settled: 0
 LgVendorPurchaseSqlResults:
-  AlreadyOwned: 102
-  Failed: 0
-  InsufficientFunds: 101
-  InsufficientSpent: 103
-  InvalidState: 107
-  NoRecord: 106
-  NotOwned: 104
-  RefundExpired: 105
-  Success: 100
+  values:
+    AlreadyOwned: 102
+    Failed: 0
+    InsufficientFunds: 101
+    InsufficientSpent: 103
+    InvalidState: 107
+    NoRecord: 106
+    NotOwned: 104
+    RefundExpired: 105
+    Success: 100
 LgVendorPurchaseState:
-  NotOwned: 0
-  Owned: 1
+  values:
+    NotOwned: 0
+    Owned: 1
 LightRadiusIndicatorType:
-  Always: 0
-  Never: 2
-  Overlap: 1
+  values:
+    Always: 0
+    Never: 2
+    Overlap: 1
 LimitedInputType:
-  MouseDown: 1
-  MouseMove: 0
-  MouseUp: 2
-  MouseWheel: 3
+  values:
+    MouseDown: 1
+    MouseMove: 0
+    MouseUp: 2
+    MouseWheel: 3
 LinkedCurrencyFlags:
-  AddIgnoresMax: 8
-  IgnoreAdd: 1
-  IgnoreSubtract: 2
-  SuppressChatLog: 4
+  values:
+    AddIgnoresMax: 8
+    IgnoreAdd: 1
+    IgnoreSubtract: 2
+    SuppressChatLog: 4
 LogicLogicop:
-  And: 1
-  None: 0
-  Or: 2
-  Xor: 3
+  values:
+    And: 1
+    None: 0
+    Or: 2
+    Xor: 3
 LogicMathop:
-  Div: 4
-  Minus: 2
-  Mod: 5
-  None: 0
-  Plus: 1
-  Times: 3
+  values:
+    Div: 4
+    Minus: 2
+    Mod: 5
+    None: 0
+    Plus: 1
+    Times: 3
 LogicRelop:
-  Equal: 1
-  Gt: 5
-  Gteq: 6
-  Lt: 3
-  Lteq: 4
-  None: 0
-  Notequal: 2
+  values:
+    Equal: 1
+    Gt: 5
+    Gteq: 6
+    Lt: 3
+    Lteq: 4
+    None: 0
+    Notequal: 2
 LogPriority:
-  Debug: 30
-  Error: 2
-  Fatal: 1
-  Normal: 10
-  Spam: 40
-  Warning: 3
+  values:
+    Debug: 30
+    Error: 2
+    Fatal: 1
+    Normal: 10
+    Spam: 40
+    Warning: 3
 LootMethod:
-  Freeforall: 0
-  Group: 3
-  Masterlooter: 2
-  Needbeforegreed: 4
-  Personal: 5
-  Roundrobin: 1
+  values:
+    Freeforall: 0
+    Group: 3
+    Masterlooter: 2
+    Needbeforegreed: 4
+    Personal: 5
+    Roundrobin: 1
 LootMethodStyles:
-  Mainline: 0
-  Vanilla: 1
+  values:
+    Mainline: 0
+    Vanilla: 1
 LootSlotType:
-  Currency: 3
-  Item: 1
-  Money: 2
-  None: 0
+  values:
+    Currency: 3
+    Item: 1
+    Money: 2
+    None: 0
 LuaCurveType:
-  Cosine: 2
-  Cubic: 3
-  Linear: 0
-  Step: 1
+  values:
+    Cosine: 2
+    Cubic: 3
+    Linear: 0
+    Step: 1
 ManipulatorEventType:
-  Complete: 2
-  Delete: 3
-  Move: 1
-  Start: 0
+  values:
+    Complete: 2
+    Delete: 3
+    Move: 1
+    Start: 0
 MapCanvasPosition:
-  BottomLeft: 1
-  BottomRight: 2
-  None: 0
-  TopLeft: 3
-  TopRight: 4
+  values:
+    BottomLeft: 1
+    BottomRight: 2
+    None: 0
+    TopLeft: 3
+    TopRight: 4
 MapIconUIWidgetSetType:
-  AdventureMapDetails: 2
-  BehindIcon: 1
-  Tooltip: 0
+  values:
+    AdventureMapDetails: 2
+    BehindIcon: 1
+    Tooltip: 0
 MapobjEventTypes:
-  PlayAnim: 0
-  SetAnimSpeed: 1
+  values:
+    PlayAnim: 0
+    SetAnimSpeed: 1
 MapPinAnimationType:
-  None: 0
-  Pulse: 1
+  values:
+    None: 0
+    Pulse: 1
 MatchDetailType:
-  Kills: 1
-  Placement: 0
-  PlunderAcquired: 2
+  values:
+    Kills: 1
+    Placement: 0
+    PlunderAcquired: 2
 MicroMenuOrder:
-  Default: 0
-  Reverse: 1
+  values:
+    Default: 0
+    Reverse: 1
 MicroMenuOrientation:
-  Horizontal: 0
-  Vertical: 1
+  values:
+    Horizontal: 0
+    Vertical: 1
 MinimapTrackingFilter:
-  AccountBanker: 4194304
-  AccountCompletedQuests: 2097152
-  Auctioneer: 1
-  Banker: 2
-  Battlemaster: 4
-  Digsites: 131072
-  Focus: 32768
-  Innkeeper: 32
-  Mailbox: 64
-  POI: 8192
-  QuestPOIs: 65536
-  Repair: 512
-  Stablemaster: 2048
-  Target: 16384
-  TaxiNode: 8
-  TrainerClass: 262144
-  TrainerProfession: 128
-  Transmogrifier: 4096
-  TrivialQuests: 1024
-  Unfiltered: 0
-  VenderFood: 16
-  VendorAmmo: 524288
-  VendorPoison: 1048576
-  VendorReagent: 256
+  values:
+    AccountBanker: 4194304
+    AccountCompletedQuests: 2097152
+    Auctioneer: 1
+    Banker: 2
+    Battlemaster: 4
+    Digsites: 131072
+    Focus: 32768
+    Innkeeper: 32
+    Mailbox: 64
+    POI: 8192
+    QuestPOIs: 65536
+    Repair: 512
+    Stablemaster: 2048
+    Target: 16384
+    TaxiNode: 8
+    TrainerClass: 262144
+    TrainerProfession: 128
+    Transmogrifier: 4096
+    TrivialQuests: 1024
+    Unfiltered: 0
+    VenderFood: 16
+    VendorAmmo: 524288
+    VendorPoison: 1048576
+    VendorReagent: 256
 ModelBlendOperation:
-  Anim: 1
-  None: 0
+  values:
+    Anim: 1
+    None: 0
 ModelLightType:
-  Directional: 0
-  Point: 1
+  values:
+    Directional: 0
+    Point: 1
 ModelSceneSetting:
-  AlignLightToOrbitDelta: 1
+  values:
+    AlignLightToOrbitDelta: 1
 ModelSceneType:
-  ArtifactRelicTalentEffect: 9
-  ArtifactTier2: 5
-  ArtifactTier2ForgingScene: 6
-  ArtifactTier2SlamEffect: 7
-  AzeriteItemLevelUpToast: 13
-  AzeritePowers: 14
-  AzeriteRewardGlow: 15
-  CommentatorVictoryFanfare: 8
-  EncounterJournal: 3
-  MountJournal: 0
-  PartyPose: 12
-  PetJournalCard: 1
-  PetJournalLoadout: 4
-  PvPWarModeFire: 11
-  PvPWarModeOrb: 10
-  ShopCard: 2
+  values:
+    ArtifactRelicTalentEffect: 9
+    ArtifactTier2: 5
+    ArtifactTier2ForgingScene: 6
+    ArtifactTier2SlamEffect: 7
+    AzeriteItemLevelUpToast: 13
+    AzeritePowers: 14
+    AzeriteRewardGlow: 15
+    CommentatorVictoryFanfare: 8
+    EncounterJournal: 3
+    MountJournal: 0
+    PartyPose: 12
+    PetJournalCard: 1
+    PetJournalLoadout: 4
+    PvPWarModeFire: 11
+    PvPWarModeOrb: 10
+    ShopCard: 2
 ModelSoundOverrideType:
-  Mute: 2
-  UseOverride: 1
-  UseParent: 0
+  values:
+    Mute: 2
+    UseOverride: 1
+    UseParent: 0
 ModelSoundTagType:
-  Looping: 2
-  Oneshot: 1
+  values:
+    Looping: 2
+    Oneshot: 1
 MountType:
-  Aquatic: 2
-  Dragonriding: 3
-  Flying: 1
-  Ground: 0
-  RideAlong: 4
+  values:
+    Aquatic: 2
+    Dragonriding: 3
+    Flying: 1
+    Ground: 0
+    RideAlong: 4
 MountTypeFlag:
-  IsAquaticMount: 2
-  IsDragonRidingMount: 4
-  IsFlyingMount: 1
-  IsRideAlongMount: 8
+  values:
+    IsAquaticMount: 2
+    IsDragonRidingMount: 4
+    IsFlyingMount: 1
+    IsRideAlongMount: 8
 NamePlateCastBarDisplay:
-  HighlightImportantCasts: 4
-  HighlightWhenCastTarget: 5
-  None: 0
-  SpellIcon: 2
-  SpellName: 1
-  SpellTarget: 3
+  values:
+    HighlightImportantCasts: 4
+    HighlightWhenCastTarget: 5
+    None: 0
+    SpellIcon: 2
+    SpellName: 1
+    SpellTarget: 3
 NamePlateEnemyNpcAuraDisplay:
-  Buffs: 1
-  CrowdControl: 3
-  Debuffs: 2
-  None: 0
+  values:
+    Buffs: 1
+    CrowdControl: 3
+    Debuffs: 2
+    None: 0
 NamePlateEnemyPlayerAuraDisplay:
-  Buffs: 1
-  Debuffs: 2
-  LossOfControl: 3
-  None: 0
+  values:
+    Buffs: 1
+    Debuffs: 2
+    LossOfControl: 3
+    None: 0
 NamePlateFriendlyPlayerAuraDisplay:
-  Buffs: 1
-  Debuffs: 2
-  LossOfControl: 3
-  None: 0
+  values:
+    Buffs: 1
+    Debuffs: 2
+    LossOfControl: 3
+    None: 0
 NamePlateInfoDisplay:
-  CurrentHealthPercent: 1
-  CurrentHealthValue: 2
-  None: 0
-  RarityIcon: 3
+  values:
+    CurrentHealthPercent: 1
+    CurrentHealthValue: 2
+    None: 0
+    RarityIcon: 3
 NamePlateSimplifiedType:
-  FriendlyNpc: 4
-  FriendlyPlayer: 3
-  Minion: 1
-  MinusMob: 2
-  None: 0
+  values:
+    FriendlyNpc: 4
+    FriendlyPlayer: 3
+    Minion: 1
+    MinusMob: 2
+    None: 0
 NamePlateSize:
-  ExtraLarge: 4
-  Huge: 5
-  Large: 3
-  Medium: 2
-  Small: 1
+  values:
+    ExtraLarge: 4
+    Huge: 5
+    Large: 3
+    Medium: 2
+    Small: 1
 NamePlateStackType:
-  Enemy: 1
-  Friendly: 2
-  None: 0
+  values:
+    Enemy: 1
+    Friendly: 2
+    None: 0
 NamePlateStyle:
-  Block: 2
-  CastFocus: 4
-  Classic: 6
-  HealthFocus: 3
-  Legacy: 5
-  Modern: 0
-  Thin: 1
+  values:
+    Block: 2
+    CastFocus: 4
+    Classic: 6
+    HealthFocus: 3
+    Legacy: 5
+    Modern: 0
+    Thin: 1
 NamePlateThreatDisplay:
-  Flash: 2
-  HealthBarColor: 3
-  None: 0
-  Progressive: 1
+  values:
+    Flash: 2
+    HealthBarColor: 3
+    None: 0
+    Progressive: 1
 NamePlateType:
-  Enemy: 1
-  Friendly: 0
+  values:
+    Enemy: 1
+    Friendly: 0
 NeighborhoodFlags:
-  None: 0
-  OpenToPublic: 2
-  PoolParent: 1
+  values:
+    None: 0
+    OpenToPublic: 2
+    PoolParent: 1
 NeighborhoodInitiativeChestResult:
-  NiNoHouseFound: 2
-  NiNoRewards: 3
-  NiServiceDisabled: 5
-  NiSuccess: 0
-  NiThrottled: 4
-  NiUnspecifiedFailure: 1
+  values:
+    NiNoHouseFound: 2
+    NiNoRewards: 3
+    NiServiceDisabled: 5
+    NiSuccess: 0
+    NiThrottled: 4
+    NiUnspecifiedFailure: 1
 NeighborhoodInitiativeFlags:
-  Disabled: 1
-  NoAbandon: 2
-  NoRepeat: 4
+  values:
+    Disabled: 1
+    NoAbandon: 2
+    NoRepeat: 4
 NeighborhoodInitiativeNeighborhoodTypes:
-  NiNeighborhoodTypePool: 1
-  NiNeighborhoodTypeSingleton: 0
+  values:
+    NiNeighborhoodTypePool: 1
+    NiNeighborhoodTypeSingleton: 0
 NeighborhoodInitiativesCompletionStates:
-  NiCompletionStateNotCompleted: 0
-  NiCompletionStatePlayerCompleted: 1
-  NiCompletionStateSystemAbandoned: 2
+  values:
+    NiCompletionStateNotCompleted: 0
+    NiCompletionStatePlayerCompleted: 1
+    NiCompletionStateSystemAbandoned: 2
 NeighborhoodInitiativeTaskType:
-  RepeatableFinite: 1
-  RepeatableInfinite: 2
-  Single: 0
+  values:
+    RepeatableFinite: 1
+    RepeatableInfinite: 2
+    Single: 0
 NeighborhoodInitiativeUpdateStatus:
-  Completed: 2
-  Failed: 3
-  MilestoneCompleted: 1
-  Started: 0
+  values:
+    Completed: 2
+    Failed: 3
+    MilestoneCompleted: 1
+    Started: 0
 NeighborhoodInviteResult:
-  AlreadyInNeighborhood: 11
-  DbError: 1
-  Faction: 5
-  GenericFailure: 3
-  InviteLimit: 7
-  NotEnoughPlots: 8
-  NotFound: 9
-  PendingInvitation: 6
-  Permission: 4
-  RpcFailure: 2
-  Success: 0
-  TooManyRequests: 10
+  values:
+    AlreadyInNeighborhood: 11
+    DbError: 1
+    Faction: 5
+    GenericFailure: 3
+    InviteLimit: 7
+    NotEnoughPlots: 8
+    NotFound: 9
+    PendingInvitation: 6
+    Permission: 4
+    RpcFailure: 2
+    Success: 0
+    TooManyRequests: 10
 NeighborhoodMapFlags:
-  AlliancePurchasable: 1
-  CanSystemGenerate: 4
-  HordePurchasable: 2
-  None: 0
+  values:
+    AlliancePurchasable: 1
+    CanSystemGenerate: 4
+    HordePurchasable: 2
+    None: 0
 NeighborhoodOwnerType:
-  Charter: 2
-  Guild: 1
-  None: 0
+  values:
+    Charter: 2
+    Guild: 1
+    None: 0
 NeighborhoodType:
-  Open: 0
-  Private: 1
-  Public: 2
+  values:
+    Open: 0
+    Private: 1
+    Public: 2
 NewCharGear:
-  Preview: 1
-  Start: 0
+  values:
+    Preview: 1
+    Start: 0
 NodeOpFailureReason:
-  AccountDataNoMatch: 25
-  DataError: 13
-  EntryNotFound: 19
-  HasMutuallyExclusiveEdge: 4
-  LevelTooLow: 22
-  MaxRank: 12
-  MissingAchievement: 8
-  MissingEdgeConnection: 1
-  MissingQuest: 9
-  MissingRequiredEdge: 3
-  NodeNeverPurchasable: 24
-  NodeNotFound: 18
-  None: 0
-  NotEnoughCurrency: 15
-  NotEnoughCurrencySpent: 6
-  NotEnoughGold: 16
-  NotEnoughGoldSpent: 7
-  NotEnoughRanksInEntry: 26
-  NotEnoughSourcedCurrency: 14
-  NotEnoughSourcedCurrencySpent: 5
-  RequiredForCondition: 20
-  RequiredForEdge: 2
-  SameSelection: 17
-  TreeFlaggedNoRefund: 23
-  WrongSelection: 11
-  WrongSpec: 10
-  WrongTreeID: 21
+  values:
+    AccountDataNoMatch: 25
+    DataError: 13
+    EntryNotFound: 19
+    HasMutuallyExclusiveEdge: 4
+    LevelTooLow: 22
+    MaxRank: 12
+    MissingAchievement: 8
+    MissingEdgeConnection: 1
+    MissingQuest: 9
+    MissingRequiredEdge: 3
+    NodeNeverPurchasable: 24
+    NodeNotFound: 18
+    None: 0
+    NotEnoughCurrency: 15
+    NotEnoughCurrencySpent: 6
+    NotEnoughGold: 16
+    NotEnoughGoldSpent: 7
+    NotEnoughRanksInEntry: 26
+    NotEnoughSourcedCurrency: 14
+    NotEnoughSourcedCurrencySpent: 5
+    RequiredForCondition: 20
+    RequiredForEdge: 2
+    SameSelection: 17
+    TreeFlaggedNoRefund: 23
+    WrongSelection: 11
+    WrongSpec: 10
+    WrongTreeID: 21
 NoRPEReason:
-  BNetToken: 8
-  FactionOrRaceChange: 7
-  HasRPE: 0
-  IneligibleMap: 3
-  LowLevel: 1
-  PlayerLocked: 9
-  RecentlyActive: 4
-  RecentlyBoosted: 5
-  Timerunner: 2
-  UpgradeInProgress: 6
+  values:
+    BNetToken: 8
+    FactionOrRaceChange: 7
+    HasRPE: 0
+    IneligibleMap: 3
+    LowLevel: 1
+    PlayerLocked: 9
+    RecentlyActive: 4
+    RecentlyBoosted: 5
+    Timerunner: 2
+    UpgradeInProgress: 6
 NpcCraftingOrderSetFlags:
-  AllowDuplicate: 2
-  AllowMultiple: 1
+  values:
+    AllowDuplicate: 2
+    AllowMultiple: 1
 NumericRuleFormatRounding:
-  Down: 2
-  Nearest: 0
-  Up: 1
+  values:
+    Down: 2
+    Nearest: 0
+    Up: 1
 PartyPlaylistEntry:
-  DuoGameMode: 1
-  SoloGameMode: 0
-  TrainingGameMode: 3
-  TrioGameMode: 2
+  values:
+    DuoGameMode: 1
+    SoloGameMode: 0
+    TrainingGameMode: 3
+    TrioGameMode: 2
 PartyPoseFlags:
-  HideLeaveInstanceButton: 1
+  values:
+    HideLeaveInstanceButton: 1
 PartyRequestJoinRelation:
-  Club: 3
-  Friend: 1
-  Guild: 2
-  None: 0
-  RecentAllies: 4
+  values:
+    Club: 3
+    Friend: 1
+    Guild: 2
+    None: 0
+    RecentAllies: 4
 PerksVendorCategoryType:
-  Achievement: 23
-  Activity: 21
-  GmAdjustment: 22
-  Illusion: 7
-  Mount: 2
-  Pet: 3
-  RefundUnused: 24
-  Stipend: 20
-  Toy: 5
-  Transmog: 1
-  Transmogset: 8
-  WarbandScene: 9
+  values:
+    Achievement: 23
+    Activity: 21
+    GmAdjustment: 22
+    Illusion: 7
+    Mount: 2
+    Pet: 3
+    RefundUnused: 24
+    Stipend: 20
+    Toy: 5
+    Transmog: 1
+    Transmogset: 8
+    WarbandScene: 9
 PermanentChatChannelType:
-  Communities: 2
-  Custom: 3
-  None: 0
-  Zone: 1
+  values:
+    Communities: 2
+    Custom: 3
+    None: 0
+    Zone: 1
 PersonalResourceDisplayVisibleSetting:
-  Always: 0
-  Hidden: 2
-  InCombat: 1
+  values:
+    Always: 0
+    Hidden: 2
+    InCombat: 1
 PetActionbuttonType:
-  Max: 18
-  Mode: 6
-  None: 0
-  Orders: 7
-  Slot1: 8
-  Slot10: 17
-  Slot1Obsolete: 2
-  Slot2: 9
-  Slot2Obsolete: 3
-  Slot3: 10
-  Slot3Obsolete: 4
-  Slot4: 11
-  Slot4Obsolete: 5
-  Slot5: 12
-  Slot6: 13
-  Slot7: 14
-  Slot8: 15
-  Slot9: 16
-  Spell: 1
-  VehicleAction: 19
+  values:
+    Max: 18
+    Mode: 6
+    None: 0
+    Orders: 7
+    Slot1: 8
+    Slot10: 17
+    Slot1Obsolete: 2
+    Slot2: 9
+    Slot2Obsolete: 3
+    Slot3: 10
+    Slot3Obsolete: 4
+    Slot4: 11
+    Slot4Obsolete: 5
+    Slot5: 12
+    Slot6: 13
+    Slot7: 14
+    Slot8: 15
+    Slot9: 16
+    Spell: 1
+    VehicleAction: 19
 PetActionFeedback:
-  Dead: 1
-  FriendlyTarget: 3
-  InvalidTarget: 2
-  NoPath: 4
-  Success: 0
+  values:
+    Dead: 1
+    FriendlyTarget: 3
+    InvalidTarget: 2
+    NoPath: 4
+    Success: 0
 PetBattleQueueStatus:
-  AlreadyQueued: 3
-  InBattle: 20
-  JoinFailed: 4
-  JoinFailedJournalLock: 6
-  JoinFailedNeutral: 7
-  JoinFailedSlots: 5
-  LostConnection: 16
-  MatchAccepted: 8
-  MatchDeclined: 9
-  Matchmaking: 15
-  MatchOpponentDeclined: 10
-  NoBattlingHere: 21
-  None: 0
-  ProposalTimedOut: 11
-  Queued: 1
-  QueuedUpdate: 2
-  Removed: 12
-  RequeuedAfterInternalError: 13
-  RequeuedAfterOpponentRemoved: 14
-  Shutdown: 17
-  Suspended: 18
-  Unsuspended: 19
+  values:
+    AlreadyQueued: 3
+    InBattle: 20
+    JoinFailed: 4
+    JoinFailedJournalLock: 6
+    JoinFailedNeutral: 7
+    JoinFailedSlots: 5
+    LostConnection: 16
+    MatchAccepted: 8
+    MatchDeclined: 9
+    Matchmaking: 15
+    MatchOpponentDeclined: 10
+    NoBattlingHere: 21
+    None: 0
+    ProposalTimedOut: 11
+    Queued: 1
+    QueuedUpdate: 2
+    Removed: 12
+    RequeuedAfterInternalError: 13
+    RequeuedAfterOpponentRemoved: 14
+    Shutdown: 17
+    Suspended: 18
+    Unsuspended: 19
 PetbattleSlot:
-  Slot_0: 0
-  Slot_1: 1
-  Slot_2: 2
+  values:
+    Slot_0: 0
+    Slot_1: 1
+    Slot_2: 2
 PetbattleState:
-  Created: 0
-  CreatedFailed: 4
-  FinalRound: 5
-  Finished: 6
-  RoundInProgress: 2
-  WaitingForFrontPets: 3
-  WaitingPreBattle: 1
+  values:
+    Created: 0
+    CreatedFailed: 4
+    FinalRound: 5
+    Finished: 6
+    RoundInProgress: 2
+    WaitingForFrontPets: 3
+    WaitingPreBattle: 1
 PetJournalError:
-  InvalidFaction: 3
-  JournalIsLocked: 2
-  NoFavoritesToSummon: 4
-  None: 0
-  NoValidRandomSummon: 5
-  PetIsDead: 1
+  values:
+    InvalidFaction: 3
+    JournalIsLocked: 2
+    NoFavoritesToSummon: 4
+    None: 0
+    NoValidRandomSummon: 5
+    PetIsDead: 1
 PetMode:
-  Aggressive: 2
-  Assist: 3
-  Defensive: 1
-  Passive: 0
+  values:
+    Aggressive: 2
+    Assist: 3
+    Defensive: 1
+    Passive: 0
 PetOrders:
-  Attack: 2
-  Dismiss: 3
-  Follow: 1
-  MoveTo: 4
-  Wait: 0
+  values:
+    Attack: 2
+    Dismiss: 3
+    Follow: 1
+    MoveTo: 4
+    Wait: 0
 PetOverride:
-  AICombatControl: 1
-  AICombatPassive: 2
-  None: 0
-  OwnerMounted: 4
+  values:
+    AICombatControl: 1
+    AICombatPassive: 2
+    None: 0
+    OwnerMounted: 4
 Pettameresult:
-  Anothersummonactive: 5
-  Cantcontrolexotic: 12
-  Creaturealreadyowned: 3
-  Dead: 10
-  EliteToohighlevel: 14
-  Internalerror: 8
-  Invalidcreature: 1
-  Invalidslot: 13
-  Nopetavailable: 7
-  Notdead: 11
-  Nottameable: 4
-  Numresults: 15
-  Ok: 0
-  Toohighlevel: 9
-  Toomany: 2
-  Unitscanttame: 6
+  values:
+    Anothersummonactive: 5
+    Cantcontrolexotic: 12
+    Creaturealreadyowned: 3
+    Dead: 10
+    EliteToohighlevel: 14
+    Internalerror: 8
+    Invalidcreature: 1
+    Invalidslot: 13
+    Nopetavailable: 7
+    Notdead: 11
+    Nottameable: 4
+    Numresults: 15
+    Ok: 0
+    Toohighlevel: 9
+    Toomany: 2
+    Unitscanttame: 6
 PhaseReason:
-  ChromieTime: 3
-  Phasing: 0
-  Sharding: 1
-  TimerunningHwt: 4
-  WarMode: 2
+  values:
+    ChromieTime: 3
+    Phasing: 0
+    Sharding: 1
+    TimerunningHwt: 4
+    WarMode: 2
 PhotoSharingStatus:
-  AADCRestricted: 6
-  Configured: 2
-  Disabled: 0
-  Error: 7
-  Expired: 3
-  FailedToClear: 8
-  NotConfigured: 1
-  ParentalControl: 4
-  TrialOrVeteran: 5
+  values:
+    AADCRestricted: 6
+    Configured: 2
+    Disabled: 0
+    Error: 7
+    Expired: 3
+    FailedToClear: 8
+    NotConfigured: 1
+    ParentalControl: 4
+    TrialOrVeteran: 5
 PhotoSharingUploadStatus:
-  CreatePageApiCallFailed: 13
-  CreatePageBadRequest: 14
-  CreatePageForbidden: 16
-  CreatePageGenericFailure: 19
-  CreatePageNoBoardIDFound: 20
-  CreatePageNotFound: 17
-  CreatePageTooManyRequests: 18
-  CreatePageUnauthorized: 15
-  CreatePostApiCallFailed: 21
-  CreatePostBadRequest: 22
-  CreatePostForbidden: 24
-  CreatePostGenericFailure: 27
-  CreatePostNoIDFound: 28
-  CreatePostNotFound: 25
-  CreatePostThrottled: 29
-  CreatePostTooManyRequests: 26
-  CreatePostUnauthorized: 23
-  Disabled: 0
-  Failed: 1
-  ListPagesApiCallFailed: 4
-  ListPagesBadRequest: 5
-  ListPagesEmptyBoardID: 11
-  ListPagesForbidden: 7
-  ListPagesGenericFailure: 10
-  ListPagesInvalidBookmark: 12
-  ListPagesNotFound: 8
-  ListPagesTooManyRequests: 9
-  ListPagesUnauthorized: 6
-  Locked: 3
-  Success: 2
+  values:
+    CreatePageApiCallFailed: 13
+    CreatePageBadRequest: 14
+    CreatePageForbidden: 16
+    CreatePageGenericFailure: 19
+    CreatePageNoBoardIDFound: 20
+    CreatePageNotFound: 17
+    CreatePageTooManyRequests: 18
+    CreatePageUnauthorized: 15
+    CreatePostApiCallFailed: 21
+    CreatePostBadRequest: 22
+    CreatePostForbidden: 24
+    CreatePostGenericFailure: 27
+    CreatePostNoIDFound: 28
+    CreatePostNotFound: 25
+    CreatePostThrottled: 29
+    CreatePostTooManyRequests: 26
+    CreatePostUnauthorized: 23
+    Disabled: 0
+    Failed: 1
+    ListPagesApiCallFailed: 4
+    ListPagesBadRequest: 5
+    ListPagesEmptyBoardID: 11
+    ListPagesForbidden: 7
+    ListPagesGenericFailure: 10
+    ListPagesInvalidBookmark: 12
+    ListPagesNotFound: 8
+    ListPagesTooManyRequests: 9
+    ListPagesUnauthorized: 6
+    Locked: 3
+    Success: 2
 PingSubjectType:
-  AlertNotThreat: 5
-  AlertThreat: 4
-  Assist: 2
-  Attack: 0
-  OnMyWay: 3
-  Warning: 1
+  values:
+    AlertNotThreat: 5
+    AlertThreat: 4
+    Assist: 2
+    Attack: 0
+    OnMyWay: 3
+    Warning: 1
 PingTextureType:
-  Center: 0
-  Expand: 1
-  Rotation: 2
+  values:
+    Center: 0
+    Expand: 1
+    Rotation: 2
 PingTypeFlags:
-  DefaultPing: 1
+  values:
+    DefaultPing: 1
 PlayerClubRequestStatus:
-  Approved: 4
-  AutoApproved: 2
-  Canceled: 7
-  Declined: 3
-  Joined: 5
-  JoinedAnother: 6
-  None: 0
-  Pending: 1
+  values:
+    Approved: 4
+    AutoApproved: 2
+    Canceled: 7
+    Declined: 3
+    Joined: 5
+    JoinedAnother: 6
+    None: 0
+    Pending: 1
 PlayerCompanionInfoFlags:
-  IgnoreSeasonInScenarios: 1
+  values:
+    IgnoreSeasonInScenarios: 1
 PlayerCurrencyFlags:
-  Incremented: 1
-  Loading: 2
+  values:
+    Incremented: 1
+    Loading: 2
 PlayerCurrencyFlagsDbFlags:
-  IgnoreMaxQtyOnload: 1
-  InBackpack: 4
-  Reuse1: 2
-  Reuse2: 16
-  UnusedInUI: 8
+  values:
+    IgnoreMaxQtyOnload: 1
+    InBackpack: 4
+    Reuse1: 2
+    Reuse2: 16
+    UnusedInUI: 8
 PlayerDataElementType:
-  Float: 1
-  Int: 0
+  values:
+    Float: 1
+    Int: 0
 PlayerInteractionType:
-  AccountBanker: 68
-  AdventureJournal: 54
-  AdventureMap: 28
-  AlliedRaceDetailsGiver: 9
-  AnimaDiversion: 47
-  AreaSpiritHealer: 19
-  ArtifactForge: 38
-  Auctioneer: 21
-  AzeriteForge: 56
-  AzeriteRespec: 42
-  Banker: 8
-  BarbersChoice: 62
-  BattleMaster: 23
-  Binder: 20
-  BlackMarketAuctioneer: 27
-  CharacterBanker: 67
-  ChromieTime: 45
-  ContributionCollector: 41
-  CornerstoneInteraction: 70
-  CovenantPreview: 46
-  CovenantSanctum: 51
-  CreateGuildNeighborhood: 74
-  ForgeMaster: 66
-  GarrArchitect: 30
-  GarrMission: 32
-  GarrRecruitment: 34
-  GarrTalent: 35
-  GarrTradeskill: 31
-  Gossip: 3
-  GuildBanker: 10
-  GuildRename: 76
-  GuildTabardVendor: 14
-  HousingBulletinBoard: 72
-  HousingPedestal: 73
-  IslandQueue: 43
-  Item: 2
-  ItemInteraction: 44
-  ItemUpgrade: 53
-  JailersTowerBuffs: 63
-  LegendaryCrafting: 48
-  LFGDungeon: 25
-  MailInfo: 17
-  MajorFactionRenown: 64
-  Merchant: 5
-  NeighborhoodCharter: 75
-  NewPlayerGuide: 52
-  None: 0
-  ObliterumForge: 39
-  OpenHouseFinder: 78
-  OpenNeighborhoodCharterConfirmation: 77
-  PerksProgramVendor: 57
-  PersonalTabardVendor: 65
-  PetitionVendor: 13
-  PlayerChoice: 37
-  ProfessionRespec: 69
-  Professions: 59
-  ProfessionsCraftingOrder: 58
-  ProfessionsCustomerOrder: 60
-  QuestGiver: 4
-  Registrar: 11
-  RenameNeighborhood: 71
-  Renown: 55
-  ScrappingMachine: 40
-  ShipmentCrafter: 33
-  Soulbind: 50
-  SpecializationMaster: 16
-  SpiritHealer: 18
-  StableMaster: 22
-  TalentMaster: 15
-  TaxiNode: 6
-  TieredEntrance: 79
-  TradePartner: 1
-  Trainer: 7
-  TraitSystem: 61
-  Transmogrifier: 24
-  Trophy: 36
-  Vendor: 12
-  VoidStorageBanker: 26
-  WeeklyRewards: 49
-  WorldMap: 29
+  values:
+    AccountBanker: 68
+    AdventureJournal: 54
+    AdventureMap: 28
+    AlliedRaceDetailsGiver: 9
+    AnimaDiversion: 47
+    AreaSpiritHealer: 19
+    ArtifactForge: 38
+    Auctioneer: 21
+    AzeriteForge: 56
+    AzeriteRespec: 42
+    Banker: 8
+    BarbersChoice: 62
+    BattleMaster: 23
+    Binder: 20
+    BlackMarketAuctioneer: 27
+    CharacterBanker: 67
+    ChromieTime: 45
+    ContributionCollector: 41
+    CornerstoneInteraction: 70
+    CovenantPreview: 46
+    CovenantSanctum: 51
+    CreateGuildNeighborhood: 74
+    ForgeMaster: 66
+    GarrArchitect: 30
+    GarrMission: 32
+    GarrRecruitment: 34
+    GarrTalent: 35
+    GarrTradeskill: 31
+    Gossip: 3
+    GuildBanker: 10
+    GuildRename: 76
+    GuildTabardVendor: 14
+    HousingBulletinBoard: 72
+    HousingPedestal: 73
+    IslandQueue: 43
+    Item: 2
+    ItemInteraction: 44
+    ItemUpgrade: 53
+    JailersTowerBuffs: 63
+    LegendaryCrafting: 48
+    LFGDungeon: 25
+    MailInfo: 17
+    MajorFactionRenown: 64
+    Merchant: 5
+    NeighborhoodCharter: 75
+    NewPlayerGuide: 52
+    None: 0
+    ObliterumForge: 39
+    OpenHouseFinder: 78
+    OpenNeighborhoodCharterConfirmation: 77
+    PerksProgramVendor: 57
+    PersonalTabardVendor: 65
+    PetitionVendor: 13
+    PlayerChoice: 37
+    ProfessionRespec: 69
+    Professions: 59
+    ProfessionsCraftingOrder: 58
+    ProfessionsCustomerOrder: 60
+    QuestGiver: 4
+    Registrar: 11
+    RenameNeighborhood: 71
+    Renown: 55
+    ScrappingMachine: 40
+    ShipmentCrafter: 33
+    Soulbind: 50
+    SpecializationMaster: 16
+    SpiritHealer: 18
+    StableMaster: 22
+    TalentMaster: 15
+    TaxiNode: 6
+    TieredEntrance: 79
+    TradePartner: 1
+    Trainer: 7
+    TraitSystem: 61
+    Transmogrifier: 24
+    Trophy: 36
+    Vendor: 12
+    VoidStorageBanker: 26
+    WeeklyRewards: 49
+    WorldMap: 29
 PlayerMentorshipApplicationResult:
-  AlreadyMentor: 1
-  Ineligible: 2
-  Success: 0
+  values:
+    AlreadyMentor: 1
+    Ineligible: 2
+    Success: 0
 PlayerMentorshipStatus:
-  Mentor: 2
-  Newcomer: 1
-  None: 0
+  values:
+    Mentor: 2
+    Newcomer: 1
+    None: 0
 PlunderstormQueueState:
-  None: 0
-  Proposed: 2
-  Queued: 1
-  Suspended: 3
+  values:
+    None: 0
+    Proposed: 2
+    Queued: 1
+    Suspended: 3
 PowerType:
-  Alternate: 10
-  AlternateEncounter: 24
-  AlternateMount: 25
-  AlternateQuest: 23
-  ArcaneCharges: 16
-  Balance: 26
-  BurningEmbers: 14
-  Chi: 12
-  ComboPoints: 4
-  DemonicFury: 15
-  Energy: 3
-  Essence: 19
-  Focus: 2
-  Fury: 17
-  Happiness: 27
-  HolyPower: 9
-  Insanity: 13
-  LunarPower: 8
-  Maelstrom: 11
-  Mana: 0
-  Pain: 18
-  Rage: 1
-  RuneBlood: 20
-  RuneChromatic: 29
-  RuneFrost: 21
-  Runes: 5
-  RuneUnholy: 22
-  RunicPower: 6
-  ShadowOrbs: 28
-  SoulShards: 7
+  values:
+    Alternate: 10
+    AlternateEncounter: 24
+    AlternateMount: 25
+    AlternateQuest: 23
+    ArcaneCharges: 16
+    Balance: 26
+    BurningEmbers: 14
+    Chi: 12
+    ComboPoints: 4
+    DemonicFury: 15
+    Energy: 3
+    Essence: 19
+    Focus: 2
+    Fury: 17
+    Happiness: 27
+    HolyPower: 9
+    Insanity: 13
+    LunarPower: 8
+    Maelstrom: 11
+    Mana: 0
+    Pain: 18
+    Rage: 1
+    RuneBlood: 20
+    RuneChromatic: 29
+    RuneFrost: 21
+    Runes: 5
+    RuneUnholy: 22
+    RunicPower: 6
+    ShadowOrbs: 28
+    SoulShards: 7
 PowerTypeSign:
-  Negative: 1
-  None: -1
-  Positive: 0
+  values:
+    Negative: 1
+    None: -1
+    Positive: 0
 PowerTypeSlot:
-  Slot_0: 0
-  Slot_1: 1
-  Slot_2: 2
-  Slot_3: 3
-  Slot_4: 4
-  Slot_5: 5
-  Slot_6: 6
-  Slot_7: 7
-  Slot_8: 8
-  Slot_9: 9
+  values:
+    Slot_0: 0
+    Slot_1: 1
+    Slot_2: 2
+    Slot_3: 3
+    Slot_4: 4
+    Slot_5: 5
+    Slot_6: 6
+    Slot_7: 7
+    Slot_8: 8
+    Slot_9: 9
 PremadeGroupFinderStyle:
-  Disabled: 0
-  Mainline: 1
-  Vanilla: 2
+  values:
+    Disabled: 0
+    Mainline: 1
+    Vanilla: 2
 PreyHuntProgressState:
-  Cold: 0
-  Final: 3
-  Hot: 2
-  Warm: 1
+  values:
+    Cold: 0
+    Final: 3
+    Hot: 2
+    Warm: 1
 ProceduralSpawnInteractionMode:
-  Manipulate: 2
-  None: 0
-  Paint: 1
+  values:
+    Manipulate: 2
+    None: 0
+    Paint: 1
 ProceduralSpawnVolumeChunkFlags:
-  AllSubChunksSet: 1
-  None: 0
+  values:
+    AllSubChunksSet: 1
+    None: 0
 Profession:
-  Alchemy: 3
-  Archaeology: 14
-  Blacksmithing: 1
-  Cooking: 5
-  Enchanting: 9
-  Engineering: 8
-  FirstAid: 0
-  Fishing: 10
-  Herbalism: 4
-  Inscription: 13
-  Jewelcrafting: 12
-  Leatherworking: 2
-  Mining: 6
-  Skinning: 11
-  Tailoring: 7
+  values:
+    Alchemy: 3
+    Archaeology: 14
+    Blacksmithing: 1
+    Cooking: 5
+    Enchanting: 9
+    Engineering: 8
+    FirstAid: 0
+    Fishing: 10
+    Herbalism: 4
+    Inscription: 13
+    Jewelcrafting: 12
+    Leatherworking: 2
+    Mining: 6
+    Skinning: 11
+    Tailoring: 7
 ProfessionActionType:
-  Craft: 0
-  Gather: 1
+  values:
+    Craft: 0
+    Gather: 1
 ProfessionEffect:
-  AccumulateRanksByLabel: 25
-  ConcentrationRefund: 30
-  DecreaseDifficulty: 22
-  IncreaseDifficulty: 23
-  ModConcentration: 27
-  ModCraftCritSize: 20
-  ModCraftExtraQuantity: 18
-  ModCraftingSpeed: 14
-  ModCraftReductionQuantity: 21
-  ModDeftness: 12
-  ModFinesse: 11
-  ModGatherExtraQuantity: 19
-  ModIngenuity: 29
-  ModInspiration: 9
-  ModMulticraft: 15
-  ModPerception: 13
-  ModResourcefulness: 10
-  ModSkillGain: 24
-  ModUnused_1: 16
-  ModUnused_2: 17
-  Skill: 0
-  StatCraftingSpeed: 6
-  StatDeftness: 4
-  StatFinesse: 3
-  StatIngenuity: 26
-  StatInspiration: 1
-  StatMulticraft: 7
-  StatPerception: 5
-  StatResourcefulness: 2
-  Tokenizer: 28
-  UnlockReagentSlot: 8
+  values:
+    AccumulateRanksByLabel: 25
+    ConcentrationRefund: 30
+    DecreaseDifficulty: 22
+    IncreaseDifficulty: 23
+    ModConcentration: 27
+    ModCraftCritSize: 20
+    ModCraftExtraQuantity: 18
+    ModCraftingSpeed: 14
+    ModCraftReductionQuantity: 21
+    ModDeftness: 12
+    ModFinesse: 11
+    ModGatherExtraQuantity: 19
+    ModIngenuity: 29
+    ModInspiration: 9
+    ModMulticraft: 15
+    ModPerception: 13
+    ModResourcefulness: 10
+    ModSkillGain: 24
+    ModUnused_1: 16
+    ModUnused_2: 17
+    Skill: 0
+    StatCraftingSpeed: 6
+    StatDeftness: 4
+    StatFinesse: 3
+    StatIngenuity: 26
+    StatInspiration: 1
+    StatMulticraft: 7
+    StatPerception: 5
+    StatResourcefulness: 2
+    Tokenizer: 28
+    UnlockReagentSlot: 8
 ProfessionRating:
-  CraftingSpeed: 5
-  Deftness: 3
-  Finesse: 2
-  Ingenuity: 7
-  Inspiration: 0
-  Multicraft: 6
-  Perception: 4
-  Resourcefulness: 1
-  Unused_2: 8
+  values:
+    CraftingSpeed: 5
+    Deftness: 3
+    Finesse: 2
+    Ingenuity: 7
+    Inspiration: 0
+    Multicraft: 6
+    Perception: 4
+    Resourcefulness: 1
+    Unused_2: 8
 ProfessionRatingType:
-  Craft: 0
-  Gather: 1
+  values:
+    Craft: 0
+    Gather: 1
 PurchaseEligibility:
-  ExpansionTooHigh: 4
-  ExpansionTooLow: 3
-  MissingRequiredDeliverable: 5
-  Ok: 0
-  Owned: 2
-  PartiallyOwned: 1
+  values:
+    ExpansionTooHigh: 4
+    ExpansionTooLow: 3
+    MissingRequiredDeliverable: 5
+    Ok: 0
+    Owned: 2
+    PartiallyOwned: 1
 PurchaseHouseDisabledReason:
-  CharterLockout: 7
-  GuildLockout: 6
-  MaxHouses: 8
-  NoExpansion: 4
-  NoGameTimeRemaining: 9
-  None: 0
-  NotInvited: 3
-  Reserved: 5
-  WrongFaction: 1
-  WrongGuild: 2
+  values:
+    CharterLockout: 7
+    GuildLockout: 6
+    MaxHouses: 8
+    NoExpansion: 4
+    NoGameTimeRemaining: 9
+    None: 0
+    NotInvited: 3
+    Reserved: 5
+    WrongFaction: 1
+    WrongGuild: 2
 PurchaseResult:
-  ErrorAuthorizingPayment: 37
-  ErrorBattlepayDisabled: 14
-  ErrorBattlepayTemporarilyUnavailable: 13
-  ErrorBattlepayTimeoutMopAndRisk: 11
-  ErrorBattlepayTimeoutValidatePurchase: 56
-  ErrorBattlepayTimeoutValidationHash: 62
-  ErrorBlockedByParentalControls: 33
-  ErrorBuyingProductNotAllowedInGlueScreen: 27
-  ErrorBuyingProductNotAllowedInWorld: 32
-  ErrorCharacterUpgradeOperationInProgress: 51
-  ErrorClientCheckoutCanceledOrFailed: 63
-  ErrorClientCheckoutTimeout: 60
-  ErrorClientDeclined: 4
-  ErrorClientDeclinedChallenge: 41
-  ErrorClientGone: 9
-  ErrorClientRestricted: 66
-  ErrorClientTimeout: 3
-  ErrorClientTimeoutChallenge: 40
-  ErrorCommerceServerDisabled: 48
-  ErrorCouldNotGetValidationHash: 64
-  ErrorCurrencyInvalidInRegion: 12
-  ErrorDistributionObjectAlreadyAssigned: 20
-  ErrorDistributionObjectExpansionBlocked: 45
-  ErrorDistributionObjectInvalidChoice: 35
-  ErrorDistributionObjectInvalidTarget: 42
-  ErrorDistributionObjectNotFound: 19
-  ErrorDistributionObjectTrialBlocked: 44
-  ErrorDistributionObjectWrongGameAccount: 65
-  ErrorFailedOldPurchaseFlow: 59
-  ErrorFailedToCreatePurchaseRecord: 5
-  ErrorFailedToGetPurchaseID: 6
-  ErrorFailedToSaveClientCheckoutStatus: 58
-  ErrorFailedToSaveMopAndRiskResponse: 8
-  ErrorFailedToSaveMopAndRiskStatus: 7
-  ErrorFailedToSavePlaceOrderStatus: 10
-  ErrorFailedToSaveRedeemTokenStatus: 67
-  ErrorFailedToSaveValidatePurchaseResponse: 55
-  ErrorFailedToSaveValidatePurchaseStatus: 54
-  ErrorFailedToSaveValidationHashStatus: 61
-  ErrorFailedToWriteVasLicenseID: 50
-  ErrorFailedToWriteVasPurchaseID: 49
-  ErrorFixedLicenseProductAlreadyExists: 43
-  ErrorInManualReview: 71
-  ErrorInvalidCreditCardExpiryDate: 36
-  ErrorInvalidDeviceID: 53
-  ErrorInvalidPlatform: 52
-  ErrorInvalidProduct: 16
-  ErrorInvalidPurchaseID: 68
-  ErrorInvalidRegionGroupMask: 17
-  ErrorMopAndRiskAmqpRpcFailed: 22
-  ErrorMopAndRiskNotEnoughBalance: 28
-  ErrorMopAndRiskNoValidPaymentMethods: 25
-  ErrorMopAndRiskRpcErrorFromBattlepay: 23
-  ErrorMopAndRiskUnexpectedResponseFromBattlepay: 24
-  ErrorNoStorePurchaseFlagIsSet: 34
-  ErrorOrderCanceledPriceChange: 26
-  ErrorOrderFailed: 2
-  ErrorOverSpendingLimit: 39
-  ErrorOwnsConsumableToken: 46
-  ErrorPaymentProviderDeniedPayment: 38
-  ErrorPlaceOrderNotEnoughBalance: 29
-  ErrorProductInvalidInRegion: 18
-  ErrorProductNotPurchasable: 57
-  ErrorProgrammerManualFail: 30
-  ErrorRiskDenied: 1
-  ErrorRiskResponseMissingScore: 21
-  ErrorServerRestarted: 15
-  ErrorThrottledByUserServer: 31
-  ErrorTokenRedemptionOrderFailed: 69
-  ErrorTooManyTokens: 47
-  ErrorVasTransactionCreateFailed: 70
-  Ok: 0
+  values:
+    ErrorAuthorizingPayment: 37
+    ErrorBattlepayDisabled: 14
+    ErrorBattlepayTemporarilyUnavailable: 13
+    ErrorBattlepayTimeoutMopAndRisk: 11
+    ErrorBattlepayTimeoutValidatePurchase: 56
+    ErrorBattlepayTimeoutValidationHash: 62
+    ErrorBlockedByParentalControls: 33
+    ErrorBuyingProductNotAllowedInGlueScreen: 27
+    ErrorBuyingProductNotAllowedInWorld: 32
+    ErrorCharacterUpgradeOperationInProgress: 51
+    ErrorClientCheckoutCanceledOrFailed: 63
+    ErrorClientCheckoutTimeout: 60
+    ErrorClientDeclined: 4
+    ErrorClientDeclinedChallenge: 41
+    ErrorClientGone: 9
+    ErrorClientRestricted: 66
+    ErrorClientTimeout: 3
+    ErrorClientTimeoutChallenge: 40
+    ErrorCommerceServerDisabled: 48
+    ErrorCouldNotGetValidationHash: 64
+    ErrorCurrencyInvalidInRegion: 12
+    ErrorDistributionObjectAlreadyAssigned: 20
+    ErrorDistributionObjectExpansionBlocked: 45
+    ErrorDistributionObjectInvalidChoice: 35
+    ErrorDistributionObjectInvalidTarget: 42
+    ErrorDistributionObjectNotFound: 19
+    ErrorDistributionObjectTrialBlocked: 44
+    ErrorDistributionObjectWrongGameAccount: 65
+    ErrorFailedOldPurchaseFlow: 59
+    ErrorFailedToCreatePurchaseRecord: 5
+    ErrorFailedToGetPurchaseID: 6
+    ErrorFailedToSaveClientCheckoutStatus: 58
+    ErrorFailedToSaveMopAndRiskResponse: 8
+    ErrorFailedToSaveMopAndRiskStatus: 7
+    ErrorFailedToSavePlaceOrderStatus: 10
+    ErrorFailedToSaveRedeemTokenStatus: 67
+    ErrorFailedToSaveValidatePurchaseResponse: 55
+    ErrorFailedToSaveValidatePurchaseStatus: 54
+    ErrorFailedToSaveValidationHashStatus: 61
+    ErrorFailedToWriteVasLicenseID: 50
+    ErrorFailedToWriteVasPurchaseID: 49
+    ErrorFixedLicenseProductAlreadyExists: 43
+    ErrorInManualReview: 71
+    ErrorInvalidCreditCardExpiryDate: 36
+    ErrorInvalidDeviceID: 53
+    ErrorInvalidPlatform: 52
+    ErrorInvalidProduct: 16
+    ErrorInvalidPurchaseID: 68
+    ErrorInvalidRegionGroupMask: 17
+    ErrorMopAndRiskAmqpRpcFailed: 22
+    ErrorMopAndRiskNotEnoughBalance: 28
+    ErrorMopAndRiskNoValidPaymentMethods: 25
+    ErrorMopAndRiskRpcErrorFromBattlepay: 23
+    ErrorMopAndRiskUnexpectedResponseFromBattlepay: 24
+    ErrorNoStorePurchaseFlagIsSet: 34
+    ErrorOrderCanceledPriceChange: 26
+    ErrorOrderFailed: 2
+    ErrorOverSpendingLimit: 39
+    ErrorOwnsConsumableToken: 46
+    ErrorPaymentProviderDeniedPayment: 38
+    ErrorPlaceOrderNotEnoughBalance: 29
+    ErrorProductInvalidInRegion: 18
+    ErrorProductNotPurchasable: 57
+    ErrorProgrammerManualFail: 30
+    ErrorRiskDenied: 1
+    ErrorRiskResponseMissingScore: 21
+    ErrorServerRestarted: 15
+    ErrorThrottledByUserServer: 31
+    ErrorTokenRedemptionOrderFailed: 69
+    ErrorTooManyTokens: 47
+    ErrorVasTransactionCreateFailed: 70
+    Ok: 0
 PvPFaction:
-  Alliance: 1
-  Horde: 0
+  values:
+    Alliance: 1
+    Horde: 0
 PvPMatchmakingType:
-  Arena: 1
-  Battleground: 0
+  values:
+    Arena: 1
+    Battleground: 0
 PvPMatchState:
-  Complete: 5
-  Engaged: 3
-  Inactive: 0
-  PostRound: 4
-  StartUp: 2
-  Waiting: 1
+  values:
+    Complete: 5
+    Engaged: 3
+    Inactive: 0
+    PostRound: 4
+    StartUp: 2
+    Waiting: 1
 PvPRanks:
-  Rank_1: 5
-  Rank_10: 14
-  Rank_11: 15
-  Rank_12: 16
-  Rank_13: 17
-  Rank_14: 18
-  Rank_2: 6
-  Rank_3: 7
-  Rank_4: 8
-  Rank_5: 9
-  Rank_6: 10
-  Rank_7: 11
-  Rank_8: 12
-  Rank_9: 13
-  RankDishonored: 4
-  RankExiled: 3
-  RankNone: 0
-  RankOutlaw: 2
-  RankPariah: 1
+  values:
+    Rank_1: 5
+    Rank_10: 14
+    Rank_11: 15
+    Rank_12: 16
+    Rank_13: 17
+    Rank_14: 18
+    Rank_2: 6
+    Rank_3: 7
+    Rank_4: 8
+    Rank_5: 9
+    Rank_6: 10
+    Rank_7: 11
+    Rank_8: 12
+    Rank_9: 13
+    RankDishonored: 4
+    RankExiled: 3
+    RankNone: 0
+    RankOutlaw: 2
+    RankPariah: 1
 PvPUnitClassification:
-  AssassinAlliance: 6
-  AssassinHorde: 5
-  CartRunnerAlliance: 4
-  CartRunnerHorde: 3
-  FlagCarrierAlliance: 1
-  FlagCarrierHorde: 0
-  FlagCarrierNeutral: 2
-  OrbCarrierBlue: 7
-  OrbCarrierGreen: 8
-  OrbCarrierOrange: 9
-  OrbCarrierPurple: 10
+  values:
+    AssassinAlliance: 6
+    AssassinHorde: 5
+    CartRunnerAlliance: 4
+    CartRunnerHorde: 3
+    FlagCarrierAlliance: 1
+    FlagCarrierHorde: 0
+    FlagCarrierNeutral: 2
+    OrbCarrierBlue: 7
+    OrbCarrierGreen: 8
+    OrbCarrierOrange: 9
+    OrbCarrierPurple: 10
 QuestClassification:
-  BonusObjective: 8
-  Calling: 3
-  Campaign: 2
-  Important: 0
-  Legendary: 1
-  Meta: 4
-  Normal: 7
-  Questline: 6
-  Recurring: 5
-  Threat: 9
-  WorldQuest: 10
+  values:
+    BonusObjective: 8
+    Calling: 3
+    Campaign: 2
+    Important: 0
+    Legendary: 1
+    Meta: 4
+    Normal: 7
+    Questline: 6
+    Recurring: 5
+    Threat: 9
+    WorldQuest: 10
 QuestCompleteSpellType:
-  Ability: 3
-  Aura: 4
-  Companion: 7
-  Follower: 1
-  LegacyBehavior: 0
-  PossibleReward: 11
-  QuestlineReward: 9
-  QuestlineUnlock: 8
-  QuestlineUnlockPart: 10
-  Spell: 5
-  Tradeskill: 2
-  Unlock: 6
+  values:
+    Ability: 3
+    Aura: 4
+    Companion: 7
+    Follower: 1
+    LegacyBehavior: 0
+    PossibleReward: 11
+    QuestlineReward: 9
+    QuestlineUnlock: 8
+    QuestlineUnlockPart: 10
+    Spell: 5
+    Tradeskill: 2
+    Unlock: 6
 QuestFrequency:
-  Daily: 1
-  Default: 0
-  ResetByScheduler: 3
-  Weekly: 2
+  values:
+    Daily: 1
+    Default: 0
+    ResetByScheduler: 3
+    Weekly: 2
 QuestLineFloorLocation:
-  Above: 0
-  Below: 1
-  Same: 2
+  values:
+    Above: 0
+    Below: 1
+    Same: 2
 QuestRepeatability:
-  Daily: 1
-  None: 0
-  Turnin: 3
-  Weekly: 2
-  World: 4
+  values:
+    Daily: 1
+    None: 0
+    Turnin: 3
+    Weekly: 2
+    World: 4
 QuestRewardContextFlags:
-  FirstCompletionBonus: 1
-  None: 0
-  RepeatCompletionBonus: 2
+  values:
+    FirstCompletionBonus: 1
+    None: 0
+    RepeatCompletionBonus: 2
 QuestSessionCommand:
-  None: 0
-  SessionActiveNoCommand: 3
-  Start: 1
-  Stop: 2
+  values:
+    None: 0
+    SessionActiveNoCommand: 3
+    Start: 1
+    Stop: 2
 QuestSessionResult:
-  AlreadyActive: 3
-  AlreadyJoined: 20
-  AlreadyMember: 17
-  AlreadyOwner: 19
-  Busy: 22
-  Disabled: 8
-  Empty: 25
-  InCombat: 32
-  InPetBattle: 29
-  InRaid: 5
-  InvalidOwner: 2
-  InvalidPublicParty: 30
-  Joined: 11
-  JoinRejected: 23
-  Left: 12
-  Logout: 24
-  MemberInCombat: 33
-  MemberTimeout: 16
-  NotActive: 4
-  NotInParty: 1
-  NotMember: 21
-  NotOwner: 18
-  Ok: 0
-  OwnerLeft: 13
-  OwnerRefused: 6
-  PartyDestroyed: 15
-  QuestNotCompleted: 26
-  ReadyCheckFailed: 14
-  Restricted: 28
-  RestrictedCrossFaction: 34
-  Resync: 27
-  Started: 9
-  Stopped: 10
-  Timeout: 7
-  Unknown: 31
+  values:
+    AlreadyActive: 3
+    AlreadyJoined: 20
+    AlreadyMember: 17
+    AlreadyOwner: 19
+    Busy: 22
+    Disabled: 8
+    Empty: 25
+    InCombat: 32
+    InPetBattle: 29
+    InRaid: 5
+    InvalidOwner: 2
+    InvalidPublicParty: 30
+    Joined: 11
+    JoinRejected: 23
+    Left: 12
+    Logout: 24
+    MemberInCombat: 33
+    MemberTimeout: 16
+    NotActive: 4
+    NotInParty: 1
+    NotMember: 21
+    NotOwner: 18
+    Ok: 0
+    OwnerLeft: 13
+    OwnerRefused: 6
+    PartyDestroyed: 15
+    QuestNotCompleted: 26
+    ReadyCheckFailed: 14
+    Restricted: 28
+    RestrictedCrossFaction: 34
+    Resync: 27
+    Started: 9
+    Stopped: 10
+    Timeout: 7
+    Unknown: 31
 QuestTag:
-  Account: 102
-  Delve: 288
-  Dungeon: 81
-  Group: 1
-  Heroic: 85
-  Legendary: 83
-  PvP: 41
-  Raid: 62
-  Raid10: 88
-  Raid25: 89
-  Scenario: 98
+  values:
+    Account: 102
+    Delve: 288
+    Dungeon: 81
+    Group: 1
+    Heroic: 85
+    Legendary: 83
+    PvP: 41
+    Raid: 62
+    Raid10: 88
+    Raid25: 89
+    Scenario: 98
 QuestTagType:
-  Bounty: 5
-  Capstone: 17
-  Contribution: 9
-  CovenantCalling: 15
-  DragonRiderRacing: 16
-  Dungeon: 6
-  FactionAssault: 12
-  Invasion: 7
-  InvasionWrapper: 11
-  Islands: 13
-  Normal: 2
-  PetBattle: 4
-  Prey: 19
-  Profession: 1
-  PvP: 3
-  Raid: 8
-  RatedReward: 10
-  Tag: 0
-  Threat: 14
-  WorldBoss: 18
+  values:
+    Bounty: 5
+    Capstone: 17
+    Contribution: 9
+    CovenantCalling: 15
+    DragonRiderRacing: 16
+    Dungeon: 6
+    FactionAssault: 12
+    Invasion: 7
+    InvasionWrapper: 11
+    Islands: 13
+    Normal: 2
+    PetBattle: 4
+    Prey: 19
+    Profession: 1
+    PvP: 3
+    Raid: 8
+    RatedReward: 10
+    Tag: 0
+    Threat: 14
+    WorldBoss: 18
 QuestTreasurePickerType:
-  Hidden: 1
-  Select: 2
-  Visible: 0
+  values:
+    Hidden: 1
+    Select: 2
+    Visible: 0
 RafLinkType:
-  Both: 3
-  Friend: 2
-  None: 0
-  Recruit: 1
+  values:
+    Both: 3
+    Friend: 2
+    None: 0
+    Recruit: 1
 RafRecruitActivityState:
-  Complete: 1
-  Incomplete: 0
-  RewardClaimed: 2
+  values:
+    Complete: 1
+    Incomplete: 0
+    RewardClaimed: 2
 RafRecruitSubStatus:
-  Active: 1
-  Inactive: 2
-  Trial: 0
+  values:
+    Active: 1
+    Inactive: 2
+    Trial: 0
 RafRewardType:
-  Appearance: 2
-  AppearanceSet: 5
-  GameTime: 4
-  Illusion: 6
-  Invalid: 7
-  Mount: 1
-  Pet: 0
-  Title: 3
+  values:
+    Appearance: 2
+    AppearanceSet: 5
+    GameTime: 4
+    Illusion: 6
+    Invalid: 7
+    Mount: 1
+    Pet: 0
+    Title: 3
 RaidAuraOrganizationType:
-  BuffsRightDebuffsLeft: 2
-  BuffsTopDebuffsBottom: 1
-  Legacy: 0
+  values:
+    BuffsRightDebuffsLeft: 2
+    BuffsTopDebuffsBottom: 1
+    Legacy: 0
 RaidDispelDisplayType:
-  Disabled: 0
-  DispellableByMe: 1
-  DisplayAll: 2
+  values:
+    Disabled: 0
+    DispellableByMe: 1
+    DisplayAll: 2
 RaidGroupDisplayType:
-  CombineGroupsHorizontal: 3
-  CombineGroupsVertical: 2
-  SeparateGroupsHorizontal: 1
-  SeparateGroupsVertical: 0
+  values:
+    CombineGroupsHorizontal: 3
+    CombineGroupsVertical: 2
+    SeparateGroupsHorizontal: 1
+    SeparateGroupsVertical: 0
 RcoCloseReason:
-  Cancel: 2
-  CrafterFulfill: 5
-  Expire: 1
-  Fulfill: 0
-  GmCancel: 4
-  Invalid: 6
-  Reject: 3
+  values:
+    Cancel: 2
+    CrafterFulfill: 5
+    Expire: 1
+    Fulfill: 0
+    GmCancel: 4
+    Invalid: 6
+    Reject: 3
 RecentAllyPinResult:
-  ServerError: 1
-  Success: 0
+  values:
+    ServerError: 1
+    Success: 0
 RecruitAFriendRewardsVersion:
-  InvalidVersion: 0
-  UnusedVersionOne: 1
-  VersionThree: 3
-  VersionTwo: 2
+  values:
+    InvalidVersion: 0
+    UnusedVersionOne: 1
+    VersionThree: 3
+    VersionTwo: 2
 ReforgeFailedReason:
-  None: 0
-  ReforgeAlreadyHasDstStat: 3
-  ReforgeInsufficientSrcStat: 2
-  ReforgeItemTooLowLevel: 4
-  ReforgeSrcStatNotFound: 1
+  values:
+    None: 0
+    ReforgeAlreadyHasDstStat: 3
+    ReforgeInsufficientSrcStat: 2
+    ReforgeItemTooLowLevel: 4
+    ReforgeSrcStatNotFound: 1
 RegisterAddonMessagePrefixResult:
-  DuplicatePrefix: 1
-  InvalidPrefix: 2
-  MaxPrefixes: 3
-  Success: 0
+  values:
+    DuplicatePrefix: 1
+    InvalidPrefix: 2
+    MaxPrefixes: 3
+    Success: 0
 RelativeContentDifficulty:
-  Difficult: 3
-  Easy: 1
-  Fair: 2
-  Impossible: 4
-  Trivial: 0
+  values:
+    Difficult: 3
+    Easy: 1
+    Fair: 2
+    Impossible: 4
+    Trivial: 0
 ReleaseType:
-  Classic: 2
-  Original: 1
+  values:
+    Classic: 2
+    Original: 1
 RenownRewardDisplayType:
-  Currency: 9
-  GarrFollower: 8
-  Item: 1
-  Mount: 3
-  None: 0
-  Spell: 2
-  Title: 7
-  Transmog: 4
-  TransmogIllusion: 6
-  TransmogSet: 5
+  values:
+    Currency: 9
+    GarrFollower: 8
+    Item: 1
+    Mount: 3
+    None: 0
+    Spell: 2
+    Title: 7
+    Transmog: 4
+    TransmogIllusion: 6
+    TransmogSet: 5
 RenownRewardsFlags:
-  AccountUnlock: 8
-  Capstone: 2
-  Hidden: 4
-  Milestone: 1
+  values:
+    AccountUnlock: 8
+    Capstone: 2
+    Hidden: 4
+    Milestone: 1
 ReportEvidenceType:
-  HouseLayoutJson: 2
-  HouseScreenshot: 1
-  Invalid: 0
+  values:
+    HouseLayoutJson: 2
+    HouseScreenshot: 1
+    Invalid: 0
 ReportMajorCategory:
-  Cheating: 2
-  GameplaySabotage: 1
-  InappropriateCommunication: 0
-  InappropriateDecor: 4
-  InappropriateName: 3
+  values:
+    Cheating: 2
+    GameplaySabotage: 1
+    InappropriateCommunication: 0
+    InappropriateDecor: 4
+    InappropriateName: 3
 ReportMinorCategory:
-  Advertisement: 256
-  Afk: 8
-  BlockingProgress: 32
-  Boosting: 2
-  Botting: 128
-  BTag: 512
-  CharacterName: 2048
-  ChildSexualExploitationAndAbuse: 262144
-  Description: 8192
-  Disruption: 65536
-  GroupName: 1024
-  GuildName: 4096
-  Hacking: 64
-  HarmfulToMinors: 32768
-  IntentionallyFeeding: 16
-  Name: 16384
-  NeighborhoodName: 524288
-  Spam: 4
-  TerroristAndViolentExtremistContent: 131072
-  TextChat: 1
+  values:
+    Advertisement: 256
+    Afk: 8
+    BlockingProgress: 32
+    Boosting: 2
+    Botting: 128
+    BTag: 512
+    CharacterName: 2048
+    ChildSexualExploitationAndAbuse: 262144
+    Description: 8192
+    Disruption: 65536
+    GroupName: 1024
+    GuildName: 4096
+    Hacking: 64
+    HarmfulToMinors: 32768
+    IntentionallyFeeding: 16
+    Name: 16384
+    NeighborhoodName: 524288
+    Spam: 4
+    TerroristAndViolentExtremistContent: 131072
+    TextChat: 1
 ReportSubComplaintTypes:
-  Advertising: 1
-  Inappropriate: 0
+  values:
+    Advertising: 1
+    Inappropriate: 0
 ReportThrottleType:
-  Expensive: 2
-  General: 1
-  Invalid: 0
+  values:
+    Expensive: 2
+    General: 1
+    Invalid: 0
 ReportType:
-  BattlePet: 10
-  Calendar: 11
-  Chat: 0
-  ClubFinderApplicant: 3
-  ClubFinderPosting: 2
-  ClubMember: 6
-  CraftingOrder: 16
-  Friend: 8
-  GroupFinderApplicant: 5
-  GroupFinderPosting: 4
-  GroupMember: 7
-  HousingDecor: 18
-  InWorld: 1
-  Mail: 12
-  Neighborhood: 19
-  NeighborhoodRoster: 20
-  Pet: 9
-  PvP: 13
-  PvPGroupMember: 15
-  PvPScoreboard: 14
-  RecentAlly: 17
+  values:
+    BattlePet: 10
+    Calendar: 11
+    Chat: 0
+    ClubFinderApplicant: 3
+    ClubFinderPosting: 2
+    ClubMember: 6
+    CraftingOrder: 16
+    Friend: 8
+    GroupFinderApplicant: 5
+    GroupFinderPosting: 4
+    GroupMember: 7
+    HousingDecor: 18
+    InWorld: 1
+    Mail: 12
+    Neighborhood: 19
+    NeighborhoodRoster: 20
+    Pet: 9
+    PvP: 13
+    PvPGroupMember: 15
+    PvPScoreboard: 14
+    RecentAlly: 17
 ReservationFlags:
-  Canceled: 2
-  None: 0
-  Plotless: 4
-  Relinquish: 1
+  values:
+    Canceled: 2
+    None: 0
+    Plotless: 4
+    Relinquish: 1
 ResidentType:
-  Manager: 1
-  Owner: 2
-  Resident: 0
+  values:
+    Manager: 1
+    Owner: 2
+    Resident: 0
 RestrictPingsTo:
-  Assist: 2
-  Lead: 1
-  None: 0
-  TankHealer: 3
+  values:
+    Assist: 2
+    Lead: 1
+    None: 0
+    TankHealer: 3
 RetroactiveDecorRewardFlags:
-  AllCriteriaRequired: 1
-  None: 0
+  values:
+    AllCriteriaRequired: 1
+    None: 0
 RolodexContextLevelType:
-  DelveTier: 3
-  Difficulty: 1
-  KeystoneLevel: 2
-  None: 0
+  values:
+    DelveTier: 3
+    Difficulty: 1
+    KeystoneLevel: 2
+    None: 0
 RolodexType:
-  CompleteArena: 16
-  CompleteBg: 17
-  CompleteDelve: 15
-  CompleteDungeon: 12
-  CreatureKill: 11
-  Duel: 18
-  GuildOrderFilledByOther: 9
-  GuildOrderFilledByYou: 10
-  KillLfrBoss: 14
-  KillRaidBoss: 13
-  None: 0
-  PartyMember: 1
-  PersonalOrderFilledByOther: 7
-  PersonalOrderFilledByYou: 8
-  PetBattle: 19
-  PublicOrderFilledByOther: 5
-  PublicOrderFilledByYou: 6
-  PvPKill: 20
-  RaidMember: 2
-  Trade: 3
-  Whisper: 4
+  values:
+    CompleteArena: 16
+    CompleteBg: 17
+    CompleteDelve: 15
+    CompleteDungeon: 12
+    CreatureKill: 11
+    Duel: 18
+    GuildOrderFilledByOther: 9
+    GuildOrderFilledByYou: 10
+    KillLfrBoss: 14
+    KillRaidBoss: 13
+    None: 0
+    PartyMember: 1
+    PersonalOrderFilledByOther: 7
+    PersonalOrderFilledByYou: 8
+    PetBattle: 19
+    PublicOrderFilledByOther: 5
+    PublicOrderFilledByYou: 6
+    PvPKill: 20
+    RaidMember: 2
+    Trade: 3
+    Whisper: 4
 RolodexTypeFlags:
-  HiddenFromHistory: 1
-  None: 0
+  values:
+    HiddenFromHistory: 1
+    None: 0
 RoomConnectionType:
-  All: 1
-  None: 0
+  values:
+    All: 1
+    None: 0
 ScalingArmorType:
-  Cloth: 0
-  Leather: 1
-  Mail: 2
-  Plate: 3
+  values:
+    Cloth: 0
+    Leather: 1
+    Mail: 2
+    Plate: 3
 ScreenLocationType:
-  Bottom: 4
-  Center: 0
-  Left: 1
-  LeftOutside: 7
-  LeftRight: 9
-  LeftRightOutside: 11
-  Right: 2
-  RightOutside: 8
-  Top: 3
-  TopBottom: 10
-  TopLeft: 5
-  TopRight: 6
+  values:
+    Bottom: 4
+    Center: 0
+    Left: 1
+    LeftOutside: 7
+    LeftRight: 9
+    LeftRightOutside: 11
+    Right: 2
+    RightOutside: 8
+    Top: 3
+    TopBottom: 10
+    TopLeft: 5
+    TopRight: 6
 ScreenshotSource:
-  Automatic: 0
-  Cheat: 2
-  PlayerReport: 1
+  values:
+    Automatic: 0
+    Cheat: 2
+    PlayerReport: 1
 ScriptedAnimationBehavior:
-  None: 0
-  SourceCollideWithTarget: 4
-  SourceRecoil: 3
-  TargetKnockBack: 2
-  TargetShake: 1
-  UIParentShake: 5
+  values:
+    None: 0
+    SourceCollideWithTarget: 4
+    SourceRecoil: 3
+    TargetKnockBack: 2
+    TargetShake: 1
+    UIParentShake: 5
 ScriptedAnimationFlags:
-  UseTargetAsSource: 1
+  values:
+    UseTargetAsSource: 1
 ScriptedAnimationTrajectory:
-  AtSource: 0
-  AtTarget: 1
-  CurveLeft: 3
-  CurveRandom: 5
-  CurveRight: 4
-  HalfwayBetween: 6
-  Straight: 2
+  values:
+    AtSource: 0
+    AtTarget: 1
+    CurveLeft: 3
+    CurveRandom: 5
+    CurveRight: 4
+    HalfwayBetween: 6
+    Straight: 2
 ScrubStringFlags:
-  AllowBarCodes: 2
-  None: 0
-  StripControlCodes: 4
-  TruncateNewLines: 1
+  values:
+    AllowBarCodes: 2
+    None: 0
+    StripControlCodes: 4
+    TruncateNewLines: 1
 SeasonID:
-  Fresh: 11
-  FreshHardcore: 12
-  Hardcore: 3
-  NoSeason: 0
-  SeasonOfDiscovery: 2
-  SeasonOfMastery: 1
+  values:
+    Fresh: 11
+    FreshHardcore: 12
+    Hardcore: 3
+    NoSeason: 0
+    SeasonOfDiscovery: 2
+    SeasonOfMastery: 1
 SecondsFormatterAbbreviation:
-  None: 0
-  OneLetter: 2
-  Truncate: 1
+  values:
+    None: 0
+    OneLetter: 2
+    Truncate: 1
 SecondsFormatterInterval:
-  Days: 3
-  Hours: 2
-  Minutes: 1
-  Seconds: 0
+  values:
+    Days: 3
+    Hours: 2
+    Minutes: 1
+    Seconds: 0
 SecondsFormatterIntervalWhitespace:
-  Preserve: 0
-  Strip: 1
-  StripIgnoreLocale: 2
+  values:
+    Preserve: 0
+    Strip: 1
+    StripIgnoreLocale: 2
 SecrecyLevel:
-  AlwaysSecret: 1
-  ContextuallySecret: 2
-  NeverSecret: 0
+  values:
+    AlwaysSecret: 1
+    ContextuallySecret: 2
+    NeverSecret: 0
 SecretAspect:
-  Alpha: 128
-  Attributes: 1
-  BarValue: 16384
-  ButtonState: 2097152
-  Cooldown: 32768
-  CooldownStyle: 524288
-  Cursor: 1024
-  Desaturation: 4096
-  FrameLevel: 256
-  Hierarchy: 1
-  ID: 2
-  MinimumWidth: 131072
-  ObjectDebug: 1
-  ObjectName: 1
-  ObjectSecrets: 1
-  ObjectSecurity: 1
-  ObjectType: 1
-  Padding: 262144
-  Rotation: 65536
-  Scale: 64
-  ScrollOffset: 4194304
-  ScrollRange: 512
-  SecureText: 16
-  Shown: 32
-  TexCoords: 8192
-  Text: 8
-  TooltipTexture: 1048576
-  Toplevel: 4
-  VertexColor: 2048
+  values:
+    Alpha: 128
+    Attributes: 1
+    BarValue: 16384
+    ButtonState: 2097152
+    Cooldown: 32768
+    CooldownStyle: 524288
+    Cursor: 1024
+    Desaturation: 4096
+    FrameLevel: 256
+    Hierarchy: 1
+    ID: 2
+    MinimumWidth: 131072
+    ObjectDebug: 1
+    ObjectName: 1
+    ObjectSecrets: 1
+    ObjectSecurity: 1
+    ObjectType: 1
+    Padding: 262144
+    Rotation: 65536
+    Scale: 64
+    ScrollOffset: 4194304
+    ScrollRange: 512
+    SecureText: 16
+    Shown: 32
+    TexCoords: 8192
+    Text: 8
+    TooltipTexture: 1048576
+    Toplevel: 4
+    VertexColor: 2048
 SelfResurrectOptionType:
-  Item: 1
-  Spell: 0
+  values:
+    Item: 1
+    Spell: 0
 SendAddonMessageResult:
-  AddOnMessageLockdown: 11
-  AddonMessageThrottle: 3
-  ChannelThrottle: 8
-  GeneralError: 9
-  InvalidChannel: 7
-  InvalidChatType: 4
-  InvalidMessage: 2
-  InvalidPrefix: 1
-  NotInGroup: 5
-  NotInGuild: 10
-  Success: 0
-  TargetOffline: 12
-  TargetRequired: 6
+  values:
+    AddOnMessageLockdown: 11
+    AddonMessageThrottle: 3
+    ChannelThrottle: 8
+    GeneralError: 9
+    InvalidChannel: 7
+    InvalidChatType: 4
+    InvalidMessage: 2
+    InvalidPrefix: 1
+    NotInGroup: 5
+    NotInGuild: 10
+    Success: 0
+    TargetOffline: 12
+    TargetRequired: 6
 SendReportResult:
-  GeneralError: 1
-  RequiresChatLine: 3
-  RequiresChatLineOrVoice: 4
-  RequiresScreenshot: 5
-  Success: 0
-  TooManyReports: 2
+  values:
+    GeneralError: 1
+    RequiresChatLine: 3
+    RequiresChatLineOrVoice: 4
+    RequiresScreenshot: 5
+    Success: 0
+    TooManyReports: 2
 SharedStringFlag:
-  InternalOnly: 1
+  values:
+    InternalOnly: 1
 ShutdownSessionReason:
-  AccountLoginCommand: 4
-  Error: 6
-  ForceLogoutCommand: 2
-  LuaScript: 5
-  RealmSelectCommand: 3
-  RestartSessionCommand: 1
-  SessionEnded: 0
+  values:
+    AccountLoginCommand: 4
+    Error: 6
+    ForceLogoutCommand: 2
+    LuaScript: 5
+    RealmSelectCommand: 3
+    RestartSessionCommand: 1
+    SessionEnded: 0
 Siflag:
-  Affectedbyaltitude: 16
-  Affectedbysanity: 2048
-  AutocreatedByBroadcastText: 4
-  CasterOwnsTargetSound: 128
-  Disablepositionallpf: 1
-  Dontplayindoors: 256
-  Dontplayunderwater: 1024
-  Dontstopondeath: 4096
-  Ignoresuppressors: 64
-  Ignorevopriority: 16384
-  Looping: 512
-  Noduplicates: 32
-  None: 0
-  Onlyplayindoors: 32768
-  Onlyplayunderwater: 65536
-  Playonlyforowner: 8192
-  Playsequential: 8
-  UseModCastSpeed: 2
+  values:
+    Affectedbyaltitude: 16
+    Affectedbysanity: 2048
+    AutocreatedByBroadcastText: 4
+    CasterOwnsTargetSound: 128
+    Disablepositionallpf: 1
+    Dontplayindoors: 256
+    Dontplayunderwater: 1024
+    Dontstopondeath: 4096
+    Ignoresuppressors: 64
+    Ignorevopriority: 16384
+    Looping: 512
+    Noduplicates: 32
+    None: 0
+    Onlyplayindoors: 32768
+    Onlyplayunderwater: 65536
+    Playonlyforowner: 8192
+    Playsequential: 8
+    UseModCastSpeed: 2
 SimpleOrderStatus:
-  Creating: 1
-  Failed: 4
-  InProgress: 2
-  Invalid: 0
-  Success: 3
+  values:
+    Creating: 1
+    Failed: 4
+    InProgress: 2
+    Invalid: 0
+    Success: 3
 SleevesGeoRange:
-  Default: 1
-  Flared: 2
-  None: 0
-  PandaCollar: 4
-  Puffy: 3
+  values:
+    Default: 1
+    Flared: 2
+    None: 0
+    PandaCollar: 4
+    Puffy: 3
 SlotRegion:
-  AccountBank: 5
-  CharacterBank: 4
-  Invalid: 0
-  PlayerBags: 2
-  PlayerEquip: 1
-  PlayerInv: 3
+  values:
+    AccountBank: 5
+    CharacterBank: 4
+    Invalid: 0
+    PlayerBags: 2
+    PlayerEquip: 1
+    PlayerInv: 3
 SlotRegionMask:
-  AccountBank: 64
-  CharacterBank: 16
-  Invalid: 1
-  PlayerBags: 4
-  PlayerEquip: 2
-  PlayerInv: 8
+  values:
+    AccountBank: 64
+    CharacterBank: 16
+    Invalid: 1
+    PlayerBags: 4
+    PlayerEquip: 2
+    PlayerInv: 8
 SocialWhoOrigin:
-  Chat: 2
-  Item: 3
-  Social: 1
-  Unknown: 0
+  values:
+    Chat: 2
+    Item: 3
+    Social: 1
+    Unknown: 0
 SoftTargetEnableFlags:
-  Any: 3
-  Gamepad: 1
-  Kbm: 2
-  None: 0
+  values:
+    Any: 3
+    Gamepad: 1
+    Kbm: 2
+    None: 0
 SortPlayersBy:
-  Alphabetical: 2
-  Group: 1
-  Role: 0
+  values:
+    Alphabetical: 2
+    Group: 1
+    Role: 0
 SoundBusFlag:
-  Disablepositionallpf: 1
+  values:
+    Disablepositionallpf: 1
 SpecializationSystem:
-  ChrSpecialization: 1
-  TalentTab: 0
+  values:
+    ChrSpecialization: 1
+    TalentTab: 0
 SpellAuraVisibilityType:
-  EnemyTarget: 2
-  RaidInCombat: 0
-  RaidOutOfCombat: 1
+  values:
+    EnemyTarget: 2
+    RaidInCombat: 0
+    RaidOutOfCombat: 1
 SpellBookItemType:
-  Flyout: 4
-  FutureSpell: 2
-  None: 0
-  PetAction: 3
-  Spell: 1
+  values:
+    Flyout: 4
+    FutureSpell: 2
+    None: 0
+    PetAction: 3
+    Spell: 1
 SpellBookSpellBank:
-  Pet: 1
-  Player: 0
+  values:
+    Pet: 1
+    Player: 0
 SpellDiminishCategory:
-  AoEKnockback: 3
-  Disarm: 7
-  Disorient: 5
-  Incapacitate: 4
-  Root: 0
-  Silence: 6
-  Stun: 2
-  Taunt: 1
+  values:
+    AoEKnockback: 3
+    Disarm: 7
+    Disorient: 5
+    Incapacitate: 4
+    Root: 0
+    Silence: 6
+    Stun: 2
+    Taunt: 1
 SpellDiminishRuleset:
-  None: 0
-  PvE: 1
-  PvP: 2
+  values:
+    None: 0
+    PvE: 1
+    PvP: 2
 SpellDisplayBorderColor:
-  Black: 1
-  Blue: 8
-  Green: 7
-  None: 0
-  Orange: 5
-  Purple: 6
-  Red: 3
-  White: 2
-  Yellow: 4
+  values:
+    Black: 1
+    Blue: 8
+    Green: 7
+    None: 0
+    Orange: 5
+    Purple: 6
+    Red: 3
+    White: 2
+    Yellow: 4
 SpellDisplayIconDisplayType:
-  Buff: 0
-  Circular: 2
-  Debuff: 1
-  NoBorder: 3
+  values:
+    Buff: 0
+    Circular: 2
+    Debuff: 1
+    NoBorder: 3
 SpellDisplayTextShownStateType:
-  Hidden: 1
-  Shown: 0
+  values:
+    Hidden: 1
+    Shown: 0
 SpellDisplayTint:
-  None: 0
-  Red: 1
+  values:
+    None: 0
+    Red: 1
 SplashScreenType:
-  SeasonRollOver: 1
-  WhatsNew: 0
+  values:
+    SeasonRollOver: 1
+    WhatsNew: 0
 StableResult:
-  AlreadyStabled: 5
-  AlreadySummoned: 6
-  BuySlotSuccess: 14
-  CantControlExotic: 11
-  CheckForLuaHack: 13
-  FavoriteToggle: 15
-  InsufficientFunds: 1
-  InternalError: 12
-  InvalidSlot: 3
-  MaxSlots: 0
-  NoPet: 4
-  NotFound: 7
-  NotStableMaster: 2
-  PetRenamed: 16
-  ReviveSuccess: 10
-  StableSuccess: 8
-  UnstableSuccess: 9
+  values:
+    AlreadyStabled: 5
+    AlreadySummoned: 6
+    BuySlotSuccess: 14
+    CantControlExotic: 11
+    CheckForLuaHack: 13
+    FavoriteToggle: 15
+    InsufficientFunds: 1
+    InternalError: 12
+    InvalidSlot: 3
+    MaxSlots: 0
+    NoPet: 4
+    NotFound: 7
+    NotStableMaster: 2
+    PetRenamed: 16
+    ReviveSuccess: 10
+    StableSuccess: 8
+    UnstableSuccess: 9
 StartTimerType:
-  ChallengeModeCountdown: 1
-  PlayerCountdown: 2
-  PlunderstormCountdown: 3
-  PvPBeginTimer: 0
+  values:
+    ChallengeModeCountdown: 1
+    PlayerCountdown: 2
+    PlunderstormCountdown: 3
+    PvPBeginTimer: 0
 StatusBarColorTintValue:
-  Black: 1
-  Blue: 8
-  Green: 7
-  None: 0
-  Orange: 5
-  Purple: 6
-  Red: 3
-  White: 2
-  Yellow: 4
+  values:
+    Black: 1
+    Blue: 8
+    Green: 7
+    None: 0
+    Orange: 5
+    Purple: 6
+    Red: 3
+    White: 2
+    Yellow: 4
 StatusBarFillStyle:
-  Center: 2
-  Reverse: 3
-  Standard: 0
-  StandardNoRangeFill: 1
+  values:
+    Center: 2
+    Reverse: 3
+    Standard: 0
+    StandardNoRangeFill: 1
 StatusBarInterpolation:
-  ExponentialEaseOut: 1
-  Immediate: 0
+  values:
+    ExponentialEaseOut: 1
+    Immediate: 0
 StatusBarOverrideBarTextShownType:
-  Always: 1
-  Never: 0
-  OnlyNotOnMouseover: 3
-  OnlyOnMouseover: 2
+  values:
+    Always: 1
+    Never: 0
+    OnlyNotOnMouseover: 3
+    OnlyOnMouseover: 2
 StatusBarTimerDirection:
-  ElapsedTime: 0
-  RemainingTime: 1
+  values:
+    ElapsedTime: 0
+    RemainingTime: 1
 StatusBarValueTextType:
-  Hidden: 0
-  Percentage: 1
-  Time: 3
-  TimeShowOneLevelOnly: 4
-  Value: 2
-  ValueOverMax: 5
-  ValueOverMaxNormalized: 6
+  values:
+    Hidden: 0
+    Percentage: 1
+    Time: 3
+    TimeShowOneLevelOnly: 4
+    Value: 2
+    ValueOverMax: 5
+    ValueOverMaxNormalized: 6
 StoreDeliveryType:
-  Battlepet: 2
-  Collection: 3
-  Item: 0
-  Mount: 1
+  values:
+    Battlepet: 2
+    Collection: 3
+    Item: 0
+    Mount: 1
 StoreError:
-  AlreadyOwned: 7
-  BattlepayDisabled: 4
-  ClientRestricted: 13
-  ConsumableTokenOwned: 10
-  InsufficientBalance: 5
-  InvalidPaymentMethod: 1
-  ItemUnavailable: 12
-  Other: 6
-  ParentalControlsNoPurchase: 8
-  PaymentFailed: 2
-  PurchaseDenied: 9
-  Success: 0
-  TooManyTokens: 11
-  WrongCurrency: 3
+  values:
+    AlreadyOwned: 7
+    BattlepayDisabled: 4
+    ClientRestricted: 13
+    ConsumableTokenOwned: 10
+    InsufficientBalance: 5
+    InvalidPaymentMethod: 1
+    ItemUnavailable: 12
+    Other: 6
+    ParentalControlsNoPurchase: 8
+    PaymentFailed: 2
+    PurchaseDenied: 9
+    Success: 0
+    TooManyTokens: 11
+    WrongCurrency: 3
 SubcontainerType:
-  AccountBankTabs: 36
-  Auction: 5
-  Bag: 0
-  Bankbag: 3
-  Bankgeneric: 2
-  BuybackSlots: 26
-  CachedReward: 27
-  CharacterBankTabs: 38
-  Childequipmentstorage: 23
-  CraftingOrder: 34
-  CraftingOrderReagents: 35
-  CreatedImmediately: 25
-  CurrencytokenOboslete: 15
-  CurrencyTransfer: 37
-  Equipablespells: 14
-  Equipped: 1
-  EquippedBags: 28
-  EquippedCooking: 31
-  EquippedFishing: 32
-  EquippedProfession1: 29
-  EquippedProfession2: 30
-  EquippedReagentbag: 33
-  GuildBank0: 7
-  GuildBank1: 8
-  GuildBank10: 20
-  GuildBank11: 21
-  GuildBank2: 9
-  GuildBank3: 10
-  GuildBank4: 11
-  GuildBank5: 12
-  GuildBank6: 16
-  GuildBank7: 17
-  GuildBank8: 18
-  GuildBank9: 19
-  GuildOverflow: 13
-  HousingDecorConversion: 39
-  Keyring: 6
-  Mail: 4
-  Quarantine: 24
-  ReagentbankObsolete: 22
+  values:
+    AccountBankTabs: 36
+    Auction: 5
+    Bag: 0
+    Bankbag: 3
+    Bankgeneric: 2
+    BuybackSlots: 26
+    CachedReward: 27
+    CharacterBankTabs: 38
+    Childequipmentstorage: 23
+    CraftingOrder: 34
+    CraftingOrderReagents: 35
+    CreatedImmediately: 25
+    CurrencytokenOboslete: 15
+    CurrencyTransfer: 37
+    Equipablespells: 14
+    Equipped: 1
+    EquippedBags: 28
+    EquippedCooking: 31
+    EquippedFishing: 32
+    EquippedProfession1: 29
+    EquippedProfession2: 30
+    EquippedReagentbag: 33
+    GuildBank0: 7
+    GuildBank1: 8
+    GuildBank10: 20
+    GuildBank11: 21
+    GuildBank2: 9
+    GuildBank3: 10
+    GuildBank4: 11
+    GuildBank5: 12
+    GuildBank6: 16
+    GuildBank7: 17
+    GuildBank8: 18
+    GuildBank9: 19
+    GuildOverflow: 13
+    HousingDecorConversion: 39
+    Keyring: 6
+    Mail: 4
+    Quarantine: 24
+    ReagentbankObsolete: 22
 SummonReason:
-  Scenario: 1
-  Spell: 0
+  values:
+    Scenario: 1
+    Spell: 0
 SummonStatus:
-  Accepted: 2
-  Declined: 3
-  None: 0
-  Pending: 1
+  values:
+    Accepted: 2
+    Declined: 3
+    None: 0
+    Pending: 1
 SurveyDeliveryFlags:
-  EncounterSucccessOnly: 1
-  None: 0
+  values:
+    EncounterSucccessOnly: 1
+    None: 0
 SurveyDeliveryMoment:
-  ChestLooted: 3
-  EncounterEnd: 5
-  Login: 0
-  MythicPlusCompleted: 4
-  ProfessionTable: 1
-  QuestTurnIn: 2
+  values:
+    ChestLooted: 3
+    EncounterEnd: 5
+    Login: 0
+    MythicPlusCompleted: 4
+    ProfessionTable: 1
+    QuestTurnIn: 2
 TableSecurityOption:
-  DisallowSecretKeys: 1
-  DisallowTaintedAccess: 0
-  SecretWrapContents: 2
+  values:
+    DisallowSecretKeys: 1
+    DisallowTaintedAccess: 0
+    SecretWrapContents: 2
 TieredEntranceType:
-  Delve: 1
-  Invalid: 0
-  Sites: 2
-  WorldTier: 3
+  values:
+    Delve: 1
+    Invalid: 0
+    Sites: 2
+    WorldTier: 3
 TimeEventFlag:
-  GlueScreenShortcut: 1
+  values:
+    GlueScreenShortcut: 1
 TitleIconVersion:
-  Large: 2
-  Medium: 1
-  Small: 0
+  values:
+    Large: 2
+    Medium: 1
+    Small: 0
 TooltipComparisonMethod:
-  Single: 0
-  WithBagMainHandItem: 2
-  WithBagOffHandItem: 3
-  WithBothHands: 1
+  values:
+    Single: 0
+    WithBagMainHandItem: 2
+    WithBagOffHandItem: 3
+    WithBothHands: 1
 TooltipDataItemBinding:
-  Account: 1
-  AccountUntilEquipped: 9
-  BindOnEquip: 7
-  BindOnPickup: 6
-  BindOnUse: 8
-  BindToAccount: 4
-  BindToAccountUntilEquipped: 10
-  BindToBnetAccount: 5
-  BnetAccount: 2
-  Quest: 0
-  Soulbound: 3
+  values:
+    Account: 1
+    AccountUntilEquipped: 9
+    BindOnEquip: 7
+    BindOnPickup: 6
+    BindOnUse: 8
+    BindToAccount: 4
+    BindToAccountUntilEquipped: 10
+    BindToBnetAccount: 5
+    BnetAccount: 2
+    Quest: 0
+    Soulbound: 3
 TooltipDataLineType:
-  AzeriteEssencePower: 5
-  AzeriteEssenceSlot: 4
-  AzeriteItemPowerDescription: 9
-  Blank: 1
-  CurrencyTotal: 14
-  DisabledLine: 42
-  EquipSlot: 21
-  ErrorLine: 41
-  FlavorText: 37
-  GemSocket: 3
-  GemSocketEnchantment: 30
-  ItemBinding: 20
-  ItemEnchantmentPermanent: 15
-  ItemLevel: 31
-  ItemName: 22
-  ItemQuality: 35
-  ItemSpellTriggerLearn: 38
-  ItemUpgradeLevel: 32
-  LearnableSpell: 6
-  LearnTransmogIllusion: 40
-  LearnTransmogSet: 39
-  NestedBlock: 19
-  None: 0
-  ProfessionCraftingQuality: 12
-  QuestObjective: 8
-  QuestPlayer: 18
-  QuestTitle: 17
-  RuneforgeLegendaryPowerDescription: 10
-  SellPrice: 11
-  Separator: 23
-  SpellDescription: 34
-  SpellName: 13
-  SpellPassive: 33
-  ToyDescription: 28
-  ToyDuration: 27
-  ToyEffect: 26
-  ToyName: 24
-  ToySource: 29
-  ToyText: 25
-  TradeTimeRemaining: 36
-  UnitName: 2
-  UnitOwner: 16
-  UnitThreat: 7
-  UsageRequirement: 43
+  values:
+    AzeriteEssencePower: 5
+    AzeriteEssenceSlot: 4
+    AzeriteItemPowerDescription: 9
+    Blank: 1
+    CurrencyTotal: 14
+    DisabledLine: 42
+    EquipSlot: 21
+    ErrorLine: 41
+    FlavorText: 37
+    GemSocket: 3
+    GemSocketEnchantment: 30
+    ItemBinding: 20
+    ItemEnchantmentPermanent: 15
+    ItemLevel: 31
+    ItemName: 22
+    ItemQuality: 35
+    ItemSpellTriggerLearn: 38
+    ItemUpgradeLevel: 32
+    LearnableSpell: 6
+    LearnTransmogIllusion: 40
+    LearnTransmogSet: 39
+    NestedBlock: 19
+    None: 0
+    ProfessionCraftingQuality: 12
+    QuestObjective: 8
+    QuestPlayer: 18
+    QuestTitle: 17
+    RuneforgeLegendaryPowerDescription: 10
+    SellPrice: 11
+    Separator: 23
+    SpellDescription: 34
+    SpellName: 13
+    SpellPassive: 33
+    ToyDescription: 28
+    ToyDuration: 27
+    ToyEffect: 26
+    ToyName: 24
+    ToySource: 29
+    ToyText: 25
+    TradeTimeRemaining: 36
+    UnitName: 2
+    UnitOwner: 16
+    UnitThreat: 7
+    UsageRequirement: 43
 TooltipDataType:
-  Achievement: 12
-  AzeriteEssence: 8
-  BattlePet: 6
-  CompanionPet: 9
-  Corpse: 3
-  CorruptionCleanser: 20
-  Currency: 5
-  Debug: 26
-  EnhancedConduit: 13
-  EquipmentSet: 14
-  Flyout: 22
-  InstanceLock: 15
-  Item: 0
-  Macro: 25
-  MinimapMouseover: 21
-  Mount: 10
-  Object: 4
-  Outfit: 27
-  PetAction: 11
-  PvPBrawl: 16
-  Quest: 23
-  QuestPartyProgress: 24
-  RecipeRankInfo: 17
-  Spell: 1
-  Totem: 18
-  Toy: 19
-  Unit: 2
-  UnitAura: 7
+  values:
+    Achievement: 12
+    AzeriteEssence: 8
+    BattlePet: 6
+    CompanionPet: 9
+    Corpse: 3
+    CorruptionCleanser: 20
+    Currency: 5
+    Debug: 26
+    EnhancedConduit: 13
+    EquipmentSet: 14
+    Flyout: 22
+    InstanceLock: 15
+    Item: 0
+    Macro: 25
+    MinimapMouseover: 21
+    Mount: 10
+    Object: 4
+    Outfit: 27
+    PetAction: 11
+    PvPBrawl: 16
+    Quest: 23
+    QuestPartyProgress: 24
+    RecipeRankInfo: 17
+    Spell: 1
+    Totem: 18
+    Toy: 19
+    Unit: 2
+    UnitAura: 7
 TooltipDataUsageRequirementType:
-  Achievement: 7
-  ArenaRating: 11
-  EarnCurrency: 12
-  EquippedItem: 9
-  Faction: 1
-  Guild: 6
-  Level: 5
-  NotAlreadyKnown: 14
-  NotInArena: 15
-  NotInRatedBg: 16
-  PvPMedal: 3
-  PvPRank: 8
-  RaceClass: 0
-  Reputation: 4
-  ShapeshiftForm: 10
-  Skill: 2
-  Specialization: 13
+  values:
+    Achievement: 7
+    ArenaRating: 11
+    EarnCurrency: 12
+    EquippedItem: 9
+    Faction: 1
+    Guild: 6
+    Level: 5
+    NotAlreadyKnown: 14
+    NotInArena: 15
+    NotInRatedBg: 16
+    PvPMedal: 3
+    PvPRank: 8
+    RaceClass: 0
+    Reputation: 4
+    ShapeshiftForm: 10
+    Skill: 2
+    Specialization: 13
 TooltipSide:
-  Bottom: 3
-  Left: 0
-  Right: 1
-  Top: 2
+  values:
+    Bottom: 3
+    Left: 0
+    Right: 1
+    Top: 2
 TooltipTextureAnchor:
-  All: 6
-  LeftBottom: 2
-  LeftCenter: 1
-  LeftTop: 0
-  RightBottom: 5
-  RightCenter: 4
-  RightTop: 3
+  values:
+    All: 6
+    LeftBottom: 2
+    LeftCenter: 1
+    LeftTop: 0
+    RightBottom: 5
+    RightCenter: 4
+    RightTop: 3
 TooltipTextureRelativeRegion:
-  LeftLine: 0
-  RightLine: 1
+  values:
+    LeftLine: 0
+    RightLine: 1
 TrackedSpellCategory:
-  Debuff: 3
-  Defensive: 2
-  None: 0
-  Offensive: 1
-  RacialAbility: 4
+  values:
+    Debuff: 3
+    Defensive: 2
+    None: 0
+    Offensive: 1
+    RacialAbility: 4
 TradeskillRelativeDifficulty:
-  Easy: 2
-  Medium: 1
-  Optimal: 0
-  Trivial: 3
+  values:
+    Easy: 2
+    Medium: 1
+    Optimal: 0
+    Trivial: 3
 TraitCombatConfigFlags:
-  ActiveForSpec: 1
-  SharedActionBars: 4
-  StarterBuild: 2
+  values:
+    ActiveForSpec: 1
+    SharedActionBars: 4
+    StarterBuild: 2
 TraitCondFlag:
-  IsAlwaysMet: 2
-  IsGate: 1
-  IsSufficient: 4
+  values:
+    IsAlwaysMet: 2
+    IsGate: 1
+    IsSufficient: 4
 TraitConditionType:
-  Available: 0
-  DisplayError: 4
-  Granted: 2
-  Increased: 3
-  RanksAllowed: 5
-  Visible: 1
+  values:
+    Available: 0
+    DisplayError: 4
+    Granted: 2
+    Increased: 3
+    RanksAllowed: 5
+    Visible: 1
 TraitConfigDbState:
-  Created: 1
-  Deleted: 3
-  Ready: 0
-  Removed: 2
+  values:
+    Created: 1
+    Deleted: 3
+    Ready: 0
+    Removed: 2
 TraitConfigType:
-  Combat: 1
-  Generic: 3
-  Invalid: 0
-  Profession: 2
+  values:
+    Combat: 1
+    Generic: 3
+    Invalid: 0
+    Profession: 2
 TraitCurrencyFlag:
-  ShowQuantityAsSpent: 1
-  TraitSourcedShowMax: 2
-  UseClassIcon: 4
-  UseSpecIcon: 8
+  values:
+    ShowQuantityAsSpent: 1
+    TraitSourcedShowMax: 2
+    UseClassIcon: 4
+    UseSpecIcon: 8
 TraitCurrencyType:
-  CurrencyTypesBased: 1
-  Gold: 0
-  TraitSourced: 2
-  TraitSourcedPlayerDataElement: 3
+  values:
+    CurrencyTypesBased: 1
+    Gold: 0
+    TraitSourced: 2
+    TraitSourcedPlayerDataElement: 3
 TraitDefinitionSubType:
-  DragonflightBlack: 4
-  DragonflightBlue: 1
-  DragonflightBronze: 3
-  DragonflightGreen: 2
-  DragonflightRed: 0
+  values:
+    DragonflightBlack: 4
+    DragonflightBlue: 1
+    DragonflightBronze: 3
+    DragonflightGreen: 2
+    DragonflightRed: 0
 TraitEdgeType:
-  DeprecatedRankConnection: 1
-  DeprecatedSelectionOption: 5
-  MutuallyExclusive: 4
-  RequiredForAvailability: 3
-  SufficientForAvailability: 2
-  VisualOnly: 0
+  values:
+    DeprecatedRankConnection: 1
+    DeprecatedSelectionOption: 5
+    MutuallyExclusive: 4
+    RequiredForAvailability: 3
+    SufficientForAvailability: 2
+    VisualOnly: 0
 TraitEdgeVisualStyle:
-  None: 0
-  Straight: 1
+  values:
+    None: 0
+    Straight: 1
 TraitNodeEntryType:
-  ArmorSet: 11
-  DeprecatedSelect: 4
-  DragAndDrop: 5
-  ProfPath: 7
-  ProfPathUnlock: 9
-  ProfPerk: 8
-  RedButton: 10
-  SpendCapstoneCircle: 13
-  SpendCapstoneSquare: 14
-  SpendCircle: 2
-  SpendDiamond: 6
-  SpendHex: 0
-  SpendInfinite: 12
-  SpendSmallCircle: 3
-  SpendSquare: 1
+  values:
+    ArmorSet: 11
+    DeprecatedSelect: 4
+    DragAndDrop: 5
+    ProfPath: 7
+    ProfPathUnlock: 9
+    ProfPerk: 8
+    RedButton: 10
+    SpendCapstoneCircle: 13
+    SpendCapstoneSquare: 14
+    SpendCircle: 2
+    SpendDiamond: 6
+    SpendHex: 0
+    SpendInfinite: 12
+    SpendSmallCircle: 3
+    SpendSquare: 1
 TraitNodeFlag:
-  ActiveAtFirstRank: 16
-  HideMaxRank: 64
-  HighestChosenRank: 128
-  NeverPurchasable: 2
-  ShowExpandedSelection: 32
-  ShowMultipleIcons: 1
-  ShowTierTrack: 256
-  TestGridPositioned: 8
-  TestPositionLocked: 4
+  values:
+    ActiveAtFirstRank: 16
+    HideMaxRank: 64
+    HighestChosenRank: 128
+    NeverPurchasable: 2
+    ShowExpandedSelection: 32
+    ShowMultipleIcons: 1
+    ShowTierTrack: 256
+    TestGridPositioned: 8
+    TestPositionLocked: 4
 TraitNodeGroupFlag:
-  AvailableByDefault: 1
+  values:
+    AvailableByDefault: 1
 TraitNodeType:
-  Selection: 2
-  Single: 0
-  SubTreeSelection: 3
-  Tiered: 1
+  values:
+    Selection: 2
+    Single: 0
+    SubTreeSelection: 3
+    Tiered: 1
 TraitPointsOperationType:
-  Multiply: 1
-  None: -1
-  Set: 0
+  values:
+    Multiply: 1
+    None: -1
+    Set: 0
 TraitSystemFlag:
-  AllowEditInChallengeMode: 8
-  AllowEditInCombat: 4
-  AllowMultipleLoadoutsPerTree: 1
-  ShowSpendConfirmation: 2
+  values:
+    AllowEditInChallengeMode: 8
+    AllowEditInCombat: 4
+    AllowMultipleLoadoutsPerTree: 1
+    ShowSpendConfirmation: 2
 TraitSystemVariationType:
-  None: 0
-  Spec: 1
+  values:
+    None: 0
+    Spec: 1
 TraitTreeFlag:
-  CannotRefund: 1
-  HideSingleRankNumbers: 2
+  values:
+    CannotRefund: 1
+    HideSingleRankNumbers: 2
 TransformManipulatorAxis:
-  X: 1
-  Y: 2
-  Z: 4
+  values:
+    X: 1
+    Y: 2
+    Z: 4
 TransformManipulatorControlState:
-  Default: 0
-  Dimmed: 2
-  ExternallyHighlighted: 3
-  Hidden: 1
-  Hovered: 4
-  Moving: 6
-  Selected: 5
+  values:
+    Default: 0
+    Dimmed: 2
+    ExternallyHighlighted: 3
+    Hidden: 1
+    Hovered: 4
+    Moving: 6
+    Selected: 5
 TransformManipulatorDirection:
-  Negative: 1
-  Positive: 0
+  values:
+    Negative: 1
+    Positive: 0
 TransformManipulatorEvent:
-  Cancel: 3
-  Change: 1
-  Complete: 2
-  Hover: 4
-  MouseDown: 5
-  MouseUp: 6
-  Start: 0
+  values:
+    Cancel: 3
+    Change: 1
+    Complete: 2
+    Hover: 4
+    MouseDown: 5
+    MouseUp: 6
+    Start: 0
 TransformManipulatorMode:
-  Rotate: 1
-  Scale: 2
-  Translate: 0
+  values:
+    Rotate: 1
+    Scale: 2
+    Translate: 0
 TransmogCameraVariation:
-  CloakBackpack: 1
-  None: 0
-  RightShoulder: 1
+  values:
+    CloakBackpack: 1
+    None: 0
+    RightShoulder: 1
 TransmogCollectionType:
-  Back: 3
-  Bow: 25
-  Chest: 4
-  Crossbow: 27
-  Dagger: 16
-  Feet: 11
-  Fist: 17
-  Gun: 26
-  Hands: 8
-  Head: 1
-  Holdable: 19
-  Legs: 10
-  None: 0
-  OneHAxe: 13
-  OneHMace: 15
-  OneHSword: 14
-  Paired: 29
-  Polearm: 24
-  Shield: 18
-  Shirt: 5
-  Shoulder: 2
-  Staff: 23
-  Tabard: 6
-  TwoHAxe: 20
-  TwoHMace: 22
-  TwoHSword: 21
-  Waist: 9
-  Wand: 12
-  Warglaives: 28
-  Wrist: 7
+  values:
+    Back: 3
+    Bow: 25
+    Chest: 4
+    Crossbow: 27
+    Dagger: 16
+    Feet: 11
+    Fist: 17
+    Gun: 26
+    Hands: 8
+    Head: 1
+    Holdable: 19
+    Legs: 10
+    None: 0
+    OneHAxe: 13
+    OneHMace: 15
+    OneHSword: 14
+    Paired: 29
+    Polearm: 24
+    Shield: 18
+    Shirt: 5
+    Shoulder: 2
+    Staff: 23
+    Tabard: 6
+    TwoHAxe: 20
+    TwoHMace: 22
+    TwoHSword: 21
+    Waist: 9
+    Wand: 12
+    Warglaives: 28
+    Wrist: 7
 TransmogIllusionFlags:
-  AllowedRangedShieldsHoldables: 4
-  HideUntilCollected: 1
-  PlayerConditionGrantsOnLogin: 2
+  values:
+    AllowedRangedShieldsHoldables: 4
+    HideUntilCollected: 1
+    PlayerConditionGrantsOnLogin: 2
 TransmogModification:
-  Main: 0
-  Secondary: 1
+  values:
+    Main: 0
+    Secondary: 1
 TransmogOutfitCostModifiersApplied:
-  AuraDiscountApplied: 8
-  DebugOnlyFreeDiscountApplied: 1
-  OutfitCostModifierApplied: 4
-  VoidRacialDiscountApplied: 2
+  values:
+    AuraDiscountApplied: 8
+    DebugOnlyFreeDiscountApplied: 1
+    OutfitCostModifierApplied: 4
+    VoidRacialDiscountApplied: 2
 TransmogOutfitDataFlags:
-  IsCachedLocally: 1
+  values:
+    IsCachedLocally: 1
 TransmogOutfitDisplayType:
-  Assigned: 1
-  Disabled: 4
-  Equipped: 2
-  Hidden: 3
-  Unassigned: 0
+  values:
+    Assigned: 1
+    Disabled: 4
+    Equipped: 2
+    Hidden: 3
+    Unassigned: 0
 TransmogOutfitEntryFlags:
-  AutomaticallyAwardedOnLogin: 1
-  IsDefaultEquipped: 32
-  OnlyAvailableDuringEvent: 4
-  SortedToTopOfList: 8
-  UseOverrideCostModifier: 16
-  UseOverrideName: 2
+  values:
+    AutomaticallyAwardedOnLogin: 1
+    IsDefaultEquipped: 32
+    OnlyAvailableDuringEvent: 4
+    SortedToTopOfList: 8
+    UseOverrideCostModifier: 16
+    UseOverrideName: 2
 TransmogOutfitEntrySource:
-  AutomaticallyAwarded: 1
-  PlayerPurchased: 2
-  StampedSource: 0
+  values:
+    AutomaticallyAwarded: 1
+    PlayerPurchased: 2
+    StampedSource: 0
 TransmogOutfitEquipAction:
-  Equip: 0
-  EquipAndLock: 1
-  Lock: 5
-  Remove: 2
-  RemoveAndLock: 3
-  Unlock: 4
+  values:
+    Equip: 0
+    EquipAndLock: 1
+    Lock: 5
+    Remove: 2
+    RemoveAndLock: 3
+    Unlock: 4
 TransmogOutfitSetType:
-  CustomSet: 2
-  Equipped: 0
-  Outfit: 1
+  values:
+    CustomSet: 2
+    Equipped: 0
+    Outfit: 1
 TransmogOutfitSlot:
-  Back: 3
-  Body: 6
-  Chest: 4
-  Feet: 11
-  Hand: 8
-  Head: 0
-  Legs: 10
-  ShoulderLeft: 2
-  ShoulderRight: 1
-  Tabard: 5
-  Waist: 9
-  WeaponMainHand: 12
-  WeaponOffHand: 13
-  WeaponRanged: 14
-  Wrist: 7
+  values:
+    Back: 3
+    Body: 6
+    Chest: 4
+    Feet: 11
+    Hand: 8
+    Head: 0
+    Legs: 10
+    ShoulderLeft: 2
+    ShoulderRight: 1
+    Tabard: 5
+    Waist: 9
+    WeaponMainHand: 12
+    WeaponOffHand: 13
+    WeaponRanged: 14
+    Wrist: 7
 TransmogOutfitSlotError:
-  CannotUseItem: 10
-  IncompatibleWithMainHand: 14
-  InvalidDestination: 5
-  InvalidItemType: 4
-  InvalidSlotForForm: 13
-  InvalidSlotForRace: 11
-  InvalidSource: 8
-  InvalidSourceQuality: 9
-  Legendary: 3
-  Mismatch: 6
-  NoIllusion: 12
-  NoItem: 1
-  NotSoulbound: 2
-  Ok: 0
-  SameItem: 7
+  values:
+    CannotUseItem: 10
+    IncompatibleWithMainHand: 14
+    InvalidDestination: 5
+    InvalidItemType: 4
+    InvalidSlotForForm: 13
+    InvalidSlotForRace: 11
+    InvalidSource: 8
+    InvalidSourceQuality: 9
+    Legendary: 3
+    Mismatch: 6
+    NoIllusion: 12
+    NoItem: 1
+    NotSoulbound: 2
+    Ok: 0
+    SameItem: 7
 TransmogOutfitSlotFlags:
-  CanHaveIllusions: 2
-  CannotBeHidden: 1
-  IsSecondarySlot: 4
+  values:
+    CanHaveIllusions: 2
+    CannotBeHidden: 1
+    IsSecondarySlot: 4
 TransmogOutfitSlotOption:
-  ArtifactSpecFour: 11
-  ArtifactSpecOne: 8
-  ArtifactSpecThree: 10
-  ArtifactSpecTwo: 9
-  DeprecatedReuseMe: 6
-  FuryTwoHandedWeapon: 7
-  None: 0
-  OffHand: 4
-  OneHandedWeapon: 1
-  RangedWeapon: 3
-  Shield: 5
-  TwoHandedWeapon: 2
+  values:
+    ArtifactSpecFour: 11
+    ArtifactSpecOne: 8
+    ArtifactSpecThree: 10
+    ArtifactSpecTwo: 9
+    DeprecatedReuseMe: 6
+    FuryTwoHandedWeapon: 7
+    None: 0
+    OffHand: 4
+    OneHandedWeapon: 1
+    RangedWeapon: 3
+    Shield: 5
+    TwoHandedWeapon: 2
 TransmogOutfitSlotOptionFlags:
-  DisablesOffhandSlot: 4
-  DynamicOptionName: 2
-  IllusionNotAllowed: 1
+  values:
+    DisablesOffhandSlot: 4
+    DynamicOptionName: 2
+    IllusionNotAllowed: 1
 TransmogOutfitSlotOptionSheatheCategory:
-  Back: 1
-  Default: 0
-  Hide: 3
-  Side: 2
+  values:
+    Back: 1
+    Default: 0
+    Hide: 3
+    Side: 2
 TransmogOutfitSlotPosition:
-  Bottom: 2
-  Left: 0
-  Right: 1
+  values:
+    Bottom: 2
+    Left: 0
+    Right: 1
 TransmogOutfitSlotSaveFlags:
-  AppearanceIsNotValid: 1
+  values:
+    AppearanceIsNotValid: 1
 TransmogOutfitSlotWarning:
-  InvalidEquippedDestinationItem: 1
-  NothingEquipped: 5
-  Ok: 0
-  PendingWeaponChanges: 3
-  WeaponDoesNotSupportIllusions: 4
-  WrongWeaponCategoryEquipped: 2
+  values:
+    InvalidEquippedDestinationItem: 1
+    NothingEquipped: 5
+    Ok: 0
+    PendingWeaponChanges: 3
+    WeaponDoesNotSupportIllusions: 4
+    WrongWeaponCategoryEquipped: 2
 TransmogOutfitTransactionFlags:
-  AddNewOutfitMask: 20
-  AddOutfitAndUpdateSlots: 28
-  CreateAndUpdateOutfitInfoMask: 6
-  CreateOutfitInfo: 4
-  FullOutfitUpdateMask: 27
-  UpdateMetadata: 1
-  UpdateOutfitInfo: 2
-  UpdateSituations: 16
-  UpdateSituationsMask: 18
-  UpdateSlots: 8
+  values:
+    AddNewOutfitMask: 20
+    AddOutfitAndUpdateSlots: 28
+    CreateAndUpdateOutfitInfoMask: 6
+    CreateOutfitInfo: 4
+    FullOutfitUpdateMask: 27
+    UpdateMetadata: 1
+    UpdateOutfitInfo: 2
+    UpdateSituations: 16
+    UpdateSituationsMask: 18
+    UpdateSlots: 8
 TransmogOutfitTransactionType:
-  CreateOutfitInfo: 2
-  UpdateMetadata: 0
-  UpdateOutfitInfo: 1
-  UpdateSituations: 4
-  UpdateSlots: 3
+  values:
+    CreateOutfitInfo: 2
+    UpdateMetadata: 0
+    UpdateOutfitInfo: 1
+    UpdateSituations: 4
+    UpdateSlots: 3
 TransmogPendingType:
-  Apply: 0
-  Revert: 1
-  ToggleOff: 3
-  ToggleOn: 2
+  values:
+    Apply: 0
+    Revert: 1
+    ToggleOff: 3
+    ToggleOn: 2
 TransmogSearchType:
-  BaseSets: 2
-  Items: 1
-  UsableSets: 3
+  values:
+    BaseSets: 2
+    Items: 1
+    UsableSets: 3
 TransmogSituation:
-  AllEquipmentSets: 17
-  AllLocations: 2
-  AllMovement: 12
-  AllRacialForms: 19
-  AllSpecs: 0
-  AllTime: 27
-  AllWeather: 22
-  EquipmentSets: 18
-  FormNative: 20
-  FormNonNative: 21
-  LocationArenas: 10
-  LocationBattlegrounds: 11
-  LocationCharacterSelect: 5
-  LocationDelves: 7
-  LocationDungeons: 8
-  LocationHouse: 4
-  LocationRaids: 9
-  LocationRested: 3
-  LocationWorld: 6
-  MovementFlyingMount: 16
-  MovementGroundMount: 15
-  MovementSwimming: 14
-  MovementUnmounted: 13
-  Spec: 1
-  TimeDay: 29
-  TimeEvening: 30
-  TimeMorning: 28
-  TimeNight: 31
-  WeatherClear: 23
-  WeatherRain: 24
-  WeatherSand: 26
-  WeatherSnow: 25
+  values:
+    AllEquipmentSets: 17
+    AllLocations: 2
+    AllMovement: 12
+    AllRacialForms: 19
+    AllSpecs: 0
+    AllTime: 27
+    AllWeather: 22
+    EquipmentSets: 18
+    FormNative: 20
+    FormNonNative: 21
+    LocationArenas: 10
+    LocationBattlegrounds: 11
+    LocationCharacterSelect: 5
+    LocationDelves: 7
+    LocationDungeons: 8
+    LocationHouse: 4
+    LocationRaids: 9
+    LocationRested: 3
+    LocationWorld: 6
+    MovementFlyingMount: 16
+    MovementGroundMount: 15
+    MovementSwimming: 14
+    MovementUnmounted: 13
+    Spec: 1
+    TimeDay: 29
+    TimeEvening: 30
+    TimeMorning: 28
+    TimeNight: 31
+    WeatherClear: 23
+    WeatherRain: 24
+    WeatherSand: 26
+    WeatherSnow: 25
 TransmogSituationFlags:
-  AllSituation: 4
-  DefaultsToOn: 8
-  DisabledSituation: 64
-  DynamicallyNamed: 16
-  IsPlayerFacing: 1
-  NoneSituation: 32
-  SpecUseTalentLoadout: 2
+  values:
+    AllSituation: 4
+    DefaultsToOn: 8
+    DisabledSituation: 64
+    DynamicallyNamed: 16
+    IsPlayerFacing: 1
+    NoneSituation: 32
+    SpecUseTalentLoadout: 2
 TransmogSituationGroupFlags:
-  DynamicallyCreatesGroups: 1
+  values:
+    DynamicallyCreatesGroups: 1
 TransmogSituationTrigger:
-  EquipmentSet: 6
-  EventOutfit: 8
-  Forms: 7
-  Location: 3
-  Manual: 1
-  Movement: 4
-  None: 0
-  Specialization: 5
-  TimeOfDay: 10
-  TransmogUpdate: 2
-  Weather: 9
+  values:
+    EquipmentSet: 6
+    EventOutfit: 8
+    Forms: 7
+    Location: 3
+    Manual: 1
+    Movement: 4
+    None: 0
+    Specialization: 5
+    TimeOfDay: 10
+    TransmogUpdate: 2
+    Weather: 9
 TransmogSituationTriggerFlags:
-  CanChangeLockedOutfit: 2
-  CanLockOutfit: 1
-  DisabledTrigger: 16
-  IsPlayerFacing: 4
-  SituationsAreExclusive: 8
+  values:
+    CanChangeLockedOutfit: 2
+    CanLockOutfit: 1
+    DisabledTrigger: 16
+    IsPlayerFacing: 4
+    SituationsAreExclusive: 8
 TransmogSituationTriggerType:
-  Automatic: 2
-  Manual: 1
-  None: 0
-  TransmogUpdate: 3
+  values:
+    Automatic: 2
+    Manual: 1
+    None: 0
+    TransmogUpdate: 3
 TransmogSlot:
-  Back: 2
-  Body: 4
-  Chest: 3
-  Feet: 10
-  Hand: 7
-  Head: 0
-  Legs: 9
-  Mainhand: 11
-  Offhand: 12
-  Ranged: 13
-  Shoulder: 1
-  Tabard: 5
-  Waist: 8
-  Wrist: 6
+  values:
+    Back: 2
+    Body: 4
+    Chest: 3
+    Feet: 10
+    Hand: 7
+    Head: 0
+    Legs: 9
+    Mainhand: 11
+    Offhand: 12
+    Ranged: 13
+    Shoulder: 1
+    Tabard: 5
+    Waist: 8
+    Wrist: 6
 TransmogSource:
-  Achievement: 7
-  CantCollect: 6
-  HiddenUntilCollected: 5
-  JournalEncounter: 1
-  None: 0
-  NotValidForTransmog: 9
-  Profession: 8
-  Quest: 2
-  TradingPost: 10
-  Vendor: 3
-  WorldDrop: 4
+  values:
+    Achievement: 7
+    CantCollect: 6
+    HiddenUntilCollected: 5
+    JournalEncounter: 1
+    None: 0
+    NotValidForTransmog: 9
+    Profession: 8
+    Quest: 2
+    TradingPost: 10
+    Vendor: 3
+    WorldDrop: 4
 TransmogTimeOfDayCategory:
-  Evening: 2
-  Midday: 1
-  Morning: 0
-  Night: 3
+  values:
+    Evening: 2
+    Midday: 1
+    Morning: 0
+    Night: 3
 TransmogType:
-  Appearance: 0
-  Illusion: 1
+  values:
+    Appearance: 0
+    Illusion: 1
 TransmogUseErrorType:
-  Ability: 3
-  Class: 7
-  Faction: 9
-  Holiday: 5
-  HotRecheckFailed: 6
-  ItemProficiency: 10
-  None: 0
-  PlayerCondition: 1
-  Race: 8
-  Reputation: 4
-  Skill: 2
+  values:
+    Ability: 3
+    Class: 7
+    Faction: 9
+    Holiday: 5
+    HotRecheckFailed: 6
+    ItemProficiency: 10
+    None: 0
+    PlayerCondition: 1
+    Race: 8
+    Reputation: 4
+    Skill: 2
 TtsBoolSetting:
-  AddCharacterNameToSpeech: 1
-  AlternateSystemVoice: 3
-  NarrateMyMessages: 4
-  PlayActivitySoundWhenNotFocused: 2
-  PlaySoundSeparatingChatLineBreaks: 0
+  values:
+    AddCharacterNameToSpeech: 1
+    AlternateSystemVoice: 3
+    NarrateMyMessages: 4
+    PlayActivitySoundWhenNotFocused: 2
+    PlaySoundSeparatingChatLineBreaks: 0
 TtsVoiceType:
-  Alternate: 1
-  Standard: 0
+  values:
+    Alternate: 1
+    Standard: 0
 TugOfWarMarkerArrowShownState:
-  Always: 1
-  FlashOnMove: 2
-  Never: 0
+  values:
+    Always: 1
+    FlashOnMove: 2
+    Never: 0
 TugOfWarStyleValue:
-  ArchaeologyBrown: 1
-  DefaultYellow: 0
+  values:
+    ArchaeologyBrown: 1
+    DefaultYellow: 0
 TurnStrafeStyle:
-  Custom: 2
-  Legacy: 1
-  Modern: 0
+  values:
+    Custom: 2
+    Legacy: 1
+    Modern: 0
 UIActionType:
-  DefaultAction: 0
-  Reserved1: 2
-  UpdateMapSystem: 1
+  values:
+    DefaultAction: 0
+    Reserved1: 2
+    UpdateMapSystem: 1
 UICovenantDisplayInfoFlags:
-  DisplayCovenantAsJourney: 1
-  UseJourneyRewardTrack: 2
-  UseJourneyUnlockToastText: 3
+  values:
+    DisplayCovenantAsJourney: 1
+    UseJourneyRewardTrack: 2
+    UseJourneyUnlockToastText: 3
 UICursorType:
-  ActionBar: 6
-  Ammo: 8
-  BattlePet: 16
-  ConduitCollectionItem: 19
-  Currency: 13
-  Default: 0
-  EquipmentSet: 12
-  Flyout: 14
-  GuildBank: 10
-  GuildBankMoney: 11
-  Item: 1
-  Macro: 7
-  Merchant: 5
-  Money: 2
-  Mount: 17
-  Outfit: 21
-  PerksProgramVendorItem: 20
-  Pet: 9
-  PetAction: 4
-  Spell: 3
-  Toy: 18
-  VoidItem: 15
+  values:
+    ActionBar: 6
+    Ammo: 8
+    BattlePet: 16
+    ConduitCollectionItem: 19
+    Currency: 13
+    Default: 0
+    EquipmentSet: 12
+    Flyout: 14
+    GuildBank: 10
+    GuildBankMoney: 11
+    Item: 1
+    Macro: 7
+    Merchant: 5
+    Money: 2
+    Mount: 17
+    Outfit: 21
+    PerksProgramVendorItem: 20
+    Pet: 9
+    PetAction: 4
+    Spell: 3
+    Toy: 18
+    VoidItem: 15
 UIItemInteractionFlags:
-  AddCurrency: 16
-  ClickShowsFlyout: 8
-  ConfirmationHasDelay: 2
-  ConversionMode: 4
-  DisplayWithInset: 1
-  UsesCharges: 32
+  values:
+    AddCurrency: 16
+    ClickShowsFlyout: 8
+    ConfirmationHasDelay: 2
+    ConversionMode: 4
+    DisplayWithInset: 1
+    UsesCharges: 32
 UIItemInteractionType:
-  CastSpell: 1
-  CleanseCorruption: 2
-  ItemConversion: 4
-  None: 0
-  RunecarverScrapping: 3
+  values:
+    CastSpell: 1
+    CleanseCorruption: 2
+    ItemConversion: 4
+    None: 0
+    RunecarverScrapping: 3
 UIMapFlag:
-  AlwaysAllowTaxiPathing: 131072
-  AlwaysAllowUserWaypoints: 65536
-  DoNotShowOnNavbar: 524288
-  DoNotTranslateBranches: 512
-  FallbackToParentMap: 16
-  FlightMapAutoZoom: 16384
-  FlightMapShowZoomOut: 8192
-  ForceAllOverlayExplored: 4096
-  ForceAllowMapLinks: 262144
-  ForceOnNavbar: 32768
-  GarrisonMap: 8
-  HideArchaeologyDigs: 256
-  HideIcons: 1024
-  HideVignettes: 2048
-  IgnoreInTranslationsToParent: 2097152
-  IsCityMap: 1048576
-  NoHighlight: 1
-  NoHighlightTexture: 32
-  NoWorldPositions: 128
-  ShowOverlays: 2
-  ShowTaskObjectives: 64
-  ShowTaxiNodes: 4
+  values:
+    AlwaysAllowTaxiPathing: 131072
+    AlwaysAllowUserWaypoints: 65536
+    DoNotShowOnNavbar: 524288
+    DoNotTranslateBranches: 512
+    FallbackToParentMap: 16
+    FlightMapAutoZoom: 16384
+    FlightMapShowZoomOut: 8192
+    ForceAllOverlayExplored: 4096
+    ForceAllowMapLinks: 262144
+    ForceOnNavbar: 32768
+    GarrisonMap: 8
+    HideArchaeologyDigs: 256
+    HideIcons: 1024
+    HideVignettes: 2048
+    IgnoreInTranslationsToParent: 2097152
+    IsCityMap: 1048576
+    NoHighlight: 1
+    NoHighlightTexture: 32
+    NoWorldPositions: 128
+    ShowOverlays: 2
+    ShowTaskObjectives: 64
+    ShowTaxiNodes: 4
 UIMapGroupFlag:
-  ShowIconsAcrossFloors: 1
+  values:
+    ShowIconsAcrossFloors: 1
 UIMapSystem:
-  Adventure: 2
-  Minimap: 3
-  Taxi: 1
-  World: 0
+  values:
+    Adventure: 2
+    Minimap: 3
+    Taxi: 1
+    World: 0
 UIMapType:
-  Continent: 2
-  Cosmic: 0
-  Dungeon: 4
-  Micro: 5
-  Orphan: 6
-  World: 1
-  Zone: 3
+  values:
+    Continent: 2
+    Cosmic: 0
+    Dungeon: 4
+    Micro: 5
+    Orphan: 6
+    World: 1
+    Zone: 3
 UIModelSceneActorFlag:
-  Deprecated1: 1
-  UseCenterForOriginX: 2
-  UseCenterForOriginY: 4
-  UseCenterForOriginZ: 8
+  values:
+    Deprecated1: 1
+    UseCenterForOriginX: 2
+    UseCenterForOriginY: 4
+    UseCenterForOriginZ: 8
 UIModelSceneContext:
-  None: -1
-  PerksProgram: 0
+  values:
+    None: -1
+    PerksProgram: 0
 UIModelSceneFlags:
-  Autodress: 4
-  HideWeapon: 2
-  NoCameraSpin: 8
-  SheatheWeapon: 1
+  values:
+    Autodress: 4
+    HideWeapon: 2
+    NoCameraSpin: 8
+    SheatheWeapon: 1
 UISystemType:
-  InGameNavigation: 0
+  values:
+    InGameNavigation: 0
 UITextureSliceMode:
-  Stretched: 0
-  Tiled: 1
+  values:
+    Stretched: 0
+    Tiled: 1
 UIWidgetBlendModeType:
-  Additive: 1
-  Opaque: 0
+  values:
+    Additive: 1
+    Opaque: 0
 UIWidgetButtonEnabledState:
-  Disabled: 0
-  Enabled: 1
+  values:
+    Disabled: 0
+    Enabled: 1
 UIWidgetButtonIconType:
-  Checkmark: 3
-  Exit: 0
-  RedX: 4
-  Speak: 1
-  Undo: 2
+  values:
+    Checkmark: 3
+    Exit: 0
+    RedX: 4
+    Speak: 1
+    Undo: 2
 UIWidgetFlag:
-  UniversalWidget: 1
+  values:
+    UniversalWidget: 1
 UIWidgetFontType:
-  Normal: 0
-  Outline: 2
-  Shadow: 1
+  values:
+    Normal: 0
+    Outline: 2
+    Shadow: 1
 UIWidgetHorizontalDirection:
-  LeftToRight: 0
-  RightToLeft: 1
+  values:
+    LeftToRight: 0
+    RightToLeft: 1
 UIWidgetLayoutDirection:
-  Default: 0
-  Horizontal: 2
-  HorizontalForceNewRow: 4
-  Overlap: 3
-  Vertical: 1
+  values:
+    Default: 0
+    Horizontal: 2
+    HorizontalForceNewRow: 4
+    Overlap: 3
+    Vertical: 1
 UIWidgetModelSceneLayer:
-  Back: 2
-  Front: 1
-  None: 0
+  values:
+    Back: 2
+    Front: 1
+    None: 0
 UIWidgetMotionType:
-  Instant: 0
-  Smooth: 1
+  values:
+    Instant: 0
+    Smooth: 1
 UIWidgetOverrideState:
-  Active: 1
-  Inactive: 0
+  values:
+    Active: 1
+    Inactive: 0
 UIWidgetRewardShownState:
-  Hidden: 0
-  ShownEarned: 1
-  ShownUnearned: 2
+  values:
+    Hidden: 0
+    ShownEarned: 1
+    ShownUnearned: 2
 UIWidgetScale:
-  Eighty: 2
-  Fifty: 5
-  Ninty: 1
-  OneHundred: 0
-  OneHundredEighty: 13
-  OneHundredFifty: 10
-  OneHundredForty: 9
-  OneHundredNinety: 14
-  OneHundredSeventy: 12
-  OneHundredSixty: 11
-  OneHundredTen: 6
-  OneHundredThirty: 8
-  OneHundredTwenty: 7
-  Seventy: 3
-  Sixty: 4
-  TwoHundred: 15
+  values:
+    Eighty: 2
+    Fifty: 5
+    Ninty: 1
+    OneHundred: 0
+    OneHundredEighty: 13
+    OneHundredFifty: 10
+    OneHundredForty: 9
+    OneHundredNinety: 14
+    OneHundredSeventy: 12
+    OneHundredSixty: 11
+    OneHundredTen: 6
+    OneHundredThirty: 8
+    OneHundredTwenty: 7
+    Seventy: 3
+    Sixty: 4
+    TwoHundred: 15
 UIWidgetSetLayoutDirection:
-  Horizontal: 1
-  Overlap: 2
-  Vertical: 0
+  values:
+    Horizontal: 1
+    Overlap: 2
+    Vertical: 0
 UIWidgetSpellButtonCooldownType:
-  HideCooldown: 0
-  ShowCooldown: 1
-  ShowCooldownAndDisableOnCooldown: 2
+  values:
+    HideCooldown: 0
+    ShowCooldown: 1
+    ShowCooldownAndDisableOnCooldown: 2
 UIWidgetTextFormatType:
-  LeadingZeroesWithSixDigits: 3
-  None: 0
-  TimeOneLevel: 1
-  TimeTwoLevel: 2
+  values:
+    LeadingZeroesWithSixDigits: 3
+    None: 0
+    TimeOneLevel: 1
+    TimeTwoLevel: 2
 UIWidgetTextSizeType:
-  Huge27Pt: 3
-  Large20Pt: 8
-  Large24Pt: 2
-  Medium16Pt: 1
-  Medium18Pt: 7
-  Small10Pt: 5
-  Small11Pt: 6
-  Small12Pt: 0
-  Standard14Pt: 4
+  values:
+    Huge27Pt: 3
+    Large20Pt: 8
+    Large24Pt: 2
+    Medium16Pt: 1
+    Medium18Pt: 7
+    Small10Pt: 5
+    Small11Pt: 6
+    Small12Pt: 0
+    Standard14Pt: 4
 UIWidgetTextureAndTextSizeType:
-  Huge: 3
-  Large: 2
-  Medium: 1
-  Medium2: 5
-  Small: 0
-  Standard: 4
+  values:
+    Huge: 3
+    Large: 2
+    Medium: 1
+    Medium2: 5
+    Small: 0
+    Standard: 4
 UIWidgetTooltipLocation:
-  Bottom: 8
-  BottomLeft: 1
-  BottomRight: 7
-  Default: 0
-  Left: 2
-  Right: 6
-  Top: 4
-  TopLeft: 3
-  TopRight: 5
+  values:
+    Bottom: 8
+    BottomLeft: 1
+    BottomRight: 7
+    Default: 0
+    Left: 2
+    Right: 6
+    Top: 4
+    TopLeft: 3
+    TopRight: 5
 UIWidgetUpdateAnimType:
-  Flash: 1
-  FlashAndAnimateNumber: 2
-  None: 0
+  values:
+    Flash: 1
+    FlashAndAnimateNumber: 2
+    None: 0
 UIWidgetVisualizationType:
-  BulletTextList: 10
-  ButtonHeader: 30
-  CaptureBar: 1
-  CaptureZone: 17
-  DiscreteProgressSteps: 19
-  DoubleIconAndText: 5
-  DoubleStateIconRow: 14
-  DoubleStatusBar: 3
-  FillUpFrames: 24
-  HorizontalCurrencies: 9
-  IconAndText: 0
-  IconTextAndBackground: 4
-  IconTextAndCurrencies: 7
-  ItemDisplay: 27
-  MapPinAnimation: 26
-  PreyHuntProgress: 31
-  ScenarioHeaderCurrenciesAndBackground: 11
-  ScenarioHeaderDelves: 29
-  ScenarioHeaderTimer: 20
-  Spacer: 22
-  SpellDisplay: 13
-  StackedResourceTracker: 6
-  StatusBar: 2
-  TextColumnRow: 21
-  TextureAndText: 12
-  TextureAndTextRow: 15
-  TextureWithAnimation: 18
-  TextWithState: 8
-  TextWithSubtext: 25
-  TugOfWar: 28
-  UnitPowerBar: 23
-  ZoneControl: 16
+  values:
+    BulletTextList: 10
+    ButtonHeader: 30
+    CaptureBar: 1
+    CaptureZone: 17
+    DiscreteProgressSteps: 19
+    DoubleIconAndText: 5
+    DoubleStateIconRow: 14
+    DoubleStatusBar: 3
+    FillUpFrames: 24
+    HorizontalCurrencies: 9
+    IconAndText: 0
+    IconTextAndBackground: 4
+    IconTextAndCurrencies: 7
+    ItemDisplay: 27
+    MapPinAnimation: 26
+    PreyHuntProgress: 31
+    ScenarioHeaderCurrenciesAndBackground: 11
+    ScenarioHeaderDelves: 29
+    ScenarioHeaderTimer: 20
+    Spacer: 22
+    SpellDisplay: 13
+    StackedResourceTracker: 6
+    StatusBar: 2
+    TextColumnRow: 21
+    TextureAndText: 12
+    TextureAndTextRow: 15
+    TextureWithAnimation: 18
+    TextWithState: 8
+    TextWithSubtext: 25
+    TugOfWar: 28
+    UnitPowerBar: 23
+    ZoneControl: 16
 UnitAuraSortDirection:
-  Normal: 0
-  Reverse: 1
+  values:
+    Normal: 0
+    Reverse: 1
 UnitAuraSortRule:
-  BigDefensive: 2
-  Default: 1
-  Expiration: 3
-  ExpirationOnly: 4
-  Name: 5
-  NameOnly: 6
-  Unsorted: 0
+  values:
+    BigDefensive: 2
+    Default: 1
+    Expiration: 3
+    ExpirationOnly: 4
+    Name: 5
+    NameOnly: 6
+    Unsorted: 0
 UnitDamageAbsorbClampMode:
-  MaximumHealth: 2
-  MissingHealth: 0
-  MissingHealthWithoutIncomingHeals: 1
+  values:
+    MaximumHealth: 2
+    MissingHealth: 0
+    MissingHealthWithoutIncomingHeals: 1
 UnitHealAbsorbClampMode:
-  CurrentHealth: 0
-  MaximumHealth: 1
+  values:
+    CurrentHealth: 0
+    MaximumHealth: 1
 UnitHealAbsorbMode:
-  ReducedByIncomingHeals: 0
-  Total: 1
+  values:
+    ReducedByIncomingHeals: 0
+    Total: 1
 UnitIncomingHealClampMode:
-  MaximumHealth: 1
-  MissingHealth: 0
+  values:
+    MaximumHealth: 1
+    MissingHealth: 0
 UnitMaximumHealthMode:
-  Default: 0
-  WithAbsorbs: 1
+  values:
+    Default: 0
+    WithAbsorbs: 1
 UnitMirrorPetFlags:
-  Dismissable: 2
-  ExtraPet: 16
-  RecentlyTamed: 4
-  Renameable: 1
-  Stampede: 8
+  values:
+    Dismissable: 2
+    ExtraPet: 16
+    RecentlyTamed: 4
+    Renameable: 1
+    Stampede: 8
 UnitSex:
-  Both: 3
-  Female: 1
-  Male: 0
-  Neutral: 4
-  None: 2
+  values:
+    Both: 3
+    Female: 1
+    Male: 0
+    Neutral: 4
+    None: 2
 UrlTextureResult:
-  Found: 1
-  NotAllowed: 4
-  NotFound: 2
-  Requested: 3
+  values:
+    Found: 1
+    NotAllowed: 4
+    NotFound: 2
+    Requested: 3
 ValidateNameResult:
-  ConsecutiveSpaces: 13
-  DeclensionDoesntMatchBaseName: 16
-  Failure: 1
-  InvalidApostrophe: 9
-  InvalidCharacter: 5
-  InvalidSpace: 12
-  MixedLanguages: 6
-  MultipleApostrophes: 10
-  NoName: 2
-  Profane: 7
-  Reserved: 8
-  RussianConsecutiveSilentCharacters: 14
-  RussianSilentCharacterAtBeginningOrEnd: 15
-  SpacesDisallowed: 17
-  Success: 0
-  ThreeConsecutive: 11
-  TooLong: 4
-  TooShort: 3
+  values:
+    ConsecutiveSpaces: 13
+    DeclensionDoesntMatchBaseName: 16
+    Failure: 1
+    InvalidApostrophe: 9
+    InvalidCharacter: 5
+    InvalidSpace: 12
+    MixedLanguages: 6
+    MultipleApostrophes: 10
+    NoName: 2
+    Profane: 7
+    Reserved: 8
+    RussianConsecutiveSilentCharacters: 14
+    RussianSilentCharacterAtBeginningOrEnd: 15
+    SpacesDisallowed: 17
+    Success: 0
+    ThreeConsecutive: 11
+    TooLong: 4
+    TooShort: 3
 VasPurchaseProgress:
-  ApplyingLicense: 3
-  Complete: 7
-  Invalid: 0
-  PaymentPending: 2
-  PrePurchase: 1
-  ProcessingFactionChange: 6
-  Ready: 5
-  WaitingOnQueue: 4
+  values:
+    ApplyingLicense: 3
+    Complete: 7
+    Invalid: 0
+    PaymentPending: 2
+    PrePurchase: 1
+    ProcessingFactionChange: 6
+    Ready: 5
+    WaitingOnQueue: 4
 VasServiceType:
-  AppearanceChange: 2
-  CharacterClone: 10
-  CharacterTransfer: 4
-  FactionChange: 1
-  FactionTransfer: 5
-  NameChange: 0
-  RaceChange: 3
+  values:
+    AppearanceChange: 2
+    CharacterClone: 10
+    CharacterTransfer: 4
+    FactionChange: 1
+    FactionTransfer: 5
+    NameChange: 0
+    RaceChange: 3
 VasTransactionPurchaseResult:
-  BeginDbErrors: 20010
-  BeginProxyErrors: 17
-  DbAccountDoesNotOwnCharacter: 20017
-  DbAllianceNotEligible: 20027
-  DbAlreadyRenameFlagged: 20055
-  DbAuthenticatorInsufficient: 20073
-  DbBatchProcessingDisabled: 20028
-  DbBatchStateInvalid: 20067
-  DbBnetAccountNotProvided: 20077
-  DbBoostProcessingDisabled: 20095
-  DbBpayDeliveryPending: 20078
-  DbCagedPetInInventory: 20084
-  DbCannotMoveArenaCaptn: 20064
-  DbCannotMoveGuildmaster: 20012
-  DbCharacterDoesNotExist: 20019
-  DbCharacterWithoutGuild: 20070
-  DbCharLocked: 20026
-  DbCharNotLocked: 20025
-  DbCouldNotObtainCharLock: 20041
-  DbCustomizeAlreadyRequested: 20057
-  DbDeletedGuild: 20071
-  DbDuplicateCharacterName: 20015
-  DbDuplicateSupportRequest: 20063
-  DbEventNotActive: 20068
-  DbEventRealmClosed: 20038
-  DbFactionChangeTooSoon: 20061
-  DbGmSenorityInsufficient: 20072
-  DbGuildLevelInsufficient: 20074
-  DbGuildRankInsufficient: 20069
-  DbHasAuctions: 20033
-  DbHasBpayToken: 20079
-  DbHasCraftingOrders: 20092
-  DbHasHeirloomItem: 20080
-  DbHasMail: 20016
-  DbHasNewPlayerExperienceRestriction: 20091
-  DbHasUnclaimedCacheRewards: 20089
-  DbHouseOwnerRestriction: 20096
-  DbIneligibleMapID: 20076
-  DbIneligibleTargetRealm: 20022
-  DbInvalidName: 20094
-  DbInventoryCorrupt: 20040
-  DbLastCustomizeTooSoon: 20058
-  DbLastRenameTooRecent: 20052
-  DbLastRequestTooSoon: 20054
-  DbLastSaveTooDistant: 20083
-  DbLastSaveTooRecent: 20034
-  DbLockAlreadyRequested: 20044
-  DbLockNotAcknowledged: 20043
-  DbMaxCharactersOnServer: 20013
-  DbMoveInProgress: 20018
-  DbMultipleTransferCn: 20056
-  DbNameChangeSkipped: 20093
-  DbNameNotAvailable: 20051
-  DbNeedsEraChoice: 20090
-  DbNeedsLevelSquish: 20088
-  DbNewLeaderInvalid: 20086
-  DbNewNameTooLong: 20024
-  DbNoCopiesAvailable: 20020
-  DbNoCsiFound: 20065
-  DbNoMixedAlliance: 20014
-  DbNoneBatchQueueID: 20029
-  DbNoneLockID: 20042
-  DbNoneRealmForEvent: 20037
-  DbNoneSupportActionID: 20046
-  DbNoneSupportQueueID: 20045
-  DbNoneTemplateForEvent: 20039
-  DbNotMovebackable: 20048
-  DbNotRollbackable: 20047
-  DbOnBoostCooldown: 20085
-  DbPendingItemAudit: 20066
-  DbPvEPvPTransferNotAllowed: 20087
-  DbRaceClassComboIneligible: 20062
-  DbRealmNotEligible: 20011
-  DbRegionalDbNotFound: 20075
-  DbRenameAlreadyRequested: 20049
-  DbReservationDoesNotMatch: 20053
-  DbReservationExpired: 20050
-  DbResultAccountRestricted: 20082
-  DbResultSourceAccountBanned: 20081
-  DbTooMuchMoneyForLevel: 20032
-  DbTransferDateTooSoon: 20023
-  DbTransferNotCancellable: 20031
-  DbTransferNotFinalized: 20030
-  DbTransferNotLockable: 20035
-  DbTransferNotUnlockable: 20036
-  DbUnableToCustomize: 20060
-  DbUnderMinLevelReq: 20021
-  DbWaitingForPayment: 20059
-  DisallowedDestinationAccount: 9
-  DisallowedSourceAccount: 8
-  EndDbErrors: 20097
-  EndProxyErrors: 56
-  EndServerErrors: 16
-  InvalidBpayDeliverableID: 14
-  InvalidBpayProductID: 13
-  InvalidBpayProductType: 15
-  InvalidDestinationAccount: 6
-  InvalidDestinationRealm: 5
-  InvalidDistribution: 12
-  InvalidSourceAccount: 7
-  LowerBoxLevel: 11
-  None: 0
-  NoneCharacter: 2
-  NoneProduct: 3
-  OnlyOneVasAtATime: 4
-  ProxyAccountDataTooBig: 55
-  ProxyBadDbType: 35
-  ProxyBadObjType: 18
-  ProxyBadRequestContained: 33
-  ProxyBindFailed: 51
-  ProxyCannotDeleteArenaCaptain: 31
-  ProxyCannotDeleteGuildLeader: 30
-  ProxyCannotInsertNull: 45
-  ProxyCannotUndeleteTrialBoostCharacter: 46
-  ProxyCharacterHasWoWToken: 53
-  ProxyCharacterLevelTooHigh: 38
-  ProxyCharacterTransferred: 39
-  ProxyCharacterTransferredNoBoostInProgress: 40
-  ProxyDataInvalid: 22
-  ProxyDbError: 21
-  ProxyDeleteNotSupported: 28
-  ProxyExternalUpdateDetected: 37
-  ProxyGenericError: 44
-  ProxyInsertRequestContainedNoData: 49
-  ProxyInvalidKey: 50
-  ProxyIsReadonly: 34
-  ProxyLockedForToken: 42
-  ProxyLockedForTransfer: 26
-  ProxyLockedForUpgrade: 41
-  ProxyLockedForVas: 43
-  ProxyLocksFailed: 24
-  ProxyLostProxyConnection: 23
-  ProxyMissingResultsPtr: 25
-  ProxyMoneyLimitExceeded: 32
-  ProxyNoReturnValue: 27
-  ProxyObjDropped: 29
-  ProxyObjNotInDb: 19
-  ProxyOperationAlreadyInProgress: 36
-  ProxyPredicateFailed: 47
-  ProxyTooBusyBackOff: 54
-  ProxyTooManyRows: 52
-  ProxyUniqueKey: 20
-  ProxyWeeklyRewardNotFound: 48
-  UnknownError: 10
-  VasPurchaseDisabled: 1
+  values:
+    BeginDbErrors: 20010
+    BeginProxyErrors: 17
+    DbAccountDoesNotOwnCharacter: 20017
+    DbAllianceNotEligible: 20027
+    DbAlreadyRenameFlagged: 20055
+    DbAuthenticatorInsufficient: 20073
+    DbBatchProcessingDisabled: 20028
+    DbBatchStateInvalid: 20067
+    DbBnetAccountNotProvided: 20077
+    DbBoostProcessingDisabled: 20095
+    DbBpayDeliveryPending: 20078
+    DbCagedPetInInventory: 20084
+    DbCannotMoveArenaCaptn: 20064
+    DbCannotMoveGuildmaster: 20012
+    DbCharacterDoesNotExist: 20019
+    DbCharacterWithoutGuild: 20070
+    DbCharLocked: 20026
+    DbCharNotLocked: 20025
+    DbCouldNotObtainCharLock: 20041
+    DbCustomizeAlreadyRequested: 20057
+    DbDeletedGuild: 20071
+    DbDuplicateCharacterName: 20015
+    DbDuplicateSupportRequest: 20063
+    DbEventNotActive: 20068
+    DbEventRealmClosed: 20038
+    DbFactionChangeTooSoon: 20061
+    DbGmSenorityInsufficient: 20072
+    DbGuildLevelInsufficient: 20074
+    DbGuildRankInsufficient: 20069
+    DbHasAuctions: 20033
+    DbHasBpayToken: 20079
+    DbHasCraftingOrders: 20092
+    DbHasHeirloomItem: 20080
+    DbHasMail: 20016
+    DbHasNewPlayerExperienceRestriction: 20091
+    DbHasUnclaimedCacheRewards: 20089
+    DbHouseOwnerRestriction: 20096
+    DbIneligibleMapID: 20076
+    DbIneligibleTargetRealm: 20022
+    DbInvalidName: 20094
+    DbInventoryCorrupt: 20040
+    DbLastCustomizeTooSoon: 20058
+    DbLastRenameTooRecent: 20052
+    DbLastRequestTooSoon: 20054
+    DbLastSaveTooDistant: 20083
+    DbLastSaveTooRecent: 20034
+    DbLockAlreadyRequested: 20044
+    DbLockNotAcknowledged: 20043
+    DbMaxCharactersOnServer: 20013
+    DbMoveInProgress: 20018
+    DbMultipleTransferCn: 20056
+    DbNameChangeSkipped: 20093
+    DbNameNotAvailable: 20051
+    DbNeedsEraChoice: 20090
+    DbNeedsLevelSquish: 20088
+    DbNewLeaderInvalid: 20086
+    DbNewNameTooLong: 20024
+    DbNoCopiesAvailable: 20020
+    DbNoCsiFound: 20065
+    DbNoMixedAlliance: 20014
+    DbNoneBatchQueueID: 20029
+    DbNoneLockID: 20042
+    DbNoneRealmForEvent: 20037
+    DbNoneSupportActionID: 20046
+    DbNoneSupportQueueID: 20045
+    DbNoneTemplateForEvent: 20039
+    DbNotMovebackable: 20048
+    DbNotRollbackable: 20047
+    DbOnBoostCooldown: 20085
+    DbPendingItemAudit: 20066
+    DbPvEPvPTransferNotAllowed: 20087
+    DbRaceClassComboIneligible: 20062
+    DbRealmNotEligible: 20011
+    DbRegionalDbNotFound: 20075
+    DbRenameAlreadyRequested: 20049
+    DbReservationDoesNotMatch: 20053
+    DbReservationExpired: 20050
+    DbResultAccountRestricted: 20082
+    DbResultSourceAccountBanned: 20081
+    DbTooMuchMoneyForLevel: 20032
+    DbTransferDateTooSoon: 20023
+    DbTransferNotCancellable: 20031
+    DbTransferNotFinalized: 20030
+    DbTransferNotLockable: 20035
+    DbTransferNotUnlockable: 20036
+    DbUnableToCustomize: 20060
+    DbUnderMinLevelReq: 20021
+    DbWaitingForPayment: 20059
+    DisallowedDestinationAccount: 9
+    DisallowedSourceAccount: 8
+    EndDbErrors: 20097
+    EndProxyErrors: 56
+    EndServerErrors: 16
+    InvalidBpayDeliverableID: 14
+    InvalidBpayProductID: 13
+    InvalidBpayProductType: 15
+    InvalidDestinationAccount: 6
+    InvalidDestinationRealm: 5
+    InvalidDistribution: 12
+    InvalidSourceAccount: 7
+    LowerBoxLevel: 11
+    None: 0
+    NoneCharacter: 2
+    NoneProduct: 3
+    OnlyOneVasAtATime: 4
+    ProxyAccountDataTooBig: 55
+    ProxyBadDbType: 35
+    ProxyBadObjType: 18
+    ProxyBadRequestContained: 33
+    ProxyBindFailed: 51
+    ProxyCannotDeleteArenaCaptain: 31
+    ProxyCannotDeleteGuildLeader: 30
+    ProxyCannotInsertNull: 45
+    ProxyCannotUndeleteTrialBoostCharacter: 46
+    ProxyCharacterHasWoWToken: 53
+    ProxyCharacterLevelTooHigh: 38
+    ProxyCharacterTransferred: 39
+    ProxyCharacterTransferredNoBoostInProgress: 40
+    ProxyDataInvalid: 22
+    ProxyDbError: 21
+    ProxyDeleteNotSupported: 28
+    ProxyExternalUpdateDetected: 37
+    ProxyGenericError: 44
+    ProxyInsertRequestContainedNoData: 49
+    ProxyInvalidKey: 50
+    ProxyIsReadonly: 34
+    ProxyLockedForToken: 42
+    ProxyLockedForTransfer: 26
+    ProxyLockedForUpgrade: 41
+    ProxyLockedForVas: 43
+    ProxyLocksFailed: 24
+    ProxyLostProxyConnection: 23
+    ProxyMissingResultsPtr: 25
+    ProxyMoneyLimitExceeded: 32
+    ProxyNoReturnValue: 27
+    ProxyObjDropped: 29
+    ProxyObjNotInDb: 19
+    ProxyOperationAlreadyInProgress: 36
+    ProxyPredicateFailed: 47
+    ProxyTooBusyBackOff: 54
+    ProxyTooManyRows: 52
+    ProxyUniqueKey: 20
+    ProxyWeeklyRewardNotFound: 48
+    UnknownError: 10
+    VasPurchaseDisabled: 1
 ViewArenaSize:
-  Three: 1
-  Two: 0
+  values:
+    Three: 1
+    Two: 0
 ViewRaidSize:
-  Forty: 2
-  Ten: 0
-  TwentyFive: 1
+  values:
+    Forty: 2
+    Ten: 0
+    TwentyFive: 1
 VignetteObjectiveType:
-  Defeat: 1
-  DefeatShowRemainingHealth: 2
-  None: 0
+  values:
+    Defeat: 1
+    DefeatShowRemainingHealth: 2
+    None: 0
 VignetteType:
-  FyrakkFlight: 4
-  Normal: 0
-  PvPBounty: 1
-  Torghast: 2
-  Treasure: 3
+  values:
+    FyrakkFlight: 4
+    Normal: 0
+    PvPBounty: 1
+    Torghast: 2
+    Treasure: 3
 Vocalerrorsounds:
-  Abilitycooling: 50
-  Alreadyingroup: 20
-  Alreadyinguild: 21
-  Ammoonlyinbag: 28
-  Bagfull: 29
-  BoundNodrop: 4
-  Cantaffordbankslot: 22
-  CantattackNotarget: 38
-  CantattackNotstandingObsolete: 37
-  Cantattackrongdirection: 36
-  CantcastOutofrange: 46
-  Cantcreate: 18
-  Cantdrinkmore: 6
-  Canteatmore: 7
-  CanteatMoving: 24
-  Cantequip2Hequipped: 42
-  Cantequip2HNoskill: 43
-  Cantequip2HSkill: 41
-  Cantflyhere: 60
-  Cantinvite: 8
-  CantlearnLevel: 13
-  Cantloot: 17
-  CantlootDidntkill: 31
-  CantlootLocked: 33
-  CantlootNotstandingObsolete: 34
-  CantlootToofar: 35
-  CantlootWrongfacing: 32
-  Cantputbag: 26
-  Cantswap: 58
-  CanttaxiNomoney: 54
-  CanttradeSoulbound: 59
-  Cantuseitem: 51
-  Cantuselocked: 55
-  Cantusetoofar: 57
-  Chestinuse: 52
-  Declinegroup: 19
-  ExhaustedObsolete: 67
-  FoodcoolingObsolete: 53
-  Genericnotarget: 45
-  Guildpermissions: 62
-  Invaliditemtarget: 66
-  Invalidtarget: 11
-  Inventoryfull: 0
-  Inviteebusy: 9
-  Itemcooling: 5
-  Itemlocked: 61
-  Itemmaxcount: 30
-  Locked: 14
-  Mustequippitem: 49
-  Noenergy: 64
-  NoequipEver: 3
-  NoequipLevel: 2
-  Noequipslotavailable: 56
-  Noessence: 65
-  Nomana: 15
-  Norage: 63
-  Notabag: 25
-  Notenoughgold: 39
-  Notenoughmoney: 40
-  Notequippable: 44
-  Notwhiledead: 16
-  Outofammo: 1
-  Potioncooling: 47
-  Proficiencyneeded: 48
-  Spellcooling: 12
-  Targettoofar: 10
-  Toomanybankslots: 23
-  Wrongslot: 27
+  values:
+    Abilitycooling: 50
+    Alreadyingroup: 20
+    Alreadyinguild: 21
+    Ammoonlyinbag: 28
+    Bagfull: 29
+    BoundNodrop: 4
+    Cantaffordbankslot: 22
+    CantattackNotarget: 38
+    CantattackNotstandingObsolete: 37
+    Cantattackrongdirection: 36
+    CantcastOutofrange: 46
+    Cantcreate: 18
+    Cantdrinkmore: 6
+    Canteatmore: 7
+    CanteatMoving: 24
+    Cantequip2Hequipped: 42
+    Cantequip2HNoskill: 43
+    Cantequip2HSkill: 41
+    Cantflyhere: 60
+    Cantinvite: 8
+    CantlearnLevel: 13
+    Cantloot: 17
+    CantlootDidntkill: 31
+    CantlootLocked: 33
+    CantlootNotstandingObsolete: 34
+    CantlootToofar: 35
+    CantlootWrongfacing: 32
+    Cantputbag: 26
+    Cantswap: 58
+    CanttaxiNomoney: 54
+    CanttradeSoulbound: 59
+    Cantuseitem: 51
+    Cantuselocked: 55
+    Cantusetoofar: 57
+    Chestinuse: 52
+    Declinegroup: 19
+    ExhaustedObsolete: 67
+    FoodcoolingObsolete: 53
+    Genericnotarget: 45
+    Guildpermissions: 62
+    Invaliditemtarget: 66
+    Invalidtarget: 11
+    Inventoryfull: 0
+    Inviteebusy: 9
+    Itemcooling: 5
+    Itemlocked: 61
+    Itemmaxcount: 30
+    Locked: 14
+    Mustequippitem: 49
+    Noenergy: 64
+    NoequipEver: 3
+    NoequipLevel: 2
+    Noequipslotavailable: 56
+    Noessence: 65
+    Nomana: 15
+    Norage: 63
+    Notabag: 25
+    Notenoughgold: 39
+    Notenoughmoney: 40
+    Notequippable: 44
+    Notwhiledead: 16
+    Outofammo: 1
+    Potioncooling: 47
+    Proficiencyneeded: 48
+    Spellcooling: 12
+    Targettoofar: 10
+    Toomanybankslots: 23
+    Wrongslot: 27
 VoiceChatStatusCode:
-  AlreadyInChannel: 10
-  ChannelAlreadyExists: 9
-  ChannelNameTooLong: 8
-  ChannelNameTooShort: 7
-  ClientAlreadyLoggedIn: 6
-  ClientNotInitialized: 4
-  ClientNotLoggedIn: 5
-  Disabled: 18
-  Failure: 12
-  InvalidCommunityStream: 20
-  InvalidInputDevice: 23
-  InvalidOutputDevice: 24
-  LoginProhibited: 3
-  OperationPending: 1
-  PlayerSilenced: 21
-  PlayerVoiceChatParentalDisabled: 22
-  ProxyConnectionTimeOut: 15
-  ProxyConnectionUnableToConnect: 16
-  ProxyConnectionUnexpectedDisconnect: 17
-  ServiceLost: 13
-  Success: 0
-  TargetNotFound: 11
-  TooManyRequests: 2
-  UnableToLaunchProxy: 14
-  UnsupportedChatChannelType: 19
+  values:
+    AlreadyInChannel: 10
+    ChannelAlreadyExists: 9
+    ChannelNameTooLong: 8
+    ChannelNameTooShort: 7
+    ClientAlreadyLoggedIn: 6
+    ClientNotInitialized: 4
+    ClientNotLoggedIn: 5
+    Disabled: 18
+    Failure: 12
+    InvalidCommunityStream: 20
+    InvalidInputDevice: 23
+    InvalidOutputDevice: 24
+    LoginProhibited: 3
+    OperationPending: 1
+    PlayerSilenced: 21
+    PlayerVoiceChatParentalDisabled: 22
+    ProxyConnectionTimeOut: 15
+    ProxyConnectionUnableToConnect: 16
+    ProxyConnectionUnexpectedDisconnect: 17
+    ServiceLost: 13
+    Success: 0
+    TargetNotFound: 11
+    TooManyRequests: 2
+    UnableToLaunchProxy: 14
+    UnsupportedChatChannelType: 19
 VoiceTtsStatusCode:
-  DestinationQueueFull: 8
-  EngineAllocationFailed: 2
-  EnqueueNotNecessary: 9
-  InputTextEnqueued: 6
-  InternalError: 13
-  InvalidArgument: 12
-  InvalidEngineType: 1
-  ManagerNotFound: 11
-  MaxCharactersExceeded: 4
-  NotSupported: 3
-  SdkNotInitialized: 7
-  Success: 0
-  UtteranceBelowMinimumDuration: 5
-  UtteranceNotFound: 10
+  values:
+    DestinationQueueFull: 8
+    EngineAllocationFailed: 2
+    EnqueueNotNecessary: 9
+    InputTextEnqueued: 6
+    InternalError: 13
+    InvalidArgument: 12
+    InvalidEngineType: 1
+    ManagerNotFound: 11
+    MaxCharactersExceeded: 4
+    NotSupported: 3
+    SdkNotInitialized: 7
+    Success: 0
+    UtteranceBelowMinimumDuration: 5
+    UtteranceNotFound: 10
 WarbandSceneFlags:
-  AwardedAutomatically: 8
-  CannotBeSaved: 4
-  DoNotInclude: 1
-  HiddenUntilCollected: 2
-  IsDefault: 16
+  values:
+    AwardedAutomatically: 8
+    CannotBeSaved: 4
+    DoNotInclude: 1
+    HiddenUntilCollected: 2
+    IsDefault: 16
 WeaponSlot:
-  MainHand: 0
-  OffHand: 1
+  values:
+    MainHand: 0
+    OffHand: 1
 WeeklyRewardChestActivityType:
-  LFGDungeons: 1
-  Scenario: 0
-  World: 2
+  values:
+    LFGDungeons: 1
+    Scenario: 0
+    World: 2
 WeeklyRewardChestClaimRewardResult:
-  CountExceeded: 7
-  DbError: 5
-  InvalidSlot: 3
-  InvalidThreshold: 1
-  LockFailure: 6
-  PlayerNotFound: 2
-  Success: 0
-  TooManyItems: 4
+  values:
+    CountExceeded: 7
+    DbError: 5
+    InvalidSlot: 3
+    InvalidThreshold: 1
+    LockFailure: 6
+    PlayerNotFound: 2
+    Success: 0
+    TooManyItems: 4
 WeeklyRewardChestThresholdType:
-  Activities: 1
-  AlsoReceive: 4
-  Concession: 5
-  None: 0
-  Raid: 3
-  RankedPvP: 2
-  World: 6
+  values:
+    Activities: 1
+    AlsoReceive: 4
+    Concession: 5
+    None: 0
+    Raid: 3
+    RankedPvP: 2
+    World: 6
 WeeklyRewardProgressResult:
-  DbError: 3
-  NoPlayer: 4
-  NoSeason: 1
-  Success: 0
-  TimedOut: 2
+  values:
+    DbError: 3
+    NoPlayer: 4
+    NoSeason: 1
+    Success: 0
+    TimedOut: 2
 WidgetAnimationType:
-  Fade: 1
-  None: 0
+  values:
+    Fade: 1
+    None: 0
 WidgetCurrencyClass:
-  Currency: 0
-  Item: 1
+  values:
+    Currency: 0
+    Item: 1
 WidgetEnabledState:
-  Artifact: 5
-  Black: 6
-  BrightBlue: 7
-  Disabled: 0
-  Green: 4
-  Red: 2
-  White: 3
-  Yellow: 1
+  values:
+    Artifact: 5
+    Black: 6
+    BrightBlue: 7
+    Disabled: 0
+    Green: 4
+    Red: 2
+    White: 3
+    Yellow: 1
 WidgetGlowAnimType:
-  None: 0
-  Pulse: 1
+  values:
+    None: 0
+    Pulse: 1
 WidgetIconSizeType:
-  Large: 2
-  Medium: 1
-  Small: 0
-  Standard: 3
+  values:
+    Large: 2
+    Medium: 1
+    Small: 0
+    Standard: 3
 WidgetIconSourceType:
-  Item: 1
-  Spell: 0
+  values:
+    Item: 1
+    Spell: 0
 WidgetOpacityType:
-  Eighty: 2
-  Fifty: 5
-  Forty: 6
-  Ninety: 1
-  OneHundred: 0
-  Seventy: 3
-  Sixty: 4
-  Ten: 9
-  Thirty: 7
-  Twenty: 8
-  Zero: 10
+  values:
+    Eighty: 2
+    Fifty: 5
+    Forty: 6
+    Ninety: 1
+    OneHundred: 0
+    Seventy: 3
+    Sixty: 4
+    Ten: 9
+    Thirty: 7
+    Twenty: 8
+    Zero: 10
 WidgetShowGlowState:
-  HideGlow: 0
-  ShowGlow: 1
+  values:
+    HideGlow: 0
+    ShowGlow: 1
 WidgetShownState:
-  Hidden: 0
-  Shown: 1
+  values:
+    Hidden: 0
+    Shown: 1
 WidgetTextHorizontalAlignmentType:
-  Center: 1
-  Left: 0
-  Right: 2
+  values:
+    Center: 1
+    Left: 0
+    Right: 2
 WidgetUnitPowerBarFlashMomentType:
-  FlashWhenMax: 0
-  FlashWhenMin: 1
-  NeverFlash: 2
+  values:
+    FlashWhenMax: 0
+    FlashWhenMin: 1
+    NeverFlash: 2
 WorldCursorAnchorType:
-  Cursor: 2
-  Default: 1
-  Nameplate: 3
-  None: 0
+  values:
+    Cursor: 2
+    Default: 1
+    Nameplate: 3
+    None: 0
 WorldElapsedTimerTypes:
-  ChallengeMode: 1
-  None: 0
-  ProvingGround: 2
+  values:
+    ChallengeMode: 1
+    None: 0
+    ProvingGround: 2
 WorldTierDifficulty:
-  Heroic: 2
-  Mythic: 3
-  Normal: 1
+  values:
+    Heroic: 2
+    Mythic: 3
+    Normal: 1
 WoWClientCursorSize:
-  ExtraLarge: 3
-  Large: 2
-  Massive: 4
-  Medium: 1
-  Standard: 0
+  values:
+    ExtraLarge: 3
+    Large: 2
+    Massive: 4
+    Medium: 1
+    Standard: 0
 WoWEntitlementType:
-  Appearance: 4
-  AppearanceSet: 5
-  Battlepet: 2
-  GameTime: 6
-  Illusion: 8
-  Invalid: 9
-  Item: 0
-  Mount: 1
-  Title: 7
-  Toy: 3
+  values:
+    Appearance: 4
+    AppearanceSet: 5
+    Battlepet: 2
+    GameTime: 6
+    Illusion: 8
+    Invalid: 9
+    Item: 0
+    Mount: 1
+    Title: 7
+    Toy: 3
 WoWLabsAreaType:
-  PlunderstormDropDense: 2
-  PlunderstormDropMedium: 1
-  PlunderstormDropSparse: 0
+  values:
+    PlunderstormDropDense: 2
+    PlunderstormDropMedium: 1
+    PlunderstormDropSparse: 0
 ZoneControlActiveState:
-  Active: 1
-  Inactive: 0
+  values:
+    Active: 1
+    Inactive: 0
 ZoneControlDangerFlashType:
-  ShowOnBadStates: 1
-  ShowOnBoth: 2
-  ShowOnGoodStates: 0
-  ShowOnNeither: 3
+  values:
+    ShowOnBadStates: 1
+    ShowOnBoth: 2
+    ShowOnGoodStates: 0
+    ShowOnNeither: 3
 ZoneControlFillType:
-  DoubleFillClockwise: 2
-  DoubleFillCounterClockwise: 3
-  SingleFillClockwise: 0
-  SingleFillCounterClockwise: 1
+  values:
+    DoubleFillClockwise: 2
+    DoubleFillCounterClockwise: 3
+    SingleFillClockwise: 0
+    SingleFillCounterClockwise: 1
 ZoneControlLeadingEdgeType:
-  NoLeadingEdge: 0
-  UseLeadingEdge: 1
+  values:
+    NoLeadingEdge: 0
+    UseLeadingEdge: 1
 ZoneControlMode:
-  BothStatesAreGood: 0
-  NeitherStateIsGood: 3
-  State1IsGood: 1
-  State2IsGood: 2
+  values:
+    BothStatesAreGood: 0
+    NeitherStateIsGood: 3
+    State1IsGood: 1
+    State2IsGood: 2
 ZoneControlState:
-  State1: 0
-  State2: 1
+  values:
+    State1: 0
+    State2: 1

--- a/data/products/wow_classic_era/enums.yaml
+++ b/data/products/wow_classic_era/enums.yaml
@@ -1,7214 +1,8007 @@
 AbbreviationDataError:
-  InvalidBreakpoint: 1
-  InvalidFractionDivisor: 4
-  InvalidSignificandDivisor: 2
-  NotMultipleOfTen: 8
+  values:
+    InvalidBreakpoint: 1
+    InvalidFractionDivisor: 4
+    InvalidSignificandDivisor: 2
+    NotMultipleOfTen: 8
 AccountCurrencyTransferResult:
-  CannotUseCurrency: 8
-  CharacterLoggedIn: 2
-  CurrencyTransferDisabled: 10
-  InsufficientCurrency: 3
-  InvalidCharacter: 1
-  InvalidCurrency: 5
-  MaxQuantity: 4
-  NoValidSourceCharacter: 6
-  ServerError: 7
-  Success: 0
-  TransactionInProgress: 9
+  values:
+    CannotUseCurrency: 8
+    CharacterLoggedIn: 2
+    CurrencyTransferDisabled: 10
+    InsufficientCurrency: 3
+    InvalidCharacter: 1
+    InvalidCurrency: 5
+    MaxQuantity: 4
+    NoValidSourceCharacter: 6
+    ServerError: 7
+    Success: 0
+    TransactionInProgress: 9
 AccountData:
-  Bindings: 2
-  Bindings2: 3
-  CharacterListOrder: 16
-  ChatSettings: 7
-  ClickBindings: 12
-  Config: 0
-  Config2: 1
-  CooldownManager: 17
-  CooldownManager2: 18
-  FlaggedIDs: 10
-  FlaggedIDs2: 11
-  FrontendChatSettings: 15
-  Macros: 4
-  Macros2: 5
-  Shop2PendingOrders: 19
-  TtsSettings: 8
-  TtsSettings2: 9
-  UIEditModeAccount: 13
-  UIEditModeChar: 14
-  UILayout: 6
+  values:
+    Bindings: 2
+    Bindings2: 3
+    CharacterListOrder: 16
+    ChatSettings: 7
+    ClickBindings: 12
+    Config: 0
+    Config2: 1
+    CooldownManager: 17
+    CooldownManager2: 18
+    FlaggedIDs: 10
+    FlaggedIDs2: 11
+    FrontendChatSettings: 15
+    Macros: 4
+    Macros2: 5
+    Shop2PendingOrders: 19
+    TtsSettings: 8
+    TtsSettings2: 9
+    UIEditModeAccount: 13
+    UIEditModeChar: 14
+    UILayout: 6
 AccountDataUpdateStatus:
-  Corrupt: 2
-  Failed: 1
-  Success: 0
-  Toobig: 3
+  values:
+    Corrupt: 2
+    Failed: 1
+    Success: 0
+    Toobig: 3
 AccountExportResult:
-  AlreadyInProgress: 11
-  Cancelled: 2
-  FailedToGenerateFile: 13
-  FailedToLockAccount: 12
-  FileInvalid: 8
-  FileWriteFailed: 9
-  NoAccountFound: 5
-  RequestedInvalidCharacter: 6
-  RpcError: 7
-  ShuttingDown: 3
-  Success: 0
-  TimedOut: 4
-  Unavailable: 10
-  UnknownError: 1
+  values:
+    AlreadyInProgress: 11
+    Cancelled: 2
+    FailedToGenerateFile: 13
+    FailedToLockAccount: 12
+    FileInvalid: 8
+    FileWriteFailed: 9
+    NoAccountFound: 5
+    RequestedInvalidCharacter: 6
+    RpcError: 7
+    ShuttingDown: 3
+    Success: 0
+    TimedOut: 4
+    Unavailable: 10
+    UnknownError: 1
 AccountSequenceCacheType:
-  HouseDecor: 2
-  Invalid: 0
-  Local: 1
+  values:
+    HouseDecor: 2
+    Invalid: 0
+    Local: 1
 AccountStateFlags:
-  AccountUpgradeComplete: 4
-  InPetCombat: 2
-  LoadFailed: 1
-  None: 0
-  TokenEligCheckComplete: 8
+  values:
+    AccountUpgradeComplete: 4
+    InPetCombat: 2
+    LoadFailed: 1
+    None: 0
+    TokenEligCheckComplete: 8
 AccountStateLoadedFlags:
-  AccountCurrenciesLoaded: '0x0000000000200000'
-  AccountFactionsLoaded: '0x0000000200000000'
-  AccountItemsLoaded: '0x0000000400000000'
-  AccountMappingLoaded: '0x0000008000000000'
-  AccountNotificationsLoaded: '0x0000000008000000'
-  AccountWowlabsLoaded: '0x0000000020000000'
-  AchievementsLoaded: '0x0000000000000001'
-  ArchivedPurchasesLoaded: '0x0000000000000200'
-  AuctionableTokensLoaded: '0x0000000000002000'
-  BanktabSettingsLoaded: '0x0000004000000000'
-  BattleNetAccountLoaded: '0x0000000000100000'
-  BitVectorsLoaded: '0x0000000100000000'
-  BpayAddLicenseObjectsLoaded: '0x0000000000000800'
-  BpayDistributionObjectsLoaded: '0x0000000000000100'
-  BpayProductitemObjectsLoaded: '0x0000000000020000'
-  CharacterItemsLoaded: '0x0000010000000000'
-  CharactersLoaded: '0x0000000000000040'
-  CombinedQuestLogLoaded: '0x0000000800000000'
-  ConsumableTokensLoaded: '0x0000000000004000'
-  CriteriaLoaded: '0x0000000000000002'
-  CurrencyCapsLoaded: '0x0000000000000010'
-  CurrencyTransferLogLoaded: '0x0000020000000000'
-  DataElementsLoaded: '0x0000001000000000'
-  DynamicCriteriaLoaded: '0x0000000001000000'
-  EventRecordsLoaded: '0x0000200000000000'
-  HousingDataLoaded: '0x0000080000000000'
-  ItemCollectionsLoaded: '0x0000000000001000'
-  LgVendorPurchaseLoaded: '0x0000040000000000'
-  LoadedNone: '0x0000000000000000'
-  MountsLoaded: '0x0000000000000004'
-  PerksHeldItemLoaded: '0x0000000040000000'
-  PerksPastRewardsLoaded: '0x0000000000008000'
-  PerksPendingPurchaseLoaded: '0x0000000010000000'
-  PerksPendingRewardsLoaded: '0x0000000080000000'
-  PetjournalInitialized: '0x0000000000000008'
-  PurchasesLoaded: '0x0000000000000080'
-  QuestCriteriaLoaded: '0x0000000000080000'
-  QuestLogLoaded: '0x0000000000000020'
-  RafActivityLoaded: '0x0000000002000000'
-  RafBalanceLoaded: '0x0000000000400000'
-  RafRewardsLoaded: '0x0000000000800000'
-  RevokedRafRewardsLoaded: '0x0000000004000000'
-  SettingsLoaded: '0x0000000000000400'
-  TransmogOutfitsLoaded: '0x0000400000000000'
-  TrialBoostHistoryLoaded: '0x0000000000040000'
-  VasTransactionsLoaded: '0x0000000000010000'
-  WarbandScenesLoaded: '0x0000100000000000'
-  WarbandsLoaded: '0x0000002000000000'
+  values:
+    AccountCurrenciesLoaded: '0x0000000000200000'
+    AccountFactionsLoaded: '0x0000000200000000'
+    AccountItemsLoaded: '0x0000000400000000'
+    AccountMappingLoaded: '0x0000008000000000'
+    AccountNotificationsLoaded: '0x0000000008000000'
+    AccountWowlabsLoaded: '0x0000000020000000'
+    AchievementsLoaded: '0x0000000000000001'
+    ArchivedPurchasesLoaded: '0x0000000000000200'
+    AuctionableTokensLoaded: '0x0000000000002000'
+    BanktabSettingsLoaded: '0x0000004000000000'
+    BattleNetAccountLoaded: '0x0000000000100000'
+    BitVectorsLoaded: '0x0000000100000000'
+    BpayAddLicenseObjectsLoaded: '0x0000000000000800'
+    BpayDistributionObjectsLoaded: '0x0000000000000100'
+    BpayProductitemObjectsLoaded: '0x0000000000020000'
+    CharacterItemsLoaded: '0x0000010000000000'
+    CharactersLoaded: '0x0000000000000040'
+    CombinedQuestLogLoaded: '0x0000000800000000'
+    ConsumableTokensLoaded: '0x0000000000004000'
+    CriteriaLoaded: '0x0000000000000002'
+    CurrencyCapsLoaded: '0x0000000000000010'
+    CurrencyTransferLogLoaded: '0x0000020000000000'
+    DataElementsLoaded: '0x0000001000000000'
+    DynamicCriteriaLoaded: '0x0000000001000000'
+    EventRecordsLoaded: '0x0000200000000000'
+    HousingDataLoaded: '0x0000080000000000'
+    ItemCollectionsLoaded: '0x0000000000001000'
+    LgVendorPurchaseLoaded: '0x0000040000000000'
+    LoadedNone: '0x0000000000000000'
+    MountsLoaded: '0x0000000000000004'
+    PerksHeldItemLoaded: '0x0000000040000000'
+    PerksPastRewardsLoaded: '0x0000000000008000'
+    PerksPendingPurchaseLoaded: '0x0000000010000000'
+    PerksPendingRewardsLoaded: '0x0000000080000000'
+    PetjournalInitialized: '0x0000000000000008'
+    PurchasesLoaded: '0x0000000000000080'
+    QuestCriteriaLoaded: '0x0000000000080000'
+    QuestLogLoaded: '0x0000000000000020'
+    RafActivityLoaded: '0x0000000002000000'
+    RafBalanceLoaded: '0x0000000000400000'
+    RafRewardsLoaded: '0x0000000000800000'
+    RevokedRafRewardsLoaded: '0x0000000004000000'
+    SettingsLoaded: '0x0000000000000400'
+    TransmogOutfitsLoaded: '0x0000400000000000'
+    TrialBoostHistoryLoaded: '0x0000000000040000'
+    VasTransactionsLoaded: '0x0000000000010000'
+    WarbandScenesLoaded: '0x0000100000000000'
+    WarbandsLoaded: '0x0000002000000000'
 AccountStoreCategoryType:
-  Creature: 1
-  Icon: 4
-  Mount: 3
-  TransmogSet: 2
+  values:
+    Creature: 1
+    Icon: 4
+    Mount: 3
+    TransmogSet: 2
 AccountStoreFrontFlag:
-  Enabled: 1
-  PurchaseEnabled: 2
-  RefundEnabled: 4
+  values:
+    Enabled: 1
+    PurchaseEnabled: 2
+    RefundEnabled: 4
 AccountStoreItemFlag:
-  DisplayAsNew: 4
-  DisplayDefaultArmor: 1
-  DisplayOnly: 8
-  NotInGameReward: 2
+  values:
+    DisplayAsNew: 4
+    DisplayDefaultArmor: 1
+    DisplayOnly: 8
+    NotInGameReward: 2
 AccountStoreItemMode:
-  Hidden: 2
-  Locked: 3
-  Normal: 1
+  values:
+    Hidden: 2
+    Locked: 3
+    Normal: 1
 AccountStoreItemRewardType:
-  Illusion: 7
-  Misc: 10
-  Mount: 2
-  Pet: 3
-  Tender: 9
-  Toy: 5
-  Transmog: 1
-  TransmogSet: 8
-  WarbandScene: 11
+  values:
+    Illusion: 7
+    Misc: 10
+    Mount: 2
+    Pet: 3
+    Tender: 9
+    Toy: 5
+    Transmog: 1
+    TransmogSet: 8
+    WarbandScene: 11
 AccountStoreItemStatus:
-  Owned: 3
-  Refundable: 2
-  Unowned: 1
+  values:
+    Owned: 3
+    Refundable: 2
+    Unowned: 1
 AccountStoreSettlementAction:
-  Give: 1
-  NotSet: 0
-  Remove: 2
+  values:
+    Give: 1
+    NotSet: 0
+    Remove: 2
 AccountStoreState:
-  Available: 0
-  Unavailable: 2
-  Unknown: 1
+  values:
+    Available: 0
+    Unavailable: 2
+    Unknown: 1
 AccountStoreTransactionResult:
-  Incomplete: 1
-  InsufficientFunds: 4
-  InvalidCurrencyType: 8
-  ItemAlreadyOwned: 6
-  ItemNotOwned: 7
-  ItemUnknown: 5
-  NotSupported: 10
-  OwnedButRefundTimeExpired: 9
-  ProxyError: 12
-  Success: 0
-  TransactionInProgress: 3
-  Unavailable: 11
-  UnknownError: 2
+  values:
+    Incomplete: 1
+    InsufficientFunds: 4
+    InvalidCurrencyType: 8
+    ItemAlreadyOwned: 6
+    ItemNotOwned: 7
+    ItemUnknown: 5
+    NotSupported: 10
+    OwnedButRefundTimeExpired: 9
+    ProxyError: 12
+    Success: 0
+    TransactionInProgress: 3
+    Unavailable: 11
+    UnknownError: 2
 AccountStoreTransactionType:
-  DebugRemoveItem: 4
-  DebugResetHistory: 3
-  Purchase: 1
-  Refund: 2
-  Undefined: 0
+  values:
+    DebugRemoveItem: 4
+    DebugResetHistory: 3
+    Purchase: 1
+    Refund: 2
+    Undefined: 0
 AccountTransType:
-  AccountCurrencies: 26
-  AccountNotifications: 38
-  AccountStore: 54
-  Achievements: 4
-  AddLicense: 16
-  ArchivedPurchases: 9
-  AuctionableToken: 18
-  BankTab: 48
-  BattlenetAccount: 25
-  Battlepet: 3
-  BitVectors: 50
-  CharacterDataMerge: 53
-  CharacterItems: 57
-  Characters: 7
-  CombinedQuestLog: 51
-  ConsumableToken: 19
-  CreateOrderInfo: 32
-  Criteria: 5
-  CriteriaNotif: 13
-  CurrencyCaps: 11
-  CurrencyTransferLog: 58
-  Distribution: 2
-  Distributions: 10
-  DynamicCriteria: 30
-  EventRecords: 63
-  Factions: 49
-  FixedLicense: 15
-  GetOrderStatusByPurchaseID: 46
-  HouseInitiativeFavor: 66
-  HousingItem: 64
-  ItemCollections: 17
-  Items: 47
-  LgVendorPurchase: 59
-  LoadWowlabs: 44
-  Mapping: 56
-  Mounts: 6
-  OutstandingRpc: 43
-  PerkItemHold: 39
-  PerkPastRewards: 41
-  PerkPendingRewards: 40
-  PerkTransaction: 42
-  PlayerDataElements: 52
-  Productitem: 21
-  Profile: 61
-  ProxyCreateAccountHonor: 34
-  ProxyForwarder: 0
-  ProxyGenerateBpayID: 37
-  ProxyGmSetHonor: 36
-  ProxyHonorInitialConversion: 33
-  ProxyValidateAccountHonor: 35
-  Purchase: 1
-  Purchases: 8
-  QuestCriteria: 24
-  QuestLog: 12
-  RafActivity: 31
-  RafFriendMonth: 28
-  RafRecruiterAcceptances: 27
-  RafReward: 29
-  SaveWarbandGroups: 60
-  Settings: 14
-  TransmogOutfitCollection: 65
-  TrialBoostHistories: 23
-  TrialBoostHistory: 22
-  UpgradeAccount: 45
-  VasTransaction: 20
-  WarbandGroups: 55
-  WarbandSceneCollection: 62
+  values:
+    AccountCurrencies: 26
+    AccountNotifications: 38
+    AccountStore: 54
+    Achievements: 4
+    AddLicense: 16
+    ArchivedPurchases: 9
+    AuctionableToken: 18
+    BankTab: 48
+    BattlenetAccount: 25
+    Battlepet: 3
+    BitVectors: 50
+    CharacterDataMerge: 53
+    CharacterItems: 57
+    Characters: 7
+    CombinedQuestLog: 51
+    ConsumableToken: 19
+    CreateOrderInfo: 32
+    Criteria: 5
+    CriteriaNotif: 13
+    CurrencyCaps: 11
+    CurrencyTransferLog: 58
+    Distribution: 2
+    Distributions: 10
+    DynamicCriteria: 30
+    EventRecords: 63
+    Factions: 49
+    FixedLicense: 15
+    GetOrderStatusByPurchaseID: 46
+    HouseInitiativeFavor: 66
+    HousingItem: 64
+    ItemCollections: 17
+    Items: 47
+    LgVendorPurchase: 59
+    LoadWowlabs: 44
+    Mapping: 56
+    Mounts: 6
+    OutstandingRpc: 43
+    PerkItemHold: 39
+    PerkPastRewards: 41
+    PerkPendingRewards: 40
+    PerkTransaction: 42
+    PlayerDataElements: 52
+    Productitem: 21
+    Profile: 61
+    ProxyCreateAccountHonor: 34
+    ProxyForwarder: 0
+    ProxyGenerateBpayID: 37
+    ProxyGmSetHonor: 36
+    ProxyHonorInitialConversion: 33
+    ProxyValidateAccountHonor: 35
+    Purchase: 1
+    Purchases: 8
+    QuestCriteria: 24
+    QuestLog: 12
+    RafActivity: 31
+    RafFriendMonth: 28
+    RafRecruiterAcceptances: 27
+    RafReward: 29
+    SaveWarbandGroups: 60
+    Settings: 14
+    TransmogOutfitCollection: 65
+    TrialBoostHistories: 23
+    TrialBoostHistory: 22
+    UpgradeAccount: 45
+    VasTransaction: 20
+    WarbandGroups: 55
+    WarbandSceneCollection: 62
 ActionBarOrientation:
-  Horizontal: 0
-  Vertical: 1
+  values:
+    Horizontal: 0
+    Vertical: 1
 ActionBarVisibleSetting:
-  Always: 0
-  Hidden: 3
-  InCombat: 1
-  OutOfCombat: 2
+  values:
+    Always: 0
+    Hidden: 3
+    InCombat: 1
+    OutOfCombat: 2
 AddOnEnableState:
-  All: 2
-  None: 0
-  Some: 1
+  values:
+    All: 2
+    None: 0
+    Some: 1
 AddOnPerformanceMessageType:
-  OverallAddOnErrorDialog: 2
-  SpecificAddOnChatWarning: 0
-  SpecificAddOnErrorDialog: 1
+  values:
+    OverallAddOnErrorDialog: 2
+    SpecificAddOnChatWarning: 0
+    SpecificAddOnErrorDialog: 1
 AddOnProfilerMetric:
-  CountTimeOver1000Ms: 11
-  CountTimeOver100Ms: 9
-  CountTimeOver10Ms: 7
-  CountTimeOver1Ms: 5
-  CountTimeOver500Ms: 10
-  CountTimeOver50Ms: 8
-  CountTimeOver5Ms: 6
-  EncounterAverageTime: 2
-  LastTime: 3
-  PeakTime: 4
-  RecentAverageTime: 1
-  SessionAverageTime: 0
+  values:
+    CountTimeOver1000Ms: 11
+    CountTimeOver100Ms: 9
+    CountTimeOver10Ms: 7
+    CountTimeOver1Ms: 5
+    CountTimeOver500Ms: 10
+    CountTimeOver50Ms: 8
+    CountTimeOver5Ms: 6
+    EncounterAverageTime: 2
+    LastTime: 3
+    PeakTime: 4
+    RecentAverageTime: 1
+    SessionAverageTime: 0
 AddOnRestrictionState:
-  Activating: 1
-  Active: 2
-  Inactive: 0
+  values:
+    Activating: 1
+    Active: 2
+    Inactive: 0
 AddOnRestrictionType:
-  ChallengeMode: 2
-  Chat: 5
-  Combat: 0
-  Encounter: 1
-  Map: 4
-  PvPMatch: 3
+  values:
+    ChallengeMode: 2
+    Chat: 5
+    Combat: 0
+    Encounter: 1
+    Map: 4
+    PvPMatch: 3
 AddOnSecurityStatus:
-  Banned: 2
-  Insecure: 1
-  NotAvailable: 3
-  Secure: 0
+  values:
+    Banned: 2
+    Insecure: 1
+    NotAvailable: 3
+    Secure: 0
 ArrowCalloutDirection:
-  Down: 1
-  Left: 2
-  Right: 3
-  Up: 0
+  values:
+    Down: 1
+    Left: 2
+    Right: 3
+    Up: 0
 ArrowCalloutType:
-  Generic: 1
-  None: 0
-  Tutorial: 3
-  WidgetContainerNoBorder: 4
-  WorldLootObject: 2
+  values:
+    Generic: 1
+    None: 0
+    Tutorial: 3
+    WidgetContainerNoBorder: 4
+    WorldLootObject: 2
 AssistActionType:
-  CapturedBuff: 6
-  GraveMarker: 2
-  LoungingPlayer: 1
-  None: 0
-  PlacedVo: 3
-  PlayerGuardian: 4
-  PlayerSlayer: 5
+  values:
+    CapturedBuff: 6
+    GraveMarker: 2
+    LoungingPlayer: 1
+    None: 0
+    PlacedVo: 3
+    PlayerGuardian: 4
+    PlayerSlayer: 5
 AuctionHouseCommoditySortOrder:
-  Quantity: 1
-  UnitPrice: 0
+  values:
+    Quantity: 1
+    UnitPrice: 0
 AuctionHouseError:
-  BidIncrement: 2
-  BidOwn: 3
-  BoundItem: 16
-  ConjuredItem: 17
-  DatabaseError: 10
-  DoubleBid: 23
-  EquippedBag: 20
-  FavoritesMaxed: 24
-  HasRestriction: 6
-  HigherBid: 1
-  IsBag: 19
-  IsBusy: 7
-  ItemBoundToAccountUntilEquip: 26
-  ItemHasQuote: 9
-  ItemNotAvailable: 25
-  ItemNotFound: 4
-  LimitedDurationItem: 18
-  LootItem: 22
-  MinBid: 11
-  NotEnoughItems: 12
-  NotEnoughMoney: 0
-  QuestItem: 15
-  RepairItem: 13
-  RestrictedAccountTrial: 5
-  Unavailable: 8
-  UsedCharges: 14
-  WrappedItem: 21
+  values:
+    BidIncrement: 2
+    BidOwn: 3
+    BoundItem: 16
+    ConjuredItem: 17
+    DatabaseError: 10
+    DoubleBid: 23
+    EquippedBag: 20
+    FavoritesMaxed: 24
+    HasRestriction: 6
+    HigherBid: 1
+    IsBag: 19
+    IsBusy: 7
+    ItemBoundToAccountUntilEquip: 26
+    ItemHasQuote: 9
+    ItemNotAvailable: 25
+    ItemNotFound: 4
+    LimitedDurationItem: 18
+    LootItem: 22
+    MinBid: 11
+    NotEnoughItems: 12
+    NotEnoughMoney: 0
+    QuestItem: 15
+    RepairItem: 13
+    RestrictedAccountTrial: 5
+    Unavailable: 8
+    UsedCharges: 14
+    WrappedItem: 21
 AuctionHouseFilter:
-  ArtifactQuality: 12
-  CommonQuality: 7
-  CurrentExpansionOnly: 3
-  EpicQuality: 10
-  ExactMatch: 5
-  LegendaryCraftedItemOnly: 13
-  LegendaryQuality: 11
-  None: 0
-  PoorQuality: 6
-  RareQuality: 9
-  UncollectedOnly: 1
-  UncommonQuality: 8
-  UpgradesOnly: 4
-  UsableOnly: 2
+  values:
+    ArtifactQuality: 12
+    CommonQuality: 7
+    CurrentExpansionOnly: 3
+    EpicQuality: 10
+    ExactMatch: 5
+    LegendaryCraftedItemOnly: 13
+    LegendaryQuality: 11
+    None: 0
+    PoorQuality: 6
+    RareQuality: 9
+    UncollectedOnly: 1
+    UncommonQuality: 8
+    UpgradesOnly: 4
+    UsableOnly: 2
 AuctionHouseItemSortOrder:
-  Bid: 0
-  Buyout: 1
+  values:
+    Bid: 0
+    Buyout: 1
 AuctionHouseNotification:
-  AuctionExpired: 5
-  AuctionOutbid: 3
-  AuctionRemoved: 1
-  AuctionSold: 4
-  AuctionWon: 2
-  BidPlaced: 0
+  values:
+    AuctionExpired: 5
+    AuctionOutbid: 3
+    AuctionRemoved: 1
+    AuctionSold: 4
+    AuctionWon: 2
+    BidPlaced: 0
 AuctionHouseSortOrder:
-  Bid: 3
-  Buyout: 4
-  Level: 2
-  Name: 1
-  Price: 0
-  TimeRemaining: 5
+  values:
+    Bid: 3
+    Buyout: 4
+    Level: 2
+    Name: 1
+    Price: 0
+    TimeRemaining: 5
 AuctionHouseTimeLeftBand:
-  Long: 2
-  Medium: 1
-  Short: 0
-  VeryLong: 3
+  values:
+    Long: 2
+    Medium: 1
+    Short: 0
+    VeryLong: 3
 AuctionStatus:
-  Active: 0
-  Sold: 1
+  values:
+    Active: 0
+    Sold: 1
 AuraFrameIconDirection:
-  Down: 0
-  Left: 0
-  Right: 1
-  Up: 1
+  values:
+    Down: 0
+    Left: 0
+    Right: 1
+    Up: 1
 AuraFrameIconWrap:
-  Down: 0
-  Left: 0
-  Right: 1
-  Up: 1
+  values:
+    Down: 0
+    Left: 0
+    Right: 1
+    Up: 1
 AuraFrameOrientation:
-  Horizontal: 0
-  Vertical: 1
+  values:
+    Horizontal: 0
+    Vertical: 1
 AuraFrameVisibleSetting:
-  Always: 0
-  Hidden: 2
-  InCombat: 1
+  values:
+    Always: 0
+    Hidden: 2
+    InCombat: 1
 AutoCompleteEntryFlag:
-  AccountCharacter: 128
-  Bnet: 8
-  Friend: 4
-  InAOI: 64
-  InGroup: 1
-  InGuild: 2
-  InteractedWith: 16
-  Online: 32
-  RecentPlayer: 256
+  values:
+    AccountCharacter: 128
+    Bnet: 8
+    Friend: 4
+    InAOI: 64
+    InGroup: 1
+    InGuild: 2
+    InteractedWith: 16
+    Online: 32
+    RecentPlayer: 256
 AutoCompletePriority:
-  AccountCharacter: 5
-  AccountCharacterSameRealm: 6
-  Friend: 4
-  Guild: 3
-  InGroup: 2
-  Interacted: 1
-  Other: 0
+  values:
+    AccountCharacter: 5
+    AccountCharacterSameRealm: 6
+    Friend: 4
+    Guild: 3
+    InGroup: 2
+    Interacted: 1
+    Other: 0
 AvgItemLevelCategories:
-  Base: 0
-  EquippedBase: 1
-  EquippedEffective: 2
-  EquippedEffectiveWeighted: 5
-  PvP: 3
-  PvPWeighted: 4
+  values:
+    Base: 0
+    EquippedBase: 1
+    EquippedEffective: 2
+    EquippedEffectiveWeighted: 5
+    PvP: 3
+    PvPWeighted: 4
 AzeriteEssenceSlot:
-  MainSlot: 0
-  PassiveOneSlot: 1
-  PassiveThreeSlot: 3
-  PassiveTwoSlot: 2
+  values:
+    MainSlot: 0
+    PassiveOneSlot: 1
+    PassiveThreeSlot: 3
+    PassiveTwoSlot: 2
 AzeritePowerLevel:
-  Base: 0
-  Downgraded: 2
-  Upgraded: 1
+  values:
+    Base: 0
+    Downgraded: 2
+    Upgraded: 1
 BagFlag:
-  AllowBagsInNonBagSlots: 1024
-  AllowBuyback: 65536
-  AllowPartialStack: 16384
-  AllowSoulboundItemInAccountBank: 134217728
-  AlreadyBound: 4
-  AlreadyOwner: 2
-  AsymmetricSwap: 1048576
-  BagIsEmpty: 16
-  DontFindStack: 1
-  HasRefund: 33554432
-  IgnoreBankcheck: 512
-  IgnoreBoundItemCheck: 64
-  IgnoreExisting: 8192
-  IgnorePetBankcheck: 131072
-  IgnoreReagentBags: 8388608
-  IgnoreSoulbound: 4194304
-  LookInAccountBankOnly: 16777216
-  LookInBankOnly: 32768
-  LookInInventory: 32
-  PreferNeutralPriorityBags: 524288
-  PreferPriorityBags: 262144
-  PreferQuivers: 2048
-  PreferReagentBags: 2097152
-  RecurseQuivers: 256
-  SkipValidCountCheck: 67108864
-  StackOnly: 128
-  Swap: 8
-  SwapBags: 4096
+  values:
+    AllowBagsInNonBagSlots: 1024
+    AllowBuyback: 65536
+    AllowPartialStack: 16384
+    AllowSoulboundItemInAccountBank: 134217728
+    AlreadyBound: 4
+    AlreadyOwner: 2
+    AsymmetricSwap: 1048576
+    BagIsEmpty: 16
+    DontFindStack: 1
+    HasRefund: 33554432
+    IgnoreBankcheck: 512
+    IgnoreBoundItemCheck: 64
+    IgnoreExisting: 8192
+    IgnorePetBankcheck: 131072
+    IgnoreReagentBags: 8388608
+    IgnoreSoulbound: 4194304
+    LookInAccountBankOnly: 16777216
+    LookInBankOnly: 32768
+    LookInInventory: 32
+    PreferNeutralPriorityBags: 524288
+    PreferPriorityBags: 262144
+    PreferQuivers: 2048
+    PreferReagentBags: 2097152
+    RecurseQuivers: 256
+    SkipValidCountCheck: 67108864
+    StackOnly: 128
+    Swap: 8
+    SwapBags: 4096
 BagIndex:
-  Accountbanktab: -5
-  AccountBankTab_1: 13
-  AccountBankTab_2: 14
-  AccountBankTab_3: 15
-  AccountBankTab_4: 16
-  AccountBankTab_5: 17
-  Backpack: 0
-  Bag_1: 1
-  Bag_2: 2
-  Bag_3: 3
-  Bag_4: 4
-  Bank: -1
-  Bankbag: -4
-  BankBag_1: 6
-  BankBag_2: 7
-  BankBag_3: 8
-  BankBag_4: 9
-  BankBag_5: 10
-  BankBag_6: 11
-  BankBag_7: 12
-  Keyring: -2
-  ReagentBag: 5
-  Reagentbank: -3
+  values:
+    Accountbanktab: -5
+    AccountBankTab_1: 13
+    AccountBankTab_2: 14
+    AccountBankTab_3: 15
+    AccountBankTab_4: 16
+    AccountBankTab_5: 17
+    Backpack: 0
+    Bag_1: 1
+    Bag_2: 2
+    Bag_3: 3
+    Bag_4: 4
+    Bank: -1
+    Bankbag: -4
+    BankBag_1: 6
+    BankBag_2: 7
+    BankBag_3: 8
+    BankBag_4: 9
+    BankBag_5: 10
+    BankBag_6: 11
+    BankBag_7: 12
+    Keyring: -2
+    ReagentBag: 5
+    Reagentbank: -3
 BagsDirection:
-  Down: 1
-  Left: 0
-  Right: 1
-  Up: 0
+  values:
+    Down: 1
+    Left: 0
+    Right: 1
+    Up: 0
 BagSlotFlags:
-  ClassConsumables: 4
-  ClassEquipment: 2
-  ClassJunk: 16
-  ClassProfessionGoods: 8
-  ClassQuestItems: 32
-  ClassReagents: 128
-  DisableAutoSort: 1
-  ExcludeJunkSell: 64
-  ExpansionCurrent: 256
-  ExpansionLegacy: 512
+  values:
+    ClassConsumables: 4
+    ClassEquipment: 2
+    ClassJunk: 16
+    ClassProfessionGoods: 8
+    ClassQuestItems: 32
+    ClassReagents: 128
+    DisableAutoSort: 1
+    ExcludeJunkSell: 64
+    ExpansionCurrent: 256
+    ExpansionLegacy: 512
 BagsOrientation:
-  Horizontal: 0
-  Vertical: 1
+  values:
+    Horizontal: 0
+    Vertical: 1
 BalanceType:
-  Eclipse: 0
-  None: -1
+  values:
+    Eclipse: 0
+    None: -1
 BankLockedReason:
-  BankConversionFailed: 3
-  BankDisabled: 2
-  NoAccountInventoryLock: 1
-  None: 0
+  values:
+    BankConversionFailed: 3
+    BankDisabled: 2
+    NoAccountInventoryLock: 1
+    None: 0
 BankType:
-  Account: 2
-  Character: 0
-  Guild: 1
+  values:
+    Account: 2
+    Character: 0
+    Guild: 1
 Base64Variant:
-  Standard: 0
-  StandardUrlSafe: 1
+  values:
+    Standard: 0
+    StandardUrlSafe: 1
 BattlepayBannerType:
-  Discount: 1
-  Featured: 2
-  New: 3
-  None: 0
+  values:
+    Discount: 1
+    Featured: 2
+    New: 3
+    None: 0
 BattlepayDisplayFlags:
-  CardAlwaysShowsTexture: 4
-  CardDoesNotShowModel: 2
-  Deprecated1: 32
-  Deprecated2: 64
-  Expansion: 1
-  HiddenPrice: 8
-  HideWhenOwned: 256
-  RafReward: 512
-  ShowFancyToast: 1024
-  UseHorizontalLayoutForFullCard: 16
-  UseIconBorderWithOverrideTexture: 2048
-  UseSquareIconBorder: 128
+  values:
+    CardAlwaysShowsTexture: 4
+    CardDoesNotShowModel: 2
+    Deprecated1: 32
+    Deprecated2: 64
+    Expansion: 1
+    HiddenPrice: 8
+    HideWhenOwned: 256
+    RafReward: 512
+    ShowFancyToast: 1024
+    UseHorizontalLayoutForFullCard: 16
+    UseIconBorderWithOverrideTexture: 2048
+    UseSquareIconBorder: 128
 BattlepayGroupDisplayType:
-  ActiveTimeOnly: 2
-  Everyone: 0
-  TrialAndVeteranOnly: 1
+  values:
+    ActiveTimeOnly: 2
+    Everyone: 0
+    TrialAndVeteranOnly: 1
 BattlepayLicenseSynthesisFlags:
-  ForceToGameAccount: 1
+  values:
+    ForceToGameAccount: 1
 BattlepayProductChoiceType:
-  ChoiceNone: 0
-  ChoiceOne: 1
-  SpecAndFaction: 2
-  VasCharacter: 3
-  VasCharacterAndName: 4
+  values:
+    ChoiceNone: 0
+    ChoiceOne: 1
+    SpecAndFaction: 2
+    VasCharacter: 3
+    VasCharacterAndName: 4
 BattlepayProductDecorator:
-  Boost: 0
-  Expansion: 1
-  VasService: 3
-  WoWToken: 2
+  values:
+    Boost: 0
+    Expansion: 1
+    VasService: 3
+    WoWToken: 2
 BattlepayProductGroupFlags:
-  DisableOwnedProducts: 4
-  EnabledForTrial: 2
-  EnabledForVeteran: 8
-  HideOwnedProducts: 1
-  None: 0
-  TrialAndVeteranOnly: 16
+  values:
+    DisableOwnedProducts: 4
+    EnabledForTrial: 2
+    EnabledForVeteran: 8
+    HideOwnedProducts: 1
+    None: 0
+    TrialAndVeteranOnly: 16
 BattlepayShopEntryBannerType:
-  Discount: 1
-  Featured: 0
-  New: 2
+  values:
+    Discount: 1
+    Featured: 0
+    New: 2
 BattlepayShopEntryFlags:
-  None: 0
+  values:
+    None: 0
 BattlePetAction:
-  Ability: 1
-  None: 0
-  Skip: 4
-  SwitchPet: 2
-  Trap: 3
+  values:
+    Ability: 1
+    None: 0
+    Skip: 4
+    SwitchPet: 2
+    Trap: 3
 BattlePetBreedQuality:
-  Common: 1
-  Epic: 4
-  Legendary: 5
-  Poor: 0
-  Rare: 3
-  Uncommon: 2
+  values:
+    Common: 1
+    Epic: 4
+    Legendary: 5
+    Poor: 0
+    Rare: 3
+    Uncommon: 2
 BattlePetOwner:
-  Ally: 1
-  Enemy: 2
-  Weather: 0
+  values:
+    Ally: 1
+    Enemy: 2
+    Weather: 0
 BattlePetSources:
-  Achievement: 5
-  Discovery: 10
-  Drop: 0
-  PetStore: 9
-  Profession: 3
-  Promotion: 7
-  Quest: 1
-  Tcg: 8
-  TradingPost: 11
-  Vendor: 2
-  WildPet: 4
-  WorldEvent: 6
+  values:
+    Achievement: 5
+    Discovery: 10
+    Drop: 0
+    PetStore: 9
+    Profession: 3
+    Promotion: 7
+    Quest: 1
+    Tcg: 8
+    TradingPost: 11
+    Vendor: 2
+    WildPet: 4
+    WorldEvent: 6
 BindingContext:
-  HousingEditor: 1
-  HousingEditorBasicAndExpertDecorMode: 7
-  HousingEditorBasicDecorMode: 2
-  HousingEditorCleanupMode: 5
-  HousingEditorCustomizeMode: 4
-  HousingEditorExpertDecorMode: 3
-  HousingEditorExteriorCustomizationMode: 8
-  HousingEditorLayoutMode: 6
-  None: 0
-  ReservedFutureFeatureBinding01: 9
+  values:
+    HousingEditor: 1
+    HousingEditorBasicAndExpertDecorMode: 7
+    HousingEditorBasicDecorMode: 2
+    HousingEditorCleanupMode: 5
+    HousingEditorCustomizeMode: 4
+    HousingEditorExpertDecorMode: 3
+    HousingEditorExteriorCustomizationMode: 8
+    HousingEditorLayoutMode: 6
+    None: 0
+    ReservedFutureFeatureBinding01: 9
 BindingSet:
-  Account: 1
-  Character: 2
-  Current: 3
-  Default: 0
+  values:
+    Account: 1
+    Character: 2
+    Current: 3
+    Default: 0
 BnetAccountFlag:
-  AccountQuestBitFixUp: 64
-  AchievementsToBi: 128
-  BattlePetTrainer: 1
-  CanBuyAhGameTimeTokens: 32768
-  CataLegendaryMountChecked: 262144
-  CataLegendaryMountObtained: 524288
-  DarkRealmLightCopy: 2048
-  Employee: 16
-  EmployeeFlagIsManual: 32
-  GdprErased: 1024
-  InvalidTransmogsFixUp: 256
-  InvalidTransmogsFixUp2: 512
-  IsLegacy: 131072
-  LockedForExport: 16384
-  MopQuestLogFlagsFixUp: 1048576
-  None: 0
-  PetAchievementFixUp: 65536
-  QuestLogFlagsFixUp: 4096
-  RafVeteranNotified: 2
-  TwitterHasTempSecret: 8
-  TwitterLinked: 4
-  WasSecured: 8192
+  values:
+    AccountQuestBitFixUp: 64
+    AchievementsToBi: 128
+    BattlePetTrainer: 1
+    CanBuyAhGameTimeTokens: 32768
+    CataLegendaryMountChecked: 262144
+    CataLegendaryMountObtained: 524288
+    DarkRealmLightCopy: 2048
+    Employee: 16
+    EmployeeFlagIsManual: 32
+    GdprErased: 1024
+    InvalidTransmogsFixUp: 256
+    InvalidTransmogsFixUp2: 512
+    IsLegacy: 131072
+    LockedForExport: 16384
+    MopQuestLogFlagsFixUp: 1048576
+    None: 0
+    PetAchievementFixUp: 65536
+    QuestLogFlagsFixUp: 4096
+    RafVeteranNotified: 2
+    TwitterHasTempSecret: 8
+    TwitterLinked: 4
+    WasSecured: 8192
 BonusStatIndex:
-  Agility: 3
-  AgilityOrIntellect: 73
-  AgilityOrStrength: 72
-  AgilityOrStrengthOrIntellect: 71
-  ArcaneResistance: 56
-  ArmorPenetrationRating: 44
-  AttackPower: 38
-  BlockRating: 15
-  BlockValue: 48
-  CombatRatingAvoidance: 63
-  CombatRatingLifesteal: 62
-  CombatRatingSpeed: 61
-  CombatRatingSturdiness: 64
-  CombatRatingUnused_0: 58
-  CombatRatingUnused_10: 68
-  CombatRatingUnused_11: 69
-  CombatRatingUnused_12: 70
-  CombatRatingUnused_2: 59
-  CombatRatingUnused_27: 66
-  CombatRatingUnused_3: 60
-  CombatRatingUnused_7: 65
-  CombatRatingUnused_9: 67
-  CritMeleeRating: 19
-  CritRangedRating: 20
-  CritRating: 32
-  CritSpellRating: 21
-  CritTakenMeleeRatingObsolete: 25
-  CritTakenRangedRatingObsolete: 26
-  CritTakenRatingObsolete: 34
-  CritTakenSpellRatingObsolete: 27
-  DefenseSkillRating: 12
-  DodgeRating: 13
-  Endurance: 2
-  Energy: 8
-  ExpertiseRating: 37
-  ExtraArmor: 50
-  FireResistance: 51
-  Focus: 10
-  FrostResistance: 52
-  HasteMeleeRatingObsolete: 28
-  HasteRangedRatingObsolete: 29
-  HasteRating: 36
-  HasteSpellRatingObsolete: 30
-  Health: 1
-  HealthRegen: 46
-  HitMeleeRating: 16
-  HitRangedRating: 17
-  HitRating: 31
-  HitSpellRating: 18
-  HitTakenMeleeRatingObsolete: 22
-  HitTakenRangedRatingObsolete: 23
-  HitTakenRatingObsolete: 33
-  HitTakenSpellRatingObsolete: 24
-  HolyResistance: 53
-  Intellect: 5
-  Mana: 0
-  ManaRegeneration: 43
-  MasteryRating: 49
-  NatureResistance: 55
-  ParryRating: 14
-  ProfessionCraftingSpeed: 80
-  ProfessionDeftness: 78
-  ProfessionFinesse: 77
-  ProfessionIngenuity: 82
-  ProfessionInspiration: 75
-  ProfessionMulticraft: 81
-  ProfessionPerception: 79
-  ProfessionResourcefulness: 76
-  PvPPower: 57
-  Rage: 9
-  RangedAttackPower: 39
-  ResilienceRating: 35
-  ShadowResistance: 54
-  SpellDamageDone: 42
-  SpellHealingDone: 41
-  SpellPenetration: 47
-  SpellPower: 45
-  Spirit: 6
-  Stamina: 7
-  Strength: 4
-  StrengthOrIntellect: 74
-  Versatility: 40
-  WeaponSkillRating: 11
+  values:
+    Agility: 3
+    AgilityOrIntellect: 73
+    AgilityOrStrength: 72
+    AgilityOrStrengthOrIntellect: 71
+    ArcaneResistance: 56
+    ArmorPenetrationRating: 44
+    AttackPower: 38
+    BlockRating: 15
+    BlockValue: 48
+    CombatRatingAvoidance: 63
+    CombatRatingLifesteal: 62
+    CombatRatingSpeed: 61
+    CombatRatingSturdiness: 64
+    CombatRatingUnused_0: 58
+    CombatRatingUnused_10: 68
+    CombatRatingUnused_11: 69
+    CombatRatingUnused_12: 70
+    CombatRatingUnused_2: 59
+    CombatRatingUnused_27: 66
+    CombatRatingUnused_3: 60
+    CombatRatingUnused_7: 65
+    CombatRatingUnused_9: 67
+    CritMeleeRating: 19
+    CritRangedRating: 20
+    CritRating: 32
+    CritSpellRating: 21
+    CritTakenMeleeRatingObsolete: 25
+    CritTakenRangedRatingObsolete: 26
+    CritTakenRatingObsolete: 34
+    CritTakenSpellRatingObsolete: 27
+    DefenseSkillRating: 12
+    DodgeRating: 13
+    Endurance: 2
+    Energy: 8
+    ExpertiseRating: 37
+    ExtraArmor: 50
+    FireResistance: 51
+    Focus: 10
+    FrostResistance: 52
+    HasteMeleeRatingObsolete: 28
+    HasteRangedRatingObsolete: 29
+    HasteRating: 36
+    HasteSpellRatingObsolete: 30
+    Health: 1
+    HealthRegen: 46
+    HitMeleeRating: 16
+    HitRangedRating: 17
+    HitRating: 31
+    HitSpellRating: 18
+    HitTakenMeleeRatingObsolete: 22
+    HitTakenRangedRatingObsolete: 23
+    HitTakenRatingObsolete: 33
+    HitTakenSpellRatingObsolete: 24
+    HolyResistance: 53
+    Intellect: 5
+    Mana: 0
+    ManaRegeneration: 43
+    MasteryRating: 49
+    NatureResistance: 55
+    ParryRating: 14
+    ProfessionCraftingSpeed: 80
+    ProfessionDeftness: 78
+    ProfessionFinesse: 77
+    ProfessionIngenuity: 82
+    ProfessionInspiration: 75
+    ProfessionMulticraft: 81
+    ProfessionPerception: 79
+    ProfessionResourcefulness: 76
+    PvPPower: 57
+    Rage: 9
+    RangedAttackPower: 39
+    ResilienceRating: 35
+    ShadowResistance: 54
+    SpellDamageDone: 42
+    SpellHealingDone: 41
+    SpellPenetration: 47
+    SpellPower: 45
+    Spirit: 6
+    Stamina: 7
+    Strength: 4
+    StrengthOrIntellect: 74
+    Versatility: 40
+    WeaponSkillRating: 11
 BrawlType:
-  Arena: 2
-  Battleground: 1
-  LFG: 3
-  None: 0
-  SoloRbg: 5
-  SoloShuffle: 4
+  values:
+    Arena: 2
+    Battleground: 1
+    LFG: 3
+    None: 0
+    SoloRbg: 5
+    SoloShuffle: 4
 BulkPurchaseResult:
-  ResultFailed: 3
-  ResultInProgress: 1
-  ResultInsufficientFunds: 6
-  ResultOk: 0
-  ResultPartialSuccess: 2
-  ResultPurchaseTimeout: 7
-  ResultSystemDisabled: 5
-  ResultTooManyProducts: 4
+  values:
+    ResultFailed: 3
+    ResultInProgress: 1
+    ResultInsufficientFunds: 6
+    ResultOk: 0
+    ResultPartialSuccess: 2
+    ResultPurchaseTimeout: 7
+    ResultSystemDisabled: 5
+    ResultTooManyProducts: 4
 BulkPurchaseStatus:
-  Done: 3
-  Failed: 4
-  FetchEntitlements: 2
-  PlacingOrders: 0
-  PurchasesPending: 1
+  values:
+    Done: 3
+    Failed: 4
+    FetchEntitlements: 2
+    PlacingOrders: 0
+    PurchasesPending: 1
 BulkRefundResult:
-  ResultFailed: 1
-  ResultInvalidRequest: 2
-  ResultOk: 0
-  ResultRefundWindowExpired: 3
-  ResultSystemDisabled: 4
-  ResultTimeout: 5
+  values:
+    ResultFailed: 1
+    ResultInvalidRequest: 2
+    ResultOk: 0
+    ResultRefundWindowExpired: 3
+    ResultSystemDisabled: 4
+    ResultTimeout: 5
 CachedRewardType:
-  Currency: 2
-  Item: 1
-  None: 0
-  Quest: 3
+  values:
+    Currency: 2
+    Item: 1
+    None: 0
+    Quest: 3
 CalendarCommandType:
-  Complain: 10
-  Create: 0
-  GetCalendar: 7
-  GetEvent: 8
-  Invite: 1
-  ModeratorStatus: 6
-  Notes: 11
-  RemoveEvent: 4
-  RemoveInvite: 3
-  Rsvp: 2
-  Status: 5
-  UpdateEvent: 9
+  values:
+    Complain: 10
+    Create: 0
+    GetCalendar: 7
+    GetEvent: 8
+    Invite: 1
+    ModeratorStatus: 6
+    Notes: 11
+    RemoveEvent: 4
+    RemoveInvite: 3
+    Rsvp: 2
+    Status: 5
+    UpdateEvent: 9
 CalendarErrorType:
-  ArenaEventsExceeded: 27
-  CalendarDisabled: 25
-  CommunityEventsExceeded: 1
-  ComplaintAdded: 50
-  ComplaintDisabled: 31
-  ComplaintGm: 34
-  ComplaintLimit: 35
-  ComplaintNotFound: 36
-  ComplaintSameGuild: 33
-  ComplaintSelf: 32
-  CreatorNotFound: 46
-  DataAlreadySet: 24
-  DeleteCreatorFailed: 23
-  EventInvalid: 6
-  EventLocked: 22
-  EventPassed: 21
-  EventsExceeded: 2
-  EventThrottled: 47
-  EventWrongServer: 37
-  Ignored: 14
-  Internal: 49
-  InvalidClub: 45
-  InvalidDate: 17
-  InvalidDescription: 44
-  InvalidMaxSize: 16
-  InvalidNotes: 42
-  InvalidSignup: 39
-  InvalidTime: 18
-  InvalidTitle: 43
-  InvitesExceeded: 15
-  InviteThrottled: 48
-  ModeratorRestricted: 41
-  NameNotFound: 12
-  NeedsTitle: 20
-  NoCommunityInvites: 38
-  NoInvite: 30
-  NoInvites: 19
-  NoModerator: 40
-  NoPermission: 5
-  NotInCommunity: 10
-  NotInGuild: 9
-  NotInvited: 7
-  OtherInvitesExceeded: 4
-  RestrictedAccount: 26
-  RestrictedLevel: 28
-  SelfInvitesExceeded: 3
-  Squelched: 29
-  Success: 0
-  TargetAlreadyInvited: 11
-  UnknownError: 8
-  WrongFaction: 13
+  values:
+    ArenaEventsExceeded: 27
+    CalendarDisabled: 25
+    CommunityEventsExceeded: 1
+    ComplaintAdded: 50
+    ComplaintDisabled: 31
+    ComplaintGm: 34
+    ComplaintLimit: 35
+    ComplaintNotFound: 36
+    ComplaintSameGuild: 33
+    ComplaintSelf: 32
+    CreatorNotFound: 46
+    DataAlreadySet: 24
+    DeleteCreatorFailed: 23
+    EventInvalid: 6
+    EventLocked: 22
+    EventPassed: 21
+    EventsExceeded: 2
+    EventThrottled: 47
+    EventWrongServer: 37
+    Ignored: 14
+    Internal: 49
+    InvalidClub: 45
+    InvalidDate: 17
+    InvalidDescription: 44
+    InvalidMaxSize: 16
+    InvalidNotes: 42
+    InvalidSignup: 39
+    InvalidTime: 18
+    InvalidTitle: 43
+    InvitesExceeded: 15
+    InviteThrottled: 48
+    ModeratorRestricted: 41
+    NameNotFound: 12
+    NeedsTitle: 20
+    NoCommunityInvites: 38
+    NoInvite: 30
+    NoInvites: 19
+    NoModerator: 40
+    NoPermission: 5
+    NotInCommunity: 10
+    NotInGuild: 9
+    NotInvited: 7
+    OtherInvitesExceeded: 4
+    RestrictedAccount: 26
+    RestrictedLevel: 28
+    SelfInvitesExceeded: 3
+    Squelched: 29
+    Success: 0
+    TargetAlreadyInvited: 11
+    UnknownError: 8
+    WrongFaction: 13
 CalendarEventBits:
-  ArenaDeprecated: 256
-  AutoApprove: 32
-  CantComplain: 3788
-  CommunityAnnouncement: 64
-  CommunitySignup: 1024
-  CommunityWide: 3136
-  GuildDeprecated: 2
-  GuildSignup: 2048
-  Holiday: 8
-  Locked: 16
-  Player: 1
-  PlayerCreated: 3395
-  RaidLockout: 128
-  RaidReset: 512
-  System: 4
+  values:
+    ArenaDeprecated: 256
+    AutoApprove: 32
+    CantComplain: 3788
+    CommunityAnnouncement: 64
+    CommunitySignup: 1024
+    CommunityWide: 3136
+    GuildDeprecated: 2
+    GuildSignup: 2048
+    Holiday: 8
+    Locked: 16
+    Player: 1
+    PlayerCreated: 3395
+    RaidLockout: 128
+    RaidReset: 512
+    System: 4
 CalendarEventRepeatOptions:
-  Biweekly: 2
-  Monthly: 3
-  Never: 0
-  Weekly: 1
+  values:
+    Biweekly: 2
+    Monthly: 3
+    Never: 0
+    Weekly: 1
 CalendarEventType:
-  Dungeon: 1
-  HeroicDeprecated: 5
-  Meeting: 3
-  Other: 4
-  PvP: 2
-  Raid: 0
+  values:
+    Dungeon: 1
+    HeroicDeprecated: 5
+    Meeting: 3
+    Other: 4
+    PvP: 2
+    Raid: 0
 CalendarFilterFlags:
-  Battleground: 4
-  Darkmoon: 2
-  RaidLockout: 8
-  RaidReset: 16
-  WeeklyHoliday: 1
+  values:
+    Battleground: 4
+    Darkmoon: 2
+    RaidLockout: 8
+    RaidReset: 16
+    WeeklyHoliday: 1
 CalendarGetEventType:
-  Add: 1
-  Copy: 2
-  Get: 0
+  values:
+    Add: 1
+    Copy: 2
+    Get: 0
 CalendarHolidayFilterType:
-  Battleground: 2
-  Darkmoon: 1
-  Weekly: 0
+  values:
+    Battleground: 2
+    Darkmoon: 1
+    Weekly: 0
 CalendarInviteBits:
-  Creator: 4
-  Moderator: 2
-  None: 0
-  PendingInvite: 1
-  Signup: 8
+  values:
+    Creator: 4
+    Moderator: 2
+    None: 0
+    PendingInvite: 1
+    Signup: 8
 CalendarInviteSortType:
-  Class: 2
-  Level: 1
-  Name: 0
-  Notes: 5
-  Party: 4
-  Status: 3
+  values:
+    Class: 2
+    Level: 1
+    Name: 0
+    Notes: 5
+    Party: 4
+    Status: 3
 CalendarInviteType:
-  Normal: 0
-  Signup: 1
+  values:
+    Normal: 0
+    Signup: 1
 CalendarModeratorStatus:
-  Creator: 2
-  Moderator: 1
-  None: 0
+  values:
+    Creator: 2
+    Moderator: 1
+    None: 0
 CalendarStatus:
-  Available: 1
-  Confirmed: 3
-  Declined: 2
-  Invited: 0
-  NotSignedup: 7
-  Out: 4
-  Signedup: 6
-  Standby: 5
-  Tentative: 8
+  values:
+    Available: 1
+    Confirmed: 3
+    Declined: 2
+    Invited: 0
+    NotSignedup: 7
+    Out: 4
+    Signedup: 6
+    Standby: 5
+    Tentative: 8
 CalendarTexturesType:
-  Dungeons: 0
-  Raid: 1
+  values:
+    Dungeons: 0
+    Raid: 1
 CalendarType:
-  Community: 1
-  Holiday: 4
-  HolidayBattleground: 7
-  HolidayDarkmoon: 6
-  HolidayWeekly: 5
-  Player: 0
-  RaidLockout: 2
-  RaidReset: 3
+  values:
+    Community: 1
+    Holiday: 4
+    HolidayBattleground: 7
+    HolidayDarkmoon: 6
+    HolidayWeekly: 5
+    Player: 0
+    RaidLockout: 2
+    RaidReset: 3
 CalendarWebActionType:
-  Accept: 0
-  Decline: 1
-  Remove: 2
-  ReportSpam: 3
-  Signup: 4
-  Tentative: 5
-  TentativeSignup: 6
+  values:
+    Accept: 0
+    Decline: 1
+    Remove: 2
+    ReportSpam: 3
+    Signup: 4
+    Tentative: 5
+    TentativeSignup: 6
 CameraModeAspectRatio:
-  Cinemascope_2_Dot_4_X_1: 3
-  Default: 0
-  HighDefinition_16_X_9: 2
-  LegacyLetterbox: 1
+  values:
+    Cinemascope_2_Dot_4_X_1: 3
+    Default: 0
+    HighDefinition_16_X_9: 2
+    LegacyLetterbox: 1
 CanRedeemTokenForBalanceResult:
-  FailureCap: 1
-  Ok: 0
+  values:
+    FailureCap: 1
+    Ok: 0
 CaptureBarWidgetFillDirectionType:
-  LeftToRight: 1
-  RightToLeft: 0
+  values:
+    LeftToRight: 1
+    RightToLeft: 0
 Causeofdeath:
-  Creature: 3
-  Drowning: 5
-  Falling: 4
-  Fatigue: 6
-  Fire: 9
-  Lava: 8
-  None: 0
-  PlayerDuel: 2
-  PlayerPvP: 1
-  Slime: 7
+  values:
+    Creature: 3
+    Drowning: 5
+    Falling: 4
+    Fatigue: 6
+    Fire: 9
+    Lava: 8
+    None: 0
+    PlayerDuel: 2
+    PlayerPvP: 1
+    Slime: 7
 CauseofdeathFlags:
-  CreatureNameNeeded: 2
-  NoneNeeded: 0
-  PlayerNameNeeded: 1
-  ZoneNameNeeded: 4
+  values:
+    CreatureNameNeeded: 2
+    NoneNeeded: 0
+    PlayerNameNeeded: 1
+    ZoneNameNeeded: 4
 ChallengeModeHistoryFlags:
-  ConfirmedLeaver: 1
-  None: 0
+  values:
+    ConfirmedLeaver: 1
+    None: 0
 ChallengeModeHistoryResult:
-  Leaver: 1
-  Successful: 0
+  values:
+    Leaver: 1
+    Successful: 0
 ChallengeModeHistoryStatus:
-  Leaver: 1
-  Normal: 0
+  values:
+    Leaver: 1
+    Normal: 0
 ChannelPlayerFlags:
-  ChannelPlayerHidden: 8
-  ChannelPlayerModerator: 2
-  ChannelPlayerNone: 0
-  ChannelPlayerOwner: 1
-  ChannelPlayerTextAllow: 4
+  values:
+    ChannelPlayerHidden: 8
+    ChannelPlayerModerator: 2
+    ChannelPlayerNone: 0
+    ChannelPlayerOwner: 1
+    ChannelPlayerTextAllow: 4
 CharacterServiceInfoFlag:
-  AllowMaxLevelBoost: 2
-  RestrictToRecommendedSpecs: 1
+  values:
+    AllowMaxLevelBoost: 2
+    RestrictToRecommendedSpecs: 1
 CharCustomizationType:
-  CustomOptionFacewear: 7
-  CustomOptionHorn: 6
-  CustomOptionTattoo: 5
-  CustomOptionTattooColor: 8
-  Face: 1
-  FacialHair: 4
-  Hair: 2
-  HairColor: 3
-  Skin: 0
+  values:
+    CustomOptionFacewear: 7
+    CustomOptionHorn: 6
+    CustomOptionTattoo: 5
+    CustomOptionTattooColor: 8
+    Face: 1
+    FacialHair: 4
+    Hair: 2
+    HairColor: 3
+    Skin: 0
 ChatChannelRuleset:
-  ChromieTimeBuringCrusade: 4
-  ChromieTimeCataclysm: 3
-  ChromieTimeLegion: 8
-  ChromieTimeMists: 6
-  ChromieTimeWoD: 7
-  ChromieTimeWrath: 5
-  Disabled: 2
-  Mentor: 1
-  None: 0
+  values:
+    ChromieTimeBuringCrusade: 4
+    ChromieTimeCataclysm: 3
+    ChromieTimeLegion: 8
+    ChromieTimeMists: 6
+    ChromieTimeWoD: 7
+    ChromieTimeWrath: 5
+    Disabled: 2
+    Mentor: 1
+    None: 0
 ChatChannelType:
-  Communities: 4
-  Custom: 1
-  None: 0
-  PrivateParty: 2
-  PublicParty: 3
+  values:
+    Communities: 4
+    Custom: 1
+    None: 0
+    PrivateParty: 2
+    PublicParty: 3
 ChatToxityFilterOptOut:
-  ExcludeFilterAll: 4294967295
-  ExcludeFilterFriend: 1
-  ExcludeFilterGuild: 2
-  FilterAll: 0
+  values:
+    ExcludeFilterAll: 4294967295
+    ExcludeFilterFriend: 1
+    ExcludeFilterGuild: 2
+    FilterAll: 0
 ChatWhisperTargetStatus:
-  CanWhisper: 0
-  CanWhisperGuild: 1
-  Offline: 2
-  WrongFaction: 3
+  values:
+    CanWhisper: 0
+    CanWhisperGuild: 1
+    Offline: 2
+    WrongFaction: 3
 ChrCustomizationCategoryFlag:
-  Subcategory: 2
-  UndressModel: 1
+  values:
+    Subcategory: 2
+    UndressModel: 1
 ChrCustomizationOptionType:
-  Checkbox: 1
-  Dropdown: 0
-  Slider: 2
+  values:
+    Checkbox: 1
+    Dropdown: 0
+    Slider: 2
 ChrModelFeatureFlags:
-  Deprecated0: 8
-  Forms: 2
-  HunterPets: 32
-  Identity: 4
-  Mounts: 16
-  None: 0
-  Players: 64
-  Summons: 1
+  values:
+    Deprecated0: 8
+    Forms: 2
+    HunterPets: 32
+    Identity: 4
+    Mounts: 16
+    None: 0
+    Players: 64
+    Summons: 1
 ChrRacesAllianceType:
-  Alliance: 0
-  Horde: 1
-  NeutralOrNpc: 2
+  values:
+    Alliance: 0
+    Horde: 1
+    NeutralOrNpc: 2
 CinematicType:
-  GameCinematicSequence: 3
-  GameClientScene: 2
-  GameMovie: 1
-  GlueMovie: 0
+  values:
+    GameCinematicSequence: 3
+    GameClientScene: 2
+    GameMovie: 1
+    GlueMovie: 0
 ClientPlatformType:
-  Macintosh: 1
-  Windows: 0
+  values:
+    Macintosh: 1
+    Windows: 0
 ClientSceneType:
-  DefaultSceneType: 0
-  MinigameSceneType: 1
+  values:
+    DefaultSceneType: 0
+    MinigameSceneType: 1
 ClientSettingsConfigFlag:
-  ClientSettingsConfigBeta: 64
-  ClientSettingsConfigBetaRetail: 128
-  ClientSettingsConfigDebug: 1
-  ClientSettingsConfigGm: 8
-  ClientSettingsConfigInternal: 2
-  ClientSettingsConfigPerf: 4
-  ClientSettingsConfigRetail: 256
-  ClientSettingsConfigTest: 16
-  ClientSettingsConfigTestRetail: 32
+  values:
+    ClientSettingsConfigBeta: 64
+    ClientSettingsConfigBetaRetail: 128
+    ClientSettingsConfigDebug: 1
+    ClientSettingsConfigGm: 8
+    ClientSettingsConfigInternal: 2
+    ClientSettingsConfigPerf: 4
+    ClientSettingsConfigRetail: 256
+    ClientSettingsConfigTest: 16
+    ClientSettingsConfigTestRetail: 32
 ClubActionType:
-  ErrorClubActionAcceptInvitation: 13
-  ErrorClubActionAddBan: 22
-  ErrorClubActionCreate: 1
-  ErrorClubActionCreateMessage: 24
-  ErrorClubActionCreateStream: 15
-  ErrorClubActionCreateTicket: 5
-  ErrorClubActionDeclineInvitation: 14
-  ErrorClubActionDestroy: 3
-  ErrorClubActionDestroyMessage: 26
-  ErrorClubActionDestroyStream: 17
-  ErrorClubActionDestroyTicket: 6
-  ErrorClubActionEdit: 2
-  ErrorClubActionEditMember: 19
-  ErrorClubActionEditMemberNote: 20
-  ErrorClubActionEditMessage: 25
-  ErrorClubActionEditStream: 16
-  ErrorClubActionGetBans: 10
-  ErrorClubActionGetInvitations: 11
-  ErrorClubActionGetTicket: 8
-  ErrorClubActionGetTickets: 9
-  ErrorClubActionInviteMember: 18
-  ErrorClubActionKickMember: 21
-  ErrorClubActionLeave: 4
-  ErrorClubActionRedeemTicket: 7
-  ErrorClubActionRemoveBan: 23
-  ErrorClubActionRevokeInvitation: 12
-  ErrorClubActionSubscribe: 0
+  values:
+    ErrorClubActionAcceptInvitation: 13
+    ErrorClubActionAddBan: 22
+    ErrorClubActionCreate: 1
+    ErrorClubActionCreateMessage: 24
+    ErrorClubActionCreateStream: 15
+    ErrorClubActionCreateTicket: 5
+    ErrorClubActionDeclineInvitation: 14
+    ErrorClubActionDestroy: 3
+    ErrorClubActionDestroyMessage: 26
+    ErrorClubActionDestroyStream: 17
+    ErrorClubActionDestroyTicket: 6
+    ErrorClubActionEdit: 2
+    ErrorClubActionEditMember: 19
+    ErrorClubActionEditMemberNote: 20
+    ErrorClubActionEditMessage: 25
+    ErrorClubActionEditStream: 16
+    ErrorClubActionGetBans: 10
+    ErrorClubActionGetInvitations: 11
+    ErrorClubActionGetTicket: 8
+    ErrorClubActionGetTickets: 9
+    ErrorClubActionInviteMember: 18
+    ErrorClubActionKickMember: 21
+    ErrorClubActionLeave: 4
+    ErrorClubActionRedeemTicket: 7
+    ErrorClubActionRemoveBan: 23
+    ErrorClubActionRevokeInvitation: 12
+    ErrorClubActionSubscribe: 0
 ClubErrorType:
-  ErrorClubAlreadyMember: 19
-  ErrorClubBanAlreadyExists: 35
-  ErrorClubBanCountAtMax: 36
-  ErrorClubDoesntAllowCrossFaction: 40
-  ErrorClubEditHasCrossFactionMembers: 41
-  ErrorClubFull: 16
-  ErrorClubInsufficientPrivileges: 24
-  ErrorClubInvalidRoleID: 23
-  ErrorClubInvitationAlreadyExists: 22
-  ErrorClubMemberHasRequiredRole: 31
-  ErrorClubNoClub: 17
-  ErrorClubNoSuchInvitation: 21
-  ErrorClubNoSuchMember: 20
-  ErrorClubNotMember: 18
-  ErrorClubReceivedInvitationCountAtMax: 33
-  ErrorClubSentInvitationCountAtMax: 32
-  ErrorClubStreamCountAtMax: 30
-  ErrorClubStreamCountAtMin: 29
-  ErrorClubStreamInvalidName: 28
-  ErrorClubStreamNoStream: 27
-  ErrorClubTargetIsBanned: 34
-  ErrorClubTicketCountAtMax: 37
-  ErrorClubTicketHasConsumedAllowedRedeemCount: 39
-  ErrorClubTicketNoSuchTicket: 38
-  ErrorClubTooManyClubsJoined: 25
-  ErrorClubVoiceFull: 26
-  ErrorCommunitiesBadTarget: 4
-  ErrorCommunitiesChatMute: 15
-  ErrorCommunitiesGuild: 8
-  ErrorCommunitiesIgnored: 7
-  ErrorCommunitiesMissingShortName: 11
-  ErrorCommunitiesNeutralFaction: 2
-  ErrorCommunitiesNone: 0
-  ErrorCommunitiesProfanity: 12
-  ErrorCommunitiesRestricted: 6
-  ErrorCommunitiesTrial: 13
-  ErrorCommunitiesUnknown: 1
-  ErrorCommunitiesUnknownRealm: 3
-  ErrorCommunitiesUnknownTicket: 10
-  ErrorCommunitiesVeteranTrial: 14
-  ErrorCommunitiesWrongFaction: 5
-  ErrorCommunitiesWrongRegion: 9
+  values:
+    ErrorClubAlreadyMember: 19
+    ErrorClubBanAlreadyExists: 35
+    ErrorClubBanCountAtMax: 36
+    ErrorClubDoesntAllowCrossFaction: 40
+    ErrorClubEditHasCrossFactionMembers: 41
+    ErrorClubFull: 16
+    ErrorClubInsufficientPrivileges: 24
+    ErrorClubInvalidRoleID: 23
+    ErrorClubInvitationAlreadyExists: 22
+    ErrorClubMemberHasRequiredRole: 31
+    ErrorClubNoClub: 17
+    ErrorClubNoSuchInvitation: 21
+    ErrorClubNoSuchMember: 20
+    ErrorClubNotMember: 18
+    ErrorClubReceivedInvitationCountAtMax: 33
+    ErrorClubSentInvitationCountAtMax: 32
+    ErrorClubStreamCountAtMax: 30
+    ErrorClubStreamCountAtMin: 29
+    ErrorClubStreamInvalidName: 28
+    ErrorClubStreamNoStream: 27
+    ErrorClubTargetIsBanned: 34
+    ErrorClubTicketCountAtMax: 37
+    ErrorClubTicketHasConsumedAllowedRedeemCount: 39
+    ErrorClubTicketNoSuchTicket: 38
+    ErrorClubTooManyClubsJoined: 25
+    ErrorClubVoiceFull: 26
+    ErrorCommunitiesBadTarget: 4
+    ErrorCommunitiesChatMute: 15
+    ErrorCommunitiesGuild: 8
+    ErrorCommunitiesIgnored: 7
+    ErrorCommunitiesMissingShortName: 11
+    ErrorCommunitiesNeutralFaction: 2
+    ErrorCommunitiesNone: 0
+    ErrorCommunitiesProfanity: 12
+    ErrorCommunitiesRestricted: 6
+    ErrorCommunitiesTrial: 13
+    ErrorCommunitiesUnknown: 1
+    ErrorCommunitiesUnknownRealm: 3
+    ErrorCommunitiesUnknownTicket: 10
+    ErrorCommunitiesVeteranTrial: 14
+    ErrorCommunitiesWrongFaction: 5
+    ErrorCommunitiesWrongRegion: 9
 ClubFieldType:
-  ClubBroadcast: 3
-  ClubDescription: 2
-  ClubName: 0
-  ClubShortName: 1
-  ClubStreamName: 4
-  ClubStreamSubject: 5
-  NumTypes: 6
+  values:
+    ClubBroadcast: 3
+    ClubDescription: 2
+    ClubName: 0
+    ClubShortName: 1
+    ClubStreamName: 4
+    ClubStreamSubject: 5
+    NumTypes: 6
 ClubFinderApplicationUpdateType:
-  AcceptInvite: 1
-  Cancel: 3
-  DeclineInvite: 2
-  None: 0
+  values:
+    AcceptInvite: 1
+    Cancel: 3
+    DeclineInvite: 2
+    None: 0
 ClubFinderClubPostingStatusFlags:
-  Banned: 5
-  FakePost: 6
-  ForceDescriptionChange: 2
-  ForceNameChange: 3
-  NeedsCacheUpdate: 1
-  None: 0
-  PendingDelete: 7
-  PostDelisted: 8
-  UnderReview: 4
+  values:
+    Banned: 5
+    FakePost: 6
+    ForceDescriptionChange: 2
+    ForceNameChange: 3
+    NeedsCacheUpdate: 1
+    None: 0
+    PendingDelete: 7
+    PostDelisted: 8
+    UnderReview: 4
 ClubFinderDisableReason:
-  Muted: 0
-  Silenced: 1
-  VeteranTrial: 2
+  values:
+    Muted: 0
+    Silenced: 1
+    VeteranTrial: 2
 ClubFinderPostingReportType:
-  ApplicantsName: 3
-  ClubName: 1
-  JoinNote: 4
-  PostersName: 0
-  PostingDescription: 2
+  values:
+    ApplicantsName: 3
+    ClubName: 1
+    JoinNote: 4
+    PostersName: 0
+    PostingDescription: 2
 ClubFinderRequestType:
-  All: 3
-  Community: 2
-  Guild: 1
-  None: 0
+  values:
+    All: 3
+    Community: 2
+    Guild: 1
+    None: 0
 ClubFinderSettingFlags:
-  AutoAccept: 14
-  Damage: 11
-  Dungeons: 1
-  EnableListing: 12
-  FactionAlliance: 16
-  FactionHorde: 15
-  FactionNeutral: 17
-  Healer: 10
-  LanguageReserved1: 21
-  LanguageReserved2: 22
-  LanguageReserved3: 23
-  LanguageReserved4: 24
-  LanguageReserved5: 25
-  Large: 8
-  MaxLevelOnly: 13
-  Medium: 7
-  None: 0
-  PvP: 3
-  Raids: 2
-  RP: 4
-  Small: 6
-  Social: 5
-  SortMemberCount: 19
-  SortNewest: 20
-  SortRelevance: 18
-  Tank: 9
+  values:
+    AutoAccept: 14
+    Damage: 11
+    Dungeons: 1
+    EnableListing: 12
+    FactionAlliance: 16
+    FactionHorde: 15
+    FactionNeutral: 17
+    Healer: 10
+    LanguageReserved1: 21
+    LanguageReserved2: 22
+    LanguageReserved3: 23
+    LanguageReserved4: 24
+    LanguageReserved5: 25
+    Large: 8
+    MaxLevelOnly: 13
+    Medium: 7
+    None: 0
+    PvP: 3
+    Raids: 2
+    RP: 4
+    Small: 6
+    Social: 5
+    SortMemberCount: 19
+    SortNewest: 20
+    SortRelevance: 18
+    Tank: 9
 ClubInvitationCandidateStatus:
-  AlreadyMember: 2
-  Available: 0
-  InvitePending: 1
+  values:
+    AlreadyMember: 2
+    Available: 0
+    InvitePending: 1
 ClubMemberPresence:
-  Away: 4
-  Busy: 5
-  Offline: 3
-  Online: 1
-  OnlineMobile: 2
-  Unknown: 0
+  values:
+    Away: 4
+    Busy: 5
+    Offline: 3
+    Online: 1
+    OnlineMobile: 2
+    Unknown: 0
 ClubRemovedReason:
-  Banned: 1
-  ClubDestroyed: 3
-  None: 0
-  Removed: 2
+  values:
+    Banned: 1
+    ClubDestroyed: 3
+    None: 0
+    Removed: 2
 ClubRestrictionReason:
-  None: 0
-  Unavailable: 1
+  values:
+    None: 0
+    Unavailable: 1
 ClubRoleIdentifier:
-  Leader: 2
-  Member: 4
-  Moderator: 3
-  Owner: 1
+  values:
+    Leader: 2
+    Member: 4
+    Moderator: 3
+    Owner: 1
 ClubStreamNotificationFilter:
-  All: 2
-  Mention: 1
-  None: 0
+  values:
+    All: 2
+    Mention: 1
+    None: 0
 ClubStreamType:
-  General: 0
-  Guild: 1
-  Officer: 2
-  Other: 3
+  values:
+    General: 0
+    Guild: 1
+    Officer: 2
+    Other: 3
 ClubType:
-  BattleNet: 0
-  Character: 1
-  Guild: 2
-  Other: 3
+  values:
+    BattleNet: 0
+    Character: 1
+    Guild: 2
+    Other: 3
 ColorOverride:
-  ItemQualityAccount: 7
-  ItemQualityArtifact: 6
-  ItemQualityCommon: 1
-  ItemQualityEpic: 4
-  ItemQualityLegendary: 5
-  ItemQualityPoor: 0
-  ItemQualityRare: 3
-  ItemQualityUncommon: 2
+  values:
+    ItemQualityAccount: 7
+    ItemQualityArtifact: 6
+    ItemQualityCommon: 1
+    ItemQualityEpic: 4
+    ItemQualityLegendary: 5
+    ItemQualityPoor: 0
+    ItemQualityRare: 3
+    ItemQualityUncommon: 2
 CombatAudioAlertCastState:
-  Off: 0
-  OnCastEnd: 2
-  OnCastStart: 1
+  values:
+    Off: 0
+    OnCastEnd: 2
+    OnCastStart: 1
 CombatAudioAlertCategory:
-  General: 0
-  PartyHealth: 7
-  PlayerCast: 3
-  PlayerDebuffs: 8
-  PlayerHealth: 1
-  PlayerResource1: 5
-  PlayerResource2: 6
-  TargetCast: 4
-  TargetHealth: 2
+  values:
+    General: 0
+    PartyHealth: 7
+    PlayerCast: 3
+    PlayerDebuffs: 8
+    PlayerHealth: 1
+    PlayerResource1: 5
+    PlayerResource2: 6
+    TargetCast: 4
+    TargetHealth: 2
 CombatAudioAlertDebuffSelfAlertValues:
-  DispelType: 1
-  Off: 0
+  values:
+    DispelType: 1
+    Off: 0
 CombatAudioAlertPartyPercentValues:
-  Off: 0
-  Under100Percent: 1
-  Under10Percent: 10
-  Under20Percent: 9
-  Under30Percent: 8
-  Under40Percent: 7
-  Under50Percent: 6
-  Under60Percent: 5
-  Under70Percent: 4
-  Under80Percent: 3
-  Under90Percent: 2
+  values:
+    Off: 0
+    Under100Percent: 1
+    Under10Percent: 10
+    Under20Percent: 9
+    Under30Percent: 8
+    Under40Percent: 7
+    Under50Percent: 6
+    Under60Percent: 5
+    Under70Percent: 4
+    Under80Percent: 3
+    Under90Percent: 2
 CombatAudioAlertPercentValues:
-  Every10Percent: 1
-  Every20Percent: 2
-  Every30Percent: 3
-  Every40Percent: 4
-  Every50Percent: 5
-  Off: 0
+  values:
+    Every10Percent: 1
+    Every20Percent: 2
+    Every30Percent: 3
+    Every40Percent: 4
+    Every50Percent: 5
+    Off: 0
 CombatAudioAlertPlayerCastFormatValues:
-  Cast: 3
-  Casting: 2
-  CastingSpellname: 0
-  CastSpellname: 1
-  Spellname: 4
+  values:
+    Cast: 3
+    Casting: 2
+    CastingSpellname: 0
+    CastSpellname: 1
+    Spellname: 4
 CombatAudioAlertPlayerDebuffFormatValues:
-  Full: 0
-  NoSpellname: 1
+  values:
+    Full: 0
+    NoSpellname: 1
 CombatAudioAlertPlayerHealthFormatValues:
-  HealthFull: 0
-  HealthNoPercent: 1
-  HealthNoPercentDiv10: 2
-  NoHealthFull: 3
-  NoHealthNoPercent: 4
-  NoHealthNoPercentDiv10: 5
+  values:
+    HealthFull: 0
+    HealthNoPercent: 1
+    HealthNoPercentDiv10: 2
+    NoHealthFull: 3
+    NoHealthNoPercent: 4
+    NoHealthNoPercentDiv10: 5
 CombatAudioAlertPlayerResourceFormatValues:
-  NoResourceFull: 3
-  NoResourceNoPercent: 4
-  NoResourceNoPercentDiv10: 5
-  ResourceFull: 0
-  ResourceNoPercent: 1
-  ResourceNoPercentDiv10: 2
+  values:
+    NoResourceFull: 3
+    NoResourceNoPercent: 4
+    NoResourceNoPercentDiv10: 5
+    ResourceFull: 0
+    ResourceNoPercent: 1
+    ResourceNoPercentDiv10: 2
 CombatAudioAlertSayIfTargetedType:
-  Aggro: 1
-  None: 0
-  Targeted: 2
-  TargetedBy: 3
+  values:
+    Aggro: 1
+    None: 0
+    Targeted: 2
+    TargetedBy: 3
 CombatAudioAlertSpecSetting:
-  Resource1Format: 1
-  Resource1Percent: 0
-  Resource1Voice: 2
-  Resource1Volume: 3
-  Resource2Format: 5
-  Resource2Percent: 4
-  Resource2Voice: 6
-  Resource2Volume: 7
-  SayIfTargeted: 8
+  values:
+    Resource1Format: 1
+    Resource1Percent: 0
+    Resource1Voice: 2
+    Resource1Volume: 3
+    Resource2Format: 5
+    Resource2Percent: 4
+    Resource2Voice: 6
+    Resource2Volume: 7
+    SayIfTargeted: 8
 CombatAudioAlertTargetCastFormatValues:
-  Cast: 5
-  Casting: 4
-  CastingSpellname: 2
-  CastSpellname: 3
-  Spellname: 6
-  TargetCastingSpellname: 0
-  TargetCastSpellname: 1
+  values:
+    Cast: 5
+    Casting: 4
+    CastingSpellname: 2
+    CastSpellname: 3
+    Spellname: 6
+    TargetCastingSpellname: 0
+    TargetCastSpellname: 1
 CombatAudioAlertTargetDeathBehavior:
-  Default: 0
-  SayTargetDead: 1
+  values:
+    Default: 0
+    SayTargetDead: 1
 CombatAudioAlertTargetHealthFormatValues:
-  HealthFull: 3
-  HealthNoPercent: 4
-  HealthNoPercentDiv10: 5
-  NoHealthFull: 0
-  NoHealthNoPercent: 1
-  NoHealthNoPercentDiv10: 2
-  TargetFull: 6
-  TargetNoPercent: 7
-  TargetNoPercentDiv10: 8
+  values:
+    HealthFull: 3
+    HealthNoPercent: 4
+    HealthNoPercentDiv10: 5
+    NoHealthFull: 0
+    NoHealthNoPercent: 1
+    NoHealthNoPercentDiv10: 2
+    TargetFull: 6
+    TargetNoPercent: 7
+    TargetNoPercentDiv10: 8
 CombatAudioAlertThrottle:
-  PlayerCast: 3
-  PlayerHealth: 1
-  PlayerHealthSamePercent: 7
-  PlayerResource1: 5
-  PlayerResource1SamePercent: 9
-  PlayerResource2: 6
-  PlayerResource2SamePercent: 10
-  Sample: 0
-  TargetCast: 4
-  TargetHealth: 2
-  TargetHealthSamePercent: 8
+  values:
+    PlayerCast: 3
+    PlayerHealth: 1
+    PlayerHealthSamePercent: 7
+    PlayerResource1: 5
+    PlayerResource1SamePercent: 9
+    PlayerResource2: 6
+    PlayerResource2SamePercent: 10
+    Sample: 0
+    TargetCast: 4
+    TargetHealth: 2
+    TargetHealthSamePercent: 8
 CombatAudioAlertType:
-  Cast: 1
-  Health: 0
+  values:
+    Cast: 1
+    Health: 0
 CombatAudioAlertUnit:
-  Player: 0
-  Target: 1
+  values:
+    Player: 0
+    Target: 1
 CombatLogMessageOrder:
-  Newest: 0
-  Oldest: 1
+  values:
+    Newest: 0
+    Oldest: 1
 CombatLogObject:
-  AffiliationMine: 1
-  AffiliationOutsider: 8
-  AffiliationParty: 2
-  AffiliationRaid: 4
-  ControlNpc: 512
-  ControlPlayer: 256
-  Empty: 0
-  Focus: 131072
-  Mainassist: 524288
-  Maintank: 262144
-  None: 2147483648
-  ReactionFriendly: 16
-  ReactionHostile: 64
-  ReactionNeutral: 32
-  Target: 65536
-  TypeGuardian: 8192
-  TypeNpc: 2048
-  TypeObject: 16384
-  TypePet: 4096
-  TypePlayer: 1024
+  values:
+    AffiliationMine: 1
+    AffiliationOutsider: 8
+    AffiliationParty: 2
+    AffiliationRaid: 4
+    ControlNpc: 512
+    ControlPlayer: 256
+    Empty: 0
+    Focus: 131072
+    Mainassist: 524288
+    Maintank: 262144
+    None: 2147483648
+    ReactionFriendly: 16
+    ReactionHostile: 64
+    ReactionNeutral: 32
+    Target: 65536
+    TypeGuardian: 8192
+    TypeNpc: 2048
+    TypeObject: 16384
+    TypePet: 4096
+    TypePlayer: 1024
 CombatLogObjectTarget:
-  RaidNone: 2147483648
-  Raidtarget1: 1
-  Raidtarget2: 2
-  Raidtarget3: 4
-  Raidtarget4: 8
-  Raidtarget5: 16
-  Raidtarget6: 32
-  Raidtarget7: 64
-  Raidtarget8: 128
+  values:
+    RaidNone: 2147483648
+    Raidtarget1: 1
+    Raidtarget2: 2
+    Raidtarget3: 4
+    Raidtarget4: 8
+    Raidtarget5: 16
+    Raidtarget6: 32
+    Raidtarget7: 64
+    Raidtarget8: 128
 CombinedQuestLogStatus:
-  Available: 0
-  Complete: 1
-  CompleteDaily: 2
-  CompleteGameReset: 6
-  CompleteMonthly: 4
-  CompleteWeekly: 3
-  CompleteYearly: 5
-  Reset: 7
+  values:
+    Available: 0
+    Complete: 1
+    CompleteDaily: 2
+    CompleteGameReset: 6
+    CompleteMonthly: 4
+    CompleteWeekly: 3
+    CompleteYearly: 5
+    Reset: 7
 CombinedQuestStatus:
-  Completed: 1
-  Invalid: 0
-  NotCompleted: 2
+  values:
+    Completed: 1
+    Invalid: 0
+    NotCompleted: 2
 CommunicationMode:
-  OpenMic: 1
-  PushToTalk: 0
+  values:
+    OpenMic: 1
+    PushToTalk: 0
 CompanionConfigSlotTypes:
-  Combat: 2
-  Role: 0
-  Utility: 1
+  values:
+    Combat: 2
+    Role: 0
+    Utility: 1
 CompressionLevel:
-  Default: 0
-  OptimizeForSize: 2
-  OptimizeForSpeed: 1
+  values:
+    Default: 0
+    OptimizeForSize: 2
+    OptimizeForSpeed: 1
 CompressionMethod:
-  Deflate: 0
-  Gzip: 2
-  Zlib: 1
+  values:
+    Deflate: 0
+    Gzip: 2
+    Zlib: 1
 ConfirmationPromptUIType:
-  BonusRoll: 1
-  SimpleWarning: 2
-  SimpleWarningAlert: 4
-  StaticText: 0
-  StaticTextAlert: 3
+  values:
+    BonusRoll: 1
+    SimpleWarning: 2
+    SimpleWarningAlert: 4
+    StaticText: 0
+    StaticTextAlert: 3
 ConsoleCategory:
-  Combat: 3
-  Console: 2
-  Debug: 0
-  Default: 5
-  Game: 4
-  Gm: 8
-  Graphics: 1
-  Net: 6
-  None: 10
-  Reveal: 9
-  Sound: 7
+  values:
+    Combat: 3
+    Console: 2
+    Debug: 0
+    Default: 5
+    Game: 4
+    Gm: 8
+    Graphics: 1
+    Net: 6
+    None: 10
+    Reveal: 9
+    Sound: 7
 ConsoleColorType:
-  AdminColor: 6
-  BackgroundColor: 8
-  ClickbufferColor: 9
-  DefaultColor: 0
-  DefaultGreen: 11
-  EchoColor: 2
-  ErrorColor: 3
-  GlobalColor: 5
-  HighlightColor: 7
-  InputColor: 1
-  PrivateColor: 10
-  WarningColor: 4
+  values:
+    AdminColor: 6
+    BackgroundColor: 8
+    ClickbufferColor: 9
+    DefaultColor: 0
+    DefaultGreen: 11
+    EchoColor: 2
+    ErrorColor: 3
+    GlobalColor: 5
+    HighlightColor: 7
+    InputColor: 1
+    PrivateColor: 10
+    WarningColor: 4
 ConsoleCommandType:
-  Command: 1
-  Cvar: 0
-  Macro: 2
-  Script: 3
+  values:
+    Command: 1
+    Cvar: 0
+    Macro: 2
+    Script: 3
 ContentTrackingError:
-  AlreadyTracked: 2
-  MaxTracked: 1
-  Untrackable: 0
+  values:
+    AlreadyTracked: 2
+    MaxTracked: 1
+    Untrackable: 0
 ContentTrackingResult:
-  DataPending: 1
-  Failure: 2
-  Success: 0
+  values:
+    DataPending: 1
+    Failure: 2
+    Success: 0
 ContentTrackingStopType:
-  Collected: 1
-  Invalidated: 0
-  Manual: 2
+  values:
+    Collected: 1
+    Invalidated: 0
+    Manual: 2
 ContentTrackingTargetType:
-  Achievement: 2
-  JournalEncounter: 0
-  Profession: 3
-  Quest: 4
-  Vendor: 1
+  values:
+    Achievement: 2
+    JournalEncounter: 0
+    Profession: 3
+    Quest: 4
+    Vendor: 1
 ContentTrackingType:
-  Achievement: 2
-  Appearance: 0
-  Decor: 3
-  Mount: 1
+  values:
+    Achievement: 2
+    Appearance: 0
+    Decor: 3
+    Mount: 1
 ContributionAppearanceFlags:
-  TooltipUseTimeRemaining: 0
+  values:
+    TooltipUseTimeRemaining: 0
 ContributionResult:
-  FailedConditionCheck: 5
-  IncorrectState: 2
-  InternalError: 7
-  InvalidID: 3
-  MustBeNearNpc: 1
-  QuestDataMissing: 4
-  Success: 0
-  UnableToCompleteTurnIn: 6
+  values:
+    FailedConditionCheck: 5
+    IncorrectState: 2
+    InternalError: 7
+    InvalidID: 3
+    MustBeNearNpc: 1
+    QuestDataMissing: 4
+    Success: 0
+    UnableToCompleteTurnIn: 6
 ContributionState:
-  Active: 2
-  Building: 1
-  Destroyed: 4
-  None: 0
-  UnderAttack: 3
+  values:
+    Active: 2
+    Building: 1
+    Destroyed: 4
+    None: 0
+    UnderAttack: 3
 CooldownSetLinkedSpellFlags:
-  UseAsTooltip: 1
+  values:
+    UseAsTooltip: 1
 CooldownSetSpellFlags:
-  HideAura: 1
-  HideByDefault: 2
+  values:
+    HideAura: 1
+    HideByDefault: 2
 CooldownViewerAddAlertStatus:
-  DuplicateAlert: 3
-  InvalidAlertType: 1
-  InvalidEventType: 2
-  Success: 0
+  values:
+    DuplicateAlert: 3
+    InvalidAlertType: 1
+    InvalidEventType: 2
+    Success: 0
 CooldownViewerAlertEventType:
-  Available: 1
-  ChargeGained: 4
-  OnAuraApplied: 5
-  OnAuraRemoved: 6
-  OnCooldown: 3
-  PandemicTime: 2
+  values:
+    Available: 1
+    ChargeGained: 4
+    OnAuraApplied: 5
+    OnAuraRemoved: 6
+    OnCooldown: 3
+    PandemicTime: 2
 CooldownViewerAlertType:
-  Sound: 1
-  Visual: 2
+  values:
+    Sound: 1
+    Visual: 2
 CooldownViewerBarContent:
-  IconAndName: 0
-  IconOnly: 1
-  NameOnly: 2
+  values:
+    IconAndName: 0
+    IconOnly: 1
+    NameOnly: 2
 CooldownViewerCategory:
-  Essential: 0
-  TrackedBar: 3
-  TrackedBuff: 2
-  Utility: 1
+  values:
+    Essential: 0
+    TrackedBar: 3
+    TrackedBuff: 2
+    Utility: 1
 CooldownViewerIconDirection:
-  Left: 0
-  Right: 1
+  values:
+    Left: 0
+    Right: 1
 CooldownViewerOrientation:
-  Horizontal: 0
-  Vertical: 1
+  values:
+    Horizontal: 0
+    Vertical: 1
 CooldownViewerVisibleSetting:
-  Always: 0
-  Hidden: 2
-  InCombat: 1
+  values:
+    Always: 0
+    Hidden: 2
+    InCombat: 1
 CornerstonePurchaseMode:
-  Basic: 0
-  Import: 1
-  Move: 2
+  values:
+    Basic: 0
+    Import: 1
+    Move: 2
 CovenantSkill:
-  Kyrian: 2730
-  Necrolord: 2733
-  NightFae: 2732
-  Venthyr: 2731
+  values:
+    Kyrian: 2730
+    Necrolord: 2733
+    NightFae: 2732
+    Venthyr: 2731
 CovenantType:
-  Kyrian: 1
-  Necrolord: 4
-  NightFae: 3
-  None: 0
-  Venthyr: 2
+  values:
+    Kyrian: 1
+    Necrolord: 4
+    NightFae: 3
+    None: 0
+    Venthyr: 2
 CraftingOrderDuration:
-  Long: 2
-  Medium: 1
-  Short: 0
+  values:
+    Long: 2
+    Medium: 1
+    Short: 0
 CraftingOrderFlags:
-  HasAllReagents: 8
-  HasNoneReagents: 2
-  HasSomeReagents: 4
-  IsFulfillable: 16
-  IsRecraft: 1
-  None: 0
+  values:
+    HasAllReagents: 8
+    HasNoneReagents: 2
+    HasSomeReagents: 4
+    IsFulfillable: 16
+    IsRecraft: 1
+    None: 0
 CraftingOrderItemFlags:
-  HasEnchantmentData: 2
-  None: 0
-  NpcProvided: 1
+  values:
+    HasEnchantmentData: 2
+    None: 0
+    NpcProvided: 1
 CraftingOrderItemType:
-  CraftedResult: 2
-  Currency: 5
-  Deprecated: 4
-  Item: 0
-  Recraft: 1
-  RemoveReagent: 3
+  values:
+    CraftedResult: 2
+    Currency: 5
+    Deprecated: 4
+    Item: 0
+    Recraft: 1
+    RemoveReagent: 3
 CraftingOrderReagentSource:
-  Any: 0
-  Crafter: 2
-  Customer: 1
-  None: 3
+  values:
+    Any: 0
+    Crafter: 2
+    Customer: 1
+    None: 3
 CraftingOrderResult:
-  Aborted: 1
-  AlreadyClaimed: 2
-  AlreadyCrafted: 3
-  CannotBeOrdered: 4
-  CannotCancel: 5
-  CannotClaim: 6
-  CannotClaimOwnOrder: 7
-  CannotCraft: 8
-  CannotCreate: 9
-  CannotFulfill: 10
-  CannotRecraft: 11
-  CannotReject: 12
-  CannotRelease: 13
-  CrafterIsIgnored: 14
-  DatabaseError: 15
-  Expired: 16
-  InvalidDuration: 18
-  InvalidMinQuality: 19
-  InvalidNotes: 20
-  InvalidReagent: 21
-  InvalidRealm: 22
-  InvalidRecipe: 23
-  InvalidRecraftItem: 24
-  InvalidSort: 25
-  InvalidTarget: 26
-  InvalidType: 27
-  Locked: 17
-  MaxOrdersReached: 28
-  MissingCraftingTable: 29
-  MissingCurrency: 30
-  MissingItem: 31
-  MissingNpc: 32
-  MissingOrder: 33
-  MissingRecraftItem: 34
-  NoAccountItems: 35
-  NotClaimed: 36
-  NotCrafted: 37
-  NotInGuild: 38
-  NotYetImplemented: 39
-  Ok: 0
-  OutOfPublicOrderCapacity: 40
-  ServerIsNotAvailable: 41
-  TargetCannotCraft: 43
-  TargetLocked: 44
-  ThrottleViolation: 42
-  Timeout: 45
-  TooManyCurrencies: 46
-  TooManyItems: 47
-  WrongVersion: 48
+  values:
+    Aborted: 1
+    AlreadyClaimed: 2
+    AlreadyCrafted: 3
+    CannotBeOrdered: 4
+    CannotCancel: 5
+    CannotClaim: 6
+    CannotClaimOwnOrder: 7
+    CannotCraft: 8
+    CannotCreate: 9
+    CannotFulfill: 10
+    CannotRecraft: 11
+    CannotReject: 12
+    CannotRelease: 13
+    CrafterIsIgnored: 14
+    DatabaseError: 15
+    Expired: 16
+    InvalidDuration: 18
+    InvalidMinQuality: 19
+    InvalidNotes: 20
+    InvalidReagent: 21
+    InvalidRealm: 22
+    InvalidRecipe: 23
+    InvalidRecraftItem: 24
+    InvalidSort: 25
+    InvalidTarget: 26
+    InvalidType: 27
+    Locked: 17
+    MaxOrdersReached: 28
+    MissingCraftingTable: 29
+    MissingCurrency: 30
+    MissingItem: 31
+    MissingNpc: 32
+    MissingOrder: 33
+    MissingRecraftItem: 34
+    NoAccountItems: 35
+    NotClaimed: 36
+    NotCrafted: 37
+    NotInGuild: 38
+    NotYetImplemented: 39
+    Ok: 0
+    OutOfPublicOrderCapacity: 40
+    ServerIsNotAvailable: 41
+    TargetCannotCraft: 43
+    TargetLocked: 44
+    ThrottleViolation: 42
+    Timeout: 45
+    TooManyCurrencies: 46
+    TooManyItems: 47
+    WrongVersion: 48
 CraftingOrderSortType:
-  AveTip: 1
-  ItemName: 0
-  MaxTip: 2
-  Quantity: 3
-  Reagents: 4
-  Status: 7
-  TimeRemaining: 6
-  Tip: 5
+  values:
+    AveTip: 1
+    ItemName: 0
+    MaxTip: 2
+    Quantity: 3
+    Reagents: 4
+    Status: 7
+    TimeRemaining: 6
+    Tip: 5
 CraftingOrderState:
-  Canceled: 13
-  Canceling: 12
-  Claimed: 4
-  Claiming: 3
-  Crafting: 8
-  Created: 2
-  Creating: 1
-  Expired: 15
-  Expiring: 14
-  Fulfilled: 11
-  Fulfilling: 10
-  None: 0
-  Recrafting: 9
-  Rejected: 6
-  Rejecting: 5
-  Releasing: 7
+  values:
+    Canceled: 13
+    Canceling: 12
+    Claimed: 4
+    Claiming: 3
+    Crafting: 8
+    Created: 2
+    Creating: 1
+    Expired: 15
+    Expiring: 14
+    Fulfilled: 11
+    Fulfilling: 10
+    None: 0
+    Recrafting: 9
+    Rejected: 6
+    Rejecting: 5
+    Releasing: 7
 CraftingOrderType:
-  Guild: 1
-  Npc: 3
-  Personal: 2
-  Public: 0
+  values:
+    Guild: 1
+    Npc: 3
+    Personal: 2
+    Public: 0
 CraftingReagentItemFlag:
-  TooltipShowsAsStatModifications: 1
+  values:
+    TooltipShowsAsStatModifications: 1
 CraftingReagentType:
-  Automatic: 3
-  Basic: 1
-  Finishing: 2
-  Modifying: 0
+  values:
+    Automatic: 3
+    Basic: 1
+    Finishing: 2
+    Modifying: 0
 CreateAllAccountData:
-  AccountCurrenciesDone: '0x0000000000200000'
-  AccountDynamicCriteriaDone: '0x0000000001000000'
-  AccountFactionsDone: '0x0000000200000000'
-  AccountItemsDone: '0x0000000400000000'
-  AccountMappingDone: '0x0000008000000000'
-  AccountNotificationsDone: '0x0000000008000000'
-  AccountStateHousingData: '0x0000080000000000'
-  AchievementsDone: '0x0000000000000001'
-  ArchivedPurchasesDone: '0x0000000000000200'
-  AuctionableTokensDone: '0x0000000000002000'
-  BanktabSettingsDone: '0x0000004000000000'
-  BattlepetsDone: '0x0000000000000008'
-  BitVectorsDone: '0x0000000100000000'
-  BpayAddLicenseObjectsDone: '0x0000000000000800'
-  BpayDistributionObjectsDone: '0x0000000000000100'
-  BpayProductitemObjectsDone: '0x0000000000020000'
-  CharacterItemsDone: '0x0000010000000000'
-  CharactersDone: '0x0000000000000040'
-  CombinedQuestLogEntriesDone: '0x0000000800000000'
-  ConsumableTokensDone: '0x0000000000004000'
-  CriteriaDone: '0x0000000000000002'
-  CurrencycapsDone: '0x0000000000000010'
-  CurrencyTransferLogDone: '0x0000020000000000'
-  DataElementsDone: '0x0000001000000000'
-  EventRecordsDone: '0x0000200000000000'
-  ItemCollectionItemsDone: '0x0000000000001000'
-  LgVendorPurchaseDone: '0x0000040000000000'
-  MountsDone: '0x0000000000000004'
-  None: '0x0000000000000000'
-  Object: '0x0000000000100000'
-  PerkHeldItemsDone: '0x0000000040000000'
-  PerkPastRewardsDone: '0x0000000000008000'
-  PerkPendingPurchasesDone: '0x0000000010000000'
-  PerkPendingRewardsDone: '0x0000000080000000'
-  PurchasesDone: '0x0000000000000080'
-  QuestCriteriaDone: '0x0000000000080000'
-  QuestLogDone: '0x0000000000000020'
-  RafActivitiesDone: '0x0000000002000000'
-  RafBalanceDone: '0x0000000000400000'
-  RafRewardsDone: '0x0000000000800000'
-  RevokedRafRewardsDone: '0x0000000004000000'
-  SettingsDone: '0x0000000000000400'
-  TransmogOutfitsLoadedDone: '0x0000400000000000'
-  TrialBoostHistoryDone: '0x0000000000040000'
-  VasTransactionsDone: '0x0000000000010000'
-  WarbandGroupsDone: '0x0000002000000000'
-  WarbandScenesLoadedDone: '0x0000100000000000'
-  WowlabsDataDone: '0x0000000020000000'
+  values:
+    AccountCurrenciesDone: '0x0000000000200000'
+    AccountDynamicCriteriaDone: '0x0000000001000000'
+    AccountFactionsDone: '0x0000000200000000'
+    AccountItemsDone: '0x0000000400000000'
+    AccountMappingDone: '0x0000008000000000'
+    AccountNotificationsDone: '0x0000000008000000'
+    AccountStateHousingData: '0x0000080000000000'
+    AchievementsDone: '0x0000000000000001'
+    ArchivedPurchasesDone: '0x0000000000000200'
+    AuctionableTokensDone: '0x0000000000002000'
+    BanktabSettingsDone: '0x0000004000000000'
+    BattlepetsDone: '0x0000000000000008'
+    BitVectorsDone: '0x0000000100000000'
+    BpayAddLicenseObjectsDone: '0x0000000000000800'
+    BpayDistributionObjectsDone: '0x0000000000000100'
+    BpayProductitemObjectsDone: '0x0000000000020000'
+    CharacterItemsDone: '0x0000010000000000'
+    CharactersDone: '0x0000000000000040'
+    CombinedQuestLogEntriesDone: '0x0000000800000000'
+    ConsumableTokensDone: '0x0000000000004000'
+    CriteriaDone: '0x0000000000000002'
+    CurrencycapsDone: '0x0000000000000010'
+    CurrencyTransferLogDone: '0x0000020000000000'
+    DataElementsDone: '0x0000001000000000'
+    EventRecordsDone: '0x0000200000000000'
+    ItemCollectionItemsDone: '0x0000000000001000'
+    LgVendorPurchaseDone: '0x0000040000000000'
+    MountsDone: '0x0000000000000004'
+    None: '0x0000000000000000'
+    Object: '0x0000000000100000'
+    PerkHeldItemsDone: '0x0000000040000000'
+    PerkPastRewardsDone: '0x0000000000008000'
+    PerkPendingPurchasesDone: '0x0000000010000000'
+    PerkPendingRewardsDone: '0x0000000080000000'
+    PurchasesDone: '0x0000000000000080'
+    QuestCriteriaDone: '0x0000000000080000'
+    QuestLogDone: '0x0000000000000020'
+    RafActivitiesDone: '0x0000000002000000'
+    RafBalanceDone: '0x0000000000400000'
+    RafRewardsDone: '0x0000000000800000'
+    RevokedRafRewardsDone: '0x0000000004000000'
+    SettingsDone: '0x0000000000000400'
+    TransmogOutfitsLoadedDone: '0x0000400000000000'
+    TrialBoostHistoryDone: '0x0000000000040000'
+    VasTransactionsDone: '0x0000000000010000'
+    WarbandGroupsDone: '0x0000002000000000'
+    WarbandScenesLoadedDone: '0x0000100000000000'
+    WowlabsDataDone: '0x0000000020000000'
 CreateNeighborhoodErrorType:
-  None: 0
-  OversizedGuild: 3
-  Profanity: 1
-  UndersizedGuild: 2
+  values:
+    None: 0
+    OversizedGuild: 3
+    Profanity: 1
+    UndersizedGuild: 2
 CurioRarity:
-  Common: 1
-  Epic: 4
-  Rare: 3
-  Uncommon: 2
+  values:
+    Common: 1
+    Epic: 4
+    Rare: 3
+    Uncommon: 2
 CurrencyConversionResult:
-  Conversion: 1
-  NoConversion: 0
-  SkippedAccountCurrency: 2
+  values:
+    Conversion: 1
+    NoConversion: 0
+    SkippedAccountCurrency: 2
 CurrencyDestroyReason:
-  BonusRoll: 9
-  Capped: 6
-  Cheat: 0
-  DroppedToCorpse: 8
-  Garrison: 7
-  LegacyConversion: 10
-  QuestTurnin: 3
-  Spell: 1
-  Trade: 5
-  Vendor: 4
-  VersionUpdate: 2
+  values:
+    BonusRoll: 9
+    Capped: 6
+    Cheat: 0
+    DroppedToCorpse: 8
+    Garrison: 7
+    LegacyConversion: 10
+    QuestTurnin: 3
+    Spell: 1
+    Trade: 5
+    Vendor: 4
+    VersionUpdate: 2
 CurrencyFlags:
-  Currency_100_Scaler: 8
-  CurrencyAccountWide: 16777216
-  CurrencyAllowOverflowMailer: 33554432
-  CurrencyAppearsInLootWindow: 2
-  CurrencyComputedWeeklyMaximum: 4
-  CurrencyDeprecated: 131072
-  CurrencyDestroyExtraOnLoot: 2097152
-  CurrencyDoNotCompressChat: 8192
-  CurrencyDoNotLogAcquisitionToBi: 16384
-  CurrencyDoNotToast: 1048576
-  CurrencyDontCoalesceInLootWindow: 8388608
-  CurrencyDontShowTotalInTooltip: 4194304
-  CurrencyDynamicMaximum: 262144
-  CurrencyHasWarmodeBonus: 134217728
-  CurrencyHasWeeklyCatchup: 4096
-  CurrencyHideAsReward: 67108864
-  CurrencyIgnoreMaxQtyOnLoad: 32
-  CurrencyIsAllianceOnly: 268435456
-  CurrencyIsHordeOnly: 536870912
-  CurrencyLimitWarmodeBonusOncePerTooltip: 1073741824
-  CurrencyLogOnWorldChange: 64
-  CurrencyNoLowLevelDrop: 16
-  CurrencyNoRaidDrop: 32768
-  CurrencyNotPersistent: 65536
-  CurrencyResetTrackedQuantity: 256
-  CurrencySingleDropInLoot: 2048
-  CurrencySuppressChatMessageOnVersionChange: 1024
-  CurrencySuppressChatMessages: 524288
-  CurrencyTrackQuantity: 128
-  CurrencyTradable: 1
-  CurrencyUpdateVersionIgnoreMax: 512
-  CurrencyUsesLedgerBalance: 2147483648
+  values:
+    Currency_100_Scaler: 8
+    CurrencyAccountWide: 16777216
+    CurrencyAllowOverflowMailer: 33554432
+    CurrencyAppearsInLootWindow: 2
+    CurrencyComputedWeeklyMaximum: 4
+    CurrencyDeprecated: 131072
+    CurrencyDestroyExtraOnLoot: 2097152
+    CurrencyDoNotCompressChat: 8192
+    CurrencyDoNotLogAcquisitionToBi: 16384
+    CurrencyDoNotToast: 1048576
+    CurrencyDontCoalesceInLootWindow: 8388608
+    CurrencyDontShowTotalInTooltip: 4194304
+    CurrencyDynamicMaximum: 262144
+    CurrencyHasWarmodeBonus: 134217728
+    CurrencyHasWeeklyCatchup: 4096
+    CurrencyHideAsReward: 67108864
+    CurrencyIgnoreMaxQtyOnLoad: 32
+    CurrencyIsAllianceOnly: 268435456
+    CurrencyIsHordeOnly: 536870912
+    CurrencyLimitWarmodeBonusOncePerTooltip: 1073741824
+    CurrencyLogOnWorldChange: 64
+    CurrencyNoLowLevelDrop: 16
+    CurrencyNoRaidDrop: 32768
+    CurrencyNotPersistent: 65536
+    CurrencyResetTrackedQuantity: 256
+    CurrencySingleDropInLoot: 2048
+    CurrencySuppressChatMessageOnVersionChange: 1024
+    CurrencySuppressChatMessages: 524288
+    CurrencyTrackQuantity: 128
+    CurrencyTradable: 1
+    CurrencyUpdateVersionIgnoreMax: 512
+    CurrencyUsesLedgerBalance: 2147483648
 CurrencyFlagsB:
-  CurrencyBAllowReductionByResourcefulness: 1024
-  CurrencyBBattlenetVirtualCurrency: 8
-  CurrencyBDontDisplayIfZero: 32
-  CurrencyBForceMaxQuantityOnConversion: 256
-  CurrencyBNoBonusXP: 2048
-  CurrencyBNoNotificationMailOnOfflineProgress: 4
-  CurrencyBScaleMaxQuantityBySeasonWeeks: 64
-  CurrencyBScaleMaxQuantityByWeeksSinceStart: 128
-  CurrencyBShowQuestXPGainInTooltip: 2
-  CurrencyBUnearnableBeforeMaxQuantityStart: 512
-  CurrencyBUseTotalEarnedForEarned: 1
-  FutureCurrencyFlag: 16
+  values:
+    CurrencyBAllowReductionByResourcefulness: 1024
+    CurrencyBBattlenetVirtualCurrency: 8
+    CurrencyBDontDisplayIfZero: 32
+    CurrencyBForceMaxQuantityOnConversion: 256
+    CurrencyBNoBonusXP: 2048
+    CurrencyBNoNotificationMailOnOfflineProgress: 4
+    CurrencyBScaleMaxQuantityBySeasonWeeks: 64
+    CurrencyBScaleMaxQuantityByWeeksSinceStart: 128
+    CurrencyBShowQuestXPGainInTooltip: 2
+    CurrencyBUnearnableBeforeMaxQuantityStart: 512
+    CurrencyBUseTotalEarnedForEarned: 1
+    FutureCurrencyFlag: 16
 CurrencyGainFlags:
-  Autotracking: 8
-  BonusAward: 1
-  DroppedFromDeath: 2
-  FromAccountServer: 4
-  None: 0
+  values:
+    Autotracking: 8
+    BonusAward: 1
+    DroppedFromDeath: 2
+    FromAccountServer: 4
+    None: 0
 CurrencySource:
-  AccountCopy: 37
-  AccountServerConversion: 46
-  Arena: 17
-  ArenaPoints: 38
-  AuctionDeposit: 41
-  AzeriteRespec: 34
-  Barbershop: 42
-  BonusRoll: 33
-  ChallengeModeDungeon: 44
-  Cheat: 4
-  ConvertOldItem: 0
-  ConvertOldPvPCurrency: 1
-  ExceededMaxQty: 18
-  GarrisonBuilding: 23
-  GarrisonBuildingRefund: 26
-  GarrisonFollowerActivation: 25
-  GarrisonMissionReward: 27
-  GarrisonResourceOverTime: 28
-  GarrisonTalent: 30
-  GarrisonWorldQuestBonus: 31
-  GuildBankWithdrawal: 21
-  InitiativeReward: 45
-  ItemDeletion: 14
-  ItemRefund: 2
-  LFGReward: 11
-  Loot: 9
-  Pushloot: 22
-  PvPCompletionBonus: 19
-  PvPDrop: 24
-  PvPHonorQuestReward: 40
-  PvPHonorReward: 32
-  PvPKillCredit: 6
-  PvPMetaCredit: 7
-  PvPScriptedAward: 8
-  PvPTeamContribution: 39
-  QuestReward: 3
-  QuestRewardIgnoreCaps: 29
-  RandomBattleground: 16
-  RatedBattleground: 15
-  Script: 20
-  SimulateLoot: 43
-  Spell: 13
-  Trade: 12
-  UpdatingVersion: 10
-  Vendor: 5
-  WorldQuestReward: 35
-  WorldQuestRewardIgnoreCaps: 36
+  values:
+    AccountCopy: 37
+    AccountServerConversion: 46
+    Arena: 17
+    ArenaPoints: 38
+    AuctionDeposit: 41
+    AzeriteRespec: 34
+    Barbershop: 42
+    BonusRoll: 33
+    ChallengeModeDungeon: 44
+    Cheat: 4
+    ConvertOldItem: 0
+    ConvertOldPvPCurrency: 1
+    ExceededMaxQty: 18
+    GarrisonBuilding: 23
+    GarrisonBuildingRefund: 26
+    GarrisonFollowerActivation: 25
+    GarrisonMissionReward: 27
+    GarrisonResourceOverTime: 28
+    GarrisonTalent: 30
+    GarrisonWorldQuestBonus: 31
+    GuildBankWithdrawal: 21
+    InitiativeReward: 45
+    ItemDeletion: 14
+    ItemRefund: 2
+    LFGReward: 11
+    Loot: 9
+    Pushloot: 22
+    PvPCompletionBonus: 19
+    PvPDrop: 24
+    PvPHonorQuestReward: 40
+    PvPHonorReward: 32
+    PvPKillCredit: 6
+    PvPMetaCredit: 7
+    PvPScriptedAward: 8
+    PvPTeamContribution: 39
+    QuestReward: 3
+    QuestRewardIgnoreCaps: 29
+    RandomBattleground: 16
+    RatedBattleground: 15
+    Script: 20
+    SimulateLoot: 43
+    Spell: 13
+    Trade: 12
+    UpdatingVersion: 10
+    Vendor: 5
+    WorldQuestReward: 35
+    WorldQuestRewardIgnoreCaps: 36
 CurrencyTokenCategoryFlags:
-  FlagPlayerItemAssignment: 2
-  FlagSortLast: 1
-  Hidden: 4
-  StartsCollapsed: 16
-  Virtual: 8
+  values:
+    FlagPlayerItemAssignment: 2
+    FlagSortLast: 1
+    Hidden: 4
+    StartsCollapsed: 16
+    Virtual: 8
 CurrencyType:
-  Copper: 0
-  Gold: 2
-  Silver: 1
+  values:
+    Copper: 0
+    Gold: 2
+    Silver: 1
 Cursormode:
-  AttackCursor: 4
-  AttackErrorCursor: 50
-  BroomCursor: 42
-  BroomErrorCursor: 88
-  BuyCursor: 3
-  BuyErrorCursor: 49
-  CampaignQuestCursor: 23
-  CampaignQuestErrorCursor: 69
-  CampaignQuestTurninCursor: 24
-  CampaignQuestTurninErrorCursor: 70
-  CastCursor: 2
-  CastErrorCursor: 48
-  CustomCursor: 91
-  EnchantCursor: 39
-  EnchantErrorCursor: 85
-  GatherCursor: 13
-  GatherErrorCursor: 59
-  GrabbingHandCursor: 44
-  GrabbingHandErrorCursor: 90
-  HoldingHandCursor: 43
-  HoldingHandErrorCursor: 89
-  InnkeeperCursor: 22
-  InnkeeperErrorCursor: 68
-  InspectCursor: 7
-  InspectErrorCursor: 53
-  InteractCursor: 5
-  InteractErrorCursor: 51
-  ItemCursor: 19
-  ItemErrorCursor: 65
-  LockCursor: 14
-  LockErrorCursor: 60
-  LootAllCursor: 16
-  LootAllErrorCursor: 62
-  MailCursor: 15
-  MailErrorCursor: 61
-  MapPinCursor: 37
-  MapPinErrorCursor: 83
-  MineCursor: 11
-  MineErrorCursor: 57
-  NoCursor: 0
-  PaletteCursor: 41
-  PaletteErrorCursor: 87
-  PickupCursor: 8
-  PickupErrorCursor: 54
-  PingCursor: 38
-  PingErrorCursor: 84
-  PointCursor: 1
-  PointErrorCursor: 47
-  QuestCursor: 25
-  QuestErrorCursor: 71
-  QuestImportantCursor: 30
-  QuestImportantErrorCursor: 76
-  QuestImportantTurninCursor: 31
-  QuestImportantTurninErrorCursor: 77
-  QuestLegendaryCursor: 28
-  QuestLegendaryErrorCursor: 74
-  QuestLegendaryTurninCursor: 29
-  QuestLegendaryTurninErrorCursor: 75
-  QuestMetaCursor: 32
-  QuestMetaErrorCursor: 78
-  QuestMetaTurninCursor: 33
-  QuestMetaTurninErrorCursor: 79
-  QuestRecurringCursor: 34
-  QuestRecurringErrorCursor: 80
-  QuestRecurringTurninCursor: 35
-  QuestRecurringTurninErrorCursor: 81
-  QuestRepeatableCursor: 26
-  QuestRepeatableErrorCursor: 72
-  QuestTurninCursor: 27
-  QuestTurninErrorCursor: 73
-  RepairCursor: 17
-  RepairErrorCursor: 63
-  RepairnpcCursor: 18
-  RepairnpcErrorCursor: 64
-  SkinAllianceCursor: 21
-  SkinAllianceErrorCursor: 67
-  SkinCursor: 12
-  SkinErrorCursor: 58
-  SkinHordeCursor: 20
-  SkinHordeErrorCursor: 66
-  SpeakCursor: 6
-  SpeakErrorCursor: 52
-  StablemasterCursor: 40
-  StablemasterErrorCursor: 86
-  TaxiCursor: 9
-  TaxiErrorCursor: 55
-  TrainerCursor: 10
-  TrainerErrorCursor: 56
-  UIMoveCursor: 45
-  UIResizeCursor: 46
-  VehicleCursor: 36
-  VehicleErrorCursor: 82
+  values:
+    AttackCursor: 4
+    AttackErrorCursor: 50
+    BroomCursor: 42
+    BroomErrorCursor: 88
+    BuyCursor: 3
+    BuyErrorCursor: 49
+    CampaignQuestCursor: 23
+    CampaignQuestErrorCursor: 69
+    CampaignQuestTurninCursor: 24
+    CampaignQuestTurninErrorCursor: 70
+    CastCursor: 2
+    CastErrorCursor: 48
+    CustomCursor: 91
+    EnchantCursor: 39
+    EnchantErrorCursor: 85
+    GatherCursor: 13
+    GatherErrorCursor: 59
+    GrabbingHandCursor: 44
+    GrabbingHandErrorCursor: 90
+    HoldingHandCursor: 43
+    HoldingHandErrorCursor: 89
+    InnkeeperCursor: 22
+    InnkeeperErrorCursor: 68
+    InspectCursor: 7
+    InspectErrorCursor: 53
+    InteractCursor: 5
+    InteractErrorCursor: 51
+    ItemCursor: 19
+    ItemErrorCursor: 65
+    LockCursor: 14
+    LockErrorCursor: 60
+    LootAllCursor: 16
+    LootAllErrorCursor: 62
+    MailCursor: 15
+    MailErrorCursor: 61
+    MapPinCursor: 37
+    MapPinErrorCursor: 83
+    MineCursor: 11
+    MineErrorCursor: 57
+    NoCursor: 0
+    PaletteCursor: 41
+    PaletteErrorCursor: 87
+    PickupCursor: 8
+    PickupErrorCursor: 54
+    PingCursor: 38
+    PingErrorCursor: 84
+    PointCursor: 1
+    PointErrorCursor: 47
+    QuestCursor: 25
+    QuestErrorCursor: 71
+    QuestImportantCursor: 30
+    QuestImportantErrorCursor: 76
+    QuestImportantTurninCursor: 31
+    QuestImportantTurninErrorCursor: 77
+    QuestLegendaryCursor: 28
+    QuestLegendaryErrorCursor: 74
+    QuestLegendaryTurninCursor: 29
+    QuestLegendaryTurninErrorCursor: 75
+    QuestMetaCursor: 32
+    QuestMetaErrorCursor: 78
+    QuestMetaTurninCursor: 33
+    QuestMetaTurninErrorCursor: 79
+    QuestRecurringCursor: 34
+    QuestRecurringErrorCursor: 80
+    QuestRecurringTurninCursor: 35
+    QuestRecurringTurninErrorCursor: 81
+    QuestRepeatableCursor: 26
+    QuestRepeatableErrorCursor: 72
+    QuestTurninCursor: 27
+    QuestTurninErrorCursor: 73
+    RepairCursor: 17
+    RepairErrorCursor: 63
+    RepairnpcCursor: 18
+    RepairnpcErrorCursor: 64
+    SkinAllianceCursor: 21
+    SkinAllianceErrorCursor: 67
+    SkinCursor: 12
+    SkinErrorCursor: 58
+    SkinHordeCursor: 20
+    SkinHordeErrorCursor: 66
+    SpeakCursor: 6
+    SpeakErrorCursor: 52
+    StablemasterCursor: 40
+    StablemasterErrorCursor: 86
+    TaxiCursor: 9
+    TaxiErrorCursor: 55
+    TrainerCursor: 10
+    TrainerErrorCursor: 56
+    UIMoveCursor: 45
+    UIResizeCursor: 46
+    VehicleCursor: 36
+    VehicleErrorCursor: 82
 CursorStyle:
-  Crosshair: 1
-  Mouse: 0
+  values:
+    Crosshair: 1
+    Mouse: 0
 CustomBindingType:
-  VoicePushToTalk: 0
+  values:
+    VoicePushToTalk: 0
 Damageclass:
-  All: 127
-  AllMagical: 126
-  AllPhysical: 1
-  Arcane: 6
-  Fire: 2
-  FirstResist: 2
-  Frost: 4
-  Holy: 1
-  LastResist: 6
-  MaskArcane: 64
-  MaskChaos: 124
-  MaskChromatic: 62
-  MaskCosmic: 106
-  MaskDivine: 66
-  MaskElemental: 28
-  MaskFire: 4
-  MaskFirestorm: 12
-  MaskFlamestrike: 5
-  MaskFrost: 16
-  MaskFrostfire: 20
-  MaskFroststorm: 24
-  MaskFroststrike: 17
-  MaskHoly: 2
-  MaskHolyfire: 6
-  MaskHolyfrost: 18
-  MaskHolystorm: 10
-  MaskHolystrike: 3
-  MaskMagical: 126
-  MaskNature: 8
-  MaskNone: 0
-  MaskPhysical: 1
-  MaskShadow: 32
-  MaskShadowflame: 36
-  MaskShadowfrost: 48
-  MaskShadowstorm: 40
-  MaskShadowstrike: 33
-  MaskSpellfire: 68
-  MaskSpellfrost: 80
-  MaskSpellshadow: 96
-  MaskSpellstorm: 72
-  MaskSpellstrike: 65
-  MaskStormstrike: 9
-  MaskTwilight: 34
-  Nature: 3
-  Physical: 0
-  Shadow: 5
+  values:
+    All: 127
+    AllMagical: 126
+    AllPhysical: 1
+    Arcane: 6
+    Fire: 2
+    FirstResist: 2
+    Frost: 4
+    Holy: 1
+    LastResist: 6
+    MaskArcane: 64
+    MaskChaos: 124
+    MaskChromatic: 62
+    MaskCosmic: 106
+    MaskDivine: 66
+    MaskElemental: 28
+    MaskFire: 4
+    MaskFirestorm: 12
+    MaskFlamestrike: 5
+    MaskFrost: 16
+    MaskFrostfire: 20
+    MaskFroststorm: 24
+    MaskFroststrike: 17
+    MaskHoly: 2
+    MaskHolyfire: 6
+    MaskHolyfrost: 18
+    MaskHolystorm: 10
+    MaskHolystrike: 3
+    MaskMagical: 126
+    MaskNature: 8
+    MaskNone: 0
+    MaskPhysical: 1
+    MaskShadow: 32
+    MaskShadowflame: 36
+    MaskShadowfrost: 48
+    MaskShadowstorm: 40
+    MaskShadowstrike: 33
+    MaskSpellfire: 68
+    MaskSpellfrost: 80
+    MaskSpellshadow: 96
+    MaskSpellstorm: 72
+    MaskSpellstrike: 65
+    MaskStormstrike: 9
+    MaskTwilight: 34
+    Nature: 3
+    Physical: 0
+    Shadow: 5
 DamageclassType:
-  Magical: 1
-  Physical: 0
+  values:
+    Magical: 1
+    Physical: 0
 DamageMeterCombineSessionType:
-  Arena: 2
-  ArenaMultiRound: 3
-  ChallengeMode: 1
-  None: 0
+  values:
+    Arena: 2
+    ArenaMultiRound: 3
+    ChallengeMode: 1
+    None: 0
 DamageMeterNumbers:
-  Compact: 1
-  Complete: 2
-  Minimal: 0
+  values:
+    Compact: 1
+    Complete: 2
+    Minimal: 0
 DamageMeterOverrideType:
-  AllowFriendlyFire: 1
-  Ignore: 0
-  IgnoreForAbsorbSpell: 4
-  RedirectSourceToAuraCaster: 3
-  RedirectSourceToOwner: 2
+  values:
+    AllowFriendlyFire: 1
+    Ignore: 0
+    IgnoreForAbsorbSpell: 4
+    RedirectSourceToAuraCaster: 3
+    RedirectSourceToOwner: 2
 DamageMeterSessionType:
-  Current: 1
-  Expired: 2
-  Overall: 0
+  values:
+    Current: 1
+    Expired: 2
+    Overall: 0
 DamageMeterSourceDisplayType:
-  Ally: 1
-  Enemy: 2
-  None: 0
+  values:
+    Ally: 1
+    Enemy: 2
+    None: 0
 DamageMeterSpellDetailsDisplayType:
-  Deaths: 3
-  EnemyDamageTaken: 4
-  SpellAffected: 2
-  SpellCasted: 0
-  UnitSpecificSpellCasted: 1
+  values:
+    Deaths: 3
+    EnemyDamageTaken: 4
+    SpellAffected: 2
+    SpellCasted: 0
+    UnitSpecificSpellCasted: 1
 DamageMeterStorageType:
-  Absorbs: 2
-  AvoidableDamageTaken: 6
-  Damage: 0
-  DamageTaken: 5
-  Deaths: 7
-  Dispels: 4
-  EnemyDamageTaken: 8
-  HealingAndAbsorbs: 1
-  Interrupts: 3
+  values:
+    Absorbs: 2
+    AvoidableDamageTaken: 6
+    Damage: 0
+    DamageTaken: 5
+    Deaths: 7
+    Dispels: 4
+    EnemyDamageTaken: 8
+    HealingAndAbsorbs: 1
+    Interrupts: 3
 DamageMeterStyle:
-  Bordered: 2
-  Default: 0
-  FullBackground: 3
-  Thin: 1
+  values:
+    Bordered: 2
+    Default: 0
+    FullBackground: 3
+    Thin: 1
 DamageMeterType:
-  Absorbs: 4
-  AvoidableDamageTaken: 8
-  DamageDone: 0
-  DamageTaken: 7
-  Deaths: 9
-  Dispels: 6
-  Dps: 1
-  EnemyDamageTaken: 10
-  HealingDone: 2
-  Hps: 3
-  Interrupts: 5
+  values:
+    Absorbs: 4
+    AvoidableDamageTaken: 8
+    DamageDone: 0
+    DamageTaken: 7
+    Deaths: 9
+    Dispels: 6
+    Dps: 1
+    EnemyDamageTaken: 10
+    HealingDone: 2
+    Hps: 3
+    Interrupts: 5
 DamageMeterVisibility:
-  Always: 0
-  Hidden: 2
-  InCombat: 1
-  InGroup: 3
+  values:
+    Always: 0
+    Hidden: 2
+    InCombat: 1
+    InGroup: 3
 DeveloperLogAssertDomain:
-  Art: 1
-  Design: 2
-  Engineering: 4
-  LiveOperations: 64
-  Performance: 32
-  Sound: 8
-  Tools: 16
+  values:
+    Art: 1
+    Design: 2
+    Engineering: 4
+    LiveOperations: 64
+    Performance: 32
+    Sound: 8
+    Tools: 16
 DeveloperLogErrorDomain:
-  Assert: 0
-  AssertData: 1
-  Frame: 2
-  TestSuite: 3
+  values:
+    Assert: 0
+    AssertData: 1
+    Frame: 2
+    TestSuite: 3
 DeveloperLogTrafficType:
-  ClientToServer: 1
-  GameEvent: 2
-  LuaToClient: 3
-  ServerToClient: 0
+  values:
+    ClientToServer: 1
+    GameEvent: 2
+    LuaToClient: 3
+    ServerToClient: 0
 DisableAccountProfilesFlags:
-  DecorsCollections: 32
-  Document: 1
-  ItemsCollections: 16
-  MountsCollections: 4
-  None: 0
-  PetsCollections: 8
-  SharedCollections: 2
+  values:
+    DecorsCollections: 32
+    Document: 1
+    ItemsCollections: 16
+    MountsCollections: 4
+    None: 0
+    PetsCollections: 8
+    SharedCollections: 2
 DurationTextBindingProperty:
-  ElapsedDuration: 2
-  ElapsedPercent: 3
-  EndTime: 6
-  RemainingDuration: 0
-  RemainingPercent: 1
-  StartTime: 5
-  TotalDuration: 4
+  values:
+    ElapsedDuration: 2
+    ElapsedPercent: 3
+    EndTime: 6
+    RemainingDuration: 0
+    RemainingPercent: 1
+    StartTime: 5
+    TotalDuration: 4
 DurationTimeModifier:
-  BaseTime: 1
-  RealTime: 0
+  values:
+    BaseTime: 1
+    RealTime: 0
 EditModeAccountSetting:
-  DeprecatedShowDebuffFrame: 11
-  EnableAdvancedOptions: 23
-  EnableSnap: 22
-  GridSpacing: 1
-  SettingsExpanded: 2
-  ShowArchaeologyBar: 27
-  ShowArenaFrames: 17
-  ShowBossFrames: 16
-  ShowBuffsAndDebuffs: 10
-  ShowCastBar: 7
-  ShowCooldownViewer: 28
-  ShowDamageMeter: 31
-  ShowDurabilityFrame: 21
-  ShowEncounterBar: 8
-  ShowEncounterEvents: 30
-  ShowExternalDefensives: 32
-  ShowExtraAbilities: 9
-  ShowGrid: 0
-  ShowHudTooltip: 19
-  ShowLootFrame: 18
-  ShowPartyFrames: 12
-  ShowPersonalResourceDisplay: 29
-  ShowPetActionBar: 5
-  ShowPetFrame: 24
-  ShowPossessActionBar: 6
-  ShowRaidFrames: 13
-  ShowStanceBar: 4
-  ShowStatusTrackingBar2: 20
-  ShowTalkingHeadFrame: 14
-  ShowTargetAndFocus: 3
-  ShowTimerBars: 25
-  ShowTotemActionBar: 33
-  ShowVehicleLeaveButton: 15
-  ShowVehicleSeatIndicator: 26
+  values:
+    DeprecatedShowDebuffFrame: 11
+    EnableAdvancedOptions: 23
+    EnableSnap: 22
+    GridSpacing: 1
+    SettingsExpanded: 2
+    ShowArchaeologyBar: 27
+    ShowArenaFrames: 17
+    ShowBossFrames: 16
+    ShowBuffsAndDebuffs: 10
+    ShowCastBar: 7
+    ShowCooldownViewer: 28
+    ShowDamageMeter: 31
+    ShowDurabilityFrame: 21
+    ShowEncounterBar: 8
+    ShowEncounterEvents: 30
+    ShowExternalDefensives: 32
+    ShowExtraAbilities: 9
+    ShowGrid: 0
+    ShowHudTooltip: 19
+    ShowLootFrame: 18
+    ShowPartyFrames: 12
+    ShowPersonalResourceDisplay: 29
+    ShowPetActionBar: 5
+    ShowPetFrame: 24
+    ShowPossessActionBar: 6
+    ShowRaidFrames: 13
+    ShowStanceBar: 4
+    ShowStatusTrackingBar2: 20
+    ShowTalkingHeadFrame: 14
+    ShowTargetAndFocus: 3
+    ShowTimerBars: 25
+    ShowTotemActionBar: 33
+    ShowVehicleLeaveButton: 15
+    ShowVehicleSeatIndicator: 26
 EditModeActionBarSetting:
-  AlwaysShowButtons: 9
-  DeprecatedSnapToSide: 7
-  HideBarArt: 6
-  HideBarScrolling: 8
-  IconPadding: 4
-  IconSize: 3
-  NumIcons: 2
-  NumRows: 1
-  Orientation: 0
-  VisibleSetting: 5
+  values:
+    AlwaysShowButtons: 9
+    DeprecatedSnapToSide: 7
+    HideBarArt: 6
+    HideBarScrolling: 8
+    IconPadding: 4
+    IconSize: 3
+    NumIcons: 2
+    NumRows: 1
+    Orientation: 0
+    VisibleSetting: 5
 EditModeActionBarSystemIndices:
-  Bar2: 2
-  Bar3: 3
-  ExtraBar1: 6
-  ExtraBar2: 7
-  ExtraBar3: 8
-  MainBar: 1
-  PetActionBar: 12
-  PossessActionBar: 13
-  RightBar1: 4
-  RightBar2: 5
-  StanceBar: 11
+  values:
+    Bar2: 2
+    Bar3: 3
+    ExtraBar1: 6
+    ExtraBar2: 7
+    ExtraBar3: 8
+    MainBar: 1
+    PetActionBar: 12
+    PossessActionBar: 13
+    RightBar1: 4
+    RightBar2: 5
+    StanceBar: 11
 EditModeArchaeologyBarSetting:
-  Size: 0
+  values:
+    Size: 0
 EditModeAuraFrameSetting:
-  DeprecatedShowFull: 7
-  IconDirection: 2
-  IconLimitBuffFrame: 3
-  IconLimitDebuffFrame: 4
-  IconPadding: 6
-  IconSize: 5
-  IconWrap: 1
-  Opacity: 9
-  Orientation: 0
-  ShowDispelType: 10
-  VisibleSetting: 8
+  values:
+    DeprecatedShowFull: 7
+    IconDirection: 2
+    IconLimitBuffFrame: 3
+    IconLimitDebuffFrame: 4
+    IconPadding: 6
+    IconSize: 5
+    IconWrap: 1
+    Opacity: 9
+    Orientation: 0
+    ShowDispelType: 10
+    VisibleSetting: 8
 EditModeAuraFrameSystemIndices:
-  BuffFrame: 1
-  DebuffFrame: 2
-  ExternalDefensivesFrame: 3
+  values:
+    BuffFrame: 1
+    DebuffFrame: 2
+    ExternalDefensivesFrame: 3
 EditModeBagsSetting:
-  BagSlotPadding: 3
-  Direction: 1
-  Orientation: 0
-  Size: 2
+  values:
+    BagSlotPadding: 3
+    Direction: 1
+    Orientation: 0
+    Size: 2
 EditModeCastBarSetting:
-  BarSize: 0
-  LockToPlayerFrame: 1
-  ShowCastTime: 2
+  values:
+    BarSize: 0
+    LockToPlayerFrame: 1
+    ShowCastTime: 2
 EditModeChatFrameSetting:
-  HeightHundreds: 2
-  HeightTensAndOnes: 3
-  WidthHundreds: 0
-  WidthTensAndOnes: 1
+  values:
+    HeightHundreds: 2
+    HeightTensAndOnes: 3
+    WidthHundreds: 0
+    WidthTensAndOnes: 1
 EditModeCooldownViewerSetting:
-  BarContent: 7
-  BarWidthScale: 11
-  HideWhenInactive: 8
-  IconDirection: 2
-  IconLimit: 1
-  IconPadding: 4
-  IconSize: 3
-  Opacity: 5
-  Orientation: 0
-  ShowTimer: 9
-  ShowTooltips: 10
-  VisibleSetting: 6
+  values:
+    BarContent: 7
+    BarWidthScale: 11
+    HideWhenInactive: 8
+    IconDirection: 2
+    IconLimit: 1
+    IconPadding: 4
+    IconSize: 3
+    Opacity: 5
+    Orientation: 0
+    ShowTimer: 9
+    ShowTooltips: 10
+    VisibleSetting: 6
 EditModeCooldownViewerSystemIndices:
-  BuffBar: 4
-  BuffIcon: 3
-  Essential: 1
-  Utility: 2
+  values:
+    BuffBar: 4
+    BuffIcon: 3
+    Essential: 1
+    Utility: 2
 EditModeDamageMeterSetting:
-  BackgroundTransparency: 12
-  BarHeight: 10
-  FrameHeight: 4
-  FrameWidth: 3
-  Numbers: 2
-  ObsoleteReuse1: 7
-  Padding: 5
-  ShowClassColor: 9
-  ShowSpecIcon: 8
-  Style: 1
-  TextSize: 11
-  Transparency: 6
-  Visibility: 0
+  values:
+    BackgroundTransparency: 12
+    BarHeight: 10
+    FrameHeight: 4
+    FrameWidth: 3
+    Numbers: 2
+    ObsoleteReuse1: 7
+    Padding: 5
+    ShowClassColor: 9
+    ShowSpecIcon: 8
+    Style: 1
+    TextSize: 11
+    Transparency: 6
+    Visibility: 0
 EditModeDurabilityFrameSetting:
-  Size: 0
+  values:
+    Size: 0
 EditModeEncounterEventsSetting:
-  BackgroundTransparency: 5
-  BarWidth: 12
-  FlipHorizontally: 11
-  IconDirection: 1
-  IconSize: 3
-  Orientation: 0
-  OverallSize: 4
-  Padding: 13
-  ShowSpellName: 2
-  ShowTimer: 9
-  TooltipAnchor: 8
-  Transparency: 6
-  ViewType: 10
-  Visibility: 7
+  values:
+    BackgroundTransparency: 5
+    BarWidth: 12
+    FlipHorizontally: 11
+    IconDirection: 1
+    IconSize: 3
+    Orientation: 0
+    OverallSize: 4
+    Padding: 13
+    ShowSpellName: 2
+    ShowTimer: 9
+    TooltipAnchor: 8
+    Transparency: 6
+    ViewType: 10
+    Visibility: 7
 EditModeEncounterEventsSystemIndices:
-  CriticalWarnings: 2
-  MediumWarnings: 3
-  NormalWarnings: 4
-  Timeline: 1
+  values:
+    CriticalWarnings: 2
+    MediumWarnings: 3
+    NormalWarnings: 4
+    Timeline: 1
 EditModeLayoutType:
-  Account: 1
-  Character: 2
-  Override: 3
-  Preset: 0
+  values:
+    Account: 1
+    Character: 2
+    Override: 3
+    Preset: 0
 EditModeMicroMenuSetting:
-  EyeSize: 3
-  Order: 1
-  Orientation: 0
-  Size: 2
+  values:
+    EyeSize: 3
+    Order: 1
+    Orientation: 0
+    Size: 2
 EditModeMinimapSetting:
-  HeaderUnderneath: 0
-  RotateMinimap: 1
-  Size: 2
+  values:
+    HeaderUnderneath: 0
+    RotateMinimap: 1
+    Size: 2
 EditModeObjectiveTrackerSetting:
-  Height: 0
-  Opacity: 1
-  TextSize: 2
+  values:
+    Height: 0
+    Opacity: 1
+    TextSize: 2
 EditModePersonalResourceDisplaySetting:
-  BarWidth: 12
-  DeprecatedOnlyShowInCombat: 1
-  HealthBarHeight: 4
-  HideAltPower: 14
-  HideClassInfo: 3
-  HideClassInfoOnPlayerFrame: 10
-  HideHealth: 0
-  HidePower: 2
-  Opacity: 7
-  Padding: 6
-  PowerBarHeight: 5
-  ShowBarText: 13
-  ShowClassColor: 11
-  Size: 9
-  VisibleSetting: 8
+  values:
+    BarWidth: 12
+    DeprecatedOnlyShowInCombat: 1
+    HealthBarHeight: 4
+    HideAltPower: 14
+    HideClassInfo: 3
+    HideClassInfoOnPlayerFrame: 10
+    HideHealth: 0
+    HidePower: 2
+    Opacity: 7
+    Padding: 6
+    PowerBarHeight: 5
+    ShowBarText: 13
+    ShowClassColor: 11
+    Size: 9
+    VisibleSetting: 8
 EditModePresetLayouts:
-  Classic: 1
-  Modern: 0
+  values:
+    Classic: 1
+    Modern: 0
 EditModeSettingDisplayType:
-  Checkbox: 1
-  Dropdown: 0
-  Slider: 2
+  values:
+    Checkbox: 1
+    Dropdown: 0
+    Slider: 2
 EditModeStatusTrackingBarSetting:
-  Height: 0
-  Size: 3
-  TextSize: 2
-  Width: 1
+  values:
+    Height: 0
+    Size: 3
+    TextSize: 2
+    Width: 1
 EditModeStatusTrackingBarSystemIndices:
-  StatusTrackingBar1: 1
-  StatusTrackingBar2: 2
+  values:
+    StatusTrackingBar1: 1
+    StatusTrackingBar2: 2
 EditModeSystem:
-  ActionBar: 0
-  ArchaeologyBar: 19
-  AuraFrame: 6
-  Bags: 14
-  CastBar: 1
-  ChatFrame: 8
-  CooldownViewer: 20
-  DamageMeter: 23
-  DurabilityFrame: 16
-  EncounterBar: 4
-  EncounterEvents: 22
-  ExtraAbilities: 5
-  HudTooltip: 11
-  LootFrame: 10
-  MicroMenu: 13
-  Minimap: 2
-  ObjectiveTracker: 12
-  PersonalResourceDisplay: 21
-  StatusTrackingBar: 15
-  TalkingHeadFrame: 7
-  TimerBars: 17
-  TotemActionBar: 24
-  UnitFrame: 3
-  VehicleLeaveButton: 9
-  VehicleSeatIndicator: 18
+  values:
+    ActionBar: 0
+    ArchaeologyBar: 19
+    AuraFrame: 6
+    Bags: 14
+    CastBar: 1
+    ChatFrame: 8
+    CooldownViewer: 20
+    DamageMeter: 23
+    DurabilityFrame: 16
+    EncounterBar: 4
+    EncounterEvents: 22
+    ExtraAbilities: 5
+    HudTooltip: 11
+    LootFrame: 10
+    MicroMenu: 13
+    Minimap: 2
+    ObjectiveTracker: 12
+    PersonalResourceDisplay: 21
+    StatusTrackingBar: 15
+    TalkingHeadFrame: 7
+    TimerBars: 17
+    TotemActionBar: 24
+    UnitFrame: 3
+    VehicleLeaveButton: 9
+    VehicleSeatIndicator: 18
 EditModeTimerBarsSetting:
-  Size: 0
+  values:
+    Size: 0
 EditModeUnitFrameSetting:
-  AuraOrganizationType: 18
-  BigDefensiveIconSize: 21
-  BuffsOnTop: 2
-  CastBarOnSide: 7
-  CastBarUnderneath: 1
-  DisplayBorder: 12
-  FrameHeight: 11
-  FrameSize: 16
-  FrameWidth: 10
-  HidePortrait: 0
-  IconSize: 19
-  Opacity: 20
-  RaidGroupDisplayType: 13
-  RowSize: 15
-  ShowCastTime: 8
-  ShowPartyFrameBackground: 5
-  SortPlayersBy: 14
-  UseHorizontalGroups: 6
-  UseLargerFrame: 3
-  UseRaidStylePartyFrames: 4
-  ViewArenaSize: 17
-  ViewRaidSize: 9
+  values:
+    AuraOrganizationType: 18
+    BigDefensiveIconSize: 21
+    BuffsOnTop: 2
+    CastBarOnSide: 7
+    CastBarUnderneath: 1
+    DisplayBorder: 12
+    FrameHeight: 11
+    FrameSize: 16
+    FrameWidth: 10
+    HidePortrait: 0
+    IconSize: 19
+    Opacity: 20
+    RaidGroupDisplayType: 13
+    RowSize: 15
+    ShowCastTime: 8
+    ShowPartyFrameBackground: 5
+    SortPlayersBy: 14
+    UseHorizontalGroups: 6
+    UseLargerFrame: 3
+    UseRaidStylePartyFrames: 4
+    ViewArenaSize: 17
+    ViewRaidSize: 9
 EditModeUnitFrameSystemIndices:
-  Arena: 7
-  Boss: 6
-  Focus: 3
-  Party: 4
-  Pet: 8
-  Player: 1
-  Raid: 5
-  Target: 2
+  values:
+    Arena: 7
+    Boss: 6
+    Focus: 3
+    Party: 4
+    Pet: 8
+    Player: 1
+    Raid: 5
+    Target: 2
 EditModeVehicleSeatIndicatorSetting:
-  Size: 0
+  values:
+    Size: 0
 EncounterEventCastState:
-  Casting: 1
-  Expired: 3
-  NotCasting: 2
+  values:
+    Casting: 1
+    Expired: 3
+    NotCasting: 2
 EncounterEventColorTrigger:
-  TextWarning: 0
-  TimelineEvent: 1
-  TimelineEventHighlight: 2
+  values:
+    TextWarning: 0
+    TimelineEvent: 1
+    TimelineEventHighlight: 2
 EncounterEventIconmask:
-  BleedEffect: 4
-  CurseEffect: 32
-  DeadlyEffect: 1
-  DiseaseEffect: 16
-  DpsRole: 512
-  EnrageEffect: 2
-  HealerRole: 256
-  MagicEffect: 8
-  PoisonEffect: 64
-  TankRole: 128
+  values:
+    BleedEffect: 4
+    CurseEffect: 32
+    DeadlyEffect: 1
+    DiseaseEffect: 16
+    DpsRole: 512
+    EnrageEffect: 2
+    HealerRole: 256
+    MagicEffect: 8
+    PoisonEffect: 64
+    TankRole: 128
 EncounterEventSeverity:
-  High: 2
-  Low: 0
-  Medium: 1
+  values:
+    High: 2
+    Low: 0
+    Medium: 1
 EncounterEventsIconDirection:
-  Bottom: 1
-  Left: 0
-  Right: 1
-  Top: 0
+  values:
+    Bottom: 1
+    Left: 0
+    Right: 1
+    Top: 0
 EncounterEventsOrientation:
-  Horizontal: 0
-  Vertical: 1
+  values:
+    Horizontal: 0
+    Vertical: 1
 EncounterEventSoundTrigger:
-  OnTextWarningShown: 0
-  OnTimelineEventFinished: 1
-  OnTimelineEventHighlight: 2
+  values:
+    OnTextWarningShown: 0
+    OnTimelineEventFinished: 1
+    OnTimelineEventHighlight: 2
 EncounterEventsTooltipAnchor:
-  Cursor: 2
-  Default: 1
-  Hidden: 0
+  values:
+    Cursor: 2
+    Default: 1
+    Hidden: 0
 EncounterEventsViewType:
-  Bars: 1
-  Timeline: 0
+  values:
+    Bars: 1
+    Timeline: 0
 EncounterEventsVisibility:
-  Always: 0
-  DeprecatedHidden: 2
-  InEncounter: 1
+  values:
+    Always: 0
+    DeprecatedHidden: 2
+    InEncounter: 1
 EncounterTimelineEventSortDirection:
-  Ascending: 1
-  Descending: 0
+  values:
+    Ascending: 1
+    Descending: 0
 EncounterTimelineEventSource:
-  EditMode: 2
-  Encounter: 0
-  Script: 1
+  values:
+    EditMode: 2
+    Encounter: 0
+    Script: 1
 EncounterTimelineEventState:
-  Active: 0
-  Canceled: 3
-  Finished: 2
-  Paused: 1
+  values:
+    Active: 0
+    Canceled: 3
+    Finished: 2
+    Paused: 1
 EncounterTimelineIconSet:
-  DamageAlert: 3
-  Deadly: 4
-  Dispel: 5
-  Enrage: 6
-  HealerAlert: 2
-  TankAlert: 1
+  values:
+    DamageAlert: 3
+    Deadly: 4
+    Dispel: 5
+    Enrage: 6
+    HealerAlert: 2
+    TankAlert: 1
 EncounterTimelineTrack:
-  Indeterminate: 4
-  Long: 3
-  Medium: 2
-  Queued: 0
-  Short: 1
+  values:
+    Indeterminate: 4
+    Long: 3
+    Medium: 2
+    Queued: 0
+    Short: 1
 EncounterTimelineTrackType:
-  Hidden: 0
-  Linear: 2
-  Sorted: 1
+  values:
+    Hidden: 0
+    Linear: 2
+    Sorted: 1
 EncounterTimelineViewType:
-  Bars: 2
-  None: 0
-  Timeline: 1
+  values:
+    Bars: 2
+    None: 0
+    Timeline: 1
 EndOfMatchType:
-  None: 0
-  Plunderstorm: 1
+  values:
+    None: 0
+    Plunderstorm: 1
 EnvironmentalDamageFlags:
-  DmgIsPct: 2
-  OneTime: 1
+  values:
+    DmgIsPct: 2
+    OneTime: 1
 Environmentaldamagetype:
-  Drowning: 1
-  Falling: 2
-  Fatigue: 0
-  Fire: 5
-  Lava: 3
-  Slime: 4
+  values:
+    Drowning: 1
+    Falling: 2
+    Fatigue: 0
+    Fire: 5
+    Lava: 3
+    Slime: 4
 EventRealmQueues:
-  None: 0
-  PlunderstormDuo: 2
-  PlunderstormSolo: 1
-  PlunderstormTraining: 8
-  PlunderstormTrio: 4
+  values:
+    None: 0
+    PlunderstormDuo: 2
+    PlunderstormSolo: 1
+    PlunderstormTraining: 8
+    PlunderstormTrio: 4
 EventToastDisplayType:
-  CapstoneUnlocked: 12
-  ChallengeMode: 7
-  FlightpointDiscovered: 11
-  HouseUpgradeAvailable: 15
-  LargeTextWithIcon: 4
-  NormalBlockText: 1
-  NormalSingleLine: 0
-  NormalTextWithIcon: 3
-  NormalTextWithIconAndRarity: 5
-  NormalTitleAndSubTitle: 2
-  Scenario: 6
-  ScenarioClickExpand: 8
-  Scoreboard: 14
-  SingleLineWithIcon: 13
-  WeeklyRewardUnlock: 9
-  WeeklyRewardUpgrade: 10
+  values:
+    CapstoneUnlocked: 12
+    ChallengeMode: 7
+    FlightpointDiscovered: 11
+    HouseUpgradeAvailable: 15
+    LargeTextWithIcon: 4
+    NormalBlockText: 1
+    NormalSingleLine: 0
+    NormalTextWithIcon: 3
+    NormalTextWithIconAndRarity: 5
+    NormalTitleAndSubTitle: 2
+    Scenario: 6
+    ScenarioClickExpand: 8
+    Scoreboard: 14
+    SingleLineWithIcon: 13
+    WeeklyRewardUnlock: 9
+    WeeklyRewardUpgrade: 10
 EventToastEventType:
-  BattlePetLevelChanged: 8
-  BattlePetLevelUpAbility: 9
-  CriteriaUpdated: 19
-  FlightpointDiscovered: 25
-  HouseUpgradeAvailable: 26
-  LevelUp: 0
-  LevelUpDungeon: 2
-  LevelUpOther: 15
-  LevelUpPvP: 4
-  LevelUpRaid: 3
-  LevelUpSpell: 1
-  MythicPlusWeeklyRecord: 11
-  PetBattleCapture: 7
-  PetBattleFinalRound: 6
-  PetBattleNewAbility: 5
-  PlayerAuraAdded: 16
-  PlayerAuraRemoved: 17
-  PvPTierUpdate: 20
-  QuestBossEmote: 10
-  QuestTurnedIn: 12
-  Scenario: 14
-  SpellLearned: 21
-  SpellScript: 18
-  TreasureItem: 22
-  WeeklyRewardUnlock: 23
-  WeeklyRewardUpgrade: 24
-  WorldStateChange: 13
+  values:
+    BattlePetLevelChanged: 8
+    BattlePetLevelUpAbility: 9
+    CriteriaUpdated: 19
+    FlightpointDiscovered: 25
+    HouseUpgradeAvailable: 26
+    LevelUp: 0
+    LevelUpDungeon: 2
+    LevelUpOther: 15
+    LevelUpPvP: 4
+    LevelUpRaid: 3
+    LevelUpSpell: 1
+    MythicPlusWeeklyRecord: 11
+    PetBattleCapture: 7
+    PetBattleFinalRound: 6
+    PetBattleNewAbility: 5
+    PlayerAuraAdded: 16
+    PlayerAuraRemoved: 17
+    PvPTierUpdate: 20
+    QuestBossEmote: 10
+    QuestTurnedIn: 12
+    Scenario: 14
+    SpellLearned: 21
+    SpellScript: 18
+    TreasureItem: 22
+    WeeklyRewardUnlock: 23
+    WeeklyRewardUpgrade: 24
+    WorldStateChange: 13
 EventToastFlags:
-  DisableRightClickDismiss: 1
+  values:
+    DisableRightClickDismiss: 1
 ExcludedCensorSources:
-  All: 255
-  Friends: 1
-  Guild: 2
-  None: 0
-  Reserve1: 4
-  Reserve2: 8
-  Reserve3: 16
-  Reserve4: 32
-  Reserve5: 64
-  Reserve6: 128
+  values:
+    All: 255
+    Friends: 1
+    Guild: 2
+    None: 0
+    Reserve1: 4
+    Reserve2: 8
+    Reserve3: 16
+    Reserve4: 32
+    Reserve5: 64
+    Reserve6: 128
 ExpansionLandingPageType:
-  Midnight: 1
-  None: 0
+  values:
+    Midnight: 1
+    None: 0
 ExpansionLevel:
-  BattleForAzeroth: 7
-  BurningCrusade: 1
-  Cataclysm: 3
-  Draenor: 5
-  Dragonflight: 9
-  LastTitan: 12
-  Legion: 6
-  Midnight: 11
-  MistsOfPandaria: 4
-  None: 0
-  Northrend: 2
-  Shadowlands: 8
-  WarWithin: 10
+  values:
+    BattleForAzeroth: 7
+    BurningCrusade: 1
+    Cataclysm: 3
+    Draenor: 5
+    Dragonflight: 9
+    LastTitan: 12
+    Legion: 6
+    Midnight: 11
+    MistsOfPandaria: 4
+    None: 0
+    Northrend: 2
+    Shadowlands: 8
+    WarWithin: 10
 FlightPathFaction:
-  Alliance: 2
-  Horde: 1
-  Neutral: 0
+  values:
+    Alliance: 2
+    Horde: 1
+    Neutral: 0
 FlightPathState:
-  Current: 0
-  Reachable: 1
-  Unreachable: 2
+  values:
+    Current: 0
+    Reachable: 1
+    Unreachable: 2
 FollowerAbilityCastResult:
-  AlreadyAtMaxDurability: 13
-  CannotTargetLimitedUseFollower: 11
-  CannotTargetNonAutoMissionFollower: 14
-  Failure: 1
-  InvalidFollowerSpell: 4
-  InvalidFollowerType: 9
-  InvalidTarget: 3
-  MustBeUnique: 10
-  MustTargetFollower: 7
-  MustTargetLimitedUseFollower: 12
-  MustTargetTrait: 8
-  NoPendingCast: 2
-  RerollNotAllowed: 5
-  SingleMissionDuration: 6
-  Success: 0
+  values:
+    AlreadyAtMaxDurability: 13
+    CannotTargetLimitedUseFollower: 11
+    CannotTargetNonAutoMissionFollower: 14
+    Failure: 1
+    InvalidFollowerSpell: 4
+    InvalidFollowerType: 9
+    InvalidTarget: 3
+    MustBeUnique: 10
+    MustTargetFollower: 7
+    MustTargetLimitedUseFollower: 12
+    MustTargetTrait: 8
+    NoPendingCast: 2
+    RerollNotAllowed: 5
+    SingleMissionDuration: 6
+    Success: 0
 FontStringScaleAnimationMode:
-  FontSize: 0
-  Vertex: 1
+  values:
+    FontSize: 0
+    Vertex: 1
 FragmentID:
-  Actor: 15
-  CgObject: 2
-  ClientObservablesData: 6
-  DeferredMessages: 9
-  EntityPosition: 1
-  FHousingDecor: 20
-  FHousingDecorActor: 28
-  FHousingDecorProxy: 26
-  FHousingFixture: 34
-  FHousingHouseDecorSet: 24
-  FHousingHouseFixtureSet: 35
-  FHousingHouseRoomSet: 25
-  FHousingPlayerHouse: 23
-  FHousingPlotAreaTrigger: 29
-  FHousingRoom: 21
-  FHousingRoomComponentMesh: 22
-  FHousingStorageMirrorData: 33
-  FJamHousingCornerstone: 27
-  FLootObjectList: 12
-  FMeshObjectData: 19
-  FMirroredPositionData: 31
-  FNeighborhoodMirrorData: 30
-  FNeighborhoodStateData: 38
-  FPathingDoor: 41
-  FPathingDynamicLinks: 40
-  FPersistableJamServers: 10
-  FPhaseShiftData: 16
-  FPlayerHouseInfo: 32
-  FPlayerInitiativeInfo: 37
-  FPlayerJamServers: 11
-  FPlayerOwnershipLink: 13
-  FTransportLink: 5
-  FUnitAIGroupLink: 39
-  FUnitAreaTriggerLink: 14
-  FVendor: 17
-  HeartbeatData: 4
-  JamDispatcher: 3
-  MirroredObjectC: 18
-  MirrorState: 0
-  ReservedArchetypeSeparator: 255
-  TagActiveClientS: 216
-  TagActiveObjectC: 217
-  TagActivePlayer: 215
-  TagAIGroup: 212
-  TagAreaTrigger: 209
-  TagAzeriteEmpoweredItem: 202
-  TagAzeriteItem: 203
-  TagContainer: 201
-  TagConversation: 211
-  TagCorpse: 208
-  TagDynamicObject: 207
-  TagGameObject: 206
-  TagHouseExteriorPiece: 224
-  TagHouseExteriorRoot: 225
-  TagHousingDecorProxyGameObject: 226
-  TagHousingPoolObject: 223
-  TagHousingRoom: 220
-  TagHousingSubdivisionObject: 222
-  TagItem: 200
-  TagLootObject: 214
-  TagMeshObject: 221
-  TagPlayer: 205
-  TagScenario: 213
-  TagSceneObject: 210
-  TagUnit: 204
-  TagUnitVehicle: 219
-  TagVisibleObjectC: 218
-  TestFragment_1: 250
-  TestFragment_2: 251
-  TestFragment_3: 252
-  TestFragment_4: 253
-  TestFragment_5: 254
-  Timer: 36
-  TimerQueues: 7
-  TransferSuspensionData: 8
+  values:
+    Actor: 15
+    CgObject: 2
+    ClientObservablesData: 6
+    DeferredMessages: 9
+    EntityPosition: 1
+    FHousingDecor: 20
+    FHousingDecorActor: 28
+    FHousingDecorProxy: 26
+    FHousingFixture: 34
+    FHousingHouseDecorSet: 24
+    FHousingHouseFixtureSet: 35
+    FHousingHouseRoomSet: 25
+    FHousingPlayerHouse: 23
+    FHousingPlotAreaTrigger: 29
+    FHousingRoom: 21
+    FHousingRoomComponentMesh: 22
+    FHousingStorageMirrorData: 33
+    FJamHousingCornerstone: 27
+    FLootObjectList: 12
+    FMeshObjectData: 19
+    FMirroredPositionData: 31
+    FNeighborhoodMirrorData: 30
+    FNeighborhoodStateData: 38
+    FPathingDoor: 41
+    FPathingDynamicLinks: 40
+    FPersistableJamServers: 10
+    FPhaseShiftData: 16
+    FPlayerHouseInfo: 32
+    FPlayerInitiativeInfo: 37
+    FPlayerJamServers: 11
+    FPlayerOwnershipLink: 13
+    FTransportLink: 5
+    FUnitAIGroupLink: 39
+    FUnitAreaTriggerLink: 14
+    FVendor: 17
+    HeartbeatData: 4
+    JamDispatcher: 3
+    MirroredObjectC: 18
+    MirrorState: 0
+    ReservedArchetypeSeparator: 255
+    TagActiveClientS: 216
+    TagActiveObjectC: 217
+    TagActivePlayer: 215
+    TagAIGroup: 212
+    TagAreaTrigger: 209
+    TagAzeriteEmpoweredItem: 202
+    TagAzeriteItem: 203
+    TagContainer: 201
+    TagConversation: 211
+    TagCorpse: 208
+    TagDynamicObject: 207
+    TagGameObject: 206
+    TagHouseExteriorPiece: 224
+    TagHouseExteriorRoot: 225
+    TagHousingDecorProxyGameObject: 226
+    TagHousingPoolObject: 223
+    TagHousingRoom: 220
+    TagHousingSubdivisionObject: 222
+    TagItem: 200
+    TagLootObject: 214
+    TagMeshObject: 221
+    TagPlayer: 205
+    TagScenario: 213
+    TagSceneObject: 210
+    TagUnit: 204
+    TagUnitVehicle: 219
+    TagVisibleObjectC: 218
+    TestFragment_1: 250
+    TestFragment_2: 251
+    TestFragment_3: 252
+    TestFragment_4: 253
+    TestFragment_5: 254
+    Timer: 36
+    TimerQueues: 7
+    TransferSuspensionData: 8
 FrameTutorialAccount:
-  AccountWideReputation: 9
-  AssistedCombatRotationActionButton: 22
-  AssistedCombatRotationDragSpell: 21
-  BindToAccountUntilEquip: 11
-  CompletedQuestsFilter: 12
-  CompletedQuestsFilterSeen: 13
-  ConcentrationCurrency: 14
-  EditModeManager: 3
-  EnconterJournalTutorialsTabSeen: 33
-  EventSchedulerTabSeen: 20
-  HeirloomJournalLevel: 7
-  HousingCleanupMode: 40
-  HousingDecorCleanup: 23
-  HousingDecorClippingGrid: 25
-  HousingDecorCustomization: 26
-  HousingDecorLayout: 27
-  HousingDecorPlace: 24
-  HousingEndeavorsTabSeen: 48
-  HousingExpertMode: 39
-  HousingHouseFinderMap: 28
-  HousingHouseFinderVisitHouse: 29
-  HousingInvalidCollision: 37
-  HousingItemAcquisition: 30
-  HousingMarketTab: 34
-  HousingModesUnlocked: 38
-  HousingNewPip: 31
-  HousingTeleportButton: 35
-  HudRevampBagChanges: 1
-  LFGList: 6
-  LocalStoriesFilterSeen: 19
-  MapLegendOpened: 15
-  MountCollectionDragonriding: 5
-  NpcCraftingOrderCreateButton: 17
-  NpcCraftingOrders: 16
-  NpcCraftingOrderTabNew: 18
-  PerksProgramActivitiesIntro: 2
-  PerksProgramActivitiesOpen: 32
-  RPETalentStarterBuild: 36
-  RunesOfPower: 49
-  TimerunnersAdvantage: 8
-  TransferableCurrencies: 10
-  TransmogCustomSets: 43
-  TransmogCustomSetsMigration: 47
-  TransmogOutfits: 41
-  TransmogSets: 42
-  TransmogSetsTab: 4
-  TransmogSituations: 44
-  TransmogTrialOfStyle: 46
-  TransmogWeaponOptions: 45
+  values:
+    AccountWideReputation: 9
+    AssistedCombatRotationActionButton: 22
+    AssistedCombatRotationDragSpell: 21
+    BindToAccountUntilEquip: 11
+    CompletedQuestsFilter: 12
+    CompletedQuestsFilterSeen: 13
+    ConcentrationCurrency: 14
+    EditModeManager: 3
+    EnconterJournalTutorialsTabSeen: 33
+    EventSchedulerTabSeen: 20
+    HeirloomJournalLevel: 7
+    HousingCleanupMode: 40
+    HousingDecorCleanup: 23
+    HousingDecorClippingGrid: 25
+    HousingDecorCustomization: 26
+    HousingDecorLayout: 27
+    HousingDecorPlace: 24
+    HousingEndeavorsTabSeen: 48
+    HousingExpertMode: 39
+    HousingHouseFinderMap: 28
+    HousingHouseFinderVisitHouse: 29
+    HousingInvalidCollision: 37
+    HousingItemAcquisition: 30
+    HousingMarketTab: 34
+    HousingModesUnlocked: 38
+    HousingNewPip: 31
+    HousingTeleportButton: 35
+    HudRevampBagChanges: 1
+    LFGList: 6
+    LocalStoriesFilterSeen: 19
+    MapLegendOpened: 15
+    MountCollectionDragonriding: 5
+    NpcCraftingOrderCreateButton: 17
+    NpcCraftingOrders: 16
+    NpcCraftingOrderTabNew: 18
+    PerksProgramActivitiesIntro: 2
+    PerksProgramActivitiesOpen: 32
+    RPETalentStarterBuild: 36
+    RunesOfPower: 49
+    TimerunnersAdvantage: 8
+    TransferableCurrencies: 10
+    TransmogCustomSets: 43
+    TransmogCustomSetsMigration: 47
+    TransmogOutfits: 41
+    TransmogSets: 42
+    TransmogSetsTab: 4
+    TransmogSituations: 44
+    TransmogTrialOfStyle: 46
+    TransmogWeaponOptions: 45
 GameMode:
-  Plunderstorm: 2
-  Standard: 1
-  WoWHack: 3
+  values:
+    Plunderstorm: 2
+    Standard: 1
+    WoWHack: 3
 GamePadPowerLevel:
-  Critical: 0
-  High: 3
-  Low: 1
-  Medium: 2
-  Unknown: 5
-  Wired: 4
+  values:
+    Critical: 0
+    High: 3
+    Low: 1
+    Medium: 2
+    Unknown: 5
+    Wired: 4
 GameRule:
-  AchievementsPanelDisabled: 40
-  ActionbarIconIntroDisabled: 60
-  ActionButtonTypeOverlayStrategy: 165
-  ActionCombatTargetLockEnabled: 87
-  AfterDeathSpectatingUI: 49
-  AllPlayersAreFastMovers: 53
-  AlwaysAllowAlliedRaces: 59
-  AutoAttacksDisabled: 103
-  BagSpaceOverride: 172
-  BagsUIDisabled: 64
-  BlockWhileSheathedAllowed: 88
-  CharacterCreateUseFixedBackgroundModel: 55
-  CharacterlessLogin: 14
-  CharacterPanelDisabled: 37
-  CharNameReservationEnabled: 2
-  CharReservationsPerRealmReopenThreshold: 8
-  ChatLinkLevelToastsDisabled: 63
-  ClearMailOnRealmTransfer: 92
-  CollectionsPanelDisabled: 36
-  CommunitiesPanelDisabled: 41
-  CompactRaidFrameManagerDisabled: 81
-  CustomActionbarOverlayHeightOffset: 33
-  DeleteItemConfirmationDisabled: 62
-  DisableCampsites: 114
-  DisableHonorDecay: 23
-  DisablePct: 9
-  DisableQuickJoin: 162
-  DisableRaidGroups: 163
-  DisableRealmSelection: 113
-  DisableVas: 119
-  DoesNotCountTowardAccountCharacterMax: 142
-  EditModeDisabled: 82
-  EjDungeonsDisabled: 149
-  EjItemSetsDisabled: 151
-  EjJourneysDisabled: 156
-  EjRaidsDisabled: 150
-  EjSuggestedContentDisabled: 148
-  EncounterJournalDisabled: 42
-  EtaRealmLaunchTime: 5
-  ExperienceBarDisabled: 159
-  FastAreaTriggerTick: 52
-  FinderPanelDisabled: 43
-  ForceAlteredFormsOn: 56
-  ForcedChatLanguage: 34
-  ForcedMultiActionBarSetting: 133
-  ForcedPartyFrameScale: 32
-  FrontEndChat: 50
-  FullCharacterCreateDisabled: 84
-  GameMode: 13
-  GdapiCharacterProfileDisabled: 153
-  GroupFinderCapabilities: 98
-  GuildsDisabled: 46
-  HardcoreRuleset: 10
-  HelpPanelDisabled: 45
-  HideAllMultiActionBars: 135
-  HideFaction: 116
-  HideTransmogZeroCost: 161
-  HideUnavailableTransmogSlots: 160
-  HousingDashboardDisabled: 102
-  HousingEnabled: 154
-  IgnoreChrclassDisabledFlag: 54
-  IngameCalendarDisabled: 75
-  IngameFriendsListDisabled: 79
-  IngameMailNotificationDisabled: 74
-  IngameTrackingDisabled: 76
-  IngameWhoListDisabled: 77
-  InstanceDifficultyBannerDisabled: 83
-  LandingPageFactionID: 35
-  LootMethodStyle: 157
-  MacrosDisabled: 80
-  MailGameRule: 132
-  MapPlunderstormCircle: 48
-  MaxAccountCharReservationsPerContentset: 4
-  MaxCharactersPerContentSet: 139
-  MaxCharReservationsPerRealm: 3
-  MaximizeWorldMapDisabled: 67
-  MaxLootDropLevel: 25
-  MaxNameplateDistance: 28
-  MaxUnitNameDistance: 27
-  MerchantFilterDisabled: 101
-  MicrobarScale: 26
-  MinimapDisabled: 146
-  MinUndeleteLevelRequired: 140
-  NameplateCastBarDisabled: 107
-  NoDebuffLimit: 1
-  NonPlayerNameplateScale: 31
-  ObjectiveTrackerDisabled: 104
-  PerksProgramActivityTrackingDisabled: 66
-  PersonalResourceDisplayDisabled: 129
-  PetBattlesDisabled: 65
-  PlayerCastBarDisabled: 105
-  PlayerFrameDisabled: 131
-  PlayerNameplateAlternateHealthColor: 58
-  PlayerNameplateDifficultyIcon: 57
-  PlunderstormAreaSelection: 94
-  PremadeGroupFinderStyle: 93
-  PvPInitialRatingOverride: 190
-  QuestLogMicrobuttonDisabled: 47
-  QuestLogPanelDisabled: 71
-  QuestLogSuperTrackingDisabled: 72
-  RaceAlteredFormsDisabled: 78
-  RecommendLeastPopulatedRealm: 169
-  ReleaseSpiritGhostDisabled: 61
-  RepairArmorDisabled: 147
-  ReplaceAbsentGmSeconds: 11
-  ReplaceGmRankLastOnlineSeconds: 12
-  RestrictedAchievementCategoryID: 155
-  Runecarving: 17
-  SelfFoundAllowed: 22
-  SpellbookPanelDisabled: 38
-  StoreDisabled: 44
-  SummoningStones: 108
-  TalentRespecCostMax: 19
-  TalentRespecCostMin: 18
-  TalentRespecCostStep: 20
-  TalentsPanelDisabled: 39
-  TargetCastBarDisabled: 106
-  TargetFrameBuffsDisabled: 85
-  TargetFrameDisabled: 130
-  TimerunningAllowed: 137
-  TransmogEnabled: 109
-  TrivialGroupXPPercent: 7
-  TutorialFrameDisabled: 73
-  UnflaggedPlayersCanAttackPvPFlaggedPlayers: 173
-  UnitFramePvPContextualDisabled: 86
-  UniversalNameplateOcclusion: 51
-  UseGameTableVariation: 164
-  UserAddonsDisabled: 29
-  UserScriptsDisabled: 30
-  UseSimpleCharacterSelectList: 115
-  VanillaAccountMailInstant: 91
-  VanillaNpcKnockback: 16
-  VanillaRageGenerationModifier: 21
-  WorldMapDisabled: 145
-  WorldMapFrameStrata: 100
-  WorldMapHelpPlateDisabled: 70
-  WorldMapLegendDisabled: 99
-  WorldMapTrackingOptionsDisabled: 68
-  WorldMapTrackingPinDisabled: 69
+  values:
+    AchievementsPanelDisabled: 40
+    ActionbarIconIntroDisabled: 60
+    ActionButtonTypeOverlayStrategy: 165
+    ActionCombatTargetLockEnabled: 87
+    AfterDeathSpectatingUI: 49
+    AllPlayersAreFastMovers: 53
+    AlwaysAllowAlliedRaces: 59
+    AutoAttacksDisabled: 103
+    BagSpaceOverride: 172
+    BagsUIDisabled: 64
+    BlockWhileSheathedAllowed: 88
+    CharacterCreateUseFixedBackgroundModel: 55
+    CharacterlessLogin: 14
+    CharacterPanelDisabled: 37
+    CharNameReservationEnabled: 2
+    CharReservationsPerRealmReopenThreshold: 8
+    ChatLinkLevelToastsDisabled: 63
+    ClearMailOnRealmTransfer: 92
+    CollectionsPanelDisabled: 36
+    CommunitiesPanelDisabled: 41
+    CompactRaidFrameManagerDisabled: 81
+    CustomActionbarOverlayHeightOffset: 33
+    DeleteItemConfirmationDisabled: 62
+    DisableCampsites: 114
+    DisableHonorDecay: 23
+    DisablePct: 9
+    DisableQuickJoin: 162
+    DisableRaidGroups: 163
+    DisableRealmSelection: 113
+    DisableVas: 119
+    DoesNotCountTowardAccountCharacterMax: 142
+    EditModeDisabled: 82
+    EjDungeonsDisabled: 149
+    EjItemSetsDisabled: 151
+    EjJourneysDisabled: 156
+    EjRaidsDisabled: 150
+    EjSuggestedContentDisabled: 148
+    EncounterJournalDisabled: 42
+    EtaRealmLaunchTime: 5
+    ExperienceBarDisabled: 159
+    FastAreaTriggerTick: 52
+    FinderPanelDisabled: 43
+    ForceAlteredFormsOn: 56
+    ForcedChatLanguage: 34
+    ForcedMultiActionBarSetting: 133
+    ForcedPartyFrameScale: 32
+    FrontEndChat: 50
+    FullCharacterCreateDisabled: 84
+    GameMode: 13
+    GdapiCharacterProfileDisabled: 153
+    GroupFinderCapabilities: 98
+    GuildsDisabled: 46
+    HardcoreRuleset: 10
+    HelpPanelDisabled: 45
+    HideAllMultiActionBars: 135
+    HideFaction: 116
+    HideTransmogZeroCost: 161
+    HideUnavailableTransmogSlots: 160
+    HousingDashboardDisabled: 102
+    HousingEnabled: 154
+    IgnoreChrclassDisabledFlag: 54
+    IngameCalendarDisabled: 75
+    IngameFriendsListDisabled: 79
+    IngameMailNotificationDisabled: 74
+    IngameTrackingDisabled: 76
+    IngameWhoListDisabled: 77
+    InstanceDifficultyBannerDisabled: 83
+    LandingPageFactionID: 35
+    LootMethodStyle: 157
+    MacrosDisabled: 80
+    MailGameRule: 132
+    MapPlunderstormCircle: 48
+    MaxAccountCharReservationsPerContentset: 4
+    MaxCharactersPerContentSet: 139
+    MaxCharReservationsPerRealm: 3
+    MaximizeWorldMapDisabled: 67
+    MaxLootDropLevel: 25
+    MaxNameplateDistance: 28
+    MaxUnitNameDistance: 27
+    MerchantFilterDisabled: 101
+    MicrobarScale: 26
+    MinimapDisabled: 146
+    MinUndeleteLevelRequired: 140
+    NameplateCastBarDisabled: 107
+    NoDebuffLimit: 1
+    NonPlayerNameplateScale: 31
+    ObjectiveTrackerDisabled: 104
+    PerksProgramActivityTrackingDisabled: 66
+    PersonalResourceDisplayDisabled: 129
+    PetBattlesDisabled: 65
+    PlayerCastBarDisabled: 105
+    PlayerFrameDisabled: 131
+    PlayerNameplateAlternateHealthColor: 58
+    PlayerNameplateDifficultyIcon: 57
+    PlunderstormAreaSelection: 94
+    PremadeGroupFinderStyle: 93
+    PvPInitialRatingOverride: 190
+    QuestLogMicrobuttonDisabled: 47
+    QuestLogPanelDisabled: 71
+    QuestLogSuperTrackingDisabled: 72
+    RaceAlteredFormsDisabled: 78
+    RecommendLeastPopulatedRealm: 169
+    ReleaseSpiritGhostDisabled: 61
+    RepairArmorDisabled: 147
+    ReplaceAbsentGmSeconds: 11
+    ReplaceGmRankLastOnlineSeconds: 12
+    RestrictedAchievementCategoryID: 155
+    Runecarving: 17
+    SelfFoundAllowed: 22
+    SpellbookPanelDisabled: 38
+    StoreDisabled: 44
+    SummoningStones: 108
+    TalentRespecCostMax: 19
+    TalentRespecCostMin: 18
+    TalentRespecCostStep: 20
+    TalentsPanelDisabled: 39
+    TargetCastBarDisabled: 106
+    TargetFrameBuffsDisabled: 85
+    TargetFrameDisabled: 130
+    TimerunningAllowed: 137
+    TransmogEnabled: 109
+    TrivialGroupXPPercent: 7
+    TutorialFrameDisabled: 73
+    UnflaggedPlayersCanAttackPvPFlaggedPlayers: 173
+    UnitFramePvPContextualDisabled: 86
+    UniversalNameplateOcclusion: 51
+    UseGameTableVariation: 164
+    UserAddonsDisabled: 29
+    UserScriptsDisabled: 30
+    UseSimpleCharacterSelectList: 115
+    VanillaAccountMailInstant: 91
+    VanillaNpcKnockback: 16
+    VanillaRageGenerationModifier: 21
+    WorldMapDisabled: 145
+    WorldMapFrameStrata: 100
+    WorldMapHelpPlateDisabled: 70
+    WorldMapLegendDisabled: 99
+    WorldMapTrackingOptionsDisabled: 68
+    WorldMapTrackingPinDisabled: 69
 GameRuleFlags:
-  AllowClient: 1
-  None: 0
-  RequiresDefault: 2
+  values:
+    AllowClient: 1
+    None: 0
+    RequiresDefault: 2
 GameRuleType:
-  Bool: 2
-  Float: 1
-  Int: 0
+  values:
+    Bool: 2
+    Float: 1
+    Int: 0
 GarrAutoBoardIndex:
-  AllyCenterFront: 3
-  AllyLeftBack: 0
-  AllyLeftFront: 2
-  AllyRightBack: 1
-  AllyRightFront: 4
-  EnemyCenterLeftBack: 10
-  EnemyCenterLeftFront: 6
-  EnemyCenterRightBack: 11
-  EnemyCenterRightFront: 7
-  EnemyLeftBack: 9
-  EnemyLeftFront: 5
-  EnemyRightBack: 12
-  EnemyRightFront: 8
-  None: -1
+  values:
+    AllyCenterFront: 3
+    AllyLeftBack: 0
+    AllyLeftFront: 2
+    AllyRightBack: 1
+    AllyRightFront: 4
+    EnemyCenterLeftBack: 10
+    EnemyCenterLeftFront: 6
+    EnemyCenterRightBack: 11
+    EnemyCenterRightFront: 7
+    EnemyLeftBack: 9
+    EnemyLeftFront: 5
+    EnemyRightBack: 12
+    EnemyRightFront: 8
+    None: -1
 GarrAutoCombatantRole:
-  HealSupport: 4
-  Melee: 1
-  None: 0
-  RangedMagic: 3
-  RangedPhysical: 2
-  Tank: 5
+  values:
+    HealSupport: 4
+    Melee: 1
+    None: 0
+    RangedMagic: 3
+    RangedPhysical: 2
+    Tank: 5
 GarrAutoCombatSpellTutorialFlag:
-  All: 4
-  Column: 2
-  None: 0
-  Row: 3
-  Single: 1
+  values:
+    All: 4
+    Column: 2
+    None: 0
+    Row: 3
+    Single: 1
 GarrAutoCombatTutorial:
-  AttackAll: 256
-  AttackColumn: 64
-  AttackRow: 128
-  AttackSingle: 32
-  BeneficialEffect: 16
-  EnvironmentalEffect: 1024
-  HealCompanion: 4
-  LevelHeal: 8
-  PlaceCompanion: 2
-  SelectMission: 1
-  TroopTutorial: 512
+  values:
+    AttackAll: 256
+    AttackColumn: 64
+    AttackRow: 128
+    AttackSingle: 32
+    BeneficialEffect: 16
+    EnvironmentalEffect: 1024
+    HealCompanion: 4
+    LevelHeal: 8
+    PlaceCompanion: 2
+    SelectMission: 1
+    TroopTutorial: 512
 GarrAutoEventFlags:
-  AutoAttack: 1
-  Environment: 4
-  None: 0
-  Passive: 2
+  values:
+    AutoAttack: 1
+    Environment: 4
+    None: 0
+    Passive: 2
 GarrAutoMissionEventType:
-  ApplyAura: 7
-  Died: 9
-  Heal: 4
-  MeleeDamage: 0
-  PeriodicDamage: 5
-  PeriodicHeal: 6
-  RangeDamage: 1
-  RemoveAura: 8
-  SpellMeleeDamage: 2
-  SpellRangeDamage: 3
+  values:
+    ApplyAura: 7
+    Died: 9
+    Heal: 4
+    MeleeDamage: 0
+    PeriodicDamage: 5
+    PeriodicHeal: 6
+    RangeDamage: 1
+    RemoveAura: 8
+    SpellMeleeDamage: 2
+    SpellRangeDamage: 3
 GarrAutoPreviewTargetType:
-  Buff: 4
-  Damage: 1
-  Debuff: 8
-  Heal: 2
-  None: 0
+  values:
+    Buff: 4
+    Damage: 1
+    Debuff: 8
+    Heal: 2
+    None: 0
 GarrFollowerMissionCompleteState:
-  Alive: 0
-  KilledByMissionFailure: 1
-  OutOfDurability: 3
-  SavedByPreventDeath: 2
+  values:
+    Alive: 0
+    KilledByMissionFailure: 1
+    OutOfDurability: 3
+    SavedByPreventDeath: 2
 GarrFollowerQuality:
-  Common: 1
-  Epic: 4
-  Legendary: 5
-  None: 0
-  Rare: 3
-  Title: 6
-  Uncommon: 2
+  values:
+    Common: 1
+    Epic: 4
+    Legendary: 5
+    None: 0
+    Rare: 3
+    Title: 6
+    Uncommon: 2
 GarrisonFollowerType:
-  FollowerType_6_0_Boat: 2
-  FollowerType_6_0_GarrisonFollower: 1
-  FollowerType_7_0_GarrisonFollower: 4
-  FollowerType_8_0_GarrisonFollower: 22
-  FollowerType_9_0_GarrisonFollower: 123
+  values:
+    FollowerType_6_0_Boat: 2
+    FollowerType_6_0_GarrisonFollower: 1
+    FollowerType_7_0_GarrisonFollower: 4
+    FollowerType_8_0_GarrisonFollower: 22
+    FollowerType_9_0_GarrisonFollower: 123
 GarrisonTalentAvailability:
-  Available: 0
-  Unavailable: 1
-  UnavailableAlreadyHave: 7
-  UnavailableAnotherIsResearching: 2
-  UnavailableNotEnoughGold: 4
-  UnavailableNotEnoughResources: 3
-  UnavailablePlayerCondition: 6
-  UnavailableRequiresPrerequisiteTalent: 8
-  UnavailableTierUnavailable: 5
+  values:
+    Available: 0
+    Unavailable: 1
+    UnavailableAlreadyHave: 7
+    UnavailableAnotherIsResearching: 2
+    UnavailableNotEnoughGold: 4
+    UnavailableNotEnoughResources: 3
+    UnavailablePlayerCondition: 6
+    UnavailableRequiresPrerequisiteTalent: 8
+    UnavailableTierUnavailable: 5
 GarrisonType:
-  Type_6_0_Garrison: 2
-  Type_7_0_Garrison: 3
-  Type_8_0_Garrison: 9
-  Type_9_0_Garrison: 111
+  values:
+    Type_6_0_Garrison: 2
+    Type_7_0_Garrison: 3
+    Type_8_0_Garrison: 9
+    Type_9_0_Garrison: 111
 GarrTalentCostType:
-  Initial: 0
-  MakePermanent: 2
-  Respec: 1
-  TreeReset: 3
+  values:
+    Initial: 0
+    MakePermanent: 2
+    Respec: 1
+    TreeReset: 3
 GarrTalentFeatureSubtype:
-  Ardenweald: 3
-  Bastion: 1
-  Generic: 0
-  Maldraxxus: 4
-  Revendreth: 2
+  values:
+    Ardenweald: 3
+    Bastion: 1
+    Generic: 0
+    Maldraxxus: 4
+    Revendreth: 2
 GarrTalentFeatureType:
-  Adventures: 3
-  AnimaDiversion: 1
-  AnimaDiversionMap: 7
-  Cyphers: 8
-  Generic: 0
-  ReservoirUpgrades: 4
-  SanctumUnique: 5
-  SoulBinds: 6
-  TravelPortals: 2
+  values:
+    Adventures: 3
+    AnimaDiversion: 1
+    AnimaDiversionMap: 7
+    Cyphers: 8
+    Generic: 0
+    ReservoirUpgrades: 4
+    SanctumUnique: 5
+    SoulBinds: 6
+    TravelPortals: 2
 GarrTalentResearchCostSource:
-  Talent: 0
-  Tree: 1
+  values:
+    Talent: 0
+    Tree: 1
 GarrTalentSocketType:
-  Conduit: 2
-  None: 0
-  Spell: 1
+  values:
+    Conduit: 2
+    None: 0
+    Spell: 1
 GarrTalentTreeType:
-  Classic: 1
-  Tiers: 0
+  values:
+    Classic: 1
+    Tiers: 0
 GarrTalentType:
-  Major: 2
-  Minor: 1
-  Socket: 3
-  Standard: 0
+  values:
+    Major: 2
+    Minor: 1
+    Socket: 3
+    Standard: 0
 GarrTalentUI:
-  AnimaDiversionMap: 3
-  CovenantSanctum: 1
-  Generic: 0
-  SoulBinds: 2
+  values:
+    AnimaDiversionMap: 3
+    CovenantSanctum: 1
+    Generic: 0
+    SoulBinds: 2
 GossipNpcOption:
-  AccountBanker: 57
-  AdventureMap: 31
-  ArtifactRespec: 21
-  Auctioneer: 10
-  AzeriteRespec: 35
-  Banker: 6
-  BarbersChoice: 52
-  Battlemaster: 9
-  Binder: 5
-  BlackMarketAuctionHouse: 46
-  CemeterySelect: 22
-  CharacterBanker: 56
-  ChromieTimeNpc: 40
-  ContributionCollector: 33
-  CovenantPreviewNpc: 41
-  CovenantRenownNpc: 45
-  DisableXPGain: 16
-  EnableXPGain: 17
-  ForgeMaster: 55
-  GarrisonArchitect: 26
-  GarrisonMissionNpc: 27
-  GarrisonRecruitment: 30
-  GarrisonTalent: 32
-  GarrisonTradeskillNpc: 29
-  GlyphMaster: 24
-  GuildBanker: 14
-  GuildRename: 62
-  GuildTabardVendor: 8
-  HouseFinder: 65
-  HousingCreateGuildNeighborhood: 60
-  HousingGetNeighborhoodCharter: 61
-  HousingOpenCharterConfirmation: 63
-  IslandsMissionNpc: 36
-  ItemUpgrade: 64
-  LFGDungeon: 20
-  Mailbox: 18
-  MajorFactionRenown: 53
-  NewPlayerGuide: 43
-  None: 0
-  PerksProgramVendor: 47
-  PersonalTabardVendor: 54
-  PetitionVendor: 7
-  PetUntrainer: 13
-  ProfessionRespec: 58
-  ProfessionsCraftingOrder: 48
-  ProfessionsCustomerOrder: 50
-  ProfessionsOpen: 49
-  QueueScenario: 25
-  RenameNeighborhood: 59
-  RuneforgeLegendaryCrafting: 42
-  RuneforgeLegendaryUpgrade: 44
-  ShipmentCrafter: 28
-  Soulbind: 39
-  SpecializationMaster: 23
-  Spellclick: 15
-  SpiritHealer: 4
-  Stablemaster: 12
-  TalentMaster: 11
-  Taxinode: 2
-  TieredEntrance: 66
-  Trainer: 3
-  TraitSystem: 51
-  Transmogrify: 34
-  UIItemInteraction: 37
-  Vendor: 1
-  WorldMap: 38
-  WorldPvPQueue: 19
+  values:
+    AccountBanker: 57
+    AdventureMap: 31
+    ArtifactRespec: 21
+    Auctioneer: 10
+    AzeriteRespec: 35
+    Banker: 6
+    BarbersChoice: 52
+    Battlemaster: 9
+    Binder: 5
+    BlackMarketAuctionHouse: 46
+    CemeterySelect: 22
+    CharacterBanker: 56
+    ChromieTimeNpc: 40
+    ContributionCollector: 33
+    CovenantPreviewNpc: 41
+    CovenantRenownNpc: 45
+    DisableXPGain: 16
+    EnableXPGain: 17
+    ForgeMaster: 55
+    GarrisonArchitect: 26
+    GarrisonMissionNpc: 27
+    GarrisonRecruitment: 30
+    GarrisonTalent: 32
+    GarrisonTradeskillNpc: 29
+    GlyphMaster: 24
+    GuildBanker: 14
+    GuildRename: 62
+    GuildTabardVendor: 8
+    HouseFinder: 65
+    HousingCreateGuildNeighborhood: 60
+    HousingGetNeighborhoodCharter: 61
+    HousingOpenCharterConfirmation: 63
+    IslandsMissionNpc: 36
+    ItemUpgrade: 64
+    LFGDungeon: 20
+    Mailbox: 18
+    MajorFactionRenown: 53
+    NewPlayerGuide: 43
+    None: 0
+    PerksProgramVendor: 47
+    PersonalTabardVendor: 54
+    PetitionVendor: 7
+    PetUntrainer: 13
+    ProfessionRespec: 58
+    ProfessionsCraftingOrder: 48
+    ProfessionsCustomerOrder: 50
+    ProfessionsOpen: 49
+    QueueScenario: 25
+    RenameNeighborhood: 59
+    RuneforgeLegendaryCrafting: 42
+    RuneforgeLegendaryUpgrade: 44
+    ShipmentCrafter: 28
+    Soulbind: 39
+    SpecializationMaster: 23
+    Spellclick: 15
+    SpiritHealer: 4
+    Stablemaster: 12
+    TalentMaster: 11
+    Taxinode: 2
+    TieredEntrance: 66
+    Trainer: 3
+    TraitSystem: 51
+    Transmogrify: 34
+    UIItemInteraction: 37
+    Vendor: 1
+    WorldMap: 38
+    WorldPvPQueue: 19
 GossipNpcOptionDisplayFlags:
-  ForceInteractionOnSingleChoice: 1
+  values:
+    ForceInteractionOnSingleChoice: 1
 GossipOptionRecFlags:
-  HideOptionIDFromClient: 2
-  PlayMovieLabelPrepend: 4
-  QuestLabelPrepend: 1
+  values:
+    HideOptionIDFromClient: 2
+    PlayMovieLabelPrepend: 4
+    QuestLabelPrepend: 1
 GossipOptionStatus:
-  AlreadyComplete: 3
-  Available: 0
-  Locked: 2
-  Unavailable: 1
+  values:
+    AlreadyComplete: 3
+    Available: 0
+    Locked: 2
+    Unavailable: 1
 GraphicsValidationResult:
-  AmdGpuUnsupported: 36
-  AppleGpuUnsupported: 35
-  CompatMode: 41
-  CpuMem_2: 6
-  CpuMem_4: 7
-  CpuMem_8: 8
-  DualCore: 4
-  Dx11Unsupported: 30
-  Dx12Win7Unsupported: 31
-  GpuDriver: 40
-  Graphics: 3
-  Illegal: 1
-  IntelGpuUnsupported: 37
-  LegacyUnsupported: 29
-  MacOsUnsupported: 27
-  Needs_5_0: 9
-  Needs_6_0: 10
-  NeedsAmdGpu: 15
-  NeedsAppleGpu: 14
-  NeedsDx12: 12
-  NeedsDx12Vrs2: 13
-  NeedsIntelGpu: 16
-  NeedsMacOs_10_13: 19
-  NeedsMacOs_10_14: 20
-  NeedsMacOs_10_15: 21
-  NeedsMacOs_11_0: 22
-  NeedsMacOs_12_0: 23
-  NeedsMacOs_13_0: 24
-  NeedsNvidiaGpu: 17
-  NeedsQualcommGpu: 18
-  NeedsRt: 11
-  NeedsWindows_10: 25
-  NeedsWindows_11: 26
-  NvapiWineUnsupported: 34
-  NvidiaGpuUnsupported: 38
-  QuadCore: 5
-  QualcommGpuUnsupported: 39
-  RemoteDesktopUnsupported: 32
-  Supported: 0
-  Unknown: 42
-  Unsupported: 2
-  WindowsUnsupported: 28
-  WineUnsupported: 33
+  values:
+    AmdGpuUnsupported: 36
+    AppleGpuUnsupported: 35
+    CompatMode: 41
+    CpuMem_2: 6
+    CpuMem_4: 7
+    CpuMem_8: 8
+    DualCore: 4
+    Dx11Unsupported: 30
+    Dx12Win7Unsupported: 31
+    GpuDriver: 40
+    Graphics: 3
+    Illegal: 1
+    IntelGpuUnsupported: 37
+    LegacyUnsupported: 29
+    MacOsUnsupported: 27
+    Needs_5_0: 9
+    Needs_6_0: 10
+    NeedsAmdGpu: 15
+    NeedsAppleGpu: 14
+    NeedsDx12: 12
+    NeedsDx12Vrs2: 13
+    NeedsIntelGpu: 16
+    NeedsMacOs_10_13: 19
+    NeedsMacOs_10_14: 20
+    NeedsMacOs_10_15: 21
+    NeedsMacOs_11_0: 22
+    NeedsMacOs_12_0: 23
+    NeedsMacOs_13_0: 24
+    NeedsNvidiaGpu: 17
+    NeedsQualcommGpu: 18
+    NeedsRt: 11
+    NeedsWindows_10: 25
+    NeedsWindows_11: 26
+    NvapiWineUnsupported: 34
+    NvidiaGpuUnsupported: 38
+    QuadCore: 5
+    QualcommGpuUnsupported: 39
+    RemoteDesktopUnsupported: 32
+    Supported: 0
+    Unknown: 42
+    Unsupported: 2
+    WindowsUnsupported: 28
+    WineUnsupported: 33
 GuildErrorType:
-  AlreadyInGuild: 2
-  BadItem: 29
-  BankNotFound: 43
-  BankTabFull: 28
-  BankTabLocked: 35
-  Busy: 20
-  CantInviteSelf: 41
-  DeleteNoAppropriateLeader: 47
-  GuildBankNotAvailable: 45
-  GuildRepTooLow: 40
-  HasRestriction: 42
-  HousingEvictError: 51
-  Ignored: 19
-  InCooldown: 49
-  InvalidBankTab: 24
-  InvitedToGuild: 4
-  LockedForMove: 39
-  NameAlreadyExists: 7
-  NameInvalid: 6
-  NewLeaderWrongFaction: 44
-  NewLeaderWrongRealm: 46
-  NoPermisson: 8
-  NotEnoughMoney: 26
-  NotInGuild: 9
-  PlayerNotFound: 11
-  RankInUse: 18
-  RankRequiresAuthenticator: 34
-  RanksLocked: 17
-  RealmMismatch: 48
-  ReservationExpired: 50
-  Success: 0
-  TargetAlreadyInGuild: 3
-  TargetInvitedToGuild: 5
-  TargetLevelTooHigh: 22
-  TargetLevelTooLow: 21
-  TargetNotInGuild: 10
-  TargetTooHigh: 13
-  TargetTooLow: 14
-  TeamNotFound: 27
-  TeamsLocked: 30
-  Throttled: 52
-  TooFewRanks: 16
-  TooManyCreate: 33
-  TooManyMembers: 23
-  TooManyRanks: 15
-  TooMuchMoney: 31
-  TrialAccount: 36
-  UndeletableDueToLevel: 38
-  UnknownError: 1
-  VeteranAccount: 37
-  WithdrawLimit: 25
-  WrongBankTab: 32
-  WrongFaction: 12
+  values:
+    AlreadyInGuild: 2
+    BadItem: 29
+    BankNotFound: 43
+    BankTabFull: 28
+    BankTabLocked: 35
+    Busy: 20
+    CantInviteSelf: 41
+    DeleteNoAppropriateLeader: 47
+    GuildBankNotAvailable: 45
+    GuildRepTooLow: 40
+    HasRestriction: 42
+    HousingEvictError: 51
+    Ignored: 19
+    InCooldown: 49
+    InvalidBankTab: 24
+    InvitedToGuild: 4
+    LockedForMove: 39
+    NameAlreadyExists: 7
+    NameInvalid: 6
+    NewLeaderWrongFaction: 44
+    NewLeaderWrongRealm: 46
+    NoPermisson: 8
+    NotEnoughMoney: 26
+    NotInGuild: 9
+    PlayerNotFound: 11
+    RankInUse: 18
+    RankRequiresAuthenticator: 34
+    RanksLocked: 17
+    RealmMismatch: 48
+    ReservationExpired: 50
+    Success: 0
+    TargetAlreadyInGuild: 3
+    TargetInvitedToGuild: 5
+    TargetLevelTooHigh: 22
+    TargetLevelTooLow: 21
+    TargetNotInGuild: 10
+    TargetTooHigh: 13
+    TargetTooLow: 14
+    TeamNotFound: 27
+    TeamsLocked: 30
+    Throttled: 52
+    TooFewRanks: 16
+    TooManyCreate: 33
+    TooManyMembers: 23
+    TooManyRanks: 15
+    TooMuchMoney: 31
+    TrialAccount: 36
+    UndeletableDueToLevel: 38
+    UnknownError: 1
+    VeteranAccount: 37
+    WithdrawLimit: 25
+    WrongBankTab: 32
+    WrongFaction: 12
 HolidayCalendarFlags:
-  Alliance: 1
-  Horde: 2
+  values:
+    Alliance: 1
+    Horde: 2
 HolidayFlags:
-  BeginEventOnlyOnStageChange: 64
-  DontDisplayBanner: 8
-  DontDisplayEnd: 4
-  DontShowInCalendar: 2
-  DurationUseMinutes: 32
-  IsRegionwide: 1
-  NotAvailableClientSide: 16
+  values:
+    BeginEventOnlyOnStageChange: 64
+    DontDisplayBanner: 8
+    DontDisplayEnd: 4
+    DontShowInCalendar: 2
+    DurationUseMinutes: 32
+    IsRegionwide: 1
+    NotAvailableClientSide: 16
 HouseEditingContext:
-  Decor: 1
-  Fixture: 3
-  None: 0
-  Room: 2
+  values:
+    Decor: 1
+    Fixture: 3
+    None: 0
+    Room: 2
 HouseEditorMode:
-  BasicDecor: 1
-  Cleanup: 5
-  Customize: 4
-  ExpertDecor: 2
-  ExteriorCustomization: 6
-  Layout: 3
-  None: 0
+  values:
+    BasicDecor: 1
+    Cleanup: 5
+    Customize: 4
+    ExpertDecor: 2
+    ExteriorCustomization: 6
+    Layout: 3
+    None: 0
 HouseExteriorWMODataFlags:
-  AllowedInAllianceNeighborhoods: 4
-  AllowedInHordeNeighborhoods: 2
-  HiddenUnlessOwned: 8
-  None: 0
-  UnlockedByDefault: 1
+  values:
+    AllowedInAllianceNeighborhoods: 4
+    AllowedInHordeNeighborhoods: 2
+    HiddenUnlessOwned: 8
+    None: 0
+    UnlockedByDefault: 1
 HouseFinderSuggestionReason:
-  BNetFriends: 8
-  CharterInvite: 2
-  Guild: 4
-  HomeOwner: 64
-  None: 0
-  Owner: 1
-  PartySync: 16
-  Random: 32
+  values:
+    BNetFriends: 8
+    CharterInvite: 2
+    Guild: 4
+    HomeOwner: 64
+    None: 0
+    Owner: 1
+    PartySync: 16
+    Random: 32
 HouseLevelRewardType:
-  Object: 1
-  Value: 0
+  values:
+    Object: 1
+    Value: 0
 HouseLevelRewardValueType:
-  ExteriorDecor: 0
-  Fixtures: 3
-  InteriorDecor: 1
-  Rooms: 2
+  values:
+    ExteriorDecor: 0
+    Fixtures: 3
+    InteriorDecor: 1
+    Rooms: 2
 HouseOwnerError:
-  Faction: 1
-  GenericPermission: 3
-  Guild: 2
-  None: 0
+  values:
+    Faction: 1
+    GenericPermission: 3
+    Guild: 2
+    None: 0
 HouseSettingFlags:
-  HouseAccessAnyone: 1
-  HouseAccessFriends: 8
-  HouseAccessGuild: 4
-  HouseAccessNeighbors: 2
-  HouseAccessParty: 16
-  None: 0
-  PlotAccessAnyone: 32
-  PlotAccessFriends: 256
-  PlotAccessGuild: 128
-  PlotAccessNeighbors: 64
-  PlotAccessParty: 512
+  values:
+    HouseAccessAnyone: 1
+    HouseAccessFriends: 8
+    HouseAccessGuild: 4
+    HouseAccessNeighbors: 2
+    HouseAccessParty: 16
+    None: 0
+    PlotAccessAnyone: 32
+    PlotAccessFriends: 256
+    PlotAccessGuild: 128
+    PlotAccessNeighbors: 64
+    PlotAccessParty: 512
 HouseVisitType:
-  Friend: 1
-  Guild: 2
-  Party: 3
-  Unknown: 0
+  values:
+    Friend: 1
+    Guild: 2
+    Party: 3
+    Unknown: 0
 HousingBasicModeTargetType:
-  Decor: 1
-  House: 2
-  None: 0
+  values:
+    Decor: 1
+    House: 2
+    None: 0
 HousingCatalogEntryModelScenePresets:
-  DecorCeiling: 1338
-  DecorDefault: 1317
-  DecorFlat: 1318
-  DecorHorizontalSurface: 1452
-  DecorHuge: 1337
-  DecorLarge: 1336
-  DecorMedium: 1335
-  DecorSmall: 1334
-  DecorTiny: 1333
-  DecorWall: 1339
+  values:
+    DecorCeiling: 1338
+    DecorDefault: 1317
+    DecorFlat: 1318
+    DecorHorizontalSurface: 1452
+    DecorHuge: 1337
+    DecorLarge: 1336
+    DecorMedium: 1335
+    DecorSmall: 1334
+    DecorTiny: 1333
+    DecorWall: 1339
 HousingCatalogEntrySize:
-  Huge: 69
-  Large: 68
-  Medium: 67
-  None: 0
-  Small: 66
-  Tiny: 65
+  values:
+    Huge: 69
+    Large: 68
+    Medium: 67
+    None: 0
+    Small: 66
+    Tiny: 65
 HousingCatalogEntryType:
-  Decor: 1
-  Invalid: 0
-  Room: 2
+  values:
+    Decor: 1
+    Invalid: 0
+    Room: 2
 HousingCatalogSortType:
-  Alphabetical: 1
-  DateAdded: 0
+  values:
+    Alphabetical: 1
+    DateAdded: 0
 HousingCleanupModeTargetType:
-  Decor: 1
-  HouseExterior: 2
-  None: 0
+  values:
+    Decor: 1
+    HouseExterior: 2
+    None: 0
 HousingCustomizeModeTargetType:
-  Decor: 1
-  ExteriorHouse: 3
-  None: 0
-  RoomComponent: 2
+  values:
+    Decor: 1
+    ExteriorHouse: 3
+    None: 0
+    RoomComponent: 2
 HousingDecorActionFlags:
-  Add: 1
-  ClickTarget: 16
-  DragMove: 4
-  HoverTarget: 32
-  IncludeTargetChildren: 512
-  MaintainLastTarget: 256
-  None: 0
-  PrecisionMove: 8
-  PreviewDecor: 2048
-  Remove: 2
-  TargetHouseExterior: 128
-  TargetRoomComponents: 64
-  UsePlacedDecorList: 1024
+  values:
+    Add: 1
+    ClickTarget: 16
+    DragMove: 4
+    HoverTarget: 32
+    IncludeTargetChildren: 512
+    MaintainLastTarget: 256
+    None: 0
+    PrecisionMove: 8
+    PreviewDecor: 2048
+    Remove: 2
+    TargetHouseExterior: 128
+    TargetRoomComponents: 64
+    UsePlacedDecorList: 1024
 HousingDecorModelType:
-  M2: 1
-  None: 0
-  WMO: 2
+  values:
+    M2: 1
+    None: 0
+    WMO: 2
 HousingDecorPlacementRestriction:
-  ChildOutsideBounds: 8
-  InvalidCollision: 32
-  InvalidLightOverlap: 64
-  InvalidTarget: 16
-  OutsidePlotBounds: 4
-  OutsideRoomBounds: 2
-  TooFarAway: 1
+  values:
+    ChildOutsideBounds: 8
+    InvalidCollision: 32
+    InvalidLightOverlap: 64
+    InvalidTarget: 16
+    OutsidePlotBounds: 4
+    OutsideRoomBounds: 2
+    TooFarAway: 1
 HousingDecorTheme:
-  BloodElf: 5
-  Folk: 1
-  Generic: 3
-  NightElf: 4
-  None: 0
-  Rugged: 2
+  values:
+    BloodElf: 5
+    Folk: 1
+    Generic: 3
+    NightElf: 4
+    None: 0
+    Rugged: 2
 HousingDecorType:
-  Ceiling: 3
-  Floor: 1
-  Flooring: 4
-  None: 0
-  Wall: 2
+  values:
+    Ceiling: 3
+    Floor: 1
+    Flooring: 4
+    None: 0
+    Wall: 2
 HousingExpertModeTargetType:
-  Decor: 1
-  House: 2
-  None: 0
+  values:
+    Decor: 1
+    House: 2
+    None: 0
 HousingExpertSubmodeRestriction:
-  NoHouseExteriorScale: 2
-  None: 0
-  NotInExpertMode: 1
-  NoWMOScale: 3
+  values:
+    NoHouseExteriorScale: 2
+    None: 0
+    NotInExpertMode: 1
+    NoWMOScale: 3
 HousingFavorUpdateSource:
-  DecorCollection: 1
-  DeferredRewards: 2
-  InitiativeChest: 6
-  InitiativeTask: 5
-  NewHouseDecorFavor: 4
-  Quest: 7
-  RetroactiveDecor: 3
-  Unknown: 0
+  values:
+    DecorCollection: 1
+    DeferredRewards: 2
+    InitiativeChest: 6
+    InitiativeTask: 5
+    NewHouseDecorFavor: 4
+    Quest: 7
+    RetroactiveDecor: 3
+    Unknown: 0
 HousingFavorUpdateType:
-  Add: 0
-  InitiativeAdd: 1
-  Set: 2
+  values:
+    Add: 0
+    InitiativeAdd: 1
+    Set: 2
 HousingFixtureDecorAction:
-  Detach: 1
-  Store: 0
+  values:
+    Detach: 1
+    Store: 0
 HousingFixtureFlags:
-  IsDefaultFixture: 1
-  None: 0
-  UnlockedByDefault: 2
+  values:
+    IsDefaultFixture: 1
+    None: 0
+    UnlockedByDefault: 2
 HousingFixtureSize:
-  Any: 1
-  Large: 4
-  Medium: 3
-  None: 0
-  Small: 2
+  values:
+    Any: 1
+    Large: 4
+    Medium: 3
+    None: 0
+    Small: 2
 HousingFixtureType:
-  Base: 9
-  Chimney: 16
-  Door: 11
-  None: 0
-  Roof: 10
-  RoofDetail: 13
-  RoofWindow: 14
-  Tower: 15
-  Window: 12
+  values:
+    Base: 9
+    Chimney: 16
+    Door: 11
+    None: 0
+    Roof: 10
+    RoofDetail: 13
+    RoofWindow: 14
+    Tower: 15
+    Window: 12
 HousingIncrementType:
-  Back: 8
-  Down: 32
-  Forward: 4
-  Left: 1
-  Right: 2
-  RotateLeft: 64
-  RotateRight: 128
-  ScaleDown: 512
-  ScaleUp: 256
-  Up: 16
+  values:
+    Back: 8
+    Down: 32
+    Forward: 4
+    Left: 1
+    Right: 2
+    RotateLeft: 64
+    RotateRight: 128
+    ScaleDown: 512
+    ScaleUp: 256
+    Up: 16
 HousingItemToastType:
-  Customization: 2
-  Decor: 3
-  Fixture: 1
-  HouseType: 4
-  Room: 0
+  values:
+    Customization: 2
+    Decor: 3
+    Fixture: 1
+    HouseType: 4
+    Room: 0
 HousingLayoutCameraDirection:
-  Down: 2
-  Left: 4
-  None: 0
-  Right: 8
-  Up: 1
+  values:
+    Down: 2
+    Left: 4
+    None: 0
+    Right: 8
+    Up: 1
 HousingLayoutPinType:
-  Door: 0
-  Room: 1
+  values:
+    Door: 0
+    Room: 1
 HousingLayoutRestriction:
-  IsBaseRoom: 4
-  LastRoom: 7
-  None: 0
-  NotHouseOwner: 3
-  NotInsideHouse: 2
-  RoomNotFound: 1
-  RoomNotLeaf: 5
-  SingleDoor: 9
-  StairwellConnection: 6
-  UnreachableRoom: 8
+  values:
+    IsBaseRoom: 4
+    LastRoom: 7
+    None: 0
+    NotHouseOwner: 3
+    NotInsideHouse: 2
+    RoomNotFound: 1
+    RoomNotLeaf: 5
+    SingleDoor: 9
+    StairwellConnection: 6
+    UnreachableRoom: 8
 HousingLayoutStairDirection:
-  Down: 1
-  Up: 0
+  values:
+    Down: 1
+    Up: 0
 HousingPlotOwnerType:
-  Friend: 2
-  None: 0
-  Self: 3
-  Stranger: 1
+  values:
+    Friend: 2
+    None: 0
+    Self: 3
+    Stranger: 1
 HousingPrecisionSubmode:
-  Rotate: 1
-  Scale: 2
-  Translate: 0
+  values:
+    Rotate: 1
+    Scale: 2
+    Translate: 0
 HousingResult:
-  ActionLockedByCombat: 1
-  BoundsFailureChildren: 2
-  BoundsFailurePlot: 3
-  BoundsFailureRoom: 4
-  BoundToStartingArea: 5
-  CannotAfford: 6
-  CharterComplete: 7
-  CollisionInvalid: 8
-  DbError: 9
-  DecorCannotBeRedeemed: 10
-  DecorItemNotDestroyable: 11
-  DecorNotFound: 12
-  DecorNotFoundInStorage: 13
-  DuplicateCharterSignature: 14
-  FilterRejected: 15
-  FixtureCantDeleteDoor: 16
-  FixtureHookEmpty: 17
-  FixtureHookOccupied: 18
-  FixtureHouseTypeMismatch: 19
-  FixtureNotFound: 20
-  FixtureSizeMismatch: 21
-  FixtureTypeMismatch: 22
-  GenericFailure: 23
-  GuildMoreAccountsNeeded: 24
-  GuildMoreActivePlayersNeeded: 25
-  GuildNotLoaded: 26
-  HookNotChildOfFixture: 35
-  HouseEditLockFailed: 27
-  HouseExteriorAlreadyThatSize: 28
-  HouseExteriorAlreadyThatType: 29
-  HouseExteriorRootNotFound: 30
-  HouseExteriorSizeNotAvailable: 34
-  HouseExteriorTypeNeighborhoodMismatch: 31
-  HouseExteriorTypeNotFound: 32
-  HouseExteriorTypeSizeMismatch: 33
-  HouseNotFound: 36
-  IncorrectFaction: 37
-  InvalidDecorItem: 38
-  InvalidDistance: 39
-  InvalidGuild: 40
-  InvalidHouse: 41
-  InvalidInstance: 42
-  InvalidInteraction: 43
-  InvalidLightOverlap: 44
-  InvalidMap: 45
-  InvalidNeighborhoodName: 46
-  InvalidRoomLayout: 47
-  LockedByOtherPlayer: 48
-  LockOperationFailed: 49
-  MaxDecorReached: 50
-  MaxPreviewDecorReached: 51
-  MissingCoreFixture: 52
-  MissingDye: 53
-  MissingExpansionAccess: 54
-  MissingFactionMap: 55
-  MissingPrivateNeighborhoodInvite: 56
-  MoreHouseSlotsNeeded: 57
-  MoreSignaturesNeeded: 58
-  NeighborhoodNotFound: 59
-  NoNeighborhoodOwnershipRequests: 60
-  NotInDecorEditMode: 61
-  NotInFixtureEditMode: 62
-  NotInLayoutEditMode: 63
-  NotInsideHouse: 64
-  NotOnOwnedPlot: 65
-  OperationAborted: 66
-  OwnerNotInGuild: 67
-  PermissionDenied: 68
-  PlacementTargetInvalid: 69
-  PlayerNotFound: 70
-  PlayerNotInInstance: 71
-  PlotNotFound: 72
-  PlotNotVacant: 73
-  PlotReservationCooldown: 74
-  PlotReserved: 75
-  RoomNotFound: 76
-  RoomUpdateFailed: 77
-  RpcFailure: 78
-  ServiceNotAvailable: 79
-  StaticDataNotFound: 80
-  Success: 0
-  TimeoutLimit: 81
-  TimerunningNotAllowed: 82
-  TokenRequired: 83
-  TooManyRequests: 84
-  TransactionFailure: 85
-  UncollectedExteriorFixture: 86
-  UncollectedHouseType: 87
-  UncollectedRoom: 88
-  UncollectedRoomMaterial: 89
-  UncollectedRoomTheme: 90
-  UnlockOperationFailed: 91
+  values:
+    ActionLockedByCombat: 1
+    BoundsFailureChildren: 2
+    BoundsFailurePlot: 3
+    BoundsFailureRoom: 4
+    BoundToStartingArea: 5
+    CannotAfford: 6
+    CharterComplete: 7
+    CollisionInvalid: 8
+    DbError: 9
+    DecorCannotBeRedeemed: 10
+    DecorItemNotDestroyable: 11
+    DecorNotFound: 12
+    DecorNotFoundInStorage: 13
+    DuplicateCharterSignature: 14
+    FilterRejected: 15
+    FixtureCantDeleteDoor: 16
+    FixtureHookEmpty: 17
+    FixtureHookOccupied: 18
+    FixtureHouseTypeMismatch: 19
+    FixtureNotFound: 20
+    FixtureSizeMismatch: 21
+    FixtureTypeMismatch: 22
+    GenericFailure: 23
+    GuildMoreAccountsNeeded: 24
+    GuildMoreActivePlayersNeeded: 25
+    GuildNotLoaded: 26
+    HookNotChildOfFixture: 35
+    HouseEditLockFailed: 27
+    HouseExteriorAlreadyThatSize: 28
+    HouseExteriorAlreadyThatType: 29
+    HouseExteriorRootNotFound: 30
+    HouseExteriorSizeNotAvailable: 34
+    HouseExteriorTypeNeighborhoodMismatch: 31
+    HouseExteriorTypeNotFound: 32
+    HouseExteriorTypeSizeMismatch: 33
+    HouseNotFound: 36
+    IncorrectFaction: 37
+    InvalidDecorItem: 38
+    InvalidDistance: 39
+    InvalidGuild: 40
+    InvalidHouse: 41
+    InvalidInstance: 42
+    InvalidInteraction: 43
+    InvalidLightOverlap: 44
+    InvalidMap: 45
+    InvalidNeighborhoodName: 46
+    InvalidRoomLayout: 47
+    LockedByOtherPlayer: 48
+    LockOperationFailed: 49
+    MaxDecorReached: 50
+    MaxPreviewDecorReached: 51
+    MissingCoreFixture: 52
+    MissingDye: 53
+    MissingExpansionAccess: 54
+    MissingFactionMap: 55
+    MissingPrivateNeighborhoodInvite: 56
+    MoreHouseSlotsNeeded: 57
+    MoreSignaturesNeeded: 58
+    NeighborhoodNotFound: 59
+    NoNeighborhoodOwnershipRequests: 60
+    NotInDecorEditMode: 61
+    NotInFixtureEditMode: 62
+    NotInLayoutEditMode: 63
+    NotInsideHouse: 64
+    NotOnOwnedPlot: 65
+    OperationAborted: 66
+    OwnerNotInGuild: 67
+    PermissionDenied: 68
+    PlacementTargetInvalid: 69
+    PlayerNotFound: 70
+    PlayerNotInInstance: 71
+    PlotNotFound: 72
+    PlotNotVacant: 73
+    PlotReservationCooldown: 74
+    PlotReserved: 75
+    RoomNotFound: 76
+    RoomUpdateFailed: 77
+    RpcFailure: 78
+    ServiceNotAvailable: 79
+    StaticDataNotFound: 80
+    Success: 0
+    TimeoutLimit: 81
+    TimerunningNotAllowed: 82
+    TokenRequired: 83
+    TooManyRequests: 84
+    TransactionFailure: 85
+    UncollectedExteriorFixture: 86
+    UncollectedHouseType: 87
+    UncollectedRoom: 88
+    UncollectedRoomMaterial: 89
+    UncollectedRoomTheme: 90
+    UnlockOperationFailed: 91
 HousingRoomComponentCeilingType:
-  Flat: 0
-  Vaulted: 1
+  values:
+    Flat: 0
+    Vaulted: 1
 HousingRoomComponentDoorType:
-  Doorway: 1
-  None: 0
-  Threshold: 2
+  values:
+    Doorway: 1
+    None: 0
+    Threshold: 2
 HousingRoomComponentFlags:
-  HiddenInLayoutMode: 1
-  None: 0
+  values:
+    HiddenInLayoutMode: 1
+    None: 0
 HousingRoomComponentFloorType:
-  Floor: 0
+  values:
+    Floor: 0
 HousingRoomComponentOptionFlags:
-  IsDefault: 1
-  None: 0
+  values:
+    IsDefault: 1
+    None: 0
 HousingRoomComponentOptionType:
-  Cosmetic: 0
-  Doorway: 2
-  DoorwayWall: 1
+  values:
+    Cosmetic: 0
+    Doorway: 2
+    DoorwayWall: 1
 HousingRoomComponentStairType:
-  MiddleToEnd: 4
-  MiddleToMiddle: 3
-  None: 0
-  StartToEnd: 1
-  StartToMiddle: 2
+  values:
+    MiddleToEnd: 4
+    MiddleToMiddle: 3
+    None: 0
+    StartToEnd: 1
+    StartToMiddle: 2
 HousingRoomComponentTextureFlags:
-  None: 0
-  UnlockedByDefault: 1
+  values:
+    None: 0
+    UnlockedByDefault: 1
 HousingRoomComponentType:
-  Ceiling: 3
-  Doorway: 7
-  DoorwayWall: 6
-  Floor: 2
-  None: 0
-  Pillar: 5
-  Stairs: 4
-  Wall: 1
+  values:
+    Ceiling: 3
+    Doorway: 7
+    DoorwayWall: 6
+    Floor: 2
+    None: 0
+    Pillar: 5
+    Stairs: 4
+    Wall: 1
 HousingRoomFlags:
-  BaseRoom: 1
-  HasCustomGeometry: 8
-  HasStairs: 2
-  None: 0
-  UnlockedByDefault: 4
+  values:
+    BaseRoom: 1
+    HasCustomGeometry: 8
+    HasStairs: 2
+    None: 0
+    UnlockedByDefault: 4
 HousingTeleportReason:
-  Booted: 3
-  Cheat: 1
-  ExitingHouse: 9
-  Friend: 6
-  GuildMember: 7
-  Homestone: 4
-  None: 0
-  PartyMember: 8
-  Portal: 10
-  Tutorial: 11
-  UnspecifiedSpellcast: 2
-  Visit: 5
+  values:
+    Booted: 3
+    Cheat: 1
+    ExitingHouse: 9
+    Friend: 6
+    GuildMember: 7
+    Homestone: 4
+    None: 0
+    PartyMember: 8
+    Portal: 10
+    Tutorial: 11
+    UnspecifiedSpellcast: 2
+    Visit: 5
 HousingThemeFlags:
-  None: 0
-  ShowInStyleSelector: 2
-  UnlockedByDefault: 1
+  values:
+    None: 0
+    ShowInStyleSelector: 2
+    UnlockedByDefault: 1
 HousingThrottleType:
-  Decoration: 1
-  General: 0
+  values:
+    Decoration: 1
+    General: 0
 IconAndTextShiftTextType:
-  None: 0
-  ShiftText: 1
+  values:
+    None: 0
+    ShiftText: 1
 IconAndTextWidgetState:
-  Hidden: 0
-  Shown: 1
-  ShownWithDynamicIconFlashing: 2
-  ShownWithDynamicIconNotFlashing: 3
+  values:
+    Hidden: 0
+    Shown: 1
+    ShownWithDynamicIconFlashing: 2
+    ShownWithDynamicIconNotFlashing: 3
 IconState:
-  Hidden: 0
-  ShowState1: 1
-  ShowState2: 2
+  values:
+    Hidden: 0
+    ShowState1: 1
+    ShowState2: 2
 ImageSharingResult:
-  AccountDataRequestFailure: 6
-  EncryptionFailure: 11
-  EncryptionSecretNotSet: 14
-  FailedToCreateHeader: 10
-  Failure: 0
-  GetAccountDataRequestFailure: 7
-  InvalidOAuthExpiration: 12
-  InvalidRefreshExpiration: 13
-  MissingFieldApiError: 5
-  NotConfigured: 2
-  PlatformApiError: 4
-  RefreshTokenExpired: 9
-  RetrievedExisting: 3
-  SetAccountDataRequestFailure: 8
-  Success: 1
+  values:
+    AccountDataRequestFailure: 6
+    EncryptionFailure: 11
+    EncryptionSecretNotSet: 14
+    FailedToCreateHeader: 10
+    Failure: 0
+    GetAccountDataRequestFailure: 7
+    InvalidOAuthExpiration: 12
+    InvalidRefreshExpiration: 13
+    MissingFieldApiError: 5
+    NotConfigured: 2
+    PlatformApiError: 4
+    RefreshTokenExpired: 9
+    RetrievedExisting: 3
+    SetAccountDataRequestFailure: 8
+    Success: 1
 InitiativeMilestoneFlags:
-  FinalMilestone: 1
+  values:
+    FinalMilestone: 1
 InitiativeRewardFlags:
-  PermanentWorldState: 1
+  values:
+    PermanentWorldState: 1
 InputContext:
-  GamePad: 3
-  Keyboard: 1
-  Mouse: 2
-  None: 0
+  values:
+    GamePad: 3
+    Keyboard: 1
+    Mouse: 2
+    None: 0
 InvalidPlotScreenshotReason:
-  Facing: 2
-  NoActivePlayer: 4
-  None: 0
-  NoNeighborhoodFound: 3
-  OutOfBounds: 1
+  values:
+    Facing: 2
+    NoActivePlayer: 4
+    None: 0
+    NoNeighborhoodFound: 3
+    OutOfBounds: 1
 InventoryType:
-  Index2HweaponType: 17
-  IndexAmmoType: 24
-  IndexBagType: 18
-  IndexBodyType: 4
-  IndexChestType: 5
-  IndexCloakType: 16
-  IndexEquipablespellDefensiveType: 33
-  IndexEquipablespellOffensiveType: 31
-  IndexEquipablespellUtilityType: 32
-  IndexEquipablespellWeaponType: 34
-  IndexFeetType: 8
-  IndexFingerType: 11
-  IndexHandType: 10
-  IndexHeadType: 1
-  IndexHoldableType: 23
-  IndexLegsType: 7
-  IndexNeckType: 2
-  IndexNonEquipType: 0
-  IndexProfessionGearType: 30
-  IndexProfessionToolType: 29
-  IndexQuiverType: 27
-  IndexRangedrightType: 26
-  IndexRangedType: 15
-  IndexRelicType: 28
-  IndexRobeType: 20
-  IndexShieldType: 14
-  IndexShoulderType: 3
-  IndexTabardType: 19
-  IndexThrownType: 25
-  IndexTrinketType: 12
-  IndexWaistType: 6
-  IndexWeaponmainhandType: 21
-  IndexWeaponoffhandType: 22
-  IndexWeaponType: 13
-  IndexWristType: 9
+  values:
+    Index2HweaponType: 17
+    IndexAmmoType: 24
+    IndexBagType: 18
+    IndexBodyType: 4
+    IndexChestType: 5
+    IndexCloakType: 16
+    IndexEquipablespellDefensiveType: 33
+    IndexEquipablespellOffensiveType: 31
+    IndexEquipablespellUtilityType: 32
+    IndexEquipablespellWeaponType: 34
+    IndexFeetType: 8
+    IndexFingerType: 11
+    IndexHandType: 10
+    IndexHeadType: 1
+    IndexHoldableType: 23
+    IndexLegsType: 7
+    IndexNeckType: 2
+    IndexNonEquipType: 0
+    IndexProfessionGearType: 30
+    IndexProfessionToolType: 29
+    IndexQuiverType: 27
+    IndexRangedrightType: 26
+    IndexRangedType: 15
+    IndexRelicType: 28
+    IndexRobeType: 20
+    IndexShieldType: 14
+    IndexShoulderType: 3
+    IndexTabardType: 19
+    IndexThrownType: 25
+    IndexTrinketType: 12
+    IndexWaistType: 6
+    IndexWeaponmainhandType: 21
+    IndexWeaponoffhandType: 22
+    IndexWeaponType: 13
+    IndexWristType: 9
 ItemArmorSubclass:
-  Cloth: 1
-  Cosmetic: 5
-  Generic: 0
-  Idol: 8
-  Leather: 2
-  Libram: 7
-  Mail: 3
-  Plate: 4
-  Relic: 11
-  Shield: 6
-  Sigil: 10
-  Totem: 9
+  values:
+    Cloth: 1
+    Cosmetic: 5
+    Generic: 0
+    Idol: 8
+    Leather: 2
+    Libram: 7
+    Mail: 3
+    Plate: 4
+    Relic: 11
+    Shield: 6
+    Sigil: 10
+    Totem: 9
 ItemBind:
-  Multi: 6
-  None: 0
-  OnAcquire: 1
-  OnEquip: 2
-  OnUse: 3
-  Quest: 4
-  QuestMulti: 5
-  ToBnetAccount: 8
-  ToBnetAccountUntilEquipped: 9
-  ToWoWAccount: 7
+  values:
+    Multi: 6
+    None: 0
+    OnAcquire: 1
+    OnEquip: 2
+    OnUse: 3
+    Quest: 4
+    QuestMulti: 5
+    ToBnetAccount: 8
+    ToBnetAccountUntilEquipped: 9
+    ToWoWAccount: 7
 ItemClass:
-  Armor: 4
-  Battlepet: 17
-  Consumable: 0
-  Container: 1
-  CurrencyTokenObsolete: 10
-  Gem: 3
-  Glyph: 16
-  Housing: 20
-  ItemEnhancement: 8
-  Key: 13
-  Miscellaneous: 15
-  PermanentObsolete: 14
-  Profession: 19
-  Projectile: 6
-  Questitem: 12
-  Quiver: 11
-  Reagent: 5
-  Recipe: 9
-  Tradegoods: 7
-  Weapon: 2
-  WoWToken: 18
+  values:
+    Armor: 4
+    Battlepet: 17
+    Consumable: 0
+    Container: 1
+    CurrencyTokenObsolete: 10
+    Gem: 3
+    Glyph: 16
+    Housing: 20
+    ItemEnhancement: 8
+    Key: 13
+    Miscellaneous: 15
+    PermanentObsolete: 14
+    Profession: 19
+    Projectile: 6
+    Questitem: 12
+    Quiver: 11
+    Reagent: 5
+    Recipe: 9
+    Tradegoods: 7
+    Weapon: 2
+    WoWToken: 18
 Itemclassfilterflags:
-  Armor: 16
-  Battlepet: 131072
-  Consumable: 1
-  Container: 2
-  CurrencyTokenObsolete: 1024
-  Gem: 8
-  Glyph: 65536
-  ItemEnhancement: 256
-  Key: 8192
-  Miscellaneous: 32768
-  PermanentObsolete: 16384
-  Projectile: 64
-  Questitemclassfilterflags: 4096
-  Quiver: 2048
-  Reagent: 32
-  Recipe: 512
-  Tradegoods: 128
-  Weapon: 4
+  values:
+    Armor: 16
+    Battlepet: 131072
+    Consumable: 1
+    Container: 2
+    CurrencyTokenObsolete: 1024
+    Gem: 8
+    Glyph: 65536
+    ItemEnhancement: 256
+    Key: 8192
+    Miscellaneous: 32768
+    PermanentObsolete: 16384
+    Projectile: 64
+    Questitemclassfilterflags: 4096
+    Quiver: 2048
+    Reagent: 32
+    Recipe: 512
+    Tradegoods: 128
+    Weapon: 4
 ItemCollectionType:
-  ExteriorFixture: 9
-  Heirloom: 2
-  HouseType: 13
-  None: 0
-  Room: 8
-  RoomMaterial: 11
-  RoomTheme: 10
-  RuneforgeLegendaryAbility: 5
-  Toy: 1
-  Transmog: 3
-  TransmogIllusion: 6
-  TransmogOutfit: 12
-  TransmogSetFavorite: 4
-  WarbandScene: 7
+  values:
+    ExteriorFixture: 9
+    Heirloom: 2
+    HouseType: 13
+    None: 0
+    Room: 8
+    RoomMaterial: 11
+    RoomTheme: 10
+    RuneforgeLegendaryAbility: 5
+    Toy: 1
+    Transmog: 3
+    TransmogIllusion: 6
+    TransmogOutfit: 12
+    TransmogSetFavorite: 4
+    WarbandScene: 7
 ItemConsumableSubclass:
-  Bandage: 7
-  CombatCurio: 11
-  Elixir: 2
-  Flasksphials: 3
-  Fooddrink: 5
-  Generic: 0
-  Itemenhancement: 6
-  Other: 8
-  Potion: 1
-  Relic: 12
-  Scroll: 4
-  UtilityCurio: 10
-  VantusRune: 9
+  values:
+    Bandage: 7
+    CombatCurio: 11
+    Elixir: 2
+    Flasksphials: 3
+    Fooddrink: 5
+    Generic: 0
+    Itemenhancement: 6
+    Other: 8
+    Potion: 1
+    Relic: 12
+    Scroll: 4
+    UtilityCurio: 10
+    VantusRune: 9
 ItemCreationContext:
-  BlackMarket: 15
-  ChallengeMode_1: 16
-  ChallengeMode_2: 33
-  ChallengeMode_3: 34
-  ChallengeMode_4: 87
-  ChallengeModeJackpot: 35
-  CharacterBoost_1: 61
-  CharacterBoost_2: 62
-  CharacterBoost_3: 86
-  CorpseRecovery: 80
-  Delves_1: 104
-  Delves_2: 106
-  Delves_3: 107
-  DelvesBonus_1: 129
-  DelvesBonus_10: 138
-  DelvesBonus_2: 130
-  DelvesBonus_3: 131
-  DelvesBonus_4: 132
-  DelvesBonus_5: 133
-  DelvesBonus_6: 134
-  DelvesBonus_7: 135
-  DelvesBonus_8: 136
-  DelvesBonus_9: 137
-  DelvesBounty_1: 117
-  DelvesBounty_2: 118
-  DelvesBounty_3: 119
-  DelvesBounty_4: 120
-  DelvesBounty_5: 121
-  DelvesBounty_6: 122
-  DelvesBounty_7: 123
-  DelvesBounty_8: 124
-  DelvesJackpot: 108
-  DelvesKey_1: 109
-  DelvesKey_2: 110
-  DelvesKey_3: 111
-  DelvesKey_4: 112
-  DelvesKey_5: 113
-  DelvesKey_6: 114
-  DelvesKey_7: 115
-  DelvesKey_8: 116
-  DelvesLevelUp_1: 125
-  DelvesLevelUp_2: 126
-  DelvesLevelUp_3: 127
-  DelvesLevelUp_4: 128
-  DungeonBonus_1: 139
-  DungeonBonus_10: 148
-  DungeonBonus_2: 140
-  DungeonBonus_3: 141
-  DungeonBonus_4: 142
-  DungeonBonus_5: 143
-  DungeonBonus_6: 144
-  DungeonBonus_7: 145
-  DungeonBonus_8: 146
-  DungeonBonus_9: 147
-  DungeonHardMode_1: 159
-  DungeonHardMode_2: 160
-  DungeonHardMode_3: 161
-  DungeonHeroic: 2
-  DungeonHeroicJackpot: 102
-  DungeonLevelUp_1: 17
-  DungeonLevelUp_2: 18
-  DungeonLevelUp_3: 19
-  DungeonLevelUp_4: 20
-  DungeonMythic: 23
-  DungeonMythicJackpot: 103
-  DungeonNormal: 1
-  DungeonNormalJackpot: 101
-  Endeavors: 185
-  ForceNone: 21
-  LegendaryCrafting_1: 63
-  LegendaryCrafting_2: 64
-  LegendaryCrafting_3: 65
-  LegendaryCrafting_4: 66
-  LegendaryCrafting_5: 67
-  LegendaryCrafting_6: 68
-  LegendaryCrafting_7: 69
-  LegendaryCrafting_8: 70
-  LegendaryCrafting_9: 71
-  LegendaryForge: 59
-  MissionReward_1: 31
-  MissionReward_2: 32
-  NewCharacter: 75
-  None: 0
-  PvPBrawl_1: 77
-  PvPBrawl_2: 78
-  PvPHonorReward: 24
-  PvPRanked_1: 8
-  PvPRanked_2: 38
-  PvPRanked_3: 39
-  PvPRanked_4: 40
-  PvPRanked_5: 44
-  PvPRanked_6: 45
-  PvPRanked_7: 46
-  PvPRanked_8: 52
-  PvPRanked_9: 88
-  PvPRankedJackpot: 56
-  PvPUnranked_1: 7
-  PvPUnranked_2: 41
-  PvPUnranked_3: 47
-  PvPUnranked_4: 48
-  PvPUnranked_5: 49
-  PvPUnranked_6: 50
-  PvPUnranked_7: 51
-  QuestBonusLoot: 60
-  QuestReward: 11
-  RaidBonus_1: 149
-  RaidBonus_10: 158
-  RaidBonus_2: 150
-  RaidBonus_3: 151
-  RaidBonus_4: 152
-  RaidBonus_5: 153
-  RaidBonus_6: 154
-  RaidBonus_7: 155
-  RaidBonus_8: 156
-  RaidBonus_9: 157
-  RaidFinder: 4
-  RaidFinderExtended: 83
-  RaidFinderExtended_2: 90
-  RaidFinderExtended_3: 94
-  RaidHeroic: 5
-  RaidHeroicExtended: 84
-  RaidHeroicExtended_2: 91
-  RaidHeroicExtended_3: 95
-  RaidMythic: 6
-  RaidMythicExtended: 85
-  RaidMythicExtended_2: 92
-  RaidMythicExtended_3: 96
-  RaidNormal: 3
-  RaidNormalExtended: 82
-  RaidNormalExtended_2: 89
-  RaidNormalExtended_3: 93
-  Relinquished: 58
-  ScenarioHeroic: 10
-  ScenarioNormal: 9
-  Store: 12
-  TemplateCharacter_1: 97
-  TemplateCharacter_2: 98
-  TemplateCharacter_3: 99
-  TemplateCharacter_4: 100
-  Timerunning: 105
-  TimewalkerLevelUp: 22
-  TimewalkerMaxLevel: 186
-  Torghast: 79
-  TournamentRealm_1: 57
-  TournamentRealm_2: 162
-  TournamentRealm_3: 163
-  TournamentRealm_4: 164
-  TradeSkill: 13
-  Vendor: 14
-  Warbound_1: 165
-  Warbound_10: 174
-  Warbound_11: 175
-  Warbound_12: 176
-  Warbound_13: 177
-  Warbound_14: 178
-  Warbound_15: 179
-  Warbound_16: 180
-  Warbound_17: 181
-  Warbound_18: 182
-  Warbound_19: 183
-  Warbound_2: 166
-  Warbound_20: 184
-  Warbound_3: 167
-  Warbound_4: 168
-  Warbound_5: 169
-  Warbound_6: 170
-  Warbound_7: 171
-  Warbound_8: 172
-  Warbound_9: 173
-  WarMode: 76
-  WeeklyRewardsAdditional: 72
-  WeeklyRewardsConcession: 73
-  WorldBoss: 81
-  WorldQuest_1: 25
-  WorldQuest_10: 43
-  WorldQuest_11: 53
-  WorldQuest_12: 54
-  WorldQuest_13: 55
-  WorldQuest_2: 26
-  WorldQuest_3: 27
-  WorldQuest_4: 28
-  WorldQuest_5: 29
-  WorldQuest_6: 30
-  WorldQuest_7: 36
-  WorldQuest_8: 37
-  WorldQuest_9: 42
-  WorldQuestJackpot: 74
+  values:
+    BlackMarket: 15
+    ChallengeMode_1: 16
+    ChallengeMode_2: 33
+    ChallengeMode_3: 34
+    ChallengeMode_4: 87
+    ChallengeModeJackpot: 35
+    CharacterBoost_1: 61
+    CharacterBoost_2: 62
+    CharacterBoost_3: 86
+    CorpseRecovery: 80
+    Delves_1: 104
+    Delves_2: 106
+    Delves_3: 107
+    DelvesBonus_1: 129
+    DelvesBonus_10: 138
+    DelvesBonus_2: 130
+    DelvesBonus_3: 131
+    DelvesBonus_4: 132
+    DelvesBonus_5: 133
+    DelvesBonus_6: 134
+    DelvesBonus_7: 135
+    DelvesBonus_8: 136
+    DelvesBonus_9: 137
+    DelvesBounty_1: 117
+    DelvesBounty_2: 118
+    DelvesBounty_3: 119
+    DelvesBounty_4: 120
+    DelvesBounty_5: 121
+    DelvesBounty_6: 122
+    DelvesBounty_7: 123
+    DelvesBounty_8: 124
+    DelvesJackpot: 108
+    DelvesKey_1: 109
+    DelvesKey_2: 110
+    DelvesKey_3: 111
+    DelvesKey_4: 112
+    DelvesKey_5: 113
+    DelvesKey_6: 114
+    DelvesKey_7: 115
+    DelvesKey_8: 116
+    DelvesLevelUp_1: 125
+    DelvesLevelUp_2: 126
+    DelvesLevelUp_3: 127
+    DelvesLevelUp_4: 128
+    DungeonBonus_1: 139
+    DungeonBonus_10: 148
+    DungeonBonus_2: 140
+    DungeonBonus_3: 141
+    DungeonBonus_4: 142
+    DungeonBonus_5: 143
+    DungeonBonus_6: 144
+    DungeonBonus_7: 145
+    DungeonBonus_8: 146
+    DungeonBonus_9: 147
+    DungeonHardMode_1: 159
+    DungeonHardMode_2: 160
+    DungeonHardMode_3: 161
+    DungeonHeroic: 2
+    DungeonHeroicJackpot: 102
+    DungeonLevelUp_1: 17
+    DungeonLevelUp_2: 18
+    DungeonLevelUp_3: 19
+    DungeonLevelUp_4: 20
+    DungeonMythic: 23
+    DungeonMythicJackpot: 103
+    DungeonNormal: 1
+    DungeonNormalJackpot: 101
+    Endeavors: 185
+    ForceNone: 21
+    LegendaryCrafting_1: 63
+    LegendaryCrafting_2: 64
+    LegendaryCrafting_3: 65
+    LegendaryCrafting_4: 66
+    LegendaryCrafting_5: 67
+    LegendaryCrafting_6: 68
+    LegendaryCrafting_7: 69
+    LegendaryCrafting_8: 70
+    LegendaryCrafting_9: 71
+    LegendaryForge: 59
+    MissionReward_1: 31
+    MissionReward_2: 32
+    NewCharacter: 75
+    None: 0
+    PvPBrawl_1: 77
+    PvPBrawl_2: 78
+    PvPHonorReward: 24
+    PvPRanked_1: 8
+    PvPRanked_2: 38
+    PvPRanked_3: 39
+    PvPRanked_4: 40
+    PvPRanked_5: 44
+    PvPRanked_6: 45
+    PvPRanked_7: 46
+    PvPRanked_8: 52
+    PvPRanked_9: 88
+    PvPRankedJackpot: 56
+    PvPUnranked_1: 7
+    PvPUnranked_2: 41
+    PvPUnranked_3: 47
+    PvPUnranked_4: 48
+    PvPUnranked_5: 49
+    PvPUnranked_6: 50
+    PvPUnranked_7: 51
+    QuestBonusLoot: 60
+    QuestReward: 11
+    RaidBonus_1: 149
+    RaidBonus_10: 158
+    RaidBonus_2: 150
+    RaidBonus_3: 151
+    RaidBonus_4: 152
+    RaidBonus_5: 153
+    RaidBonus_6: 154
+    RaidBonus_7: 155
+    RaidBonus_8: 156
+    RaidBonus_9: 157
+    RaidFinder: 4
+    RaidFinderExtended: 83
+    RaidFinderExtended_2: 90
+    RaidFinderExtended_3: 94
+    RaidHeroic: 5
+    RaidHeroicExtended: 84
+    RaidHeroicExtended_2: 91
+    RaidHeroicExtended_3: 95
+    RaidMythic: 6
+    RaidMythicExtended: 85
+    RaidMythicExtended_2: 92
+    RaidMythicExtended_3: 96
+    RaidNormal: 3
+    RaidNormalExtended: 82
+    RaidNormalExtended_2: 89
+    RaidNormalExtended_3: 93
+    Relinquished: 58
+    ScenarioHeroic: 10
+    ScenarioNormal: 9
+    Store: 12
+    TemplateCharacter_1: 97
+    TemplateCharacter_2: 98
+    TemplateCharacter_3: 99
+    TemplateCharacter_4: 100
+    Timerunning: 105
+    TimewalkerLevelUp: 22
+    TimewalkerMaxLevel: 186
+    Torghast: 79
+    TournamentRealm_1: 57
+    TournamentRealm_2: 162
+    TournamentRealm_3: 163
+    TournamentRealm_4: 164
+    TradeSkill: 13
+    Vendor: 14
+    Warbound_1: 165
+    Warbound_10: 174
+    Warbound_11: 175
+    Warbound_12: 176
+    Warbound_13: 177
+    Warbound_14: 178
+    Warbound_15: 179
+    Warbound_16: 180
+    Warbound_17: 181
+    Warbound_18: 182
+    Warbound_19: 183
+    Warbound_2: 166
+    Warbound_20: 184
+    Warbound_3: 167
+    Warbound_4: 168
+    Warbound_5: 169
+    Warbound_6: 170
+    Warbound_7: 171
+    Warbound_8: 172
+    Warbound_9: 173
+    WarMode: 76
+    WeeklyRewardsAdditional: 72
+    WeeklyRewardsConcession: 73
+    WorldBoss: 81
+    WorldQuest_1: 25
+    WorldQuest_10: 43
+    WorldQuest_11: 53
+    WorldQuest_12: 54
+    WorldQuest_13: 55
+    WorldQuest_2: 26
+    WorldQuest_3: 27
+    WorldQuest_4: 28
+    WorldQuest_5: 29
+    WorldQuest_6: 30
+    WorldQuest_7: 36
+    WorldQuest_8: 37
+    WorldQuest_9: 42
+    WorldQuestJackpot: 74
 ItemDisplayTextDisplayStyle:
-  ItemNameAndInfoText: 1
-  ItemNameOnlyCentered: 2
-  PlayerChoiceReward: 3
-  WorldQuestReward: 0
+  values:
+    ItemNameAndInfoText: 1
+    ItemNameOnlyCentered: 2
+    PlayerChoiceReward: 3
+    WorldQuestReward: 0
 ItemDisplayTooltipEnabledType:
-  Disabled: 1
-  Enabled: 0
+  values:
+    Disabled: 1
+    Enabled: 0
 ItemGemColor:
-  Arcane: 1024
-  Blood: 128
-  Blue: 8
-  Cogwheel: 32
-  Cypher: 8388608
-  DominationBlood: 1048576
-  DominationFrost: 2097152
-  DominationUnholy: 4194304
-  Fel: 512
-  Fiber: 1073741824
-  Fire: 4096
-  Fragrance: 67108864
-  Frost: 2048
-  Holy: 65536
-  Hydraulic: 16
-  Iron: 64
-  Life: 16384
-  Meta: 1
-  Primordial: 33554432
-  PunchcardBlue: 524288
-  PunchcardRed: 131072
-  PunchcardYellow: 262144
-  Red: 2
-  Shadow: 256
-  SingingSea: 268435456
-  SingingThunder: 134217728
-  SingingWind: 536870912
-  Tinker: 16777216
-  Water: 8192
-  Wind: 32768
-  Yellow: 4
+  values:
+    Arcane: 1024
+    Blood: 128
+    Blue: 8
+    Cogwheel: 32
+    Cypher: 8388608
+    DominationBlood: 1048576
+    DominationFrost: 2097152
+    DominationUnholy: 4194304
+    Fel: 512
+    Fiber: 1073741824
+    Fire: 4096
+    Fragrance: 67108864
+    Frost: 2048
+    Holy: 65536
+    Hydraulic: 16
+    Iron: 64
+    Life: 16384
+    Meta: 1
+    Primordial: 33554432
+    PunchcardBlue: 524288
+    PunchcardRed: 131072
+    PunchcardYellow: 262144
+    Red: 2
+    Shadow: 256
+    SingingSea: 268435456
+    SingingThunder: 134217728
+    SingingWind: 536870912
+    Tinker: 16777216
+    Water: 8192
+    Wind: 32768
+    Yellow: 4
 ItemGemSubclass:
-  Blue: 1
-  Green: 4
-  Meta: 6
-  Orange: 5
-  Prismatic: 8
-  Purple: 3
-  Red: 0
-  Simple: 7
-  Yellow: 2
+  values:
+    Blue: 1
+    Green: 4
+    Meta: 6
+    Orange: 5
+    Prismatic: 8
+    Purple: 3
+    Red: 0
+    Simple: 7
+    Yellow: 2
 ItemHousingSubclass:
-  Decor: 0
-  Dye: 1
-  ExteriorCustomization: 4
-  Room: 2
-  RoomCustomization: 3
-  ServiceItem: 5
+  values:
+    Decor: 0
+    Dye: 1
+    ExteriorCustomization: 4
+    Room: 2
+    RoomCustomization: 3
+    ServiceItem: 5
 ItemMiscellaneousSubclass:
-  CompanionPet: 2
-  Holiday: 3
-  Junk: 0
-  Mount: 5
-  MountEquipment: 6
-  Other: 4
-  Reagent: 1
+  values:
+    CompanionPet: 2
+    Holiday: 3
+    Junk: 0
+    Mount: 5
+    MountEquipment: 6
+    Other: 4
+    Reagent: 1
 ItemModification:
-  ArtifactAppearanceID: 8
-  ArtifactTier: 24
-  BattlePetBreed: 4
-  BattlePetCreaturedisplayid: 6
-  BattlePetLevel: 5
-  BattlePetSpecies: 3
-  ChangeModifiedCraftingStat_1: 29
-  ChangeModifiedCraftingStat_2: 30
-  ContentTuningID: 28
-  CraftingDataID: 40
-  CraftingQualityID: 38
-  CraftingReagentSlot_0: 43
-  CraftingReagentSlot_1: 44
-  CraftingReagentSlot_10: 53
-  CraftingReagentSlot_11: 54
-  CraftingReagentSlot_12: 55
-  CraftingReagentSlot_13: 56
-  CraftingReagentSlot_14: 57
-  CraftingReagentSlot_2: 45
-  CraftingReagentSlot_3: 46
-  CraftingReagentSlot_4: 47
-  CraftingReagentSlot_5: 48
-  CraftingReagentSlot_6: 49
-  CraftingReagentSlot_7: 50
-  CraftingReagentSlot_8: 51
-  CraftingReagentSlot_9: 52
-  CraftingSkillLineAbilityID: 39
-  CraftingSkillReagents: 41
-  CraftingSkillWatermark: 42
-  CurrencyWalletID: 61
-  CurrencyWalletQuantity: 62
-  CurrencyWalletVersion: 63
-  DbidHigh: 59
-  DbidLow: 60
-  IncrementLevel: 2
-  KeystoneAffix0: 19
-  KeystoneAffix01: 20
-  KeystoneAffix02: 21
-  KeystoneAffix03: 22
-  KeystoneMapChallengeModeID: 17
-  KeystonePowerLevel: 18
-  LegionArtifactKnowledgeObsolete: 23
-  PvPRating: 26
-  RedirectedBaseStats: 64
-  Reforge: 58
-  SoulbindConduitRank: 37
-  TimewalkerLevel: 9
-  TransmogrifyItemModifiedAppearanceIDSpec_0: 1
-  TransmogrifyItemModifiedAppearanceIDSpec_1: 11
-  TransmogrifyItemModifiedAppearanceIDSpec_2: 13
-  TransmogrifyItemModifiedAppearanceIDSpec_3: 15
-  TransmogrifyItemModifiedAppearanceIDSpec_4: 25
-  TransmogrifyItemModifiedAppearanceIDSpecAll: 0
-  TransmogrifyOverrideEnchantVisualIDSpec_0: 10
-  TransmogrifyOverrideEnchantVisualIDSpec_1: 12
-  TransmogrifyOverrideEnchantVisualIDSpec_2: 14
-  TransmogrifyOverrideEnchantVisualIDSpec_3: 16
-  TransmogrifyOverrideEnchantVisualIDSpec_4: 27
-  TransmogrifyOverrideEnchantVisualIDSpecAll: 7
-  TransmogrifySecondaryItemModifiedAppearanceIDSpec_0: 32
-  TransmogrifySecondaryItemModifiedAppearanceIDSpec_1: 33
-  TransmogrifySecondaryItemModifiedAppearanceIDSpec_2: 34
-  TransmogrifySecondaryItemModifiedAppearanceIDSpec_3: 35
-  TransmogrifySecondaryItemModifiedAppearanceIDSpec_4: 36
-  TransmogrifySecondaryItemModifiedAppearanceIDSpecAll: 31
+  values:
+    ArtifactAppearanceID: 8
+    ArtifactTier: 24
+    BattlePetBreed: 4
+    BattlePetCreaturedisplayid: 6
+    BattlePetLevel: 5
+    BattlePetSpecies: 3
+    ChangeModifiedCraftingStat_1: 29
+    ChangeModifiedCraftingStat_2: 30
+    ContentTuningID: 28
+    CraftingDataID: 40
+    CraftingQualityID: 38
+    CraftingReagentSlot_0: 43
+    CraftingReagentSlot_1: 44
+    CraftingReagentSlot_10: 53
+    CraftingReagentSlot_11: 54
+    CraftingReagentSlot_12: 55
+    CraftingReagentSlot_13: 56
+    CraftingReagentSlot_14: 57
+    CraftingReagentSlot_2: 45
+    CraftingReagentSlot_3: 46
+    CraftingReagentSlot_4: 47
+    CraftingReagentSlot_5: 48
+    CraftingReagentSlot_6: 49
+    CraftingReagentSlot_7: 50
+    CraftingReagentSlot_8: 51
+    CraftingReagentSlot_9: 52
+    CraftingSkillLineAbilityID: 39
+    CraftingSkillReagents: 41
+    CraftingSkillWatermark: 42
+    CurrencyWalletID: 61
+    CurrencyWalletQuantity: 62
+    CurrencyWalletVersion: 63
+    DbidHigh: 59
+    DbidLow: 60
+    IncrementLevel: 2
+    KeystoneAffix0: 19
+    KeystoneAffix01: 20
+    KeystoneAffix02: 21
+    KeystoneAffix03: 22
+    KeystoneMapChallengeModeID: 17
+    KeystonePowerLevel: 18
+    LegionArtifactKnowledgeObsolete: 23
+    PvPRating: 26
+    RedirectedBaseStats: 64
+    Reforge: 58
+    SoulbindConduitRank: 37
+    TimewalkerLevel: 9
+    TransmogrifyItemModifiedAppearanceIDSpec_0: 1
+    TransmogrifyItemModifiedAppearanceIDSpec_1: 11
+    TransmogrifyItemModifiedAppearanceIDSpec_2: 13
+    TransmogrifyItemModifiedAppearanceIDSpec_3: 15
+    TransmogrifyItemModifiedAppearanceIDSpec_4: 25
+    TransmogrifyItemModifiedAppearanceIDSpecAll: 0
+    TransmogrifyOverrideEnchantVisualIDSpec_0: 10
+    TransmogrifyOverrideEnchantVisualIDSpec_1: 12
+    TransmogrifyOverrideEnchantVisualIDSpec_2: 14
+    TransmogrifyOverrideEnchantVisualIDSpec_3: 16
+    TransmogrifyOverrideEnchantVisualIDSpec_4: 27
+    TransmogrifyOverrideEnchantVisualIDSpecAll: 7
+    TransmogrifySecondaryItemModifiedAppearanceIDSpec_0: 32
+    TransmogrifySecondaryItemModifiedAppearanceIDSpec_1: 33
+    TransmogrifySecondaryItemModifiedAppearanceIDSpec_2: 34
+    TransmogrifySecondaryItemModifiedAppearanceIDSpec_3: 35
+    TransmogrifySecondaryItemModifiedAppearanceIDSpec_4: 36
+    TransmogrifySecondaryItemModifiedAppearanceIDSpecAll: 31
 ItemProfessionSubclass:
-  Alchemy: 2
-  Archaeology: 13
-  Blacksmithing: 0
-  Cooking: 4
-  Enchanting: 8
-  Engineering: 7
-  Fishing: 9
-  Herbalism: 3
-  Inscription: 12
-  Jewelcrafting: 11
-  Leatherworking: 1
-  Mining: 5
-  Skinning: 10
-  Tailoring: 6
+  values:
+    Alchemy: 2
+    Archaeology: 13
+    Blacksmithing: 0
+    Cooking: 4
+    Enchanting: 8
+    Engineering: 7
+    Fishing: 9
+    Herbalism: 3
+    Inscription: 12
+    Jewelcrafting: 11
+    Leatherworking: 1
+    Mining: 5
+    Skinning: 10
+    Tailoring: 6
 ItemQuality:
-  Artifact: 6
-  Epic: 4
-  Good: 2
-  Heirloom: 7
-  Legendary: 5
-  Poor: 0
-  Rare: 3
-  Standard: 1
-  WoWToken: 8
+  values:
+    Artifact: 6
+    Epic: 4
+    Good: 2
+    Heirloom: 7
+    Legendary: 5
+    Poor: 0
+    Rare: 3
+    Standard: 1
+    WoWToken: 8
 ItemReagentSubclass:
-  ContextToken: 2
-  Keystone: 1
-  Reagent: 0
+  values:
+    ContextToken: 2
+    Keystone: 1
+    Reagent: 0
 ItemRecipeSubclass:
-  Alchemy: 6
-  Blacksmithing: 4
-  Book: 0
-  Cooking: 5
-  Enchanting: 8
-  Engineering: 3
-  FirstAid: 7
-  Fishing: 9
-  Inscription: 11
-  Jewelcrafting: 10
-  Leatherworking: 1
-  Tailoring: 2
+  values:
+    Alchemy: 6
+    Blacksmithing: 4
+    Book: 0
+    Cooking: 5
+    Enchanting: 8
+    Engineering: 3
+    FirstAid: 7
+    Fishing: 9
+    Inscription: 11
+    Jewelcrafting: 10
+    Leatherworking: 1
+    Tailoring: 2
 ItemRecraftFlags:
-  Invalid: 1
+  values:
+    Invalid: 1
 Itemsetflags:
-  Legacy: 1
-  RequiresPvPTalentsActive: 4
-  UseItemHistorySetSlots: 2
+  values:
+    Legacy: 1
+    RequiresPvPTalentsActive: 4
+    UseItemHistorySetSlots: 2
 ItemSlotFilterType:
-  Chest: 4
-  Cloak: 3
-  Feet: 9
-  Finger: 12
-  Hand: 6
-  Head: 0
-  Legs: 8
-  MainHand: 10
-  Neck: 1
-  NoFilter: 15
-  OffHand: 11
-  Other: 14
-  Shoulder: 2
-  Trinket: 13
-  Waist: 7
-  Wrist: 5
+  values:
+    Chest: 4
+    Cloak: 3
+    Feet: 9
+    Finger: 12
+    Hand: 6
+    Head: 0
+    Legs: 8
+    MainHand: 10
+    Neck: 1
+    NoFilter: 15
+    OffHand: 11
+    Other: 14
+    Shoulder: 2
+    Trinket: 13
+    Waist: 7
+    Wrist: 5
 ItemSocketInfoUIType:
-  Default: 0
+  values:
+    Default: 0
 ItemSocketType:
-  Arcane: 12
-  Blood: 9
-  Blue: 4
-  Cogwheel: 6
-  Cypher: 23
-  Domination: 22
-  Fel: 11
-  Fiber: 30
-  Fire: 14
-  Fragrance: 26
-  Frost: 13
-  Holy: 18
-  Hydraulic: 5
-  Iron: 8
-  Life: 16
-  Meta: 1
-  None: 0
-  Primordial: 25
-  Prismatic: 7
-  PunchcardBlue: 21
-  PunchcardRed: 19
-  PunchcardYellow: 20
-  Red: 2
-  Shadow: 10
-  SingingSea: 28
-  SingingThunder: 27
-  SingingWind: 29
-  Tinker: 24
-  Water: 15
-  Wind: 17
-  Yellow: 3
+  values:
+    Arcane: 12
+    Blood: 9
+    Blue: 4
+    Cogwheel: 6
+    Cypher: 23
+    Domination: 22
+    Fel: 11
+    Fiber: 30
+    Fire: 14
+    Fragrance: 26
+    Frost: 13
+    Holy: 18
+    Hydraulic: 5
+    Iron: 8
+    Life: 16
+    Meta: 1
+    None: 0
+    Primordial: 25
+    Prismatic: 7
+    PunchcardBlue: 21
+    PunchcardRed: 19
+    PunchcardYellow: 20
+    Red: 2
+    Shadow: 10
+    SingingSea: 28
+    SingingThunder: 27
+    SingingWind: 29
+    Tinker: 24
+    Water: 15
+    Wind: 17
+    Yellow: 3
 ItemSoundType:
-  Close: 3
-  Drop: 1
-  Pickup: 0
-  Use: 2
+  values:
+    Close: 3
+    Drop: 1
+    Pickup: 0
+    Use: 2
 ItemSubclassDisplay:
-  HideSubclassInAuction: 2
-  HideSubclassInTooltips: 1
-  ShowItemCount: 4
+  values:
+    HideSubclassInAuction: 2
+    HideSubclassInTooltips: 1
+    ShowItemCount: 4
 ItemSubclassFlag:
-  ArmorsubclassLfgscalingarmor: 1024
-  ItemsubclassQuivernotrequired: 64
-  ItemsubclassUsesInvtype: 512
-  WeaponsubclassCanparry: 1
-  WeaponsubclassDeprecatedReuseMe: 256
-  WeaponsubclassIsrifle: 8
-  WeaponsubclassIsthrown: 16
-  WeaponsubclassIsunarmed: 4
-  WeaponsubclassRanged: 128
-  WeaponsubclassRighthandRanged: 32
-  WeaponsubclassSetfingerseq: 2
+  values:
+    ArmorsubclassLfgscalingarmor: 1024
+    ItemsubclassQuivernotrequired: 64
+    ItemsubclassUsesInvtype: 512
+    WeaponsubclassCanparry: 1
+    WeaponsubclassDeprecatedReuseMe: 256
+    WeaponsubclassIsrifle: 8
+    WeaponsubclassIsthrown: 16
+    WeaponsubclassIsunarmed: 4
+    WeaponsubclassRanged: 128
+    WeaponsubclassRighthandRanged: 32
+    WeaponsubclassSetfingerseq: 2
 ItemTryOnReason:
-  DataPending: 3
-  NotEquippable: 2
-  Success: 0
-  WrongRace: 1
+  values:
+    DataPending: 3
+    NotEquippable: 2
+    Success: 0
+    WrongRace: 1
 ItemWeaponSubclass:
-  Axe1H: 0
-  Axe2H: 1
-  Bearclaw: 11
-  Bows: 2
-  Catclaw: 12
-  Crossbow: 18
-  Dagger: 15
-  Fishingpole: 20
-  Generic: 14
-  Guns: 3
-  Mace1H: 4
-  Mace2H: 5
-  Obsolete3: 17
-  Polearm: 6
-  Staff: 10
-  Sword1H: 7
-  Sword2H: 8
-  Thrown: 16
-  Unarmed: 13
-  Wand: 19
-  Warglaive: 9
+  values:
+    Axe1H: 0
+    Axe2H: 1
+    Bearclaw: 11
+    Bows: 2
+    Catclaw: 12
+    Crossbow: 18
+    Dagger: 15
+    Fishingpole: 20
+    Generic: 14
+    Guns: 3
+    Mace1H: 4
+    Mace2H: 5
+    Obsolete3: 17
+    Polearm: 6
+    Staff: 10
+    Sword1H: 7
+    Sword2H: 8
+    Thrown: 16
+    Unarmed: 13
+    Wand: 19
+    Warglaive: 9
 JailersTowerType:
-  AdamantVaults: 11
-  ArkobanHall: 7
-  BossRush: 14
-  Coldheart: 4
-  ForgottenCatacombs: 12
-  FractureChambers: 2
-  Mortregar: 5
-  Ossuary: 13
-  SkoldusHalls: 1
-  Soulforges: 3
-  TormentChamberAnduin: 10
-  TormentChamberJaina: 8
-  TormentChamberThrall: 9
-  TwistingCorridors: 0
-  UpperReaches: 6
+  values:
+    AdamantVaults: 11
+    ArkobanHall: 7
+    BossRush: 14
+    Coldheart: 4
+    ForgottenCatacombs: 12
+    FractureChambers: 2
+    Mortregar: 5
+    Ossuary: 13
+    SkoldusHalls: 1
+    Soulforges: 3
+    TormentChamberAnduin: 10
+    TormentChamberJaina: 8
+    TormentChamberThrall: 9
+    TwistingCorridors: 0
+    UpperReaches: 6
 JournalEncounterFlags:
-  AllianceOnly: 4
-  DoNotDisplayEncounter: 64
-  HordeOnly: 8
-  InternalOnly: 32
-  LimitDifficulties: 2
-  NoMap: 16
-  Obsolete: 1
+  values:
+    AllianceOnly: 4
+    DoNotDisplayEncounter: 64
+    HordeOnly: 8
+    InternalOnly: 32
+    LimitDifficulties: 2
+    NoMap: 16
+    Obsolete: 1
 JournalEncounterIconFlags:
-  Bleed: 8192
-  Curse: 256
-  Deadly: 16
-  Disease: 1024
-  Dps: 2
-  Enrage: 2048
-  Healer: 4
-  Heroic: 8
-  Important: 32
-  Interruptible: 64
-  Magic: 128
-  Mythic: 4096
-  Poison: 512
-  Tank: 1
+  values:
+    Bleed: 8192
+    Curse: 256
+    Deadly: 16
+    Disease: 1024
+    Dps: 2
+    Enrage: 2048
+    Healer: 4
+    Heroic: 8
+    Important: 32
+    Interruptible: 64
+    Magic: 128
+    Mythic: 4096
+    Poison: 512
+    Tank: 1
 JournalEncounterItemFlags:
-  DisplayAsExtremelyRare: 16
-  DisplayAsPerPlayerLoot: 4
-  DisplayAsVeryRare: 8
-  LimitDifficulties: 2
-  Obsolete: 1
+  values:
+    DisplayAsExtremelyRare: 16
+    DisplayAsPerPlayerLoot: 4
+    DisplayAsVeryRare: 8
+    LimitDifficulties: 2
+    Obsolete: 1
 JournalEncounterLocFlags:
-  Primary: 1
+  values:
+    Primary: 1
 JournalEncounterSectionFlags:
-  LimitDifficulties: 2
-  StartExpanded: 1
+  values:
+    LimitDifficulties: 2
+    StartExpanded: 1
 JournalEncounterSecTypes:
-  Ability: 2
-  Creature: 1
-  Generic: 0
-  Overview: 3
+  values:
+    Ability: 2
+    Creature: 1
+    Generic: 0
+    Overview: 3
 JournalInstanceFlags:
-  DoNotDisplayInstance: 4
-  HideUserSelectableDifficulty: 2
-  Timewalker: 1
+  values:
+    DoNotDisplayInstance: 4
+    HideUserSelectableDifficulty: 2
+    Timewalker: 1
 JournalLinkTypes:
-  Encounter: 1
-  Instance: 0
-  Section: 2
-  Tier: 3
+  values:
+    Encounter: 1
+    Instance: 0
+    Section: 2
+    Tier: 3
 LanguageFlag:
-  HiddenFromPlayer: 2
-  HideLanguageNameInChat: 4
-  IsExotic: 1
+  values:
+    HiddenFromPlayer: 2
+    HideLanguageNameInChat: 4
+    IsExotic: 1
 LeavePartyConfirmReason:
-  QuestSync: 0
-  RestrictedChallengeMode: 1
+  values:
+    QuestSync: 0
+    RestrictedChallengeMode: 1
 LFGEntryGeneralPlaystyle:
-  Expert: 4
-  FunRelaxed: 2
-  FunSerious: 3
-  Learning: 1
-  None: 0
+  values:
+    Expert: 4
+    FunRelaxed: 2
+    FunSerious: 3
+    Learning: 1
+    None: 0
 LFGEntryPlaystyle:
-  Casual: 2
-  Hardcore: 3
-  None: 0
-  Standard: 1
+  values:
+    Casual: 2
+    Hardcore: 3
+    None: 0
+    Standard: 1
 LFGListDisplayType:
-  ClassEnumerate: 2
-  Comment: 5
-  HideAll: 3
-  PlayerCount: 4
-  RoleCount: 0
-  RoleEnumerate: 1
+  values:
+    ClassEnumerate: 2
+    Comment: 5
+    HideAll: 3
+    PlayerCount: 4
+    RoleCount: 0
+    RoleEnumerate: 1
 LFGListFilter:
-  CurrentExpansion: 32
-  CurrentSeason: 64
-  NotCurrentSeason: 128
-  NotRecommended: 2
-  PvE: 4
-  PvP: 8
-  Recommended: 1
-  Timerunning: 16
+  values:
+    CurrentExpansion: 32
+    CurrentSeason: 64
+    NotCurrentSeason: 128
+    NotRecommended: 2
+    PvE: 4
+    PvP: 8
+    Recommended: 1
+    Timerunning: 16
 LFGRole:
-  Damage: 2
-  Healer: 1
-  Tank: 0
+  values:
+    Damage: 2
+    Healer: 1
+    Tank: 0
 LFGSlotInvalidReason:
-  AreaNotExplored: 9
-  CannotRunAnyChildDungeon: 14
-  ChromieTime: 16
-  EngagedInPvP: 12
-  ExpansionTooLow: 1
-  GearTooHigh: 5
-  GearTooLow: 4
-  LevelTargetTooHigh: 8
-  LevelTargetTooLow: 7
-  LevelTooHigh: 3
-  LevelTooLow: 2
-  None: 0
-  NoSpec: 13
-  NoValidRoles: 11
-  Npe: 17
-  PlayerConditionFailed: 19
-  RaidLocked: 6
-  Restricted: 15
-  Timerunning: 18
-  WrongFaction: 10
+  values:
+    AreaNotExplored: 9
+    CannotRunAnyChildDungeon: 14
+    ChromieTime: 16
+    EngagedInPvP: 12
+    ExpansionTooLow: 1
+    GearTooHigh: 5
+    GearTooLow: 4
+    LevelTargetTooHigh: 8
+    LevelTargetTooLow: 7
+    LevelTooHigh: 3
+    LevelTooLow: 2
+    None: 0
+    NoSpec: 13
+    NoValidRoles: 11
+    Npe: 17
+    PlayerConditionFailed: 19
+    RaidLocked: 6
+    Restricted: 15
+    Timerunning: 18
+    WrongFaction: 10
 LgVendorPurchaseSettlementState:
-  NotSettled: 1
-  Settled: 0
+  values:
+    NotSettled: 1
+    Settled: 0
 LgVendorPurchaseSqlResults:
-  AlreadyOwned: 102
-  Failed: 0
-  InsufficientFunds: 101
-  InsufficientSpent: 103
-  InvalidState: 107
-  NoRecord: 106
-  NotOwned: 104
-  RefundExpired: 105
-  Success: 100
+  values:
+    AlreadyOwned: 102
+    Failed: 0
+    InsufficientFunds: 101
+    InsufficientSpent: 103
+    InvalidState: 107
+    NoRecord: 106
+    NotOwned: 104
+    RefundExpired: 105
+    Success: 100
 LgVendorPurchaseState:
-  NotOwned: 0
-  Owned: 1
+  values:
+    NotOwned: 0
+    Owned: 1
 LightRadiusIndicatorType:
-  Always: 0
-  Never: 2
-  Overlap: 1
+  values:
+    Always: 0
+    Never: 2
+    Overlap: 1
 LimitedInputType:
-  MouseDown: 1
-  MouseMove: 0
-  MouseUp: 2
-  MouseWheel: 3
+  values:
+    MouseDown: 1
+    MouseMove: 0
+    MouseUp: 2
+    MouseWheel: 3
 LinkedCurrencyFlags:
-  AddIgnoresMax: 8
-  IgnoreAdd: 1
-  IgnoreSubtract: 2
-  SuppressChatLog: 4
+  values:
+    AddIgnoresMax: 8
+    IgnoreAdd: 1
+    IgnoreSubtract: 2
+    SuppressChatLog: 4
 LogicLogicop:
-  And: 1
-  None: 0
-  Or: 2
-  Xor: 3
+  values:
+    And: 1
+    None: 0
+    Or: 2
+    Xor: 3
 LogicMathop:
-  Div: 4
-  Minus: 2
-  Mod: 5
-  None: 0
-  Plus: 1
-  Times: 3
+  values:
+    Div: 4
+    Minus: 2
+    Mod: 5
+    None: 0
+    Plus: 1
+    Times: 3
 LogicRelop:
-  Equal: 1
-  Gt: 5
-  Gteq: 6
-  Lt: 3
-  Lteq: 4
-  None: 0
-  Notequal: 2
+  values:
+    Equal: 1
+    Gt: 5
+    Gteq: 6
+    Lt: 3
+    Lteq: 4
+    None: 0
+    Notequal: 2
 LogPriority:
-  Debug: 30
-  Error: 2
-  Fatal: 1
-  Normal: 10
-  Spam: 40
-  Warning: 3
+  values:
+    Debug: 30
+    Error: 2
+    Fatal: 1
+    Normal: 10
+    Spam: 40
+    Warning: 3
 LootMethod:
-  Freeforall: 0
-  Group: 3
-  Masterlooter: 2
-  Needbeforegreed: 4
-  Personal: 5
-  Roundrobin: 1
+  values:
+    Freeforall: 0
+    Group: 3
+    Masterlooter: 2
+    Needbeforegreed: 4
+    Personal: 5
+    Roundrobin: 1
 LootMethodStyles:
-  Mainline: 0
-  Vanilla: 1
+  values:
+    Mainline: 0
+    Vanilla: 1
 LootSlotType:
-  Currency: 3
-  Item: 1
-  Money: 2
-  None: 0
+  values:
+    Currency: 3
+    Item: 1
+    Money: 2
+    None: 0
 LuaCurveType:
-  Cosine: 2
-  Cubic: 3
-  Linear: 0
-  Step: 1
+  values:
+    Cosine: 2
+    Cubic: 3
+    Linear: 0
+    Step: 1
 ManipulatorEventType:
-  Complete: 2
-  Delete: 3
-  Move: 1
-  Start: 0
+  values:
+    Complete: 2
+    Delete: 3
+    Move: 1
+    Start: 0
 MapCanvasPosition:
-  BottomLeft: 1
-  BottomRight: 2
-  None: 0
-  TopLeft: 3
-  TopRight: 4
+  values:
+    BottomLeft: 1
+    BottomRight: 2
+    None: 0
+    TopLeft: 3
+    TopRight: 4
 MapIconUIWidgetSetType:
-  AdventureMapDetails: 2
-  BehindIcon: 1
-  Tooltip: 0
+  values:
+    AdventureMapDetails: 2
+    BehindIcon: 1
+    Tooltip: 0
 MapobjEventTypes:
-  PlayAnim: 0
-  SetAnimSpeed: 1
+  values:
+    PlayAnim: 0
+    SetAnimSpeed: 1
 MapPinAnimationType:
-  None: 0
-  Pulse: 1
+  values:
+    None: 0
+    Pulse: 1
 MatchDetailType:
-  Kills: 1
-  Placement: 0
-  PlunderAcquired: 2
+  values:
+    Kills: 1
+    Placement: 0
+    PlunderAcquired: 2
 MicroMenuOrder:
-  Default: 0
-  Reverse: 1
+  values:
+    Default: 0
+    Reverse: 1
 MicroMenuOrientation:
-  Horizontal: 0
-  Vertical: 1
+  values:
+    Horizontal: 0
+    Vertical: 1
 MinimapTrackingFilter:
-  AccountBanker: 4194304
-  AccountCompletedQuests: 2097152
-  Auctioneer: 1
-  Banker: 2
-  Battlemaster: 4
-  Digsites: 131072
-  Focus: 32768
-  Innkeeper: 32
-  Mailbox: 64
-  POI: 8192
-  QuestPOIs: 65536
-  Repair: 512
-  Stablemaster: 2048
-  Target: 16384
-  TaxiNode: 8
-  TrainerClass: 262144
-  TrainerProfession: 128
-  Transmogrifier: 4096
-  TrivialQuests: 1024
-  Unfiltered: 0
-  VenderFood: 16
-  VendorAmmo: 524288
-  VendorPoison: 1048576
-  VendorReagent: 256
+  values:
+    AccountBanker: 4194304
+    AccountCompletedQuests: 2097152
+    Auctioneer: 1
+    Banker: 2
+    Battlemaster: 4
+    Digsites: 131072
+    Focus: 32768
+    Innkeeper: 32
+    Mailbox: 64
+    POI: 8192
+    QuestPOIs: 65536
+    Repair: 512
+    Stablemaster: 2048
+    Target: 16384
+    TaxiNode: 8
+    TrainerClass: 262144
+    TrainerProfession: 128
+    Transmogrifier: 4096
+    TrivialQuests: 1024
+    Unfiltered: 0
+    VenderFood: 16
+    VendorAmmo: 524288
+    VendorPoison: 1048576
+    VendorReagent: 256
 ModelBlendOperation:
-  Anim: 1
-  None: 0
+  values:
+    Anim: 1
+    None: 0
 ModelLightType:
-  Directional: 0
-  Point: 1
+  values:
+    Directional: 0
+    Point: 1
 ModelSceneSetting:
-  AlignLightToOrbitDelta: 1
+  values:
+    AlignLightToOrbitDelta: 1
 ModelSceneType:
-  ArtifactRelicTalentEffect: 9
-  ArtifactTier2: 5
-  ArtifactTier2ForgingScene: 6
-  ArtifactTier2SlamEffect: 7
-  AzeriteItemLevelUpToast: 13
-  AzeritePowers: 14
-  AzeriteRewardGlow: 15
-  CommentatorVictoryFanfare: 8
-  EncounterJournal: 3
-  MountJournal: 0
-  PartyPose: 12
-  PetJournalCard: 1
-  PetJournalLoadout: 4
-  PvPWarModeFire: 11
-  PvPWarModeOrb: 10
-  ShopCard: 2
+  values:
+    ArtifactRelicTalentEffect: 9
+    ArtifactTier2: 5
+    ArtifactTier2ForgingScene: 6
+    ArtifactTier2SlamEffect: 7
+    AzeriteItemLevelUpToast: 13
+    AzeritePowers: 14
+    AzeriteRewardGlow: 15
+    CommentatorVictoryFanfare: 8
+    EncounterJournal: 3
+    MountJournal: 0
+    PartyPose: 12
+    PetJournalCard: 1
+    PetJournalLoadout: 4
+    PvPWarModeFire: 11
+    PvPWarModeOrb: 10
+    ShopCard: 2
 ModelSoundOverrideType:
-  Mute: 2
-  UseOverride: 1
-  UseParent: 0
+  values:
+    Mute: 2
+    UseOverride: 1
+    UseParent: 0
 ModelSoundTagType:
-  Looping: 2
-  Oneshot: 1
+  values:
+    Looping: 2
+    Oneshot: 1
 MountType:
-  Aquatic: 2
-  Dragonriding: 3
-  Flying: 1
-  Ground: 0
-  RideAlong: 4
+  values:
+    Aquatic: 2
+    Dragonriding: 3
+    Flying: 1
+    Ground: 0
+    RideAlong: 4
 MountTypeFlag:
-  IsAquaticMount: 2
-  IsDragonRidingMount: 4
-  IsFlyingMount: 1
-  IsRideAlongMount: 8
+  values:
+    IsAquaticMount: 2
+    IsDragonRidingMount: 4
+    IsFlyingMount: 1
+    IsRideAlongMount: 8
 NamePlateCastBarDisplay:
-  HighlightImportantCasts: 4
-  HighlightWhenCastTarget: 5
-  None: 0
-  SpellIcon: 2
-  SpellName: 1
-  SpellTarget: 3
+  values:
+    HighlightImportantCasts: 4
+    HighlightWhenCastTarget: 5
+    None: 0
+    SpellIcon: 2
+    SpellName: 1
+    SpellTarget: 3
 NamePlateEnemyNpcAuraDisplay:
-  Buffs: 1
-  CrowdControl: 3
-  Debuffs: 2
-  None: 0
+  values:
+    Buffs: 1
+    CrowdControl: 3
+    Debuffs: 2
+    None: 0
 NamePlateEnemyPlayerAuraDisplay:
-  Buffs: 1
-  Debuffs: 2
-  LossOfControl: 3
-  None: 0
+  values:
+    Buffs: 1
+    Debuffs: 2
+    LossOfControl: 3
+    None: 0
 NamePlateFriendlyPlayerAuraDisplay:
-  Buffs: 1
-  Debuffs: 2
-  LossOfControl: 3
-  None: 0
+  values:
+    Buffs: 1
+    Debuffs: 2
+    LossOfControl: 3
+    None: 0
 NamePlateInfoDisplay:
-  CurrentHealthPercent: 1
-  CurrentHealthValue: 2
-  None: 0
-  RarityIcon: 3
+  values:
+    CurrentHealthPercent: 1
+    CurrentHealthValue: 2
+    None: 0
+    RarityIcon: 3
 NamePlateSimplifiedType:
-  FriendlyNpc: 4
-  FriendlyPlayer: 3
-  Minion: 1
-  MinusMob: 2
-  None: 0
+  values:
+    FriendlyNpc: 4
+    FriendlyPlayer: 3
+    Minion: 1
+    MinusMob: 2
+    None: 0
 NamePlateSize:
-  ExtraLarge: 4
-  Huge: 5
-  Large: 3
-  Medium: 2
-  Small: 1
+  values:
+    ExtraLarge: 4
+    Huge: 5
+    Large: 3
+    Medium: 2
+    Small: 1
 NamePlateStackType:
-  Enemy: 1
-  Friendly: 2
-  None: 0
+  values:
+    Enemy: 1
+    Friendly: 2
+    None: 0
 NamePlateStyle:
-  Block: 2
-  CastFocus: 4
-  Classic: 6
-  HealthFocus: 3
-  Legacy: 5
-  Modern: 0
-  Thin: 1
+  values:
+    Block: 2
+    CastFocus: 4
+    Classic: 6
+    HealthFocus: 3
+    Legacy: 5
+    Modern: 0
+    Thin: 1
 NamePlateThreatDisplay:
-  Flash: 2
-  HealthBarColor: 3
-  None: 0
-  Progressive: 1
+  values:
+    Flash: 2
+    HealthBarColor: 3
+    None: 0
+    Progressive: 1
 NamePlateType:
-  Enemy: 1
-  Friendly: 0
+  values:
+    Enemy: 1
+    Friendly: 0
 NeighborhoodFlags:
-  None: 0
-  OpenToPublic: 2
-  PoolParent: 1
+  values:
+    None: 0
+    OpenToPublic: 2
+    PoolParent: 1
 NeighborhoodInitiativeChestResult:
-  NiNoHouseFound: 2
-  NiNoRewards: 3
-  NiServiceDisabled: 5
-  NiSuccess: 0
-  NiThrottled: 4
-  NiUnspecifiedFailure: 1
+  values:
+    NiNoHouseFound: 2
+    NiNoRewards: 3
+    NiServiceDisabled: 5
+    NiSuccess: 0
+    NiThrottled: 4
+    NiUnspecifiedFailure: 1
 NeighborhoodInitiativeFlags:
-  Disabled: 1
-  NoAbandon: 2
-  NoRepeat: 4
+  values:
+    Disabled: 1
+    NoAbandon: 2
+    NoRepeat: 4
 NeighborhoodInitiativeNeighborhoodTypes:
-  NiNeighborhoodTypePool: 1
-  NiNeighborhoodTypeSingleton: 0
+  values:
+    NiNeighborhoodTypePool: 1
+    NiNeighborhoodTypeSingleton: 0
 NeighborhoodInitiativesCompletionStates:
-  NiCompletionStateNotCompleted: 0
-  NiCompletionStatePlayerCompleted: 1
-  NiCompletionStateSystemAbandoned: 2
+  values:
+    NiCompletionStateNotCompleted: 0
+    NiCompletionStatePlayerCompleted: 1
+    NiCompletionStateSystemAbandoned: 2
 NeighborhoodInitiativeTaskType:
-  RepeatableFinite: 1
-  RepeatableInfinite: 2
-  Single: 0
+  values:
+    RepeatableFinite: 1
+    RepeatableInfinite: 2
+    Single: 0
 NeighborhoodInitiativeUpdateStatus:
-  Completed: 2
-  Failed: 3
-  MilestoneCompleted: 1
-  Started: 0
+  values:
+    Completed: 2
+    Failed: 3
+    MilestoneCompleted: 1
+    Started: 0
 NeighborhoodInviteResult:
-  AlreadyInNeighborhood: 11
-  DbError: 1
-  Faction: 5
-  GenericFailure: 3
-  InviteLimit: 7
-  NotEnoughPlots: 8
-  NotFound: 9
-  PendingInvitation: 6
-  Permission: 4
-  RpcFailure: 2
-  Success: 0
-  TooManyRequests: 10
+  values:
+    AlreadyInNeighborhood: 11
+    DbError: 1
+    Faction: 5
+    GenericFailure: 3
+    InviteLimit: 7
+    NotEnoughPlots: 8
+    NotFound: 9
+    PendingInvitation: 6
+    Permission: 4
+    RpcFailure: 2
+    Success: 0
+    TooManyRequests: 10
 NeighborhoodMapFlags:
-  AlliancePurchasable: 1
-  CanSystemGenerate: 4
-  HordePurchasable: 2
-  None: 0
+  values:
+    AlliancePurchasable: 1
+    CanSystemGenerate: 4
+    HordePurchasable: 2
+    None: 0
 NeighborhoodOwnerType:
-  Charter: 2
-  Guild: 1
-  None: 0
+  values:
+    Charter: 2
+    Guild: 1
+    None: 0
 NeighborhoodType:
-  Open: 0
-  Private: 1
-  Public: 2
+  values:
+    Open: 0
+    Private: 1
+    Public: 2
 NewCharGear:
-  Preview: 1
-  Start: 0
+  values:
+    Preview: 1
+    Start: 0
 NodeOpFailureReason:
-  AccountDataNoMatch: 25
-  DataError: 13
-  EntryNotFound: 19
-  HasMutuallyExclusiveEdge: 4
-  LevelTooLow: 22
-  MaxRank: 12
-  MissingAchievement: 8
-  MissingEdgeConnection: 1
-  MissingQuest: 9
-  MissingRequiredEdge: 3
-  NodeNeverPurchasable: 24
-  NodeNotFound: 18
-  None: 0
-  NotEnoughCurrency: 15
-  NotEnoughCurrencySpent: 6
-  NotEnoughGold: 16
-  NotEnoughGoldSpent: 7
-  NotEnoughRanksInEntry: 26
-  NotEnoughSourcedCurrency: 14
-  NotEnoughSourcedCurrencySpent: 5
-  RequiredForCondition: 20
-  RequiredForEdge: 2
-  SameSelection: 17
-  TreeFlaggedNoRefund: 23
-  WrongSelection: 11
-  WrongSpec: 10
-  WrongTreeID: 21
+  values:
+    AccountDataNoMatch: 25
+    DataError: 13
+    EntryNotFound: 19
+    HasMutuallyExclusiveEdge: 4
+    LevelTooLow: 22
+    MaxRank: 12
+    MissingAchievement: 8
+    MissingEdgeConnection: 1
+    MissingQuest: 9
+    MissingRequiredEdge: 3
+    NodeNeverPurchasable: 24
+    NodeNotFound: 18
+    None: 0
+    NotEnoughCurrency: 15
+    NotEnoughCurrencySpent: 6
+    NotEnoughGold: 16
+    NotEnoughGoldSpent: 7
+    NotEnoughRanksInEntry: 26
+    NotEnoughSourcedCurrency: 14
+    NotEnoughSourcedCurrencySpent: 5
+    RequiredForCondition: 20
+    RequiredForEdge: 2
+    SameSelection: 17
+    TreeFlaggedNoRefund: 23
+    WrongSelection: 11
+    WrongSpec: 10
+    WrongTreeID: 21
 NoRPEReason:
-  BNetToken: 8
-  FactionOrRaceChange: 7
-  HasRPE: 0
-  IneligibleMap: 3
-  LowLevel: 1
-  PlayerLocked: 9
-  RecentlyActive: 4
-  RecentlyBoosted: 5
-  Timerunner: 2
-  UpgradeInProgress: 6
+  values:
+    BNetToken: 8
+    FactionOrRaceChange: 7
+    HasRPE: 0
+    IneligibleMap: 3
+    LowLevel: 1
+    PlayerLocked: 9
+    RecentlyActive: 4
+    RecentlyBoosted: 5
+    Timerunner: 2
+    UpgradeInProgress: 6
 NpcCraftingOrderSetFlags:
-  AllowDuplicate: 2
-  AllowMultiple: 1
+  values:
+    AllowDuplicate: 2
+    AllowMultiple: 1
 NumericRuleFormatRounding:
-  Down: 2
-  Nearest: 0
-  Up: 1
+  values:
+    Down: 2
+    Nearest: 0
+    Up: 1
 PartyPlaylistEntry:
-  DuoGameMode: 1
-  SoloGameMode: 0
-  TrainingGameMode: 3
-  TrioGameMode: 2
+  values:
+    DuoGameMode: 1
+    SoloGameMode: 0
+    TrainingGameMode: 3
+    TrioGameMode: 2
 PartyPoseFlags:
-  HideLeaveInstanceButton: 1
+  values:
+    HideLeaveInstanceButton: 1
 PartyRequestJoinRelation:
-  Club: 3
-  Friend: 1
-  Guild: 2
-  None: 0
-  RecentAllies: 4
+  values:
+    Club: 3
+    Friend: 1
+    Guild: 2
+    None: 0
+    RecentAllies: 4
 PerksVendorCategoryType:
-  Achievement: 23
-  Activity: 21
-  GmAdjustment: 22
-  Illusion: 7
-  Mount: 2
-  Pet: 3
-  RefundUnused: 24
-  Stipend: 20
-  Toy: 5
-  Transmog: 1
-  Transmogset: 8
-  WarbandScene: 9
+  values:
+    Achievement: 23
+    Activity: 21
+    GmAdjustment: 22
+    Illusion: 7
+    Mount: 2
+    Pet: 3
+    RefundUnused: 24
+    Stipend: 20
+    Toy: 5
+    Transmog: 1
+    Transmogset: 8
+    WarbandScene: 9
 PermanentChatChannelType:
-  Communities: 2
-  Custom: 3
-  None: 0
-  Zone: 1
+  values:
+    Communities: 2
+    Custom: 3
+    None: 0
+    Zone: 1
 PersonalResourceDisplayVisibleSetting:
-  Always: 0
-  Hidden: 2
-  InCombat: 1
+  values:
+    Always: 0
+    Hidden: 2
+    InCombat: 1
 PetActionbuttonType:
-  Max: 18
-  Mode: 6
-  None: 0
-  Orders: 7
-  Slot1: 8
-  Slot10: 17
-  Slot1Obsolete: 2
-  Slot2: 9
-  Slot2Obsolete: 3
-  Slot3: 10
-  Slot3Obsolete: 4
-  Slot4: 11
-  Slot4Obsolete: 5
-  Slot5: 12
-  Slot6: 13
-  Slot7: 14
-  Slot8: 15
-  Slot9: 16
-  Spell: 1
-  VehicleAction: 19
+  values:
+    Max: 18
+    Mode: 6
+    None: 0
+    Orders: 7
+    Slot1: 8
+    Slot10: 17
+    Slot1Obsolete: 2
+    Slot2: 9
+    Slot2Obsolete: 3
+    Slot3: 10
+    Slot3Obsolete: 4
+    Slot4: 11
+    Slot4Obsolete: 5
+    Slot5: 12
+    Slot6: 13
+    Slot7: 14
+    Slot8: 15
+    Slot9: 16
+    Spell: 1
+    VehicleAction: 19
 PetActionFeedback:
-  Dead: 1
-  FriendlyTarget: 3
-  InvalidTarget: 2
-  NoPath: 4
-  Success: 0
+  values:
+    Dead: 1
+    FriendlyTarget: 3
+    InvalidTarget: 2
+    NoPath: 4
+    Success: 0
 PetBattleQueueStatus:
-  AlreadyQueued: 3
-  InBattle: 20
-  JoinFailed: 4
-  JoinFailedJournalLock: 6
-  JoinFailedNeutral: 7
-  JoinFailedSlots: 5
-  LostConnection: 16
-  MatchAccepted: 8
-  MatchDeclined: 9
-  Matchmaking: 15
-  MatchOpponentDeclined: 10
-  NoBattlingHere: 21
-  None: 0
-  ProposalTimedOut: 11
-  Queued: 1
-  QueuedUpdate: 2
-  Removed: 12
-  RequeuedAfterInternalError: 13
-  RequeuedAfterOpponentRemoved: 14
-  Shutdown: 17
-  Suspended: 18
-  Unsuspended: 19
+  values:
+    AlreadyQueued: 3
+    InBattle: 20
+    JoinFailed: 4
+    JoinFailedJournalLock: 6
+    JoinFailedNeutral: 7
+    JoinFailedSlots: 5
+    LostConnection: 16
+    MatchAccepted: 8
+    MatchDeclined: 9
+    Matchmaking: 15
+    MatchOpponentDeclined: 10
+    NoBattlingHere: 21
+    None: 0
+    ProposalTimedOut: 11
+    Queued: 1
+    QueuedUpdate: 2
+    Removed: 12
+    RequeuedAfterInternalError: 13
+    RequeuedAfterOpponentRemoved: 14
+    Shutdown: 17
+    Suspended: 18
+    Unsuspended: 19
 PetbattleSlot:
-  Slot_0: 0
-  Slot_1: 1
-  Slot_2: 2
+  values:
+    Slot_0: 0
+    Slot_1: 1
+    Slot_2: 2
 PetbattleState:
-  Created: 0
-  CreatedFailed: 4
-  FinalRound: 5
-  Finished: 6
-  RoundInProgress: 2
-  WaitingForFrontPets: 3
-  WaitingPreBattle: 1
+  values:
+    Created: 0
+    CreatedFailed: 4
+    FinalRound: 5
+    Finished: 6
+    RoundInProgress: 2
+    WaitingForFrontPets: 3
+    WaitingPreBattle: 1
 PetJournalError:
-  InvalidFaction: 3
-  JournalIsLocked: 2
-  NoFavoritesToSummon: 4
-  None: 0
-  NoValidRandomSummon: 5
-  PetIsDead: 1
+  values:
+    InvalidFaction: 3
+    JournalIsLocked: 2
+    NoFavoritesToSummon: 4
+    None: 0
+    NoValidRandomSummon: 5
+    PetIsDead: 1
 PetMode:
-  Aggressive: 2
-  Assist: 3
-  Defensive: 1
-  Passive: 0
+  values:
+    Aggressive: 2
+    Assist: 3
+    Defensive: 1
+    Passive: 0
 PetOrders:
-  Attack: 2
-  Dismiss: 3
-  Follow: 1
-  MoveTo: 4
-  Wait: 0
+  values:
+    Attack: 2
+    Dismiss: 3
+    Follow: 1
+    MoveTo: 4
+    Wait: 0
 PetOverride:
-  AICombatControl: 1
-  AICombatPassive: 2
-  None: 0
-  OwnerMounted: 4
+  values:
+    AICombatControl: 1
+    AICombatPassive: 2
+    None: 0
+    OwnerMounted: 4
 Pettameresult:
-  Anothersummonactive: 5
-  Cantcontrolexotic: 12
-  Creaturealreadyowned: 3
-  Dead: 10
-  EliteToohighlevel: 14
-  Internalerror: 8
-  Invalidcreature: 1
-  Invalidslot: 13
-  Nopetavailable: 7
-  Notdead: 11
-  Nottameable: 4
-  Numresults: 15
-  Ok: 0
-  Toohighlevel: 9
-  Toomany: 2
-  Unitscanttame: 6
+  values:
+    Anothersummonactive: 5
+    Cantcontrolexotic: 12
+    Creaturealreadyowned: 3
+    Dead: 10
+    EliteToohighlevel: 14
+    Internalerror: 8
+    Invalidcreature: 1
+    Invalidslot: 13
+    Nopetavailable: 7
+    Notdead: 11
+    Nottameable: 4
+    Numresults: 15
+    Ok: 0
+    Toohighlevel: 9
+    Toomany: 2
+    Unitscanttame: 6
 PhaseReason:
-  ChromieTime: 3
-  Phasing: 0
-  Sharding: 1
-  TimerunningHwt: 4
-  WarMode: 2
+  values:
+    ChromieTime: 3
+    Phasing: 0
+    Sharding: 1
+    TimerunningHwt: 4
+    WarMode: 2
 PhotoSharingStatus:
-  AADCRestricted: 6
-  Configured: 2
-  Disabled: 0
-  Error: 7
-  Expired: 3
-  FailedToClear: 8
-  NotConfigured: 1
-  ParentalControl: 4
-  TrialOrVeteran: 5
+  values:
+    AADCRestricted: 6
+    Configured: 2
+    Disabled: 0
+    Error: 7
+    Expired: 3
+    FailedToClear: 8
+    NotConfigured: 1
+    ParentalControl: 4
+    TrialOrVeteran: 5
 PhotoSharingUploadStatus:
-  CreatePageApiCallFailed: 13
-  CreatePageBadRequest: 14
-  CreatePageForbidden: 16
-  CreatePageGenericFailure: 19
-  CreatePageNoBoardIDFound: 20
-  CreatePageNotFound: 17
-  CreatePageTooManyRequests: 18
-  CreatePageUnauthorized: 15
-  CreatePostApiCallFailed: 21
-  CreatePostBadRequest: 22
-  CreatePostForbidden: 24
-  CreatePostGenericFailure: 27
-  CreatePostNoIDFound: 28
-  CreatePostNotFound: 25
-  CreatePostThrottled: 29
-  CreatePostTooManyRequests: 26
-  CreatePostUnauthorized: 23
-  Disabled: 0
-  Failed: 1
-  ListPagesApiCallFailed: 4
-  ListPagesBadRequest: 5
-  ListPagesEmptyBoardID: 11
-  ListPagesForbidden: 7
-  ListPagesGenericFailure: 10
-  ListPagesInvalidBookmark: 12
-  ListPagesNotFound: 8
-  ListPagesTooManyRequests: 9
-  ListPagesUnauthorized: 6
-  Locked: 3
-  Success: 2
+  values:
+    CreatePageApiCallFailed: 13
+    CreatePageBadRequest: 14
+    CreatePageForbidden: 16
+    CreatePageGenericFailure: 19
+    CreatePageNoBoardIDFound: 20
+    CreatePageNotFound: 17
+    CreatePageTooManyRequests: 18
+    CreatePageUnauthorized: 15
+    CreatePostApiCallFailed: 21
+    CreatePostBadRequest: 22
+    CreatePostForbidden: 24
+    CreatePostGenericFailure: 27
+    CreatePostNoIDFound: 28
+    CreatePostNotFound: 25
+    CreatePostThrottled: 29
+    CreatePostTooManyRequests: 26
+    CreatePostUnauthorized: 23
+    Disabled: 0
+    Failed: 1
+    ListPagesApiCallFailed: 4
+    ListPagesBadRequest: 5
+    ListPagesEmptyBoardID: 11
+    ListPagesForbidden: 7
+    ListPagesGenericFailure: 10
+    ListPagesInvalidBookmark: 12
+    ListPagesNotFound: 8
+    ListPagesTooManyRequests: 9
+    ListPagesUnauthorized: 6
+    Locked: 3
+    Success: 2
 PingSubjectType:
-  AlertNotThreat: 5
-  AlertThreat: 4
-  Assist: 2
-  Attack: 0
-  OnMyWay: 3
-  Warning: 1
+  values:
+    AlertNotThreat: 5
+    AlertThreat: 4
+    Assist: 2
+    Attack: 0
+    OnMyWay: 3
+    Warning: 1
 PingTextureType:
-  Center: 0
-  Expand: 1
-  Rotation: 2
+  values:
+    Center: 0
+    Expand: 1
+    Rotation: 2
 PingTypeFlags:
-  DefaultPing: 1
+  values:
+    DefaultPing: 1
 PlayerClubRequestStatus:
-  Approved: 4
-  AutoApproved: 2
-  Canceled: 7
-  Declined: 3
-  Joined: 5
-  JoinedAnother: 6
-  None: 0
-  Pending: 1
+  values:
+    Approved: 4
+    AutoApproved: 2
+    Canceled: 7
+    Declined: 3
+    Joined: 5
+    JoinedAnother: 6
+    None: 0
+    Pending: 1
 PlayerCompanionInfoFlags:
-  IgnoreSeasonInScenarios: 1
+  values:
+    IgnoreSeasonInScenarios: 1
 PlayerCurrencyFlags:
-  Incremented: 1
-  Loading: 2
+  values:
+    Incremented: 1
+    Loading: 2
 PlayerCurrencyFlagsDbFlags:
-  IgnoreMaxQtyOnload: 1
-  InBackpack: 4
-  Reuse1: 2
-  Reuse2: 16
-  UnusedInUI: 8
+  values:
+    IgnoreMaxQtyOnload: 1
+    InBackpack: 4
+    Reuse1: 2
+    Reuse2: 16
+    UnusedInUI: 8
 PlayerDataElementType:
-  Float: 1
-  Int: 0
+  values:
+    Float: 1
+    Int: 0
 PlayerInteractionType:
-  AccountBanker: 68
-  AdventureJournal: 54
-  AdventureMap: 28
-  AlliedRaceDetailsGiver: 9
-  AnimaDiversion: 47
-  AreaSpiritHealer: 19
-  ArtifactForge: 38
-  Auctioneer: 21
-  AzeriteForge: 56
-  AzeriteRespec: 42
-  Banker: 8
-  BarbersChoice: 62
-  BattleMaster: 23
-  Binder: 20
-  BlackMarketAuctioneer: 27
-  CharacterBanker: 67
-  ChromieTime: 45
-  ContributionCollector: 41
-  CornerstoneInteraction: 70
-  CovenantPreview: 46
-  CovenantSanctum: 51
-  CreateGuildNeighborhood: 74
-  ForgeMaster: 66
-  GarrArchitect: 30
-  GarrMission: 32
-  GarrRecruitment: 34
-  GarrTalent: 35
-  GarrTradeskill: 31
-  Gossip: 3
-  GuildBanker: 10
-  GuildRename: 76
-  GuildTabardVendor: 14
-  HousingBulletinBoard: 72
-  HousingPedestal: 73
-  IslandQueue: 43
-  Item: 2
-  ItemInteraction: 44
-  ItemUpgrade: 53
-  JailersTowerBuffs: 63
-  LegendaryCrafting: 48
-  LFGDungeon: 25
-  MailInfo: 17
-  MajorFactionRenown: 64
-  Merchant: 5
-  NeighborhoodCharter: 75
-  NewPlayerGuide: 52
-  None: 0
-  ObliterumForge: 39
-  OpenHouseFinder: 78
-  OpenNeighborhoodCharterConfirmation: 77
-  PerksProgramVendor: 57
-  PersonalTabardVendor: 65
-  PetitionVendor: 13
-  PlayerChoice: 37
-  ProfessionRespec: 69
-  Professions: 59
-  ProfessionsCraftingOrder: 58
-  ProfessionsCustomerOrder: 60
-  QuestGiver: 4
-  Registrar: 11
-  RenameNeighborhood: 71
-  Renown: 55
-  ScrappingMachine: 40
-  ShipmentCrafter: 33
-  Soulbind: 50
-  SpecializationMaster: 16
-  SpiritHealer: 18
-  StableMaster: 22
-  TalentMaster: 15
-  TaxiNode: 6
-  TieredEntrance: 79
-  TradePartner: 1
-  Trainer: 7
-  TraitSystem: 61
-  Transmogrifier: 24
-  Trophy: 36
-  Vendor: 12
-  VoidStorageBanker: 26
-  WeeklyRewards: 49
-  WorldMap: 29
+  values:
+    AccountBanker: 68
+    AdventureJournal: 54
+    AdventureMap: 28
+    AlliedRaceDetailsGiver: 9
+    AnimaDiversion: 47
+    AreaSpiritHealer: 19
+    ArtifactForge: 38
+    Auctioneer: 21
+    AzeriteForge: 56
+    AzeriteRespec: 42
+    Banker: 8
+    BarbersChoice: 62
+    BattleMaster: 23
+    Binder: 20
+    BlackMarketAuctioneer: 27
+    CharacterBanker: 67
+    ChromieTime: 45
+    ContributionCollector: 41
+    CornerstoneInteraction: 70
+    CovenantPreview: 46
+    CovenantSanctum: 51
+    CreateGuildNeighborhood: 74
+    ForgeMaster: 66
+    GarrArchitect: 30
+    GarrMission: 32
+    GarrRecruitment: 34
+    GarrTalent: 35
+    GarrTradeskill: 31
+    Gossip: 3
+    GuildBanker: 10
+    GuildRename: 76
+    GuildTabardVendor: 14
+    HousingBulletinBoard: 72
+    HousingPedestal: 73
+    IslandQueue: 43
+    Item: 2
+    ItemInteraction: 44
+    ItemUpgrade: 53
+    JailersTowerBuffs: 63
+    LegendaryCrafting: 48
+    LFGDungeon: 25
+    MailInfo: 17
+    MajorFactionRenown: 64
+    Merchant: 5
+    NeighborhoodCharter: 75
+    NewPlayerGuide: 52
+    None: 0
+    ObliterumForge: 39
+    OpenHouseFinder: 78
+    OpenNeighborhoodCharterConfirmation: 77
+    PerksProgramVendor: 57
+    PersonalTabardVendor: 65
+    PetitionVendor: 13
+    PlayerChoice: 37
+    ProfessionRespec: 69
+    Professions: 59
+    ProfessionsCraftingOrder: 58
+    ProfessionsCustomerOrder: 60
+    QuestGiver: 4
+    Registrar: 11
+    RenameNeighborhood: 71
+    Renown: 55
+    ScrappingMachine: 40
+    ShipmentCrafter: 33
+    Soulbind: 50
+    SpecializationMaster: 16
+    SpiritHealer: 18
+    StableMaster: 22
+    TalentMaster: 15
+    TaxiNode: 6
+    TieredEntrance: 79
+    TradePartner: 1
+    Trainer: 7
+    TraitSystem: 61
+    Transmogrifier: 24
+    Trophy: 36
+    Vendor: 12
+    VoidStorageBanker: 26
+    WeeklyRewards: 49
+    WorldMap: 29
 PlayerMentorshipApplicationResult:
-  AlreadyMentor: 1
-  Ineligible: 2
-  Success: 0
+  values:
+    AlreadyMentor: 1
+    Ineligible: 2
+    Success: 0
 PlayerMentorshipStatus:
-  Mentor: 2
-  Newcomer: 1
-  None: 0
+  values:
+    Mentor: 2
+    Newcomer: 1
+    None: 0
 PlunderstormQueueState:
-  None: 0
-  Proposed: 2
-  Queued: 1
-  Suspended: 3
+  values:
+    None: 0
+    Proposed: 2
+    Queued: 1
+    Suspended: 3
 PowerType:
-  Alternate: 10
-  AlternateEncounter: 24
-  AlternateMount: 25
-  AlternateQuest: 23
-  ArcaneCharges: 16
-  Balance: 26
-  BurningEmbers: 14
-  Chi: 12
-  ComboPoints: 4
-  DemonicFury: 15
-  Energy: 3
-  Essence: 19
-  Focus: 2
-  Fury: 17
-  Happiness: 27
-  HolyPower: 9
-  Insanity: 13
-  LunarPower: 8
-  Maelstrom: 11
-  Mana: 0
-  Pain: 18
-  Rage: 1
-  RuneBlood: 20
-  RuneChromatic: 29
-  RuneFrost: 21
-  Runes: 5
-  RuneUnholy: 22
-  RunicPower: 6
-  ShadowOrbs: 28
-  SoulShards: 7
+  values:
+    Alternate: 10
+    AlternateEncounter: 24
+    AlternateMount: 25
+    AlternateQuest: 23
+    ArcaneCharges: 16
+    Balance: 26
+    BurningEmbers: 14
+    Chi: 12
+    ComboPoints: 4
+    DemonicFury: 15
+    Energy: 3
+    Essence: 19
+    Focus: 2
+    Fury: 17
+    Happiness: 27
+    HolyPower: 9
+    Insanity: 13
+    LunarPower: 8
+    Maelstrom: 11
+    Mana: 0
+    Pain: 18
+    Rage: 1
+    RuneBlood: 20
+    RuneChromatic: 29
+    RuneFrost: 21
+    Runes: 5
+    RuneUnholy: 22
+    RunicPower: 6
+    ShadowOrbs: 28
+    SoulShards: 7
 PowerTypeSign:
-  Negative: 1
-  None: -1
-  Positive: 0
+  values:
+    Negative: 1
+    None: -1
+    Positive: 0
 PowerTypeSlot:
-  Slot_0: 0
-  Slot_1: 1
-  Slot_2: 2
-  Slot_3: 3
-  Slot_4: 4
-  Slot_5: 5
-  Slot_6: 6
-  Slot_7: 7
-  Slot_8: 8
-  Slot_9: 9
+  values:
+    Slot_0: 0
+    Slot_1: 1
+    Slot_2: 2
+    Slot_3: 3
+    Slot_4: 4
+    Slot_5: 5
+    Slot_6: 6
+    Slot_7: 7
+    Slot_8: 8
+    Slot_9: 9
 PremadeGroupFinderStyle:
-  Disabled: 0
-  Mainline: 1
-  Vanilla: 2
+  values:
+    Disabled: 0
+    Mainline: 1
+    Vanilla: 2
 PreyHuntProgressState:
-  Cold: 0
-  Final: 3
-  Hot: 2
-  Warm: 1
+  values:
+    Cold: 0
+    Final: 3
+    Hot: 2
+    Warm: 1
 ProceduralSpawnInteractionMode:
-  Manipulate: 2
-  None: 0
-  Paint: 1
+  values:
+    Manipulate: 2
+    None: 0
+    Paint: 1
 ProceduralSpawnVolumeChunkFlags:
-  AllSubChunksSet: 1
-  None: 0
+  values:
+    AllSubChunksSet: 1
+    None: 0
 Profession:
-  Alchemy: 3
-  Archaeology: 14
-  Blacksmithing: 1
-  Cooking: 5
-  Enchanting: 9
-  Engineering: 8
-  FirstAid: 0
-  Fishing: 10
-  Herbalism: 4
-  Inscription: 13
-  Jewelcrafting: 12
-  Leatherworking: 2
-  Mining: 6
-  Skinning: 11
-  Tailoring: 7
+  values:
+    Alchemy: 3
+    Archaeology: 14
+    Blacksmithing: 1
+    Cooking: 5
+    Enchanting: 9
+    Engineering: 8
+    FirstAid: 0
+    Fishing: 10
+    Herbalism: 4
+    Inscription: 13
+    Jewelcrafting: 12
+    Leatherworking: 2
+    Mining: 6
+    Skinning: 11
+    Tailoring: 7
 ProfessionActionType:
-  Craft: 0
-  Gather: 1
+  values:
+    Craft: 0
+    Gather: 1
 ProfessionEffect:
-  AccumulateRanksByLabel: 25
-  ConcentrationRefund: 30
-  DecreaseDifficulty: 22
-  IncreaseDifficulty: 23
-  ModConcentration: 27
-  ModCraftCritSize: 20
-  ModCraftExtraQuantity: 18
-  ModCraftingSpeed: 14
-  ModCraftReductionQuantity: 21
-  ModDeftness: 12
-  ModFinesse: 11
-  ModGatherExtraQuantity: 19
-  ModIngenuity: 29
-  ModInspiration: 9
-  ModMulticraft: 15
-  ModPerception: 13
-  ModResourcefulness: 10
-  ModSkillGain: 24
-  ModUnused_1: 16
-  ModUnused_2: 17
-  Skill: 0
-  StatCraftingSpeed: 6
-  StatDeftness: 4
-  StatFinesse: 3
-  StatIngenuity: 26
-  StatInspiration: 1
-  StatMulticraft: 7
-  StatPerception: 5
-  StatResourcefulness: 2
-  Tokenizer: 28
-  UnlockReagentSlot: 8
+  values:
+    AccumulateRanksByLabel: 25
+    ConcentrationRefund: 30
+    DecreaseDifficulty: 22
+    IncreaseDifficulty: 23
+    ModConcentration: 27
+    ModCraftCritSize: 20
+    ModCraftExtraQuantity: 18
+    ModCraftingSpeed: 14
+    ModCraftReductionQuantity: 21
+    ModDeftness: 12
+    ModFinesse: 11
+    ModGatherExtraQuantity: 19
+    ModIngenuity: 29
+    ModInspiration: 9
+    ModMulticraft: 15
+    ModPerception: 13
+    ModResourcefulness: 10
+    ModSkillGain: 24
+    ModUnused_1: 16
+    ModUnused_2: 17
+    Skill: 0
+    StatCraftingSpeed: 6
+    StatDeftness: 4
+    StatFinesse: 3
+    StatIngenuity: 26
+    StatInspiration: 1
+    StatMulticraft: 7
+    StatPerception: 5
+    StatResourcefulness: 2
+    Tokenizer: 28
+    UnlockReagentSlot: 8
 ProfessionRating:
-  CraftingSpeed: 5
-  Deftness: 3
-  Finesse: 2
-  Ingenuity: 7
-  Inspiration: 0
-  Multicraft: 6
-  Perception: 4
-  Resourcefulness: 1
-  Unused_2: 8
+  values:
+    CraftingSpeed: 5
+    Deftness: 3
+    Finesse: 2
+    Ingenuity: 7
+    Inspiration: 0
+    Multicraft: 6
+    Perception: 4
+    Resourcefulness: 1
+    Unused_2: 8
 ProfessionRatingType:
-  Craft: 0
-  Gather: 1
+  values:
+    Craft: 0
+    Gather: 1
 PurchaseEligibility:
-  ExpansionTooHigh: 4
-  ExpansionTooLow: 3
-  MissingRequiredDeliverable: 5
-  Ok: 0
-  Owned: 2
-  PartiallyOwned: 1
+  values:
+    ExpansionTooHigh: 4
+    ExpansionTooLow: 3
+    MissingRequiredDeliverable: 5
+    Ok: 0
+    Owned: 2
+    PartiallyOwned: 1
 PurchaseHouseDisabledReason:
-  CharterLockout: 7
-  GuildLockout: 6
-  MaxHouses: 8
-  NoExpansion: 4
-  NoGameTimeRemaining: 9
-  None: 0
-  NotInvited: 3
-  Reserved: 5
-  WrongFaction: 1
-  WrongGuild: 2
+  values:
+    CharterLockout: 7
+    GuildLockout: 6
+    MaxHouses: 8
+    NoExpansion: 4
+    NoGameTimeRemaining: 9
+    None: 0
+    NotInvited: 3
+    Reserved: 5
+    WrongFaction: 1
+    WrongGuild: 2
 PurchaseResult:
-  ErrorAuthorizingPayment: 37
-  ErrorBattlepayDisabled: 14
-  ErrorBattlepayTemporarilyUnavailable: 13
-  ErrorBattlepayTimeoutMopAndRisk: 11
-  ErrorBattlepayTimeoutValidatePurchase: 56
-  ErrorBattlepayTimeoutValidationHash: 62
-  ErrorBlockedByParentalControls: 33
-  ErrorBuyingProductNotAllowedInGlueScreen: 27
-  ErrorBuyingProductNotAllowedInWorld: 32
-  ErrorCharacterUpgradeOperationInProgress: 51
-  ErrorClientCheckoutCanceledOrFailed: 63
-  ErrorClientCheckoutTimeout: 60
-  ErrorClientDeclined: 4
-  ErrorClientDeclinedChallenge: 41
-  ErrorClientGone: 9
-  ErrorClientRestricted: 66
-  ErrorClientTimeout: 3
-  ErrorClientTimeoutChallenge: 40
-  ErrorCommerceServerDisabled: 48
-  ErrorCouldNotGetValidationHash: 64
-  ErrorCurrencyInvalidInRegion: 12
-  ErrorDistributionObjectAlreadyAssigned: 20
-  ErrorDistributionObjectExpansionBlocked: 45
-  ErrorDistributionObjectInvalidChoice: 35
-  ErrorDistributionObjectInvalidTarget: 42
-  ErrorDistributionObjectNotFound: 19
-  ErrorDistributionObjectTrialBlocked: 44
-  ErrorDistributionObjectWrongGameAccount: 65
-  ErrorFailedOldPurchaseFlow: 59
-  ErrorFailedToCreatePurchaseRecord: 5
-  ErrorFailedToGetPurchaseID: 6
-  ErrorFailedToSaveClientCheckoutStatus: 58
-  ErrorFailedToSaveMopAndRiskResponse: 8
-  ErrorFailedToSaveMopAndRiskStatus: 7
-  ErrorFailedToSavePlaceOrderStatus: 10
-  ErrorFailedToSaveRedeemTokenStatus: 67
-  ErrorFailedToSaveValidatePurchaseResponse: 55
-  ErrorFailedToSaveValidatePurchaseStatus: 54
-  ErrorFailedToSaveValidationHashStatus: 61
-  ErrorFailedToWriteVasLicenseID: 50
-  ErrorFailedToWriteVasPurchaseID: 49
-  ErrorFixedLicenseProductAlreadyExists: 43
-  ErrorInManualReview: 71
-  ErrorInvalidCreditCardExpiryDate: 36
-  ErrorInvalidDeviceID: 53
-  ErrorInvalidPlatform: 52
-  ErrorInvalidProduct: 16
-  ErrorInvalidPurchaseID: 68
-  ErrorInvalidRegionGroupMask: 17
-  ErrorMopAndRiskAmqpRpcFailed: 22
-  ErrorMopAndRiskNotEnoughBalance: 28
-  ErrorMopAndRiskNoValidPaymentMethods: 25
-  ErrorMopAndRiskRpcErrorFromBattlepay: 23
-  ErrorMopAndRiskUnexpectedResponseFromBattlepay: 24
-  ErrorNoStorePurchaseFlagIsSet: 34
-  ErrorOrderCanceledPriceChange: 26
-  ErrorOrderFailed: 2
-  ErrorOverSpendingLimit: 39
-  ErrorOwnsConsumableToken: 46
-  ErrorPaymentProviderDeniedPayment: 38
-  ErrorPlaceOrderNotEnoughBalance: 29
-  ErrorProductInvalidInRegion: 18
-  ErrorProductNotPurchasable: 57
-  ErrorProgrammerManualFail: 30
-  ErrorRiskDenied: 1
-  ErrorRiskResponseMissingScore: 21
-  ErrorServerRestarted: 15
-  ErrorThrottledByUserServer: 31
-  ErrorTokenRedemptionOrderFailed: 69
-  ErrorTooManyTokens: 47
-  ErrorVasTransactionCreateFailed: 70
-  Ok: 0
+  values:
+    ErrorAuthorizingPayment: 37
+    ErrorBattlepayDisabled: 14
+    ErrorBattlepayTemporarilyUnavailable: 13
+    ErrorBattlepayTimeoutMopAndRisk: 11
+    ErrorBattlepayTimeoutValidatePurchase: 56
+    ErrorBattlepayTimeoutValidationHash: 62
+    ErrorBlockedByParentalControls: 33
+    ErrorBuyingProductNotAllowedInGlueScreen: 27
+    ErrorBuyingProductNotAllowedInWorld: 32
+    ErrorCharacterUpgradeOperationInProgress: 51
+    ErrorClientCheckoutCanceledOrFailed: 63
+    ErrorClientCheckoutTimeout: 60
+    ErrorClientDeclined: 4
+    ErrorClientDeclinedChallenge: 41
+    ErrorClientGone: 9
+    ErrorClientRestricted: 66
+    ErrorClientTimeout: 3
+    ErrorClientTimeoutChallenge: 40
+    ErrorCommerceServerDisabled: 48
+    ErrorCouldNotGetValidationHash: 64
+    ErrorCurrencyInvalidInRegion: 12
+    ErrorDistributionObjectAlreadyAssigned: 20
+    ErrorDistributionObjectExpansionBlocked: 45
+    ErrorDistributionObjectInvalidChoice: 35
+    ErrorDistributionObjectInvalidTarget: 42
+    ErrorDistributionObjectNotFound: 19
+    ErrorDistributionObjectTrialBlocked: 44
+    ErrorDistributionObjectWrongGameAccount: 65
+    ErrorFailedOldPurchaseFlow: 59
+    ErrorFailedToCreatePurchaseRecord: 5
+    ErrorFailedToGetPurchaseID: 6
+    ErrorFailedToSaveClientCheckoutStatus: 58
+    ErrorFailedToSaveMopAndRiskResponse: 8
+    ErrorFailedToSaveMopAndRiskStatus: 7
+    ErrorFailedToSavePlaceOrderStatus: 10
+    ErrorFailedToSaveRedeemTokenStatus: 67
+    ErrorFailedToSaveValidatePurchaseResponse: 55
+    ErrorFailedToSaveValidatePurchaseStatus: 54
+    ErrorFailedToSaveValidationHashStatus: 61
+    ErrorFailedToWriteVasLicenseID: 50
+    ErrorFailedToWriteVasPurchaseID: 49
+    ErrorFixedLicenseProductAlreadyExists: 43
+    ErrorInManualReview: 71
+    ErrorInvalidCreditCardExpiryDate: 36
+    ErrorInvalidDeviceID: 53
+    ErrorInvalidPlatform: 52
+    ErrorInvalidProduct: 16
+    ErrorInvalidPurchaseID: 68
+    ErrorInvalidRegionGroupMask: 17
+    ErrorMopAndRiskAmqpRpcFailed: 22
+    ErrorMopAndRiskNotEnoughBalance: 28
+    ErrorMopAndRiskNoValidPaymentMethods: 25
+    ErrorMopAndRiskRpcErrorFromBattlepay: 23
+    ErrorMopAndRiskUnexpectedResponseFromBattlepay: 24
+    ErrorNoStorePurchaseFlagIsSet: 34
+    ErrorOrderCanceledPriceChange: 26
+    ErrorOrderFailed: 2
+    ErrorOverSpendingLimit: 39
+    ErrorOwnsConsumableToken: 46
+    ErrorPaymentProviderDeniedPayment: 38
+    ErrorPlaceOrderNotEnoughBalance: 29
+    ErrorProductInvalidInRegion: 18
+    ErrorProductNotPurchasable: 57
+    ErrorProgrammerManualFail: 30
+    ErrorRiskDenied: 1
+    ErrorRiskResponseMissingScore: 21
+    ErrorServerRestarted: 15
+    ErrorThrottledByUserServer: 31
+    ErrorTokenRedemptionOrderFailed: 69
+    ErrorTooManyTokens: 47
+    ErrorVasTransactionCreateFailed: 70
+    Ok: 0
 PvPFaction:
-  Alliance: 1
-  Horde: 0
+  values:
+    Alliance: 1
+    Horde: 0
 PvPMatchmakingType:
-  Arena: 1
-  Battleground: 0
+  values:
+    Arena: 1
+    Battleground: 0
 PvPMatchState:
-  Complete: 5
-  Engaged: 3
-  Inactive: 0
-  PostRound: 4
-  StartUp: 2
-  Waiting: 1
+  values:
+    Complete: 5
+    Engaged: 3
+    Inactive: 0
+    PostRound: 4
+    StartUp: 2
+    Waiting: 1
 PvPRanks:
-  Rank_1: 5
-  Rank_10: 14
-  Rank_11: 15
-  Rank_12: 16
-  Rank_13: 17
-  Rank_14: 18
-  Rank_2: 6
-  Rank_3: 7
-  Rank_4: 8
-  Rank_5: 9
-  Rank_6: 10
-  Rank_7: 11
-  Rank_8: 12
-  Rank_9: 13
-  RankDishonored: 4
-  RankExiled: 3
-  RankNone: 0
-  RankOutlaw: 2
-  RankPariah: 1
+  values:
+    Rank_1: 5
+    Rank_10: 14
+    Rank_11: 15
+    Rank_12: 16
+    Rank_13: 17
+    Rank_14: 18
+    Rank_2: 6
+    Rank_3: 7
+    Rank_4: 8
+    Rank_5: 9
+    Rank_6: 10
+    Rank_7: 11
+    Rank_8: 12
+    Rank_9: 13
+    RankDishonored: 4
+    RankExiled: 3
+    RankNone: 0
+    RankOutlaw: 2
+    RankPariah: 1
 PvPUnitClassification:
-  AssassinAlliance: 6
-  AssassinHorde: 5
-  CartRunnerAlliance: 4
-  CartRunnerHorde: 3
-  FlagCarrierAlliance: 1
-  FlagCarrierHorde: 0
-  FlagCarrierNeutral: 2
-  OrbCarrierBlue: 7
-  OrbCarrierGreen: 8
-  OrbCarrierOrange: 9
-  OrbCarrierPurple: 10
+  values:
+    AssassinAlliance: 6
+    AssassinHorde: 5
+    CartRunnerAlliance: 4
+    CartRunnerHorde: 3
+    FlagCarrierAlliance: 1
+    FlagCarrierHorde: 0
+    FlagCarrierNeutral: 2
+    OrbCarrierBlue: 7
+    OrbCarrierGreen: 8
+    OrbCarrierOrange: 9
+    OrbCarrierPurple: 10
 QuestClassification:
-  BonusObjective: 8
-  Calling: 3
-  Campaign: 2
-  Important: 0
-  Legendary: 1
-  Meta: 4
-  Normal: 7
-  Questline: 6
-  Recurring: 5
-  Threat: 9
-  WorldQuest: 10
+  values:
+    BonusObjective: 8
+    Calling: 3
+    Campaign: 2
+    Important: 0
+    Legendary: 1
+    Meta: 4
+    Normal: 7
+    Questline: 6
+    Recurring: 5
+    Threat: 9
+    WorldQuest: 10
 QuestCompleteSpellType:
-  Ability: 3
-  Aura: 4
-  Companion: 7
-  Follower: 1
-  LegacyBehavior: 0
-  PossibleReward: 11
-  QuestlineReward: 9
-  QuestlineUnlock: 8
-  QuestlineUnlockPart: 10
-  Spell: 5
-  Tradeskill: 2
-  Unlock: 6
+  values:
+    Ability: 3
+    Aura: 4
+    Companion: 7
+    Follower: 1
+    LegacyBehavior: 0
+    PossibleReward: 11
+    QuestlineReward: 9
+    QuestlineUnlock: 8
+    QuestlineUnlockPart: 10
+    Spell: 5
+    Tradeskill: 2
+    Unlock: 6
 QuestFrequency:
-  Daily: 1
-  Default: 0
-  ResetByScheduler: 3
-  Weekly: 2
+  values:
+    Daily: 1
+    Default: 0
+    ResetByScheduler: 3
+    Weekly: 2
 QuestLineFloorLocation:
-  Above: 0
-  Below: 1
-  Same: 2
+  values:
+    Above: 0
+    Below: 1
+    Same: 2
 QuestRepeatability:
-  Daily: 1
-  None: 0
-  Turnin: 3
-  Weekly: 2
-  World: 4
+  values:
+    Daily: 1
+    None: 0
+    Turnin: 3
+    Weekly: 2
+    World: 4
 QuestRewardContextFlags:
-  FirstCompletionBonus: 1
-  None: 0
-  RepeatCompletionBonus: 2
+  values:
+    FirstCompletionBonus: 1
+    None: 0
+    RepeatCompletionBonus: 2
 QuestSessionCommand:
-  None: 0
-  SessionActiveNoCommand: 3
-  Start: 1
-  Stop: 2
+  values:
+    None: 0
+    SessionActiveNoCommand: 3
+    Start: 1
+    Stop: 2
 QuestSessionResult:
-  AlreadyActive: 3
-  AlreadyJoined: 20
-  AlreadyMember: 17
-  AlreadyOwner: 19
-  Busy: 22
-  Disabled: 8
-  Empty: 25
-  InCombat: 32
-  InPetBattle: 29
-  InRaid: 5
-  InvalidOwner: 2
-  InvalidPublicParty: 30
-  Joined: 11
-  JoinRejected: 23
-  Left: 12
-  Logout: 24
-  MemberInCombat: 33
-  MemberTimeout: 16
-  NotActive: 4
-  NotInParty: 1
-  NotMember: 21
-  NotOwner: 18
-  Ok: 0
-  OwnerLeft: 13
-  OwnerRefused: 6
-  PartyDestroyed: 15
-  QuestNotCompleted: 26
-  ReadyCheckFailed: 14
-  Restricted: 28
-  RestrictedCrossFaction: 34
-  Resync: 27
-  Started: 9
-  Stopped: 10
-  Timeout: 7
-  Unknown: 31
+  values:
+    AlreadyActive: 3
+    AlreadyJoined: 20
+    AlreadyMember: 17
+    AlreadyOwner: 19
+    Busy: 22
+    Disabled: 8
+    Empty: 25
+    InCombat: 32
+    InPetBattle: 29
+    InRaid: 5
+    InvalidOwner: 2
+    InvalidPublicParty: 30
+    Joined: 11
+    JoinRejected: 23
+    Left: 12
+    Logout: 24
+    MemberInCombat: 33
+    MemberTimeout: 16
+    NotActive: 4
+    NotInParty: 1
+    NotMember: 21
+    NotOwner: 18
+    Ok: 0
+    OwnerLeft: 13
+    OwnerRefused: 6
+    PartyDestroyed: 15
+    QuestNotCompleted: 26
+    ReadyCheckFailed: 14
+    Restricted: 28
+    RestrictedCrossFaction: 34
+    Resync: 27
+    Started: 9
+    Stopped: 10
+    Timeout: 7
+    Unknown: 31
 QuestTag:
-  Account: 102
-  Delve: 288
-  Dungeon: 81
-  Group: 1
-  Heroic: 85
-  Legendary: 83
-  PvP: 41
-  Raid: 62
-  Raid10: 88
-  Raid25: 89
-  Scenario: 98
+  values:
+    Account: 102
+    Delve: 288
+    Dungeon: 81
+    Group: 1
+    Heroic: 85
+    Legendary: 83
+    PvP: 41
+    Raid: 62
+    Raid10: 88
+    Raid25: 89
+    Scenario: 98
 QuestTagType:
-  Bounty: 5
-  Capstone: 17
-  Contribution: 9
-  CovenantCalling: 15
-  DragonRiderRacing: 16
-  Dungeon: 6
-  FactionAssault: 12
-  Invasion: 7
-  InvasionWrapper: 11
-  Islands: 13
-  Normal: 2
-  PetBattle: 4
-  Prey: 19
-  Profession: 1
-  PvP: 3
-  Raid: 8
-  RatedReward: 10
-  Tag: 0
-  Threat: 14
-  WorldBoss: 18
+  values:
+    Bounty: 5
+    Capstone: 17
+    Contribution: 9
+    CovenantCalling: 15
+    DragonRiderRacing: 16
+    Dungeon: 6
+    FactionAssault: 12
+    Invasion: 7
+    InvasionWrapper: 11
+    Islands: 13
+    Normal: 2
+    PetBattle: 4
+    Prey: 19
+    Profession: 1
+    PvP: 3
+    Raid: 8
+    RatedReward: 10
+    Tag: 0
+    Threat: 14
+    WorldBoss: 18
 QuestTreasurePickerType:
-  Hidden: 1
-  Select: 2
-  Visible: 0
+  values:
+    Hidden: 1
+    Select: 2
+    Visible: 0
 RafLinkType:
-  Both: 3
-  Friend: 2
-  None: 0
-  Recruit: 1
+  values:
+    Both: 3
+    Friend: 2
+    None: 0
+    Recruit: 1
 RafRecruitActivityState:
-  Complete: 1
-  Incomplete: 0
-  RewardClaimed: 2
+  values:
+    Complete: 1
+    Incomplete: 0
+    RewardClaimed: 2
 RafRecruitSubStatus:
-  Active: 1
-  Inactive: 2
-  Trial: 0
+  values:
+    Active: 1
+    Inactive: 2
+    Trial: 0
 RafRewardType:
-  Appearance: 2
-  AppearanceSet: 5
-  GameTime: 4
-  Illusion: 6
-  Invalid: 7
-  Mount: 1
-  Pet: 0
-  Title: 3
+  values:
+    Appearance: 2
+    AppearanceSet: 5
+    GameTime: 4
+    Illusion: 6
+    Invalid: 7
+    Mount: 1
+    Pet: 0
+    Title: 3
 RaidAuraOrganizationType:
-  BuffsRightDebuffsLeft: 2
-  BuffsTopDebuffsBottom: 1
-  Legacy: 0
+  values:
+    BuffsRightDebuffsLeft: 2
+    BuffsTopDebuffsBottom: 1
+    Legacy: 0
 RaidDispelDisplayType:
-  Disabled: 0
-  DispellableByMe: 1
-  DisplayAll: 2
+  values:
+    Disabled: 0
+    DispellableByMe: 1
+    DisplayAll: 2
 RaidGroupDisplayType:
-  CombineGroupsHorizontal: 3
-  CombineGroupsVertical: 2
-  SeparateGroupsHorizontal: 1
-  SeparateGroupsVertical: 0
+  values:
+    CombineGroupsHorizontal: 3
+    CombineGroupsVertical: 2
+    SeparateGroupsHorizontal: 1
+    SeparateGroupsVertical: 0
 RcoCloseReason:
-  Cancel: 2
-  CrafterFulfill: 5
-  Expire: 1
-  Fulfill: 0
-  GmCancel: 4
-  Invalid: 6
-  Reject: 3
+  values:
+    Cancel: 2
+    CrafterFulfill: 5
+    Expire: 1
+    Fulfill: 0
+    GmCancel: 4
+    Invalid: 6
+    Reject: 3
 RecentAllyPinResult:
-  ServerError: 1
-  Success: 0
+  values:
+    ServerError: 1
+    Success: 0
 RecruitAFriendRewardsVersion:
-  InvalidVersion: 0
-  UnusedVersionOne: 1
-  VersionThree: 3
-  VersionTwo: 2
+  values:
+    InvalidVersion: 0
+    UnusedVersionOne: 1
+    VersionThree: 3
+    VersionTwo: 2
 ReforgeFailedReason:
-  None: 0
-  ReforgeAlreadyHasDstStat: 3
-  ReforgeInsufficientSrcStat: 2
-  ReforgeItemTooLowLevel: 4
-  ReforgeSrcStatNotFound: 1
+  values:
+    None: 0
+    ReforgeAlreadyHasDstStat: 3
+    ReforgeInsufficientSrcStat: 2
+    ReforgeItemTooLowLevel: 4
+    ReforgeSrcStatNotFound: 1
 RegisterAddonMessagePrefixResult:
-  DuplicatePrefix: 1
-  InvalidPrefix: 2
-  MaxPrefixes: 3
-  Success: 0
+  values:
+    DuplicatePrefix: 1
+    InvalidPrefix: 2
+    MaxPrefixes: 3
+    Success: 0
 RelativeContentDifficulty:
-  Difficult: 3
-  Easy: 1
-  Fair: 2
-  Impossible: 4
-  Trivial: 0
+  values:
+    Difficult: 3
+    Easy: 1
+    Fair: 2
+    Impossible: 4
+    Trivial: 0
 ReleaseType:
-  Classic: 2
-  Original: 1
+  values:
+    Classic: 2
+    Original: 1
 RenownRewardDisplayType:
-  Currency: 9
-  GarrFollower: 8
-  Item: 1
-  Mount: 3
-  None: 0
-  Spell: 2
-  Title: 7
-  Transmog: 4
-  TransmogIllusion: 6
-  TransmogSet: 5
+  values:
+    Currency: 9
+    GarrFollower: 8
+    Item: 1
+    Mount: 3
+    None: 0
+    Spell: 2
+    Title: 7
+    Transmog: 4
+    TransmogIllusion: 6
+    TransmogSet: 5
 RenownRewardsFlags:
-  AccountUnlock: 8
-  Capstone: 2
-  Hidden: 4
-  Milestone: 1
+  values:
+    AccountUnlock: 8
+    Capstone: 2
+    Hidden: 4
+    Milestone: 1
 ReportEvidenceType:
-  HouseLayoutJson: 2
-  HouseScreenshot: 1
-  Invalid: 0
+  values:
+    HouseLayoutJson: 2
+    HouseScreenshot: 1
+    Invalid: 0
 ReportMajorCategory:
-  Cheating: 2
-  GameplaySabotage: 1
-  InappropriateCommunication: 0
-  InappropriateDecor: 4
-  InappropriateName: 3
+  values:
+    Cheating: 2
+    GameplaySabotage: 1
+    InappropriateCommunication: 0
+    InappropriateDecor: 4
+    InappropriateName: 3
 ReportMinorCategory:
-  Advertisement: 256
-  Afk: 8
-  BlockingProgress: 32
-  Boosting: 2
-  Botting: 128
-  BTag: 512
-  CharacterName: 2048
-  ChildSexualExploitationAndAbuse: 262144
-  Description: 8192
-  Disruption: 65536
-  GroupName: 1024
-  GuildName: 4096
-  Hacking: 64
-  HarmfulToMinors: 32768
-  IntentionallyFeeding: 16
-  Name: 16384
-  NeighborhoodName: 524288
-  Spam: 4
-  TerroristAndViolentExtremistContent: 131072
-  TextChat: 1
+  values:
+    Advertisement: 256
+    Afk: 8
+    BlockingProgress: 32
+    Boosting: 2
+    Botting: 128
+    BTag: 512
+    CharacterName: 2048
+    ChildSexualExploitationAndAbuse: 262144
+    Description: 8192
+    Disruption: 65536
+    GroupName: 1024
+    GuildName: 4096
+    Hacking: 64
+    HarmfulToMinors: 32768
+    IntentionallyFeeding: 16
+    Name: 16384
+    NeighborhoodName: 524288
+    Spam: 4
+    TerroristAndViolentExtremistContent: 131072
+    TextChat: 1
 ReportSubComplaintTypes:
-  Advertising: 1
-  Inappropriate: 0
+  values:
+    Advertising: 1
+    Inappropriate: 0
 ReportThrottleType:
-  Expensive: 2
-  General: 1
-  Invalid: 0
+  values:
+    Expensive: 2
+    General: 1
+    Invalid: 0
 ReportType:
-  BattlePet: 10
-  Calendar: 11
-  Chat: 0
-  ClubFinderApplicant: 3
-  ClubFinderPosting: 2
-  ClubMember: 6
-  CraftingOrder: 16
-  Friend: 8
-  GroupFinderApplicant: 5
-  GroupFinderPosting: 4
-  GroupMember: 7
-  HousingDecor: 18
-  InWorld: 1
-  Mail: 12
-  Neighborhood: 19
-  NeighborhoodRoster: 20
-  Pet: 9
-  PvP: 13
-  PvPGroupMember: 15
-  PvPScoreboard: 14
-  RecentAlly: 17
+  values:
+    BattlePet: 10
+    Calendar: 11
+    Chat: 0
+    ClubFinderApplicant: 3
+    ClubFinderPosting: 2
+    ClubMember: 6
+    CraftingOrder: 16
+    Friend: 8
+    GroupFinderApplicant: 5
+    GroupFinderPosting: 4
+    GroupMember: 7
+    HousingDecor: 18
+    InWorld: 1
+    Mail: 12
+    Neighborhood: 19
+    NeighborhoodRoster: 20
+    Pet: 9
+    PvP: 13
+    PvPGroupMember: 15
+    PvPScoreboard: 14
+    RecentAlly: 17
 ReservationFlags:
-  Canceled: 2
-  None: 0
-  Plotless: 4
-  Relinquish: 1
+  values:
+    Canceled: 2
+    None: 0
+    Plotless: 4
+    Relinquish: 1
 ResidentType:
-  Manager: 1
-  Owner: 2
-  Resident: 0
+  values:
+    Manager: 1
+    Owner: 2
+    Resident: 0
 RestrictPingsTo:
-  Assist: 2
-  Lead: 1
-  None: 0
-  TankHealer: 3
+  values:
+    Assist: 2
+    Lead: 1
+    None: 0
+    TankHealer: 3
 RetroactiveDecorRewardFlags:
-  AllCriteriaRequired: 1
-  None: 0
+  values:
+    AllCriteriaRequired: 1
+    None: 0
 RolodexContextLevelType:
-  DelveTier: 3
-  Difficulty: 1
-  KeystoneLevel: 2
-  None: 0
+  values:
+    DelveTier: 3
+    Difficulty: 1
+    KeystoneLevel: 2
+    None: 0
 RolodexType:
-  CompleteArena: 16
-  CompleteBg: 17
-  CompleteDelve: 15
-  CompleteDungeon: 12
-  CreatureKill: 11
-  Duel: 18
-  GuildOrderFilledByOther: 9
-  GuildOrderFilledByYou: 10
-  KillLfrBoss: 14
-  KillRaidBoss: 13
-  None: 0
-  PartyMember: 1
-  PersonalOrderFilledByOther: 7
-  PersonalOrderFilledByYou: 8
-  PetBattle: 19
-  PublicOrderFilledByOther: 5
-  PublicOrderFilledByYou: 6
-  PvPKill: 20
-  RaidMember: 2
-  Trade: 3
-  Whisper: 4
+  values:
+    CompleteArena: 16
+    CompleteBg: 17
+    CompleteDelve: 15
+    CompleteDungeon: 12
+    CreatureKill: 11
+    Duel: 18
+    GuildOrderFilledByOther: 9
+    GuildOrderFilledByYou: 10
+    KillLfrBoss: 14
+    KillRaidBoss: 13
+    None: 0
+    PartyMember: 1
+    PersonalOrderFilledByOther: 7
+    PersonalOrderFilledByYou: 8
+    PetBattle: 19
+    PublicOrderFilledByOther: 5
+    PublicOrderFilledByYou: 6
+    PvPKill: 20
+    RaidMember: 2
+    Trade: 3
+    Whisper: 4
 RolodexTypeFlags:
-  HiddenFromHistory: 1
-  None: 0
+  values:
+    HiddenFromHistory: 1
+    None: 0
 RoomConnectionType:
-  All: 1
-  None: 0
+  values:
+    All: 1
+    None: 0
 ScalingArmorType:
-  Cloth: 0
-  Leather: 1
-  Mail: 2
-  Plate: 3
+  values:
+    Cloth: 0
+    Leather: 1
+    Mail: 2
+    Plate: 3
 ScreenLocationType:
-  Bottom: 4
-  Center: 0
-  Left: 1
-  LeftOutside: 7
-  LeftRight: 9
-  LeftRightOutside: 11
-  Right: 2
-  RightOutside: 8
-  Top: 3
-  TopBottom: 10
-  TopLeft: 5
-  TopRight: 6
+  values:
+    Bottom: 4
+    Center: 0
+    Left: 1
+    LeftOutside: 7
+    LeftRight: 9
+    LeftRightOutside: 11
+    Right: 2
+    RightOutside: 8
+    Top: 3
+    TopBottom: 10
+    TopLeft: 5
+    TopRight: 6
 ScreenshotSource:
-  Automatic: 0
-  Cheat: 2
-  PlayerReport: 1
+  values:
+    Automatic: 0
+    Cheat: 2
+    PlayerReport: 1
 ScriptedAnimationBehavior:
-  None: 0
-  SourceCollideWithTarget: 4
-  SourceRecoil: 3
-  TargetKnockBack: 2
-  TargetShake: 1
-  UIParentShake: 5
+  values:
+    None: 0
+    SourceCollideWithTarget: 4
+    SourceRecoil: 3
+    TargetKnockBack: 2
+    TargetShake: 1
+    UIParentShake: 5
 ScriptedAnimationFlags:
-  UseTargetAsSource: 1
+  values:
+    UseTargetAsSource: 1
 ScriptedAnimationTrajectory:
-  AtSource: 0
-  AtTarget: 1
-  CurveLeft: 3
-  CurveRandom: 5
-  CurveRight: 4
-  HalfwayBetween: 6
-  Straight: 2
+  values:
+    AtSource: 0
+    AtTarget: 1
+    CurveLeft: 3
+    CurveRandom: 5
+    CurveRight: 4
+    HalfwayBetween: 6
+    Straight: 2
 ScrubStringFlags:
-  AllowBarCodes: 2
-  None: 0
-  StripControlCodes: 4
-  TruncateNewLines: 1
+  values:
+    AllowBarCodes: 2
+    None: 0
+    StripControlCodes: 4
+    TruncateNewLines: 1
 SeasonID:
-  Fresh: 11
-  FreshHardcore: 12
-  Hardcore: 3
-  NoSeason: 0
-  SeasonOfDiscovery: 2
-  SeasonOfMastery: 1
+  values:
+    Fresh: 11
+    FreshHardcore: 12
+    Hardcore: 3
+    NoSeason: 0
+    SeasonOfDiscovery: 2
+    SeasonOfMastery: 1
 SecondsFormatterAbbreviation:
-  None: 0
-  OneLetter: 2
-  Truncate: 1
+  values:
+    None: 0
+    OneLetter: 2
+    Truncate: 1
 SecondsFormatterInterval:
-  Days: 3
-  Hours: 2
-  Minutes: 1
-  Seconds: 0
+  values:
+    Days: 3
+    Hours: 2
+    Minutes: 1
+    Seconds: 0
 SecondsFormatterIntervalWhitespace:
-  Preserve: 0
-  Strip: 1
-  StripIgnoreLocale: 2
+  values:
+    Preserve: 0
+    Strip: 1
+    StripIgnoreLocale: 2
 SecrecyLevel:
-  AlwaysSecret: 1
-  ContextuallySecret: 2
-  NeverSecret: 0
+  values:
+    AlwaysSecret: 1
+    ContextuallySecret: 2
+    NeverSecret: 0
 SecretAspect:
-  Alpha: 128
-  Attributes: 1
-  BarValue: 16384
-  ButtonState: 2097152
-  Cooldown: 32768
-  CooldownStyle: 524288
-  Cursor: 1024
-  Desaturation: 4096
-  FrameLevel: 256
-  Hierarchy: 1
-  ID: 2
-  MinimumWidth: 131072
-  ObjectDebug: 1
-  ObjectName: 1
-  ObjectSecrets: 1
-  ObjectSecurity: 1
-  ObjectType: 1
-  Padding: 262144
-  Rotation: 65536
-  Scale: 64
-  ScrollOffset: 4194304
-  ScrollRange: 512
-  SecureText: 16
-  Shown: 32
-  TexCoords: 8192
-  Text: 8
-  TooltipTexture: 1048576
-  Toplevel: 4
-  VertexColor: 2048
+  values:
+    Alpha: 128
+    Attributes: 1
+    BarValue: 16384
+    ButtonState: 2097152
+    Cooldown: 32768
+    CooldownStyle: 524288
+    Cursor: 1024
+    Desaturation: 4096
+    FrameLevel: 256
+    Hierarchy: 1
+    ID: 2
+    MinimumWidth: 131072
+    ObjectDebug: 1
+    ObjectName: 1
+    ObjectSecrets: 1
+    ObjectSecurity: 1
+    ObjectType: 1
+    Padding: 262144
+    Rotation: 65536
+    Scale: 64
+    ScrollOffset: 4194304
+    ScrollRange: 512
+    SecureText: 16
+    Shown: 32
+    TexCoords: 8192
+    Text: 8
+    TooltipTexture: 1048576
+    Toplevel: 4
+    VertexColor: 2048
 SelfResurrectOptionType:
-  Item: 1
-  Spell: 0
+  values:
+    Item: 1
+    Spell: 0
 SendAddonMessageResult:
-  AddOnMessageLockdown: 11
-  AddonMessageThrottle: 3
-  ChannelThrottle: 8
-  GeneralError: 9
-  InvalidChannel: 7
-  InvalidChatType: 4
-  InvalidMessage: 2
-  InvalidPrefix: 1
-  NotInGroup: 5
-  NotInGuild: 10
-  Success: 0
-  TargetOffline: 12
-  TargetRequired: 6
+  values:
+    AddOnMessageLockdown: 11
+    AddonMessageThrottle: 3
+    ChannelThrottle: 8
+    GeneralError: 9
+    InvalidChannel: 7
+    InvalidChatType: 4
+    InvalidMessage: 2
+    InvalidPrefix: 1
+    NotInGroup: 5
+    NotInGuild: 10
+    Success: 0
+    TargetOffline: 12
+    TargetRequired: 6
 SendReportResult:
-  GeneralError: 1
-  RequiresChatLine: 3
-  RequiresChatLineOrVoice: 4
-  RequiresScreenshot: 5
-  Success: 0
-  TooManyReports: 2
+  values:
+    GeneralError: 1
+    RequiresChatLine: 3
+    RequiresChatLineOrVoice: 4
+    RequiresScreenshot: 5
+    Success: 0
+    TooManyReports: 2
 SharedStringFlag:
-  InternalOnly: 1
+  values:
+    InternalOnly: 1
 ShutdownSessionReason:
-  AccountLoginCommand: 4
-  Error: 6
-  ForceLogoutCommand: 2
-  LuaScript: 5
-  RealmSelectCommand: 3
-  RestartSessionCommand: 1
-  SessionEnded: 0
+  values:
+    AccountLoginCommand: 4
+    Error: 6
+    ForceLogoutCommand: 2
+    LuaScript: 5
+    RealmSelectCommand: 3
+    RestartSessionCommand: 1
+    SessionEnded: 0
 Siflag:
-  Affectedbyaltitude: 16
-  Affectedbysanity: 2048
-  AutocreatedByBroadcastText: 4
-  CasterOwnsTargetSound: 128
-  Disablepositionallpf: 1
-  Dontplayindoors: 256
-  Dontplayunderwater: 1024
-  Dontstopondeath: 4096
-  Ignoresuppressors: 64
-  Ignorevopriority: 16384
-  Looping: 512
-  Noduplicates: 32
-  None: 0
-  Onlyplayindoors: 32768
-  Onlyplayunderwater: 65536
-  Playonlyforowner: 8192
-  Playsequential: 8
-  UseModCastSpeed: 2
+  values:
+    Affectedbyaltitude: 16
+    Affectedbysanity: 2048
+    AutocreatedByBroadcastText: 4
+    CasterOwnsTargetSound: 128
+    Disablepositionallpf: 1
+    Dontplayindoors: 256
+    Dontplayunderwater: 1024
+    Dontstopondeath: 4096
+    Ignoresuppressors: 64
+    Ignorevopriority: 16384
+    Looping: 512
+    Noduplicates: 32
+    None: 0
+    Onlyplayindoors: 32768
+    Onlyplayunderwater: 65536
+    Playonlyforowner: 8192
+    Playsequential: 8
+    UseModCastSpeed: 2
 SimpleOrderStatus:
-  Creating: 1
-  Failed: 4
-  InProgress: 2
-  Invalid: 0
-  Success: 3
+  values:
+    Creating: 1
+    Failed: 4
+    InProgress: 2
+    Invalid: 0
+    Success: 3
 SleevesGeoRange:
-  Default: 1
-  Flared: 2
-  None: 0
-  PandaCollar: 4
-  Puffy: 3
+  values:
+    Default: 1
+    Flared: 2
+    None: 0
+    PandaCollar: 4
+    Puffy: 3
 SlotRegion:
-  AccountBank: 5
-  CharacterBank: 4
-  Invalid: 0
-  PlayerBags: 2
-  PlayerEquip: 1
-  PlayerInv: 3
+  values:
+    AccountBank: 5
+    CharacterBank: 4
+    Invalid: 0
+    PlayerBags: 2
+    PlayerEquip: 1
+    PlayerInv: 3
 SlotRegionMask:
-  AccountBank: 64
-  CharacterBank: 16
-  Invalid: 1
-  PlayerBags: 4
-  PlayerEquip: 2
-  PlayerInv: 8
+  values:
+    AccountBank: 64
+    CharacterBank: 16
+    Invalid: 1
+    PlayerBags: 4
+    PlayerEquip: 2
+    PlayerInv: 8
 SocialWhoOrigin:
-  Chat: 2
-  Item: 3
-  Social: 1
-  Unknown: 0
+  values:
+    Chat: 2
+    Item: 3
+    Social: 1
+    Unknown: 0
 SoftTargetEnableFlags:
-  Any: 3
-  Gamepad: 1
-  Kbm: 2
-  None: 0
+  values:
+    Any: 3
+    Gamepad: 1
+    Kbm: 2
+    None: 0
 SortPlayersBy:
-  Alphabetical: 2
-  Group: 1
-  Role: 0
+  values:
+    Alphabetical: 2
+    Group: 1
+    Role: 0
 SoundBusFlag:
-  Disablepositionallpf: 1
+  values:
+    Disablepositionallpf: 1
 SpecializationSystem:
-  ChrSpecialization: 1
-  TalentTab: 0
+  values:
+    ChrSpecialization: 1
+    TalentTab: 0
 SpellAuraVisibilityType:
-  EnemyTarget: 2
-  RaidInCombat: 0
-  RaidOutOfCombat: 1
+  values:
+    EnemyTarget: 2
+    RaidInCombat: 0
+    RaidOutOfCombat: 1
 SpellBookItemType:
-  Flyout: 4
-  FutureSpell: 2
-  None: 0
-  PetAction: 3
-  Spell: 1
+  values:
+    Flyout: 4
+    FutureSpell: 2
+    None: 0
+    PetAction: 3
+    Spell: 1
 SpellBookSpellBank:
-  Pet: 1
-  Player: 0
+  values:
+    Pet: 1
+    Player: 0
 SpellDiminishCategory:
-  AoEKnockback: 3
-  Disarm: 7
-  Disorient: 5
-  Incapacitate: 4
-  Root: 0
-  Silence: 6
-  Stun: 2
-  Taunt: 1
+  values:
+    AoEKnockback: 3
+    Disarm: 7
+    Disorient: 5
+    Incapacitate: 4
+    Root: 0
+    Silence: 6
+    Stun: 2
+    Taunt: 1
 SpellDiminishRuleset:
-  None: 0
-  PvE: 1
-  PvP: 2
+  values:
+    None: 0
+    PvE: 1
+    PvP: 2
 SpellDisplayBorderColor:
-  Black: 1
-  Blue: 8
-  Green: 7
-  None: 0
-  Orange: 5
-  Purple: 6
-  Red: 3
-  White: 2
-  Yellow: 4
+  values:
+    Black: 1
+    Blue: 8
+    Green: 7
+    None: 0
+    Orange: 5
+    Purple: 6
+    Red: 3
+    White: 2
+    Yellow: 4
 SpellDisplayIconDisplayType:
-  Buff: 0
-  Circular: 2
-  Debuff: 1
-  NoBorder: 3
+  values:
+    Buff: 0
+    Circular: 2
+    Debuff: 1
+    NoBorder: 3
 SpellDisplayTextShownStateType:
-  Hidden: 1
-  Shown: 0
+  values:
+    Hidden: 1
+    Shown: 0
 SpellDisplayTint:
-  None: 0
-  Red: 1
+  values:
+    None: 0
+    Red: 1
 SplashScreenType:
-  SeasonRollOver: 1
-  WhatsNew: 0
+  values:
+    SeasonRollOver: 1
+    WhatsNew: 0
 StableResult:
-  AlreadyStabled: 5
-  AlreadySummoned: 6
-  BuySlotSuccess: 14
-  CantControlExotic: 11
-  CheckForLuaHack: 13
-  FavoriteToggle: 15
-  InsufficientFunds: 1
-  InternalError: 12
-  InvalidSlot: 3
-  MaxSlots: 0
-  NoPet: 4
-  NotFound: 7
-  NotStableMaster: 2
-  PetRenamed: 16
-  ReviveSuccess: 10
-  StableSuccess: 8
-  UnstableSuccess: 9
+  values:
+    AlreadyStabled: 5
+    AlreadySummoned: 6
+    BuySlotSuccess: 14
+    CantControlExotic: 11
+    CheckForLuaHack: 13
+    FavoriteToggle: 15
+    InsufficientFunds: 1
+    InternalError: 12
+    InvalidSlot: 3
+    MaxSlots: 0
+    NoPet: 4
+    NotFound: 7
+    NotStableMaster: 2
+    PetRenamed: 16
+    ReviveSuccess: 10
+    StableSuccess: 8
+    UnstableSuccess: 9
 StartTimerType:
-  ChallengeModeCountdown: 1
-  PlayerCountdown: 2
-  PlunderstormCountdown: 3
-  PvPBeginTimer: 0
+  values:
+    ChallengeModeCountdown: 1
+    PlayerCountdown: 2
+    PlunderstormCountdown: 3
+    PvPBeginTimer: 0
 StatusBarColorTintValue:
-  Black: 1
-  Blue: 8
-  Green: 7
-  None: 0
-  Orange: 5
-  Purple: 6
-  Red: 3
-  White: 2
-  Yellow: 4
+  values:
+    Black: 1
+    Blue: 8
+    Green: 7
+    None: 0
+    Orange: 5
+    Purple: 6
+    Red: 3
+    White: 2
+    Yellow: 4
 StatusBarFillStyle:
-  Center: 2
-  Reverse: 3
-  Standard: 0
-  StandardNoRangeFill: 1
+  values:
+    Center: 2
+    Reverse: 3
+    Standard: 0
+    StandardNoRangeFill: 1
 StatusBarInterpolation:
-  ExponentialEaseOut: 1
-  Immediate: 0
+  values:
+    ExponentialEaseOut: 1
+    Immediate: 0
 StatusBarOverrideBarTextShownType:
-  Always: 1
-  Never: 0
-  OnlyNotOnMouseover: 3
-  OnlyOnMouseover: 2
+  values:
+    Always: 1
+    Never: 0
+    OnlyNotOnMouseover: 3
+    OnlyOnMouseover: 2
 StatusBarTimerDirection:
-  ElapsedTime: 0
-  RemainingTime: 1
+  values:
+    ElapsedTime: 0
+    RemainingTime: 1
 StatusBarValueTextType:
-  Hidden: 0
-  Percentage: 1
-  Time: 3
-  TimeShowOneLevelOnly: 4
-  Value: 2
-  ValueOverMax: 5
-  ValueOverMaxNormalized: 6
+  values:
+    Hidden: 0
+    Percentage: 1
+    Time: 3
+    TimeShowOneLevelOnly: 4
+    Value: 2
+    ValueOverMax: 5
+    ValueOverMaxNormalized: 6
 StoreDeliveryType:
-  Battlepet: 2
-  Collection: 3
-  Item: 0
-  Mount: 1
+  values:
+    Battlepet: 2
+    Collection: 3
+    Item: 0
+    Mount: 1
 StoreError:
-  AlreadyOwned: 7
-  BattlepayDisabled: 4
-  ClientRestricted: 13
-  ConsumableTokenOwned: 10
-  InsufficientBalance: 5
-  InvalidPaymentMethod: 1
-  ItemUnavailable: 12
-  Other: 6
-  ParentalControlsNoPurchase: 8
-  PaymentFailed: 2
-  PurchaseDenied: 9
-  Success: 0
-  TooManyTokens: 11
-  WrongCurrency: 3
+  values:
+    AlreadyOwned: 7
+    BattlepayDisabled: 4
+    ClientRestricted: 13
+    ConsumableTokenOwned: 10
+    InsufficientBalance: 5
+    InvalidPaymentMethod: 1
+    ItemUnavailable: 12
+    Other: 6
+    ParentalControlsNoPurchase: 8
+    PaymentFailed: 2
+    PurchaseDenied: 9
+    Success: 0
+    TooManyTokens: 11
+    WrongCurrency: 3
 SubcontainerType:
-  AccountBankTabs: 36
-  Auction: 5
-  Bag: 0
-  Bankbag: 3
-  Bankgeneric: 2
-  BuybackSlots: 26
-  CachedReward: 27
-  CharacterBankTabs: 38
-  Childequipmentstorage: 23
-  CraftingOrder: 34
-  CraftingOrderReagents: 35
-  CreatedImmediately: 25
-  CurrencytokenOboslete: 15
-  CurrencyTransfer: 37
-  Equipablespells: 14
-  Equipped: 1
-  EquippedBags: 28
-  EquippedCooking: 31
-  EquippedFishing: 32
-  EquippedProfession1: 29
-  EquippedProfession2: 30
-  EquippedReagentbag: 33
-  GuildBank0: 7
-  GuildBank1: 8
-  GuildBank10: 20
-  GuildBank11: 21
-  GuildBank2: 9
-  GuildBank3: 10
-  GuildBank4: 11
-  GuildBank5: 12
-  GuildBank6: 16
-  GuildBank7: 17
-  GuildBank8: 18
-  GuildBank9: 19
-  GuildOverflow: 13
-  HousingDecorConversion: 39
-  Keyring: 6
-  Mail: 4
-  Quarantine: 24
-  ReagentbankObsolete: 22
+  values:
+    AccountBankTabs: 36
+    Auction: 5
+    Bag: 0
+    Bankbag: 3
+    Bankgeneric: 2
+    BuybackSlots: 26
+    CachedReward: 27
+    CharacterBankTabs: 38
+    Childequipmentstorage: 23
+    CraftingOrder: 34
+    CraftingOrderReagents: 35
+    CreatedImmediately: 25
+    CurrencytokenOboslete: 15
+    CurrencyTransfer: 37
+    Equipablespells: 14
+    Equipped: 1
+    EquippedBags: 28
+    EquippedCooking: 31
+    EquippedFishing: 32
+    EquippedProfession1: 29
+    EquippedProfession2: 30
+    EquippedReagentbag: 33
+    GuildBank0: 7
+    GuildBank1: 8
+    GuildBank10: 20
+    GuildBank11: 21
+    GuildBank2: 9
+    GuildBank3: 10
+    GuildBank4: 11
+    GuildBank5: 12
+    GuildBank6: 16
+    GuildBank7: 17
+    GuildBank8: 18
+    GuildBank9: 19
+    GuildOverflow: 13
+    HousingDecorConversion: 39
+    Keyring: 6
+    Mail: 4
+    Quarantine: 24
+    ReagentbankObsolete: 22
 SummonReason:
-  Scenario: 1
-  Spell: 0
+  values:
+    Scenario: 1
+    Spell: 0
 SummonStatus:
-  Accepted: 2
-  Declined: 3
-  None: 0
-  Pending: 1
+  values:
+    Accepted: 2
+    Declined: 3
+    None: 0
+    Pending: 1
 SurveyDeliveryFlags:
-  EncounterSucccessOnly: 1
-  None: 0
+  values:
+    EncounterSucccessOnly: 1
+    None: 0
 SurveyDeliveryMoment:
-  ChestLooted: 3
-  EncounterEnd: 5
-  Login: 0
-  MythicPlusCompleted: 4
-  ProfessionTable: 1
-  QuestTurnIn: 2
+  values:
+    ChestLooted: 3
+    EncounterEnd: 5
+    Login: 0
+    MythicPlusCompleted: 4
+    ProfessionTable: 1
+    QuestTurnIn: 2
 TableSecurityOption:
-  DisallowSecretKeys: 1
-  DisallowTaintedAccess: 0
-  SecretWrapContents: 2
+  values:
+    DisallowSecretKeys: 1
+    DisallowTaintedAccess: 0
+    SecretWrapContents: 2
 TieredEntranceType:
-  Delve: 1
-  Invalid: 0
-  Sites: 2
-  WorldTier: 3
+  values:
+    Delve: 1
+    Invalid: 0
+    Sites: 2
+    WorldTier: 3
 TimeEventFlag:
-  GlueScreenShortcut: 1
+  values:
+    GlueScreenShortcut: 1
 TitleIconVersion:
-  Large: 2
-  Medium: 1
-  Small: 0
+  values:
+    Large: 2
+    Medium: 1
+    Small: 0
 TooltipComparisonMethod:
-  Single: 0
-  WithBagMainHandItem: 2
-  WithBagOffHandItem: 3
-  WithBothHands: 1
+  values:
+    Single: 0
+    WithBagMainHandItem: 2
+    WithBagOffHandItem: 3
+    WithBothHands: 1
 TooltipDataItemBinding:
-  Account: 1
-  AccountUntilEquipped: 9
-  BindOnEquip: 7
-  BindOnPickup: 6
-  BindOnUse: 8
-  BindToAccount: 4
-  BindToAccountUntilEquipped: 10
-  BindToBnetAccount: 5
-  BnetAccount: 2
-  Quest: 0
-  Soulbound: 3
+  values:
+    Account: 1
+    AccountUntilEquipped: 9
+    BindOnEquip: 7
+    BindOnPickup: 6
+    BindOnUse: 8
+    BindToAccount: 4
+    BindToAccountUntilEquipped: 10
+    BindToBnetAccount: 5
+    BnetAccount: 2
+    Quest: 0
+    Soulbound: 3
 TooltipDataLineType:
-  AzeriteEssencePower: 5
-  AzeriteEssenceSlot: 4
-  AzeriteItemPowerDescription: 9
-  Blank: 1
-  CurrencyTotal: 14
-  DisabledLine: 42
-  EquipSlot: 21
-  ErrorLine: 41
-  FlavorText: 37
-  GemSocket: 3
-  GemSocketEnchantment: 30
-  ItemBinding: 20
-  ItemEnchantmentPermanent: 15
-  ItemLevel: 31
-  ItemName: 22
-  ItemQuality: 35
-  ItemSpellTriggerLearn: 38
-  ItemUpgradeLevel: 32
-  LearnableSpell: 6
-  LearnTransmogIllusion: 40
-  LearnTransmogSet: 39
-  NestedBlock: 19
-  None: 0
-  ProfessionCraftingQuality: 12
-  QuestObjective: 8
-  QuestPlayer: 18
-  QuestTitle: 17
-  RuneforgeLegendaryPowerDescription: 10
-  SellPrice: 11
-  Separator: 23
-  SpellDescription: 34
-  SpellName: 13
-  SpellPassive: 33
-  ToyDescription: 28
-  ToyDuration: 27
-  ToyEffect: 26
-  ToyName: 24
-  ToySource: 29
-  ToyText: 25
-  TradeTimeRemaining: 36
-  UnitName: 2
-  UnitOwner: 16
-  UnitThreat: 7
-  UsageRequirement: 43
+  values:
+    AzeriteEssencePower: 5
+    AzeriteEssenceSlot: 4
+    AzeriteItemPowerDescription: 9
+    Blank: 1
+    CurrencyTotal: 14
+    DisabledLine: 42
+    EquipSlot: 21
+    ErrorLine: 41
+    FlavorText: 37
+    GemSocket: 3
+    GemSocketEnchantment: 30
+    ItemBinding: 20
+    ItemEnchantmentPermanent: 15
+    ItemLevel: 31
+    ItemName: 22
+    ItemQuality: 35
+    ItemSpellTriggerLearn: 38
+    ItemUpgradeLevel: 32
+    LearnableSpell: 6
+    LearnTransmogIllusion: 40
+    LearnTransmogSet: 39
+    NestedBlock: 19
+    None: 0
+    ProfessionCraftingQuality: 12
+    QuestObjective: 8
+    QuestPlayer: 18
+    QuestTitle: 17
+    RuneforgeLegendaryPowerDescription: 10
+    SellPrice: 11
+    Separator: 23
+    SpellDescription: 34
+    SpellName: 13
+    SpellPassive: 33
+    ToyDescription: 28
+    ToyDuration: 27
+    ToyEffect: 26
+    ToyName: 24
+    ToySource: 29
+    ToyText: 25
+    TradeTimeRemaining: 36
+    UnitName: 2
+    UnitOwner: 16
+    UnitThreat: 7
+    UsageRequirement: 43
 TooltipDataType:
-  Achievement: 12
-  AzeriteEssence: 8
-  BattlePet: 6
-  CompanionPet: 9
-  Corpse: 3
-  CorruptionCleanser: 20
-  Currency: 5
-  Debug: 26
-  EnhancedConduit: 13
-  EquipmentSet: 14
-  Flyout: 22
-  InstanceLock: 15
-  Item: 0
-  Macro: 25
-  MinimapMouseover: 21
-  Mount: 10
-  Object: 4
-  Outfit: 27
-  PetAction: 11
-  PvPBrawl: 16
-  Quest: 23
-  QuestPartyProgress: 24
-  RecipeRankInfo: 17
-  Spell: 1
-  Totem: 18
-  Toy: 19
-  Unit: 2
-  UnitAura: 7
+  values:
+    Achievement: 12
+    AzeriteEssence: 8
+    BattlePet: 6
+    CompanionPet: 9
+    Corpse: 3
+    CorruptionCleanser: 20
+    Currency: 5
+    Debug: 26
+    EnhancedConduit: 13
+    EquipmentSet: 14
+    Flyout: 22
+    InstanceLock: 15
+    Item: 0
+    Macro: 25
+    MinimapMouseover: 21
+    Mount: 10
+    Object: 4
+    Outfit: 27
+    PetAction: 11
+    PvPBrawl: 16
+    Quest: 23
+    QuestPartyProgress: 24
+    RecipeRankInfo: 17
+    Spell: 1
+    Totem: 18
+    Toy: 19
+    Unit: 2
+    UnitAura: 7
 TooltipDataUsageRequirementType:
-  Achievement: 7
-  ArenaRating: 11
-  EarnCurrency: 12
-  EquippedItem: 9
-  Faction: 1
-  Guild: 6
-  Level: 5
-  NotAlreadyKnown: 14
-  NotInArena: 15
-  NotInRatedBg: 16
-  PvPMedal: 3
-  PvPRank: 8
-  RaceClass: 0
-  Reputation: 4
-  ShapeshiftForm: 10
-  Skill: 2
-  Specialization: 13
+  values:
+    Achievement: 7
+    ArenaRating: 11
+    EarnCurrency: 12
+    EquippedItem: 9
+    Faction: 1
+    Guild: 6
+    Level: 5
+    NotAlreadyKnown: 14
+    NotInArena: 15
+    NotInRatedBg: 16
+    PvPMedal: 3
+    PvPRank: 8
+    RaceClass: 0
+    Reputation: 4
+    ShapeshiftForm: 10
+    Skill: 2
+    Specialization: 13
 TooltipSide:
-  Bottom: 3
-  Left: 0
-  Right: 1
-  Top: 2
+  values:
+    Bottom: 3
+    Left: 0
+    Right: 1
+    Top: 2
 TooltipTextureAnchor:
-  All: 6
-  LeftBottom: 2
-  LeftCenter: 1
-  LeftTop: 0
-  RightBottom: 5
-  RightCenter: 4
-  RightTop: 3
+  values:
+    All: 6
+    LeftBottom: 2
+    LeftCenter: 1
+    LeftTop: 0
+    RightBottom: 5
+    RightCenter: 4
+    RightTop: 3
 TooltipTextureRelativeRegion:
-  LeftLine: 0
-  RightLine: 1
+  values:
+    LeftLine: 0
+    RightLine: 1
 TrackedSpellCategory:
-  Debuff: 3
-  Defensive: 2
-  None: 0
-  Offensive: 1
-  RacialAbility: 4
+  values:
+    Debuff: 3
+    Defensive: 2
+    None: 0
+    Offensive: 1
+    RacialAbility: 4
 TradeskillRelativeDifficulty:
-  Easy: 2
-  Medium: 1
-  Optimal: 0
-  Trivial: 3
+  values:
+    Easy: 2
+    Medium: 1
+    Optimal: 0
+    Trivial: 3
 TraitCombatConfigFlags:
-  ActiveForSpec: 1
-  SharedActionBars: 4
-  StarterBuild: 2
+  values:
+    ActiveForSpec: 1
+    SharedActionBars: 4
+    StarterBuild: 2
 TraitCondFlag:
-  IsAlwaysMet: 2
-  IsGate: 1
-  IsSufficient: 4
+  values:
+    IsAlwaysMet: 2
+    IsGate: 1
+    IsSufficient: 4
 TraitConditionType:
-  Available: 0
-  DisplayError: 4
-  Granted: 2
-  Increased: 3
-  RanksAllowed: 5
-  Visible: 1
+  values:
+    Available: 0
+    DisplayError: 4
+    Granted: 2
+    Increased: 3
+    RanksAllowed: 5
+    Visible: 1
 TraitConfigDbState:
-  Created: 1
-  Deleted: 3
-  Ready: 0
-  Removed: 2
+  values:
+    Created: 1
+    Deleted: 3
+    Ready: 0
+    Removed: 2
 TraitConfigType:
-  Combat: 1
-  Generic: 3
-  Invalid: 0
-  Profession: 2
+  values:
+    Combat: 1
+    Generic: 3
+    Invalid: 0
+    Profession: 2
 TraitCurrencyFlag:
-  ShowQuantityAsSpent: 1
-  TraitSourcedShowMax: 2
-  UseClassIcon: 4
-  UseSpecIcon: 8
+  values:
+    ShowQuantityAsSpent: 1
+    TraitSourcedShowMax: 2
+    UseClassIcon: 4
+    UseSpecIcon: 8
 TraitCurrencyType:
-  CurrencyTypesBased: 1
-  Gold: 0
-  TraitSourced: 2
-  TraitSourcedPlayerDataElement: 3
+  values:
+    CurrencyTypesBased: 1
+    Gold: 0
+    TraitSourced: 2
+    TraitSourcedPlayerDataElement: 3
 TraitDefinitionSubType:
-  DragonflightBlack: 4
-  DragonflightBlue: 1
-  DragonflightBronze: 3
-  DragonflightGreen: 2
-  DragonflightRed: 0
+  values:
+    DragonflightBlack: 4
+    DragonflightBlue: 1
+    DragonflightBronze: 3
+    DragonflightGreen: 2
+    DragonflightRed: 0
 TraitEdgeType:
-  DeprecatedRankConnection: 1
-  DeprecatedSelectionOption: 5
-  MutuallyExclusive: 4
-  RequiredForAvailability: 3
-  SufficientForAvailability: 2
-  VisualOnly: 0
+  values:
+    DeprecatedRankConnection: 1
+    DeprecatedSelectionOption: 5
+    MutuallyExclusive: 4
+    RequiredForAvailability: 3
+    SufficientForAvailability: 2
+    VisualOnly: 0
 TraitEdgeVisualStyle:
-  None: 0
-  Straight: 1
+  values:
+    None: 0
+    Straight: 1
 TraitNodeEntryType:
-  ArmorSet: 11
-  DeprecatedSelect: 4
-  DragAndDrop: 5
-  ProfPath: 7
-  ProfPathUnlock: 9
-  ProfPerk: 8
-  RedButton: 10
-  SpendCapstoneCircle: 13
-  SpendCapstoneSquare: 14
-  SpendCircle: 2
-  SpendDiamond: 6
-  SpendHex: 0
-  SpendInfinite: 12
-  SpendSmallCircle: 3
-  SpendSquare: 1
+  values:
+    ArmorSet: 11
+    DeprecatedSelect: 4
+    DragAndDrop: 5
+    ProfPath: 7
+    ProfPathUnlock: 9
+    ProfPerk: 8
+    RedButton: 10
+    SpendCapstoneCircle: 13
+    SpendCapstoneSquare: 14
+    SpendCircle: 2
+    SpendDiamond: 6
+    SpendHex: 0
+    SpendInfinite: 12
+    SpendSmallCircle: 3
+    SpendSquare: 1
 TraitNodeFlag:
-  ActiveAtFirstRank: 16
-  HideMaxRank: 64
-  HighestChosenRank: 128
-  NeverPurchasable: 2
-  ShowExpandedSelection: 32
-  ShowMultipleIcons: 1
-  ShowTierTrack: 256
-  TestGridPositioned: 8
-  TestPositionLocked: 4
+  values:
+    ActiveAtFirstRank: 16
+    HideMaxRank: 64
+    HighestChosenRank: 128
+    NeverPurchasable: 2
+    ShowExpandedSelection: 32
+    ShowMultipleIcons: 1
+    ShowTierTrack: 256
+    TestGridPositioned: 8
+    TestPositionLocked: 4
 TraitNodeGroupFlag:
-  AvailableByDefault: 1
+  values:
+    AvailableByDefault: 1
 TraitNodeType:
-  Selection: 2
-  Single: 0
-  SubTreeSelection: 3
-  Tiered: 1
+  values:
+    Selection: 2
+    Single: 0
+    SubTreeSelection: 3
+    Tiered: 1
 TraitPointsOperationType:
-  Multiply: 1
-  None: -1
-  Set: 0
+  values:
+    Multiply: 1
+    None: -1
+    Set: 0
 TraitSystemFlag:
-  AllowEditInChallengeMode: 8
-  AllowEditInCombat: 4
-  AllowMultipleLoadoutsPerTree: 1
-  ShowSpendConfirmation: 2
+  values:
+    AllowEditInChallengeMode: 8
+    AllowEditInCombat: 4
+    AllowMultipleLoadoutsPerTree: 1
+    ShowSpendConfirmation: 2
 TraitSystemVariationType:
-  None: 0
-  Spec: 1
+  values:
+    None: 0
+    Spec: 1
 TraitTreeFlag:
-  CannotRefund: 1
-  HideSingleRankNumbers: 2
+  values:
+    CannotRefund: 1
+    HideSingleRankNumbers: 2
 TransformManipulatorAxis:
-  X: 1
-  Y: 2
-  Z: 4
+  values:
+    X: 1
+    Y: 2
+    Z: 4
 TransformManipulatorControlState:
-  Default: 0
-  Dimmed: 2
-  ExternallyHighlighted: 3
-  Hidden: 1
-  Hovered: 4
-  Moving: 6
-  Selected: 5
+  values:
+    Default: 0
+    Dimmed: 2
+    ExternallyHighlighted: 3
+    Hidden: 1
+    Hovered: 4
+    Moving: 6
+    Selected: 5
 TransformManipulatorDirection:
-  Negative: 1
-  Positive: 0
+  values:
+    Negative: 1
+    Positive: 0
 TransformManipulatorEvent:
-  Cancel: 3
-  Change: 1
-  Complete: 2
-  Hover: 4
-  MouseDown: 5
-  MouseUp: 6
-  Start: 0
+  values:
+    Cancel: 3
+    Change: 1
+    Complete: 2
+    Hover: 4
+    MouseDown: 5
+    MouseUp: 6
+    Start: 0
 TransformManipulatorMode:
-  Rotate: 1
-  Scale: 2
-  Translate: 0
+  values:
+    Rotate: 1
+    Scale: 2
+    Translate: 0
 TransmogCameraVariation:
-  CloakBackpack: 1
-  None: 0
-  RightShoulder: 1
+  values:
+    CloakBackpack: 1
+    None: 0
+    RightShoulder: 1
 TransmogCollectionType:
-  Back: 3
-  Bow: 25
-  Chest: 4
-  Crossbow: 27
-  Dagger: 16
-  Feet: 11
-  Fist: 17
-  Gun: 26
-  Hands: 8
-  Head: 1
-  Holdable: 19
-  Legs: 10
-  None: 0
-  OneHAxe: 13
-  OneHMace: 15
-  OneHSword: 14
-  Paired: 29
-  Polearm: 24
-  Shield: 18
-  Shirt: 5
-  Shoulder: 2
-  Staff: 23
-  Tabard: 6
-  TwoHAxe: 20
-  TwoHMace: 22
-  TwoHSword: 21
-  Waist: 9
-  Wand: 12
-  Warglaives: 28
-  Wrist: 7
+  values:
+    Back: 3
+    Bow: 25
+    Chest: 4
+    Crossbow: 27
+    Dagger: 16
+    Feet: 11
+    Fist: 17
+    Gun: 26
+    Hands: 8
+    Head: 1
+    Holdable: 19
+    Legs: 10
+    None: 0
+    OneHAxe: 13
+    OneHMace: 15
+    OneHSword: 14
+    Paired: 29
+    Polearm: 24
+    Shield: 18
+    Shirt: 5
+    Shoulder: 2
+    Staff: 23
+    Tabard: 6
+    TwoHAxe: 20
+    TwoHMace: 22
+    TwoHSword: 21
+    Waist: 9
+    Wand: 12
+    Warglaives: 28
+    Wrist: 7
 TransmogIllusionFlags:
-  AllowedRangedShieldsHoldables: 4
-  HideUntilCollected: 1
-  PlayerConditionGrantsOnLogin: 2
+  values:
+    AllowedRangedShieldsHoldables: 4
+    HideUntilCollected: 1
+    PlayerConditionGrantsOnLogin: 2
 TransmogModification:
-  Main: 0
-  Secondary: 1
+  values:
+    Main: 0
+    Secondary: 1
 TransmogOutfitCostModifiersApplied:
-  AuraDiscountApplied: 8
-  DebugOnlyFreeDiscountApplied: 1
-  OutfitCostModifierApplied: 4
-  VoidRacialDiscountApplied: 2
+  values:
+    AuraDiscountApplied: 8
+    DebugOnlyFreeDiscountApplied: 1
+    OutfitCostModifierApplied: 4
+    VoidRacialDiscountApplied: 2
 TransmogOutfitDataFlags:
-  IsCachedLocally: 1
+  values:
+    IsCachedLocally: 1
 TransmogOutfitDisplayType:
-  Assigned: 1
-  Disabled: 4
-  Equipped: 2
-  Hidden: 3
-  Unassigned: 0
+  values:
+    Assigned: 1
+    Disabled: 4
+    Equipped: 2
+    Hidden: 3
+    Unassigned: 0
 TransmogOutfitEntryFlags:
-  AutomaticallyAwardedOnLogin: 1
-  IsDefaultEquipped: 32
-  OnlyAvailableDuringEvent: 4
-  SortedToTopOfList: 8
-  UseOverrideCostModifier: 16
-  UseOverrideName: 2
+  values:
+    AutomaticallyAwardedOnLogin: 1
+    IsDefaultEquipped: 32
+    OnlyAvailableDuringEvent: 4
+    SortedToTopOfList: 8
+    UseOverrideCostModifier: 16
+    UseOverrideName: 2
 TransmogOutfitEntrySource:
-  AutomaticallyAwarded: 1
-  PlayerPurchased: 2
-  StampedSource: 0
+  values:
+    AutomaticallyAwarded: 1
+    PlayerPurchased: 2
+    StampedSource: 0
 TransmogOutfitEquipAction:
-  Equip: 0
-  EquipAndLock: 1
-  Lock: 5
-  Remove: 2
-  RemoveAndLock: 3
-  Unlock: 4
+  values:
+    Equip: 0
+    EquipAndLock: 1
+    Lock: 5
+    Remove: 2
+    RemoveAndLock: 3
+    Unlock: 4
 TransmogOutfitSetType:
-  CustomSet: 2
-  Equipped: 0
-  Outfit: 1
+  values:
+    CustomSet: 2
+    Equipped: 0
+    Outfit: 1
 TransmogOutfitSlot:
-  Back: 3
-  Body: 6
-  Chest: 4
-  Feet: 11
-  Hand: 8
-  Head: 0
-  Legs: 10
-  ShoulderLeft: 2
-  ShoulderRight: 1
-  Tabard: 5
-  Waist: 9
-  WeaponMainHand: 12
-  WeaponOffHand: 13
-  WeaponRanged: 14
-  Wrist: 7
+  values:
+    Back: 3
+    Body: 6
+    Chest: 4
+    Feet: 11
+    Hand: 8
+    Head: 0
+    Legs: 10
+    ShoulderLeft: 2
+    ShoulderRight: 1
+    Tabard: 5
+    Waist: 9
+    WeaponMainHand: 12
+    WeaponOffHand: 13
+    WeaponRanged: 14
+    Wrist: 7
 TransmogOutfitSlotError:
-  CannotUseItem: 10
-  IncompatibleWithMainHand: 14
-  InvalidDestination: 5
-  InvalidItemType: 4
-  InvalidSlotForForm: 13
-  InvalidSlotForRace: 11
-  InvalidSource: 8
-  InvalidSourceQuality: 9
-  Legendary: 3
-  Mismatch: 6
-  NoIllusion: 12
-  NoItem: 1
-  NotSoulbound: 2
-  Ok: 0
-  SameItem: 7
+  values:
+    CannotUseItem: 10
+    IncompatibleWithMainHand: 14
+    InvalidDestination: 5
+    InvalidItemType: 4
+    InvalidSlotForForm: 13
+    InvalidSlotForRace: 11
+    InvalidSource: 8
+    InvalidSourceQuality: 9
+    Legendary: 3
+    Mismatch: 6
+    NoIllusion: 12
+    NoItem: 1
+    NotSoulbound: 2
+    Ok: 0
+    SameItem: 7
 TransmogOutfitSlotFlags:
-  CanHaveIllusions: 2
-  CannotBeHidden: 1
-  IsSecondarySlot: 4
+  values:
+    CanHaveIllusions: 2
+    CannotBeHidden: 1
+    IsSecondarySlot: 4
 TransmogOutfitSlotOption:
-  ArtifactSpecFour: 11
-  ArtifactSpecOne: 8
-  ArtifactSpecThree: 10
-  ArtifactSpecTwo: 9
-  DeprecatedReuseMe: 6
-  FuryTwoHandedWeapon: 7
-  None: 0
-  OffHand: 4
-  OneHandedWeapon: 1
-  RangedWeapon: 3
-  Shield: 5
-  TwoHandedWeapon: 2
+  values:
+    ArtifactSpecFour: 11
+    ArtifactSpecOne: 8
+    ArtifactSpecThree: 10
+    ArtifactSpecTwo: 9
+    DeprecatedReuseMe: 6
+    FuryTwoHandedWeapon: 7
+    None: 0
+    OffHand: 4
+    OneHandedWeapon: 1
+    RangedWeapon: 3
+    Shield: 5
+    TwoHandedWeapon: 2
 TransmogOutfitSlotOptionFlags:
-  DisablesOffhandSlot: 4
-  DynamicOptionName: 2
-  IllusionNotAllowed: 1
+  values:
+    DisablesOffhandSlot: 4
+    DynamicOptionName: 2
+    IllusionNotAllowed: 1
 TransmogOutfitSlotOptionSheatheCategory:
-  Back: 1
-  Default: 0
-  Hide: 3
-  Side: 2
+  values:
+    Back: 1
+    Default: 0
+    Hide: 3
+    Side: 2
 TransmogOutfitSlotPosition:
-  Bottom: 2
-  Left: 0
-  Right: 1
+  values:
+    Bottom: 2
+    Left: 0
+    Right: 1
 TransmogOutfitSlotSaveFlags:
-  AppearanceIsNotValid: 1
+  values:
+    AppearanceIsNotValid: 1
 TransmogOutfitSlotWarning:
-  InvalidEquippedDestinationItem: 1
-  NothingEquipped: 5
-  Ok: 0
-  PendingWeaponChanges: 3
-  WeaponDoesNotSupportIllusions: 4
-  WrongWeaponCategoryEquipped: 2
+  values:
+    InvalidEquippedDestinationItem: 1
+    NothingEquipped: 5
+    Ok: 0
+    PendingWeaponChanges: 3
+    WeaponDoesNotSupportIllusions: 4
+    WrongWeaponCategoryEquipped: 2
 TransmogOutfitTransactionFlags:
-  AddNewOutfitMask: 20
-  AddOutfitAndUpdateSlots: 28
-  CreateAndUpdateOutfitInfoMask: 6
-  CreateOutfitInfo: 4
-  FullOutfitUpdateMask: 27
-  UpdateMetadata: 1
-  UpdateOutfitInfo: 2
-  UpdateSituations: 16
-  UpdateSituationsMask: 18
-  UpdateSlots: 8
+  values:
+    AddNewOutfitMask: 20
+    AddOutfitAndUpdateSlots: 28
+    CreateAndUpdateOutfitInfoMask: 6
+    CreateOutfitInfo: 4
+    FullOutfitUpdateMask: 27
+    UpdateMetadata: 1
+    UpdateOutfitInfo: 2
+    UpdateSituations: 16
+    UpdateSituationsMask: 18
+    UpdateSlots: 8
 TransmogOutfitTransactionType:
-  CreateOutfitInfo: 2
-  UpdateMetadata: 0
-  UpdateOutfitInfo: 1
-  UpdateSituations: 4
-  UpdateSlots: 3
+  values:
+    CreateOutfitInfo: 2
+    UpdateMetadata: 0
+    UpdateOutfitInfo: 1
+    UpdateSituations: 4
+    UpdateSlots: 3
 TransmogPendingType:
-  Apply: 0
-  Revert: 1
-  ToggleOff: 3
-  ToggleOn: 2
+  values:
+    Apply: 0
+    Revert: 1
+    ToggleOff: 3
+    ToggleOn: 2
 TransmogSearchType:
-  BaseSets: 2
-  Items: 1
-  UsableSets: 3
+  values:
+    BaseSets: 2
+    Items: 1
+    UsableSets: 3
 TransmogSituation:
-  AllEquipmentSets: 17
-  AllLocations: 2
-  AllMovement: 12
-  AllRacialForms: 19
-  AllSpecs: 0
-  AllTime: 27
-  AllWeather: 22
-  EquipmentSets: 18
-  FormNative: 20
-  FormNonNative: 21
-  LocationArenas: 10
-  LocationBattlegrounds: 11
-  LocationCharacterSelect: 5
-  LocationDelves: 7
-  LocationDungeons: 8
-  LocationHouse: 4
-  LocationRaids: 9
-  LocationRested: 3
-  LocationWorld: 6
-  MovementFlyingMount: 16
-  MovementGroundMount: 15
-  MovementSwimming: 14
-  MovementUnmounted: 13
-  Spec: 1
-  TimeDay: 29
-  TimeEvening: 30
-  TimeMorning: 28
-  TimeNight: 31
-  WeatherClear: 23
-  WeatherRain: 24
-  WeatherSand: 26
-  WeatherSnow: 25
+  values:
+    AllEquipmentSets: 17
+    AllLocations: 2
+    AllMovement: 12
+    AllRacialForms: 19
+    AllSpecs: 0
+    AllTime: 27
+    AllWeather: 22
+    EquipmentSets: 18
+    FormNative: 20
+    FormNonNative: 21
+    LocationArenas: 10
+    LocationBattlegrounds: 11
+    LocationCharacterSelect: 5
+    LocationDelves: 7
+    LocationDungeons: 8
+    LocationHouse: 4
+    LocationRaids: 9
+    LocationRested: 3
+    LocationWorld: 6
+    MovementFlyingMount: 16
+    MovementGroundMount: 15
+    MovementSwimming: 14
+    MovementUnmounted: 13
+    Spec: 1
+    TimeDay: 29
+    TimeEvening: 30
+    TimeMorning: 28
+    TimeNight: 31
+    WeatherClear: 23
+    WeatherRain: 24
+    WeatherSand: 26
+    WeatherSnow: 25
 TransmogSituationFlags:
-  AllSituation: 4
-  DefaultsToOn: 8
-  DisabledSituation: 64
-  DynamicallyNamed: 16
-  IsPlayerFacing: 1
-  NoneSituation: 32
-  SpecUseTalentLoadout: 2
+  values:
+    AllSituation: 4
+    DefaultsToOn: 8
+    DisabledSituation: 64
+    DynamicallyNamed: 16
+    IsPlayerFacing: 1
+    NoneSituation: 32
+    SpecUseTalentLoadout: 2
 TransmogSituationGroupFlags:
-  DynamicallyCreatesGroups: 1
+  values:
+    DynamicallyCreatesGroups: 1
 TransmogSituationTrigger:
-  EquipmentSet: 6
-  EventOutfit: 8
-  Forms: 7
-  Location: 3
-  Manual: 1
-  Movement: 4
-  None: 0
-  Specialization: 5
-  TimeOfDay: 10
-  TransmogUpdate: 2
-  Weather: 9
+  values:
+    EquipmentSet: 6
+    EventOutfit: 8
+    Forms: 7
+    Location: 3
+    Manual: 1
+    Movement: 4
+    None: 0
+    Specialization: 5
+    TimeOfDay: 10
+    TransmogUpdate: 2
+    Weather: 9
 TransmogSituationTriggerFlags:
-  CanChangeLockedOutfit: 2
-  CanLockOutfit: 1
-  DisabledTrigger: 16
-  IsPlayerFacing: 4
-  SituationsAreExclusive: 8
+  values:
+    CanChangeLockedOutfit: 2
+    CanLockOutfit: 1
+    DisabledTrigger: 16
+    IsPlayerFacing: 4
+    SituationsAreExclusive: 8
 TransmogSituationTriggerType:
-  Automatic: 2
-  Manual: 1
-  None: 0
-  TransmogUpdate: 3
+  values:
+    Automatic: 2
+    Manual: 1
+    None: 0
+    TransmogUpdate: 3
 TransmogSlot:
-  Back: 2
-  Body: 4
-  Chest: 3
-  Feet: 10
-  Hand: 7
-  Head: 0
-  Legs: 9
-  Mainhand: 11
-  Offhand: 12
-  Ranged: 13
-  Shoulder: 1
-  Tabard: 5
-  Waist: 8
-  Wrist: 6
+  values:
+    Back: 2
+    Body: 4
+    Chest: 3
+    Feet: 10
+    Hand: 7
+    Head: 0
+    Legs: 9
+    Mainhand: 11
+    Offhand: 12
+    Ranged: 13
+    Shoulder: 1
+    Tabard: 5
+    Waist: 8
+    Wrist: 6
 TransmogSource:
-  Achievement: 7
-  CantCollect: 6
-  HiddenUntilCollected: 5
-  JournalEncounter: 1
-  None: 0
-  NotValidForTransmog: 9
-  Profession: 8
-  Quest: 2
-  TradingPost: 10
-  Vendor: 3
-  WorldDrop: 4
+  values:
+    Achievement: 7
+    CantCollect: 6
+    HiddenUntilCollected: 5
+    JournalEncounter: 1
+    None: 0
+    NotValidForTransmog: 9
+    Profession: 8
+    Quest: 2
+    TradingPost: 10
+    Vendor: 3
+    WorldDrop: 4
 TransmogTimeOfDayCategory:
-  Evening: 2
-  Midday: 1
-  Morning: 0
-  Night: 3
+  values:
+    Evening: 2
+    Midday: 1
+    Morning: 0
+    Night: 3
 TransmogType:
-  Appearance: 0
-  Illusion: 1
+  values:
+    Appearance: 0
+    Illusion: 1
 TransmogUseErrorType:
-  Ability: 3
-  Class: 7
-  Faction: 9
-  Holiday: 5
-  HotRecheckFailed: 6
-  ItemProficiency: 10
-  None: 0
-  PlayerCondition: 1
-  Race: 8
-  Reputation: 4
-  Skill: 2
+  values:
+    Ability: 3
+    Class: 7
+    Faction: 9
+    Holiday: 5
+    HotRecheckFailed: 6
+    ItemProficiency: 10
+    None: 0
+    PlayerCondition: 1
+    Race: 8
+    Reputation: 4
+    Skill: 2
 TtsBoolSetting:
-  AddCharacterNameToSpeech: 1
-  AlternateSystemVoice: 3
-  NarrateMyMessages: 4
-  PlayActivitySoundWhenNotFocused: 2
-  PlaySoundSeparatingChatLineBreaks: 0
+  values:
+    AddCharacterNameToSpeech: 1
+    AlternateSystemVoice: 3
+    NarrateMyMessages: 4
+    PlayActivitySoundWhenNotFocused: 2
+    PlaySoundSeparatingChatLineBreaks: 0
 TtsVoiceType:
-  Alternate: 1
-  Standard: 0
+  values:
+    Alternate: 1
+    Standard: 0
 TugOfWarMarkerArrowShownState:
-  Always: 1
-  FlashOnMove: 2
-  Never: 0
+  values:
+    Always: 1
+    FlashOnMove: 2
+    Never: 0
 TugOfWarStyleValue:
-  ArchaeologyBrown: 1
-  DefaultYellow: 0
+  values:
+    ArchaeologyBrown: 1
+    DefaultYellow: 0
 TurnStrafeStyle:
-  Custom: 2
-  Legacy: 1
-  Modern: 0
+  values:
+    Custom: 2
+    Legacy: 1
+    Modern: 0
 UIActionType:
-  DefaultAction: 0
-  Reserved1: 2
-  UpdateMapSystem: 1
+  values:
+    DefaultAction: 0
+    Reserved1: 2
+    UpdateMapSystem: 1
 UICovenantDisplayInfoFlags:
-  DisplayCovenantAsJourney: 1
-  UseJourneyRewardTrack: 2
-  UseJourneyUnlockToastText: 3
+  values:
+    DisplayCovenantAsJourney: 1
+    UseJourneyRewardTrack: 2
+    UseJourneyUnlockToastText: 3
 UICursorType:
-  ActionBar: 6
-  Ammo: 8
-  BattlePet: 16
-  ConduitCollectionItem: 19
-  Currency: 13
-  Default: 0
-  EquipmentSet: 12
-  Flyout: 14
-  GuildBank: 10
-  GuildBankMoney: 11
-  Item: 1
-  Macro: 7
-  Merchant: 5
-  Money: 2
-  Mount: 17
-  Outfit: 21
-  PerksProgramVendorItem: 20
-  Pet: 9
-  PetAction: 4
-  Spell: 3
-  Toy: 18
-  VoidItem: 15
+  values:
+    ActionBar: 6
+    Ammo: 8
+    BattlePet: 16
+    ConduitCollectionItem: 19
+    Currency: 13
+    Default: 0
+    EquipmentSet: 12
+    Flyout: 14
+    GuildBank: 10
+    GuildBankMoney: 11
+    Item: 1
+    Macro: 7
+    Merchant: 5
+    Money: 2
+    Mount: 17
+    Outfit: 21
+    PerksProgramVendorItem: 20
+    Pet: 9
+    PetAction: 4
+    Spell: 3
+    Toy: 18
+    VoidItem: 15
 UIItemInteractionFlags:
-  AddCurrency: 16
-  ClickShowsFlyout: 8
-  ConfirmationHasDelay: 2
-  ConversionMode: 4
-  DisplayWithInset: 1
-  UsesCharges: 32
+  values:
+    AddCurrency: 16
+    ClickShowsFlyout: 8
+    ConfirmationHasDelay: 2
+    ConversionMode: 4
+    DisplayWithInset: 1
+    UsesCharges: 32
 UIItemInteractionType:
-  CastSpell: 1
-  CleanseCorruption: 2
-  ItemConversion: 4
-  None: 0
-  RunecarverScrapping: 3
+  values:
+    CastSpell: 1
+    CleanseCorruption: 2
+    ItemConversion: 4
+    None: 0
+    RunecarverScrapping: 3
 UIMapFlag:
-  AlwaysAllowTaxiPathing: 131072
-  AlwaysAllowUserWaypoints: 65536
-  DoNotShowOnNavbar: 524288
-  DoNotTranslateBranches: 512
-  FallbackToParentMap: 16
-  FlightMapAutoZoom: 16384
-  FlightMapShowZoomOut: 8192
-  ForceAllOverlayExplored: 4096
-  ForceAllowMapLinks: 262144
-  ForceOnNavbar: 32768
-  GarrisonMap: 8
-  HideArchaeologyDigs: 256
-  HideIcons: 1024
-  HideVignettes: 2048
-  IgnoreInTranslationsToParent: 2097152
-  IsCityMap: 1048576
-  NoHighlight: 1
-  NoHighlightTexture: 32
-  NoWorldPositions: 128
-  ShowOverlays: 2
-  ShowTaskObjectives: 64
-  ShowTaxiNodes: 4
+  values:
+    AlwaysAllowTaxiPathing: 131072
+    AlwaysAllowUserWaypoints: 65536
+    DoNotShowOnNavbar: 524288
+    DoNotTranslateBranches: 512
+    FallbackToParentMap: 16
+    FlightMapAutoZoom: 16384
+    FlightMapShowZoomOut: 8192
+    ForceAllOverlayExplored: 4096
+    ForceAllowMapLinks: 262144
+    ForceOnNavbar: 32768
+    GarrisonMap: 8
+    HideArchaeologyDigs: 256
+    HideIcons: 1024
+    HideVignettes: 2048
+    IgnoreInTranslationsToParent: 2097152
+    IsCityMap: 1048576
+    NoHighlight: 1
+    NoHighlightTexture: 32
+    NoWorldPositions: 128
+    ShowOverlays: 2
+    ShowTaskObjectives: 64
+    ShowTaxiNodes: 4
 UIMapGroupFlag:
-  ShowIconsAcrossFloors: 1
+  values:
+    ShowIconsAcrossFloors: 1
 UIMapSystem:
-  Adventure: 2
-  Minimap: 3
-  Taxi: 1
-  World: 0
+  values:
+    Adventure: 2
+    Minimap: 3
+    Taxi: 1
+    World: 0
 UIMapType:
-  Continent: 2
-  Cosmic: 0
-  Dungeon: 4
-  Micro: 5
-  Orphan: 6
-  World: 1
-  Zone: 3
+  values:
+    Continent: 2
+    Cosmic: 0
+    Dungeon: 4
+    Micro: 5
+    Orphan: 6
+    World: 1
+    Zone: 3
 UIModelSceneActorFlag:
-  Deprecated1: 1
-  UseCenterForOriginX: 2
-  UseCenterForOriginY: 4
-  UseCenterForOriginZ: 8
+  values:
+    Deprecated1: 1
+    UseCenterForOriginX: 2
+    UseCenterForOriginY: 4
+    UseCenterForOriginZ: 8
 UIModelSceneContext:
-  None: -1
-  PerksProgram: 0
+  values:
+    None: -1
+    PerksProgram: 0
 UIModelSceneFlags:
-  Autodress: 4
-  HideWeapon: 2
-  NoCameraSpin: 8
-  SheatheWeapon: 1
+  values:
+    Autodress: 4
+    HideWeapon: 2
+    NoCameraSpin: 8
+    SheatheWeapon: 1
 UISystemType:
-  InGameNavigation: 0
+  values:
+    InGameNavigation: 0
 UITextureSliceMode:
-  Stretched: 0
-  Tiled: 1
+  values:
+    Stretched: 0
+    Tiled: 1
 UIWidgetBlendModeType:
-  Additive: 1
-  Opaque: 0
+  values:
+    Additive: 1
+    Opaque: 0
 UIWidgetButtonEnabledState:
-  Disabled: 0
-  Enabled: 1
+  values:
+    Disabled: 0
+    Enabled: 1
 UIWidgetButtonIconType:
-  Checkmark: 3
-  Exit: 0
-  RedX: 4
-  Speak: 1
-  Undo: 2
+  values:
+    Checkmark: 3
+    Exit: 0
+    RedX: 4
+    Speak: 1
+    Undo: 2
 UIWidgetFlag:
-  UniversalWidget: 1
+  values:
+    UniversalWidget: 1
 UIWidgetFontType:
-  Normal: 0
-  Outline: 2
-  Shadow: 1
+  values:
+    Normal: 0
+    Outline: 2
+    Shadow: 1
 UIWidgetHorizontalDirection:
-  LeftToRight: 0
-  RightToLeft: 1
+  values:
+    LeftToRight: 0
+    RightToLeft: 1
 UIWidgetLayoutDirection:
-  Default: 0
-  Horizontal: 2
-  HorizontalForceNewRow: 4
-  Overlap: 3
-  Vertical: 1
+  values:
+    Default: 0
+    Horizontal: 2
+    HorizontalForceNewRow: 4
+    Overlap: 3
+    Vertical: 1
 UIWidgetModelSceneLayer:
-  Back: 2
-  Front: 1
-  None: 0
+  values:
+    Back: 2
+    Front: 1
+    None: 0
 UIWidgetMotionType:
-  Instant: 0
-  Smooth: 1
+  values:
+    Instant: 0
+    Smooth: 1
 UIWidgetOverrideState:
-  Active: 1
-  Inactive: 0
+  values:
+    Active: 1
+    Inactive: 0
 UIWidgetRewardShownState:
-  Hidden: 0
-  ShownEarned: 1
-  ShownUnearned: 2
+  values:
+    Hidden: 0
+    ShownEarned: 1
+    ShownUnearned: 2
 UIWidgetScale:
-  Eighty: 2
-  Fifty: 5
-  Ninty: 1
-  OneHundred: 0
-  OneHundredEighty: 13
-  OneHundredFifty: 10
-  OneHundredForty: 9
-  OneHundredNinety: 14
-  OneHundredSeventy: 12
-  OneHundredSixty: 11
-  OneHundredTen: 6
-  OneHundredThirty: 8
-  OneHundredTwenty: 7
-  Seventy: 3
-  Sixty: 4
-  TwoHundred: 15
+  values:
+    Eighty: 2
+    Fifty: 5
+    Ninty: 1
+    OneHundred: 0
+    OneHundredEighty: 13
+    OneHundredFifty: 10
+    OneHundredForty: 9
+    OneHundredNinety: 14
+    OneHundredSeventy: 12
+    OneHundredSixty: 11
+    OneHundredTen: 6
+    OneHundredThirty: 8
+    OneHundredTwenty: 7
+    Seventy: 3
+    Sixty: 4
+    TwoHundred: 15
 UIWidgetSetLayoutDirection:
-  Horizontal: 1
-  Overlap: 2
-  Vertical: 0
+  values:
+    Horizontal: 1
+    Overlap: 2
+    Vertical: 0
 UIWidgetSpellButtonCooldownType:
-  HideCooldown: 0
-  ShowCooldown: 1
-  ShowCooldownAndDisableOnCooldown: 2
+  values:
+    HideCooldown: 0
+    ShowCooldown: 1
+    ShowCooldownAndDisableOnCooldown: 2
 UIWidgetTextFormatType:
-  LeadingZeroesWithSixDigits: 3
-  None: 0
-  TimeOneLevel: 1
-  TimeTwoLevel: 2
+  values:
+    LeadingZeroesWithSixDigits: 3
+    None: 0
+    TimeOneLevel: 1
+    TimeTwoLevel: 2
 UIWidgetTextSizeType:
-  Huge27Pt: 3
-  Large20Pt: 8
-  Large24Pt: 2
-  Medium16Pt: 1
-  Medium18Pt: 7
-  Small10Pt: 5
-  Small11Pt: 6
-  Small12Pt: 0
-  Standard14Pt: 4
+  values:
+    Huge27Pt: 3
+    Large20Pt: 8
+    Large24Pt: 2
+    Medium16Pt: 1
+    Medium18Pt: 7
+    Small10Pt: 5
+    Small11Pt: 6
+    Small12Pt: 0
+    Standard14Pt: 4
 UIWidgetTextureAndTextSizeType:
-  Huge: 3
-  Large: 2
-  Medium: 1
-  Medium2: 5
-  Small: 0
-  Standard: 4
+  values:
+    Huge: 3
+    Large: 2
+    Medium: 1
+    Medium2: 5
+    Small: 0
+    Standard: 4
 UIWidgetTooltipLocation:
-  Bottom: 8
-  BottomLeft: 1
-  BottomRight: 7
-  Default: 0
-  Left: 2
-  Right: 6
-  Top: 4
-  TopLeft: 3
-  TopRight: 5
+  values:
+    Bottom: 8
+    BottomLeft: 1
+    BottomRight: 7
+    Default: 0
+    Left: 2
+    Right: 6
+    Top: 4
+    TopLeft: 3
+    TopRight: 5
 UIWidgetUpdateAnimType:
-  Flash: 1
-  FlashAndAnimateNumber: 2
-  None: 0
+  values:
+    Flash: 1
+    FlashAndAnimateNumber: 2
+    None: 0
 UIWidgetVisualizationType:
-  BulletTextList: 10
-  ButtonHeader: 30
-  CaptureBar: 1
-  CaptureZone: 17
-  DiscreteProgressSteps: 19
-  DoubleIconAndText: 5
-  DoubleStateIconRow: 14
-  DoubleStatusBar: 3
-  FillUpFrames: 24
-  HorizontalCurrencies: 9
-  IconAndText: 0
-  IconTextAndBackground: 4
-  IconTextAndCurrencies: 7
-  ItemDisplay: 27
-  MapPinAnimation: 26
-  PreyHuntProgress: 31
-  ScenarioHeaderCurrenciesAndBackground: 11
-  ScenarioHeaderDelves: 29
-  ScenarioHeaderTimer: 20
-  Spacer: 22
-  SpellDisplay: 13
-  StackedResourceTracker: 6
-  StatusBar: 2
-  TextColumnRow: 21
-  TextureAndText: 12
-  TextureAndTextRow: 15
-  TextureWithAnimation: 18
-  TextWithState: 8
-  TextWithSubtext: 25
-  TugOfWar: 28
-  UnitPowerBar: 23
-  ZoneControl: 16
+  values:
+    BulletTextList: 10
+    ButtonHeader: 30
+    CaptureBar: 1
+    CaptureZone: 17
+    DiscreteProgressSteps: 19
+    DoubleIconAndText: 5
+    DoubleStateIconRow: 14
+    DoubleStatusBar: 3
+    FillUpFrames: 24
+    HorizontalCurrencies: 9
+    IconAndText: 0
+    IconTextAndBackground: 4
+    IconTextAndCurrencies: 7
+    ItemDisplay: 27
+    MapPinAnimation: 26
+    PreyHuntProgress: 31
+    ScenarioHeaderCurrenciesAndBackground: 11
+    ScenarioHeaderDelves: 29
+    ScenarioHeaderTimer: 20
+    Spacer: 22
+    SpellDisplay: 13
+    StackedResourceTracker: 6
+    StatusBar: 2
+    TextColumnRow: 21
+    TextureAndText: 12
+    TextureAndTextRow: 15
+    TextureWithAnimation: 18
+    TextWithState: 8
+    TextWithSubtext: 25
+    TugOfWar: 28
+    UnitPowerBar: 23
+    ZoneControl: 16
 UnitAuraSortDirection:
-  Normal: 0
-  Reverse: 1
+  values:
+    Normal: 0
+    Reverse: 1
 UnitAuraSortRule:
-  BigDefensive: 2
-  Default: 1
-  Expiration: 3
-  ExpirationOnly: 4
-  Name: 5
-  NameOnly: 6
-  Unsorted: 0
+  values:
+    BigDefensive: 2
+    Default: 1
+    Expiration: 3
+    ExpirationOnly: 4
+    Name: 5
+    NameOnly: 6
+    Unsorted: 0
 UnitDamageAbsorbClampMode:
-  MaximumHealth: 2
-  MissingHealth: 0
-  MissingHealthWithoutIncomingHeals: 1
+  values:
+    MaximumHealth: 2
+    MissingHealth: 0
+    MissingHealthWithoutIncomingHeals: 1
 UnitHealAbsorbClampMode:
-  CurrentHealth: 0
-  MaximumHealth: 1
+  values:
+    CurrentHealth: 0
+    MaximumHealth: 1
 UnitHealAbsorbMode:
-  ReducedByIncomingHeals: 0
-  Total: 1
+  values:
+    ReducedByIncomingHeals: 0
+    Total: 1
 UnitIncomingHealClampMode:
-  MaximumHealth: 1
-  MissingHealth: 0
+  values:
+    MaximumHealth: 1
+    MissingHealth: 0
 UnitMaximumHealthMode:
-  Default: 0
-  WithAbsorbs: 1
+  values:
+    Default: 0
+    WithAbsorbs: 1
 UnitMirrorPetFlags:
-  Dismissable: 2
-  ExtraPet: 16
-  RecentlyTamed: 4
-  Renameable: 1
-  Stampede: 8
+  values:
+    Dismissable: 2
+    ExtraPet: 16
+    RecentlyTamed: 4
+    Renameable: 1
+    Stampede: 8
 UnitSex:
-  Both: 3
-  Female: 1
-  Male: 0
-  Neutral: 4
-  None: 2
+  values:
+    Both: 3
+    Female: 1
+    Male: 0
+    Neutral: 4
+    None: 2
 UrlTextureResult:
-  Found: 1
-  NotAllowed: 4
-  NotFound: 2
-  Requested: 3
+  values:
+    Found: 1
+    NotAllowed: 4
+    NotFound: 2
+    Requested: 3
 ValidateNameResult:
-  ConsecutiveSpaces: 13
-  DeclensionDoesntMatchBaseName: 16
-  Failure: 1
-  InvalidApostrophe: 9
-  InvalidCharacter: 5
-  InvalidSpace: 12
-  MixedLanguages: 6
-  MultipleApostrophes: 10
-  NoName: 2
-  Profane: 7
-  Reserved: 8
-  RussianConsecutiveSilentCharacters: 14
-  RussianSilentCharacterAtBeginningOrEnd: 15
-  SpacesDisallowed: 17
-  Success: 0
-  ThreeConsecutive: 11
-  TooLong: 4
-  TooShort: 3
+  values:
+    ConsecutiveSpaces: 13
+    DeclensionDoesntMatchBaseName: 16
+    Failure: 1
+    InvalidApostrophe: 9
+    InvalidCharacter: 5
+    InvalidSpace: 12
+    MixedLanguages: 6
+    MultipleApostrophes: 10
+    NoName: 2
+    Profane: 7
+    Reserved: 8
+    RussianConsecutiveSilentCharacters: 14
+    RussianSilentCharacterAtBeginningOrEnd: 15
+    SpacesDisallowed: 17
+    Success: 0
+    ThreeConsecutive: 11
+    TooLong: 4
+    TooShort: 3
 VasPurchaseProgress:
-  ApplyingLicense: 3
-  Complete: 7
-  Invalid: 0
-  PaymentPending: 2
-  PrePurchase: 1
-  ProcessingFactionChange: 6
-  Ready: 5
-  WaitingOnQueue: 4
+  values:
+    ApplyingLicense: 3
+    Complete: 7
+    Invalid: 0
+    PaymentPending: 2
+    PrePurchase: 1
+    ProcessingFactionChange: 6
+    Ready: 5
+    WaitingOnQueue: 4
 VasServiceType:
-  AppearanceChange: 2
-  CharacterClone: 10
-  CharacterTransfer: 4
-  FactionChange: 1
-  FactionTransfer: 5
-  NameChange: 0
-  RaceChange: 3
+  values:
+    AppearanceChange: 2
+    CharacterClone: 10
+    CharacterTransfer: 4
+    FactionChange: 1
+    FactionTransfer: 5
+    NameChange: 0
+    RaceChange: 3
 VasTransactionPurchaseResult:
-  BeginDbErrors: 20010
-  BeginProxyErrors: 17
-  DbAccountDoesNotOwnCharacter: 20017
-  DbAllianceNotEligible: 20027
-  DbAlreadyRenameFlagged: 20055
-  DbAuthenticatorInsufficient: 20073
-  DbBatchProcessingDisabled: 20028
-  DbBatchStateInvalid: 20067
-  DbBnetAccountNotProvided: 20077
-  DbBoostProcessingDisabled: 20095
-  DbBpayDeliveryPending: 20078
-  DbCagedPetInInventory: 20084
-  DbCannotMoveArenaCaptn: 20064
-  DbCannotMoveGuildmaster: 20012
-  DbCharacterDoesNotExist: 20019
-  DbCharacterWithoutGuild: 20070
-  DbCharLocked: 20026
-  DbCharNotLocked: 20025
-  DbCouldNotObtainCharLock: 20041
-  DbCustomizeAlreadyRequested: 20057
-  DbDeletedGuild: 20071
-  DbDuplicateCharacterName: 20015
-  DbDuplicateSupportRequest: 20063
-  DbEventNotActive: 20068
-  DbEventRealmClosed: 20038
-  DbFactionChangeTooSoon: 20061
-  DbGmSenorityInsufficient: 20072
-  DbGuildLevelInsufficient: 20074
-  DbGuildRankInsufficient: 20069
-  DbHasAuctions: 20033
-  DbHasBpayToken: 20079
-  DbHasCraftingOrders: 20092
-  DbHasHeirloomItem: 20080
-  DbHasMail: 20016
-  DbHasNewPlayerExperienceRestriction: 20091
-  DbHasUnclaimedCacheRewards: 20089
-  DbHouseOwnerRestriction: 20096
-  DbIneligibleMapID: 20076
-  DbIneligibleTargetRealm: 20022
-  DbInvalidName: 20094
-  DbInventoryCorrupt: 20040
-  DbLastCustomizeTooSoon: 20058
-  DbLastRenameTooRecent: 20052
-  DbLastRequestTooSoon: 20054
-  DbLastSaveTooDistant: 20083
-  DbLastSaveTooRecent: 20034
-  DbLockAlreadyRequested: 20044
-  DbLockNotAcknowledged: 20043
-  DbMaxCharactersOnServer: 20013
-  DbMoveInProgress: 20018
-  DbMultipleTransferCn: 20056
-  DbNameChangeSkipped: 20093
-  DbNameNotAvailable: 20051
-  DbNeedsEraChoice: 20090
-  DbNeedsLevelSquish: 20088
-  DbNewLeaderInvalid: 20086
-  DbNewNameTooLong: 20024
-  DbNoCopiesAvailable: 20020
-  DbNoCsiFound: 20065
-  DbNoMixedAlliance: 20014
-  DbNoneBatchQueueID: 20029
-  DbNoneLockID: 20042
-  DbNoneRealmForEvent: 20037
-  DbNoneSupportActionID: 20046
-  DbNoneSupportQueueID: 20045
-  DbNoneTemplateForEvent: 20039
-  DbNotMovebackable: 20048
-  DbNotRollbackable: 20047
-  DbOnBoostCooldown: 20085
-  DbPendingItemAudit: 20066
-  DbPvEPvPTransferNotAllowed: 20087
-  DbRaceClassComboIneligible: 20062
-  DbRealmNotEligible: 20011
-  DbRegionalDbNotFound: 20075
-  DbRenameAlreadyRequested: 20049
-  DbReservationDoesNotMatch: 20053
-  DbReservationExpired: 20050
-  DbResultAccountRestricted: 20082
-  DbResultSourceAccountBanned: 20081
-  DbTooMuchMoneyForLevel: 20032
-  DbTransferDateTooSoon: 20023
-  DbTransferNotCancellable: 20031
-  DbTransferNotFinalized: 20030
-  DbTransferNotLockable: 20035
-  DbTransferNotUnlockable: 20036
-  DbUnableToCustomize: 20060
-  DbUnderMinLevelReq: 20021
-  DbWaitingForPayment: 20059
-  DisallowedDestinationAccount: 9
-  DisallowedSourceAccount: 8
-  EndDbErrors: 20097
-  EndProxyErrors: 56
-  EndServerErrors: 16
-  InvalidBpayDeliverableID: 14
-  InvalidBpayProductID: 13
-  InvalidBpayProductType: 15
-  InvalidDestinationAccount: 6
-  InvalidDestinationRealm: 5
-  InvalidDistribution: 12
-  InvalidSourceAccount: 7
-  LowerBoxLevel: 11
-  None: 0
-  NoneCharacter: 2
-  NoneProduct: 3
-  OnlyOneVasAtATime: 4
-  ProxyAccountDataTooBig: 55
-  ProxyBadDbType: 35
-  ProxyBadObjType: 18
-  ProxyBadRequestContained: 33
-  ProxyBindFailed: 51
-  ProxyCannotDeleteArenaCaptain: 31
-  ProxyCannotDeleteGuildLeader: 30
-  ProxyCannotInsertNull: 45
-  ProxyCannotUndeleteTrialBoostCharacter: 46
-  ProxyCharacterHasWoWToken: 53
-  ProxyCharacterLevelTooHigh: 38
-  ProxyCharacterTransferred: 39
-  ProxyCharacterTransferredNoBoostInProgress: 40
-  ProxyDataInvalid: 22
-  ProxyDbError: 21
-  ProxyDeleteNotSupported: 28
-  ProxyExternalUpdateDetected: 37
-  ProxyGenericError: 44
-  ProxyInsertRequestContainedNoData: 49
-  ProxyInvalidKey: 50
-  ProxyIsReadonly: 34
-  ProxyLockedForToken: 42
-  ProxyLockedForTransfer: 26
-  ProxyLockedForUpgrade: 41
-  ProxyLockedForVas: 43
-  ProxyLocksFailed: 24
-  ProxyLostProxyConnection: 23
-  ProxyMissingResultsPtr: 25
-  ProxyMoneyLimitExceeded: 32
-  ProxyNoReturnValue: 27
-  ProxyObjDropped: 29
-  ProxyObjNotInDb: 19
-  ProxyOperationAlreadyInProgress: 36
-  ProxyPredicateFailed: 47
-  ProxyTooBusyBackOff: 54
-  ProxyTooManyRows: 52
-  ProxyUniqueKey: 20
-  ProxyWeeklyRewardNotFound: 48
-  UnknownError: 10
-  VasPurchaseDisabled: 1
+  values:
+    BeginDbErrors: 20010
+    BeginProxyErrors: 17
+    DbAccountDoesNotOwnCharacter: 20017
+    DbAllianceNotEligible: 20027
+    DbAlreadyRenameFlagged: 20055
+    DbAuthenticatorInsufficient: 20073
+    DbBatchProcessingDisabled: 20028
+    DbBatchStateInvalid: 20067
+    DbBnetAccountNotProvided: 20077
+    DbBoostProcessingDisabled: 20095
+    DbBpayDeliveryPending: 20078
+    DbCagedPetInInventory: 20084
+    DbCannotMoveArenaCaptn: 20064
+    DbCannotMoveGuildmaster: 20012
+    DbCharacterDoesNotExist: 20019
+    DbCharacterWithoutGuild: 20070
+    DbCharLocked: 20026
+    DbCharNotLocked: 20025
+    DbCouldNotObtainCharLock: 20041
+    DbCustomizeAlreadyRequested: 20057
+    DbDeletedGuild: 20071
+    DbDuplicateCharacterName: 20015
+    DbDuplicateSupportRequest: 20063
+    DbEventNotActive: 20068
+    DbEventRealmClosed: 20038
+    DbFactionChangeTooSoon: 20061
+    DbGmSenorityInsufficient: 20072
+    DbGuildLevelInsufficient: 20074
+    DbGuildRankInsufficient: 20069
+    DbHasAuctions: 20033
+    DbHasBpayToken: 20079
+    DbHasCraftingOrders: 20092
+    DbHasHeirloomItem: 20080
+    DbHasMail: 20016
+    DbHasNewPlayerExperienceRestriction: 20091
+    DbHasUnclaimedCacheRewards: 20089
+    DbHouseOwnerRestriction: 20096
+    DbIneligibleMapID: 20076
+    DbIneligibleTargetRealm: 20022
+    DbInvalidName: 20094
+    DbInventoryCorrupt: 20040
+    DbLastCustomizeTooSoon: 20058
+    DbLastRenameTooRecent: 20052
+    DbLastRequestTooSoon: 20054
+    DbLastSaveTooDistant: 20083
+    DbLastSaveTooRecent: 20034
+    DbLockAlreadyRequested: 20044
+    DbLockNotAcknowledged: 20043
+    DbMaxCharactersOnServer: 20013
+    DbMoveInProgress: 20018
+    DbMultipleTransferCn: 20056
+    DbNameChangeSkipped: 20093
+    DbNameNotAvailable: 20051
+    DbNeedsEraChoice: 20090
+    DbNeedsLevelSquish: 20088
+    DbNewLeaderInvalid: 20086
+    DbNewNameTooLong: 20024
+    DbNoCopiesAvailable: 20020
+    DbNoCsiFound: 20065
+    DbNoMixedAlliance: 20014
+    DbNoneBatchQueueID: 20029
+    DbNoneLockID: 20042
+    DbNoneRealmForEvent: 20037
+    DbNoneSupportActionID: 20046
+    DbNoneSupportQueueID: 20045
+    DbNoneTemplateForEvent: 20039
+    DbNotMovebackable: 20048
+    DbNotRollbackable: 20047
+    DbOnBoostCooldown: 20085
+    DbPendingItemAudit: 20066
+    DbPvEPvPTransferNotAllowed: 20087
+    DbRaceClassComboIneligible: 20062
+    DbRealmNotEligible: 20011
+    DbRegionalDbNotFound: 20075
+    DbRenameAlreadyRequested: 20049
+    DbReservationDoesNotMatch: 20053
+    DbReservationExpired: 20050
+    DbResultAccountRestricted: 20082
+    DbResultSourceAccountBanned: 20081
+    DbTooMuchMoneyForLevel: 20032
+    DbTransferDateTooSoon: 20023
+    DbTransferNotCancellable: 20031
+    DbTransferNotFinalized: 20030
+    DbTransferNotLockable: 20035
+    DbTransferNotUnlockable: 20036
+    DbUnableToCustomize: 20060
+    DbUnderMinLevelReq: 20021
+    DbWaitingForPayment: 20059
+    DisallowedDestinationAccount: 9
+    DisallowedSourceAccount: 8
+    EndDbErrors: 20097
+    EndProxyErrors: 56
+    EndServerErrors: 16
+    InvalidBpayDeliverableID: 14
+    InvalidBpayProductID: 13
+    InvalidBpayProductType: 15
+    InvalidDestinationAccount: 6
+    InvalidDestinationRealm: 5
+    InvalidDistribution: 12
+    InvalidSourceAccount: 7
+    LowerBoxLevel: 11
+    None: 0
+    NoneCharacter: 2
+    NoneProduct: 3
+    OnlyOneVasAtATime: 4
+    ProxyAccountDataTooBig: 55
+    ProxyBadDbType: 35
+    ProxyBadObjType: 18
+    ProxyBadRequestContained: 33
+    ProxyBindFailed: 51
+    ProxyCannotDeleteArenaCaptain: 31
+    ProxyCannotDeleteGuildLeader: 30
+    ProxyCannotInsertNull: 45
+    ProxyCannotUndeleteTrialBoostCharacter: 46
+    ProxyCharacterHasWoWToken: 53
+    ProxyCharacterLevelTooHigh: 38
+    ProxyCharacterTransferred: 39
+    ProxyCharacterTransferredNoBoostInProgress: 40
+    ProxyDataInvalid: 22
+    ProxyDbError: 21
+    ProxyDeleteNotSupported: 28
+    ProxyExternalUpdateDetected: 37
+    ProxyGenericError: 44
+    ProxyInsertRequestContainedNoData: 49
+    ProxyInvalidKey: 50
+    ProxyIsReadonly: 34
+    ProxyLockedForToken: 42
+    ProxyLockedForTransfer: 26
+    ProxyLockedForUpgrade: 41
+    ProxyLockedForVas: 43
+    ProxyLocksFailed: 24
+    ProxyLostProxyConnection: 23
+    ProxyMissingResultsPtr: 25
+    ProxyMoneyLimitExceeded: 32
+    ProxyNoReturnValue: 27
+    ProxyObjDropped: 29
+    ProxyObjNotInDb: 19
+    ProxyOperationAlreadyInProgress: 36
+    ProxyPredicateFailed: 47
+    ProxyTooBusyBackOff: 54
+    ProxyTooManyRows: 52
+    ProxyUniqueKey: 20
+    ProxyWeeklyRewardNotFound: 48
+    UnknownError: 10
+    VasPurchaseDisabled: 1
 ViewArenaSize:
-  Three: 1
-  Two: 0
+  values:
+    Three: 1
+    Two: 0
 ViewRaidSize:
-  Forty: 2
-  Ten: 0
-  TwentyFive: 1
+  values:
+    Forty: 2
+    Ten: 0
+    TwentyFive: 1
 VignetteObjectiveType:
-  Defeat: 1
-  DefeatShowRemainingHealth: 2
-  None: 0
+  values:
+    Defeat: 1
+    DefeatShowRemainingHealth: 2
+    None: 0
 VignetteType:
-  FyrakkFlight: 4
-  Normal: 0
-  PvPBounty: 1
-  Torghast: 2
-  Treasure: 3
+  values:
+    FyrakkFlight: 4
+    Normal: 0
+    PvPBounty: 1
+    Torghast: 2
+    Treasure: 3
 Vocalerrorsounds:
-  Abilitycooling: 50
-  Alreadyingroup: 20
-  Alreadyinguild: 21
-  Ammoonlyinbag: 28
-  Bagfull: 29
-  BoundNodrop: 4
-  Cantaffordbankslot: 22
-  CantattackNotarget: 38
-  CantattackNotstandingObsolete: 37
-  Cantattackrongdirection: 36
-  CantcastOutofrange: 46
-  Cantcreate: 18
-  Cantdrinkmore: 6
-  Canteatmore: 7
-  CanteatMoving: 24
-  Cantequip2Hequipped: 42
-  Cantequip2HNoskill: 43
-  Cantequip2HSkill: 41
-  Cantflyhere: 60
-  Cantinvite: 8
-  CantlearnLevel: 13
-  Cantloot: 17
-  CantlootDidntkill: 31
-  CantlootLocked: 33
-  CantlootNotstandingObsolete: 34
-  CantlootToofar: 35
-  CantlootWrongfacing: 32
-  Cantputbag: 26
-  Cantswap: 58
-  CanttaxiNomoney: 54
-  CanttradeSoulbound: 59
-  Cantuseitem: 51
-  Cantuselocked: 55
-  Cantusetoofar: 57
-  Chestinuse: 52
-  Declinegroup: 19
-  ExhaustedObsolete: 67
-  FoodcoolingObsolete: 53
-  Genericnotarget: 45
-  Guildpermissions: 62
-  Invaliditemtarget: 66
-  Invalidtarget: 11
-  Inventoryfull: 0
-  Inviteebusy: 9
-  Itemcooling: 5
-  Itemlocked: 61
-  Itemmaxcount: 30
-  Locked: 14
-  Mustequippitem: 49
-  Noenergy: 64
-  NoequipEver: 3
-  NoequipLevel: 2
-  Noequipslotavailable: 56
-  Noessence: 65
-  Nomana: 15
-  Norage: 63
-  Notabag: 25
-  Notenoughgold: 39
-  Notenoughmoney: 40
-  Notequippable: 44
-  Notwhiledead: 16
-  Outofammo: 1
-  Potioncooling: 47
-  Proficiencyneeded: 48
-  Spellcooling: 12
-  Targettoofar: 10
-  Toomanybankslots: 23
-  Wrongslot: 27
+  values:
+    Abilitycooling: 50
+    Alreadyingroup: 20
+    Alreadyinguild: 21
+    Ammoonlyinbag: 28
+    Bagfull: 29
+    BoundNodrop: 4
+    Cantaffordbankslot: 22
+    CantattackNotarget: 38
+    CantattackNotstandingObsolete: 37
+    Cantattackrongdirection: 36
+    CantcastOutofrange: 46
+    Cantcreate: 18
+    Cantdrinkmore: 6
+    Canteatmore: 7
+    CanteatMoving: 24
+    Cantequip2Hequipped: 42
+    Cantequip2HNoskill: 43
+    Cantequip2HSkill: 41
+    Cantflyhere: 60
+    Cantinvite: 8
+    CantlearnLevel: 13
+    Cantloot: 17
+    CantlootDidntkill: 31
+    CantlootLocked: 33
+    CantlootNotstandingObsolete: 34
+    CantlootToofar: 35
+    CantlootWrongfacing: 32
+    Cantputbag: 26
+    Cantswap: 58
+    CanttaxiNomoney: 54
+    CanttradeSoulbound: 59
+    Cantuseitem: 51
+    Cantuselocked: 55
+    Cantusetoofar: 57
+    Chestinuse: 52
+    Declinegroup: 19
+    ExhaustedObsolete: 67
+    FoodcoolingObsolete: 53
+    Genericnotarget: 45
+    Guildpermissions: 62
+    Invaliditemtarget: 66
+    Invalidtarget: 11
+    Inventoryfull: 0
+    Inviteebusy: 9
+    Itemcooling: 5
+    Itemlocked: 61
+    Itemmaxcount: 30
+    Locked: 14
+    Mustequippitem: 49
+    Noenergy: 64
+    NoequipEver: 3
+    NoequipLevel: 2
+    Noequipslotavailable: 56
+    Noessence: 65
+    Nomana: 15
+    Norage: 63
+    Notabag: 25
+    Notenoughgold: 39
+    Notenoughmoney: 40
+    Notequippable: 44
+    Notwhiledead: 16
+    Outofammo: 1
+    Potioncooling: 47
+    Proficiencyneeded: 48
+    Spellcooling: 12
+    Targettoofar: 10
+    Toomanybankslots: 23
+    Wrongslot: 27
 VoiceChatStatusCode:
-  AlreadyInChannel: 10
-  ChannelAlreadyExists: 9
-  ChannelNameTooLong: 8
-  ChannelNameTooShort: 7
-  ClientAlreadyLoggedIn: 6
-  ClientNotInitialized: 4
-  ClientNotLoggedIn: 5
-  Disabled: 18
-  Failure: 12
-  InvalidCommunityStream: 20
-  InvalidInputDevice: 23
-  InvalidOutputDevice: 24
-  LoginProhibited: 3
-  OperationPending: 1
-  PlayerSilenced: 21
-  PlayerVoiceChatParentalDisabled: 22
-  ProxyConnectionTimeOut: 15
-  ProxyConnectionUnableToConnect: 16
-  ProxyConnectionUnexpectedDisconnect: 17
-  ServiceLost: 13
-  Success: 0
-  TargetNotFound: 11
-  TooManyRequests: 2
-  UnableToLaunchProxy: 14
-  UnsupportedChatChannelType: 19
+  values:
+    AlreadyInChannel: 10
+    ChannelAlreadyExists: 9
+    ChannelNameTooLong: 8
+    ChannelNameTooShort: 7
+    ClientAlreadyLoggedIn: 6
+    ClientNotInitialized: 4
+    ClientNotLoggedIn: 5
+    Disabled: 18
+    Failure: 12
+    InvalidCommunityStream: 20
+    InvalidInputDevice: 23
+    InvalidOutputDevice: 24
+    LoginProhibited: 3
+    OperationPending: 1
+    PlayerSilenced: 21
+    PlayerVoiceChatParentalDisabled: 22
+    ProxyConnectionTimeOut: 15
+    ProxyConnectionUnableToConnect: 16
+    ProxyConnectionUnexpectedDisconnect: 17
+    ServiceLost: 13
+    Success: 0
+    TargetNotFound: 11
+    TooManyRequests: 2
+    UnableToLaunchProxy: 14
+    UnsupportedChatChannelType: 19
 VoiceTtsStatusCode:
-  DestinationQueueFull: 8
-  EngineAllocationFailed: 2
-  EnqueueNotNecessary: 9
-  InputTextEnqueued: 6
-  InternalError: 13
-  InvalidArgument: 12
-  InvalidEngineType: 1
-  ManagerNotFound: 11
-  MaxCharactersExceeded: 4
-  NotSupported: 3
-  SdkNotInitialized: 7
-  Success: 0
-  UtteranceBelowMinimumDuration: 5
-  UtteranceNotFound: 10
+  values:
+    DestinationQueueFull: 8
+    EngineAllocationFailed: 2
+    EnqueueNotNecessary: 9
+    InputTextEnqueued: 6
+    InternalError: 13
+    InvalidArgument: 12
+    InvalidEngineType: 1
+    ManagerNotFound: 11
+    MaxCharactersExceeded: 4
+    NotSupported: 3
+    SdkNotInitialized: 7
+    Success: 0
+    UtteranceBelowMinimumDuration: 5
+    UtteranceNotFound: 10
 WarbandSceneFlags:
-  AwardedAutomatically: 8
-  CannotBeSaved: 4
-  DoNotInclude: 1
-  HiddenUntilCollected: 2
-  IsDefault: 16
+  values:
+    AwardedAutomatically: 8
+    CannotBeSaved: 4
+    DoNotInclude: 1
+    HiddenUntilCollected: 2
+    IsDefault: 16
 WeaponSlot:
-  MainHand: 0
-  OffHand: 1
+  values:
+    MainHand: 0
+    OffHand: 1
 WeeklyRewardChestActivityType:
-  LFGDungeons: 1
-  Scenario: 0
-  World: 2
+  values:
+    LFGDungeons: 1
+    Scenario: 0
+    World: 2
 WeeklyRewardChestClaimRewardResult:
-  CountExceeded: 7
-  DbError: 5
-  InvalidSlot: 3
-  InvalidThreshold: 1
-  LockFailure: 6
-  PlayerNotFound: 2
-  Success: 0
-  TooManyItems: 4
+  values:
+    CountExceeded: 7
+    DbError: 5
+    InvalidSlot: 3
+    InvalidThreshold: 1
+    LockFailure: 6
+    PlayerNotFound: 2
+    Success: 0
+    TooManyItems: 4
 WeeklyRewardChestThresholdType:
-  Activities: 1
-  AlsoReceive: 4
-  Concession: 5
-  None: 0
-  Raid: 3
-  RankedPvP: 2
-  World: 6
+  values:
+    Activities: 1
+    AlsoReceive: 4
+    Concession: 5
+    None: 0
+    Raid: 3
+    RankedPvP: 2
+    World: 6
 WeeklyRewardProgressResult:
-  DbError: 3
-  NoPlayer: 4
-  NoSeason: 1
-  Success: 0
-  TimedOut: 2
+  values:
+    DbError: 3
+    NoPlayer: 4
+    NoSeason: 1
+    Success: 0
+    TimedOut: 2
 WidgetAnimationType:
-  Fade: 1
-  None: 0
+  values:
+    Fade: 1
+    None: 0
 WidgetCurrencyClass:
-  Currency: 0
-  Item: 1
+  values:
+    Currency: 0
+    Item: 1
 WidgetEnabledState:
-  Artifact: 5
-  Black: 6
-  BrightBlue: 7
-  Disabled: 0
-  Green: 4
-  Red: 2
-  White: 3
-  Yellow: 1
+  values:
+    Artifact: 5
+    Black: 6
+    BrightBlue: 7
+    Disabled: 0
+    Green: 4
+    Red: 2
+    White: 3
+    Yellow: 1
 WidgetGlowAnimType:
-  None: 0
-  Pulse: 1
+  values:
+    None: 0
+    Pulse: 1
 WidgetIconSizeType:
-  Large: 2
-  Medium: 1
-  Small: 0
-  Standard: 3
+  values:
+    Large: 2
+    Medium: 1
+    Small: 0
+    Standard: 3
 WidgetIconSourceType:
-  Item: 1
-  Spell: 0
+  values:
+    Item: 1
+    Spell: 0
 WidgetOpacityType:
-  Eighty: 2
-  Fifty: 5
-  Forty: 6
-  Ninety: 1
-  OneHundred: 0
-  Seventy: 3
-  Sixty: 4
-  Ten: 9
-  Thirty: 7
-  Twenty: 8
-  Zero: 10
+  values:
+    Eighty: 2
+    Fifty: 5
+    Forty: 6
+    Ninety: 1
+    OneHundred: 0
+    Seventy: 3
+    Sixty: 4
+    Ten: 9
+    Thirty: 7
+    Twenty: 8
+    Zero: 10
 WidgetShowGlowState:
-  HideGlow: 0
-  ShowGlow: 1
+  values:
+    HideGlow: 0
+    ShowGlow: 1
 WidgetShownState:
-  Hidden: 0
-  Shown: 1
+  values:
+    Hidden: 0
+    Shown: 1
 WidgetTextHorizontalAlignmentType:
-  Center: 1
-  Left: 0
-  Right: 2
+  values:
+    Center: 1
+    Left: 0
+    Right: 2
 WidgetUnitPowerBarFlashMomentType:
-  FlashWhenMax: 0
-  FlashWhenMin: 1
-  NeverFlash: 2
+  values:
+    FlashWhenMax: 0
+    FlashWhenMin: 1
+    NeverFlash: 2
 WorldCursorAnchorType:
-  Cursor: 2
-  Default: 1
-  Nameplate: 3
-  None: 0
+  values:
+    Cursor: 2
+    Default: 1
+    Nameplate: 3
+    None: 0
 WorldElapsedTimerTypes:
-  ChallengeMode: 1
-  None: 0
-  ProvingGround: 2
+  values:
+    ChallengeMode: 1
+    None: 0
+    ProvingGround: 2
 WorldTierDifficulty:
-  Heroic: 2
-  Mythic: 3
-  Normal: 1
+  values:
+    Heroic: 2
+    Mythic: 3
+    Normal: 1
 WoWClientCursorSize:
-  ExtraLarge: 3
-  Large: 2
-  Massive: 4
-  Medium: 1
-  Standard: 0
+  values:
+    ExtraLarge: 3
+    Large: 2
+    Massive: 4
+    Medium: 1
+    Standard: 0
 WoWEntitlementType:
-  Appearance: 4
-  AppearanceSet: 5
-  Battlepet: 2
-  GameTime: 6
-  Illusion: 8
-  Invalid: 9
-  Item: 0
-  Mount: 1
-  Title: 7
-  Toy: 3
+  values:
+    Appearance: 4
+    AppearanceSet: 5
+    Battlepet: 2
+    GameTime: 6
+    Illusion: 8
+    Invalid: 9
+    Item: 0
+    Mount: 1
+    Title: 7
+    Toy: 3
 WoWLabsAreaType:
-  PlunderstormDropDense: 2
-  PlunderstormDropMedium: 1
-  PlunderstormDropSparse: 0
+  values:
+    PlunderstormDropDense: 2
+    PlunderstormDropMedium: 1
+    PlunderstormDropSparse: 0
 ZoneControlActiveState:
-  Active: 1
-  Inactive: 0
+  values:
+    Active: 1
+    Inactive: 0
 ZoneControlDangerFlashType:
-  ShowOnBadStates: 1
-  ShowOnBoth: 2
-  ShowOnGoodStates: 0
-  ShowOnNeither: 3
+  values:
+    ShowOnBadStates: 1
+    ShowOnBoth: 2
+    ShowOnGoodStates: 0
+    ShowOnNeither: 3
 ZoneControlFillType:
-  DoubleFillClockwise: 2
-  DoubleFillCounterClockwise: 3
-  SingleFillClockwise: 0
-  SingleFillCounterClockwise: 1
+  values:
+    DoubleFillClockwise: 2
+    DoubleFillCounterClockwise: 3
+    SingleFillClockwise: 0
+    SingleFillCounterClockwise: 1
 ZoneControlLeadingEdgeType:
-  NoLeadingEdge: 0
-  UseLeadingEdge: 1
+  values:
+    NoLeadingEdge: 0
+    UseLeadingEdge: 1
 ZoneControlMode:
-  BothStatesAreGood: 0
-  NeitherStateIsGood: 3
-  State1IsGood: 1
-  State2IsGood: 2
+  values:
+    BothStatesAreGood: 0
+    NeitherStateIsGood: 3
+    State1IsGood: 1
+    State2IsGood: 2
 ZoneControlState:
-  State1: 0
-  State2: 1
+  values:
+    State1: 0
+    State2: 1

--- a/data/products/wow_classic_era_ptr/enums.yaml
+++ b/data/products/wow_classic_era_ptr/enums.yaml
@@ -1,7214 +1,8007 @@
 AbbreviationDataError:
-  InvalidBreakpoint: 1
-  InvalidFractionDivisor: 4
-  InvalidSignificandDivisor: 2
-  NotMultipleOfTen: 8
+  values:
+    InvalidBreakpoint: 1
+    InvalidFractionDivisor: 4
+    InvalidSignificandDivisor: 2
+    NotMultipleOfTen: 8
 AccountCurrencyTransferResult:
-  CannotUseCurrency: 8
-  CharacterLoggedIn: 2
-  CurrencyTransferDisabled: 10
-  InsufficientCurrency: 3
-  InvalidCharacter: 1
-  InvalidCurrency: 5
-  MaxQuantity: 4
-  NoValidSourceCharacter: 6
-  ServerError: 7
-  Success: 0
-  TransactionInProgress: 9
+  values:
+    CannotUseCurrency: 8
+    CharacterLoggedIn: 2
+    CurrencyTransferDisabled: 10
+    InsufficientCurrency: 3
+    InvalidCharacter: 1
+    InvalidCurrency: 5
+    MaxQuantity: 4
+    NoValidSourceCharacter: 6
+    ServerError: 7
+    Success: 0
+    TransactionInProgress: 9
 AccountData:
-  Bindings: 2
-  Bindings2: 3
-  CharacterListOrder: 16
-  ChatSettings: 7
-  ClickBindings: 12
-  Config: 0
-  Config2: 1
-  CooldownManager: 17
-  CooldownManager2: 18
-  FlaggedIDs: 10
-  FlaggedIDs2: 11
-  FrontendChatSettings: 15
-  Macros: 4
-  Macros2: 5
-  Shop2PendingOrders: 19
-  TtsSettings: 8
-  TtsSettings2: 9
-  UIEditModeAccount: 13
-  UIEditModeChar: 14
-  UILayout: 6
+  values:
+    Bindings: 2
+    Bindings2: 3
+    CharacterListOrder: 16
+    ChatSettings: 7
+    ClickBindings: 12
+    Config: 0
+    Config2: 1
+    CooldownManager: 17
+    CooldownManager2: 18
+    FlaggedIDs: 10
+    FlaggedIDs2: 11
+    FrontendChatSettings: 15
+    Macros: 4
+    Macros2: 5
+    Shop2PendingOrders: 19
+    TtsSettings: 8
+    TtsSettings2: 9
+    UIEditModeAccount: 13
+    UIEditModeChar: 14
+    UILayout: 6
 AccountDataUpdateStatus:
-  Corrupt: 2
-  Failed: 1
-  Success: 0
-  Toobig: 3
+  values:
+    Corrupt: 2
+    Failed: 1
+    Success: 0
+    Toobig: 3
 AccountExportResult:
-  AlreadyInProgress: 11
-  Cancelled: 2
-  FailedToGenerateFile: 13
-  FailedToLockAccount: 12
-  FileInvalid: 8
-  FileWriteFailed: 9
-  NoAccountFound: 5
-  RequestedInvalidCharacter: 6
-  RpcError: 7
-  ShuttingDown: 3
-  Success: 0
-  TimedOut: 4
-  Unavailable: 10
-  UnknownError: 1
+  values:
+    AlreadyInProgress: 11
+    Cancelled: 2
+    FailedToGenerateFile: 13
+    FailedToLockAccount: 12
+    FileInvalid: 8
+    FileWriteFailed: 9
+    NoAccountFound: 5
+    RequestedInvalidCharacter: 6
+    RpcError: 7
+    ShuttingDown: 3
+    Success: 0
+    TimedOut: 4
+    Unavailable: 10
+    UnknownError: 1
 AccountSequenceCacheType:
-  HouseDecor: 2
-  Invalid: 0
-  Local: 1
+  values:
+    HouseDecor: 2
+    Invalid: 0
+    Local: 1
 AccountStateFlags:
-  AccountUpgradeComplete: 4
-  InPetCombat: 2
-  LoadFailed: 1
-  None: 0
-  TokenEligCheckComplete: 8
+  values:
+    AccountUpgradeComplete: 4
+    InPetCombat: 2
+    LoadFailed: 1
+    None: 0
+    TokenEligCheckComplete: 8
 AccountStateLoadedFlags:
-  AccountCurrenciesLoaded: '0x0000000000200000'
-  AccountFactionsLoaded: '0x0000000200000000'
-  AccountItemsLoaded: '0x0000000400000000'
-  AccountMappingLoaded: '0x0000008000000000'
-  AccountNotificationsLoaded: '0x0000000008000000'
-  AccountWowlabsLoaded: '0x0000000020000000'
-  AchievementsLoaded: '0x0000000000000001'
-  ArchivedPurchasesLoaded: '0x0000000000000200'
-  AuctionableTokensLoaded: '0x0000000000002000'
-  BanktabSettingsLoaded: '0x0000004000000000'
-  BattleNetAccountLoaded: '0x0000000000100000'
-  BitVectorsLoaded: '0x0000000100000000'
-  BpayAddLicenseObjectsLoaded: '0x0000000000000800'
-  BpayDistributionObjectsLoaded: '0x0000000000000100'
-  BpayProductitemObjectsLoaded: '0x0000000000020000'
-  CharacterItemsLoaded: '0x0000010000000000'
-  CharactersLoaded: '0x0000000000000040'
-  CombinedQuestLogLoaded: '0x0000000800000000'
-  ConsumableTokensLoaded: '0x0000000000004000'
-  CriteriaLoaded: '0x0000000000000002'
-  CurrencyCapsLoaded: '0x0000000000000010'
-  CurrencyTransferLogLoaded: '0x0000020000000000'
-  DataElementsLoaded: '0x0000001000000000'
-  DynamicCriteriaLoaded: '0x0000000001000000'
-  EventRecordsLoaded: '0x0000200000000000'
-  HousingDataLoaded: '0x0000080000000000'
-  ItemCollectionsLoaded: '0x0000000000001000'
-  LgVendorPurchaseLoaded: '0x0000040000000000'
-  LoadedNone: '0x0000000000000000'
-  MountsLoaded: '0x0000000000000004'
-  PerksHeldItemLoaded: '0x0000000040000000'
-  PerksPastRewardsLoaded: '0x0000000000008000'
-  PerksPendingPurchaseLoaded: '0x0000000010000000'
-  PerksPendingRewardsLoaded: '0x0000000080000000'
-  PetjournalInitialized: '0x0000000000000008'
-  PurchasesLoaded: '0x0000000000000080'
-  QuestCriteriaLoaded: '0x0000000000080000'
-  QuestLogLoaded: '0x0000000000000020'
-  RafActivityLoaded: '0x0000000002000000'
-  RafBalanceLoaded: '0x0000000000400000'
-  RafRewardsLoaded: '0x0000000000800000'
-  RevokedRafRewardsLoaded: '0x0000000004000000'
-  SettingsLoaded: '0x0000000000000400'
-  TransmogOutfitsLoaded: '0x0000400000000000'
-  TrialBoostHistoryLoaded: '0x0000000000040000'
-  VasTransactionsLoaded: '0x0000000000010000'
-  WarbandScenesLoaded: '0x0000100000000000'
-  WarbandsLoaded: '0x0000002000000000'
+  values:
+    AccountCurrenciesLoaded: '0x0000000000200000'
+    AccountFactionsLoaded: '0x0000000200000000'
+    AccountItemsLoaded: '0x0000000400000000'
+    AccountMappingLoaded: '0x0000008000000000'
+    AccountNotificationsLoaded: '0x0000000008000000'
+    AccountWowlabsLoaded: '0x0000000020000000'
+    AchievementsLoaded: '0x0000000000000001'
+    ArchivedPurchasesLoaded: '0x0000000000000200'
+    AuctionableTokensLoaded: '0x0000000000002000'
+    BanktabSettingsLoaded: '0x0000004000000000'
+    BattleNetAccountLoaded: '0x0000000000100000'
+    BitVectorsLoaded: '0x0000000100000000'
+    BpayAddLicenseObjectsLoaded: '0x0000000000000800'
+    BpayDistributionObjectsLoaded: '0x0000000000000100'
+    BpayProductitemObjectsLoaded: '0x0000000000020000'
+    CharacterItemsLoaded: '0x0000010000000000'
+    CharactersLoaded: '0x0000000000000040'
+    CombinedQuestLogLoaded: '0x0000000800000000'
+    ConsumableTokensLoaded: '0x0000000000004000'
+    CriteriaLoaded: '0x0000000000000002'
+    CurrencyCapsLoaded: '0x0000000000000010'
+    CurrencyTransferLogLoaded: '0x0000020000000000'
+    DataElementsLoaded: '0x0000001000000000'
+    DynamicCriteriaLoaded: '0x0000000001000000'
+    EventRecordsLoaded: '0x0000200000000000'
+    HousingDataLoaded: '0x0000080000000000'
+    ItemCollectionsLoaded: '0x0000000000001000'
+    LgVendorPurchaseLoaded: '0x0000040000000000'
+    LoadedNone: '0x0000000000000000'
+    MountsLoaded: '0x0000000000000004'
+    PerksHeldItemLoaded: '0x0000000040000000'
+    PerksPastRewardsLoaded: '0x0000000000008000'
+    PerksPendingPurchaseLoaded: '0x0000000010000000'
+    PerksPendingRewardsLoaded: '0x0000000080000000'
+    PetjournalInitialized: '0x0000000000000008'
+    PurchasesLoaded: '0x0000000000000080'
+    QuestCriteriaLoaded: '0x0000000000080000'
+    QuestLogLoaded: '0x0000000000000020'
+    RafActivityLoaded: '0x0000000002000000'
+    RafBalanceLoaded: '0x0000000000400000'
+    RafRewardsLoaded: '0x0000000000800000'
+    RevokedRafRewardsLoaded: '0x0000000004000000'
+    SettingsLoaded: '0x0000000000000400'
+    TransmogOutfitsLoaded: '0x0000400000000000'
+    TrialBoostHistoryLoaded: '0x0000000000040000'
+    VasTransactionsLoaded: '0x0000000000010000'
+    WarbandScenesLoaded: '0x0000100000000000'
+    WarbandsLoaded: '0x0000002000000000'
 AccountStoreCategoryType:
-  Creature: 1
-  Icon: 4
-  Mount: 3
-  TransmogSet: 2
+  values:
+    Creature: 1
+    Icon: 4
+    Mount: 3
+    TransmogSet: 2
 AccountStoreFrontFlag:
-  Enabled: 1
-  PurchaseEnabled: 2
-  RefundEnabled: 4
+  values:
+    Enabled: 1
+    PurchaseEnabled: 2
+    RefundEnabled: 4
 AccountStoreItemFlag:
-  DisplayAsNew: 4
-  DisplayDefaultArmor: 1
-  DisplayOnly: 8
-  NotInGameReward: 2
+  values:
+    DisplayAsNew: 4
+    DisplayDefaultArmor: 1
+    DisplayOnly: 8
+    NotInGameReward: 2
 AccountStoreItemMode:
-  Hidden: 2
-  Locked: 3
-  Normal: 1
+  values:
+    Hidden: 2
+    Locked: 3
+    Normal: 1
 AccountStoreItemRewardType:
-  Illusion: 7
-  Misc: 10
-  Mount: 2
-  Pet: 3
-  Tender: 9
-  Toy: 5
-  Transmog: 1
-  TransmogSet: 8
-  WarbandScene: 11
+  values:
+    Illusion: 7
+    Misc: 10
+    Mount: 2
+    Pet: 3
+    Tender: 9
+    Toy: 5
+    Transmog: 1
+    TransmogSet: 8
+    WarbandScene: 11
 AccountStoreItemStatus:
-  Owned: 3
-  Refundable: 2
-  Unowned: 1
+  values:
+    Owned: 3
+    Refundable: 2
+    Unowned: 1
 AccountStoreSettlementAction:
-  Give: 1
-  NotSet: 0
-  Remove: 2
+  values:
+    Give: 1
+    NotSet: 0
+    Remove: 2
 AccountStoreState:
-  Available: 0
-  Unavailable: 2
-  Unknown: 1
+  values:
+    Available: 0
+    Unavailable: 2
+    Unknown: 1
 AccountStoreTransactionResult:
-  Incomplete: 1
-  InsufficientFunds: 4
-  InvalidCurrencyType: 8
-  ItemAlreadyOwned: 6
-  ItemNotOwned: 7
-  ItemUnknown: 5
-  NotSupported: 10
-  OwnedButRefundTimeExpired: 9
-  ProxyError: 12
-  Success: 0
-  TransactionInProgress: 3
-  Unavailable: 11
-  UnknownError: 2
+  values:
+    Incomplete: 1
+    InsufficientFunds: 4
+    InvalidCurrencyType: 8
+    ItemAlreadyOwned: 6
+    ItemNotOwned: 7
+    ItemUnknown: 5
+    NotSupported: 10
+    OwnedButRefundTimeExpired: 9
+    ProxyError: 12
+    Success: 0
+    TransactionInProgress: 3
+    Unavailable: 11
+    UnknownError: 2
 AccountStoreTransactionType:
-  DebugRemoveItem: 4
-  DebugResetHistory: 3
-  Purchase: 1
-  Refund: 2
-  Undefined: 0
+  values:
+    DebugRemoveItem: 4
+    DebugResetHistory: 3
+    Purchase: 1
+    Refund: 2
+    Undefined: 0
 AccountTransType:
-  AccountCurrencies: 26
-  AccountNotifications: 38
-  AccountStore: 54
-  Achievements: 4
-  AddLicense: 16
-  ArchivedPurchases: 9
-  AuctionableToken: 18
-  BankTab: 48
-  BattlenetAccount: 25
-  Battlepet: 3
-  BitVectors: 50
-  CharacterDataMerge: 53
-  CharacterItems: 57
-  Characters: 7
-  CombinedQuestLog: 51
-  ConsumableToken: 19
-  CreateOrderInfo: 32
-  Criteria: 5
-  CriteriaNotif: 13
-  CurrencyCaps: 11
-  CurrencyTransferLog: 58
-  Distribution: 2
-  Distributions: 10
-  DynamicCriteria: 30
-  EventRecords: 63
-  Factions: 49
-  FixedLicense: 15
-  GetOrderStatusByPurchaseID: 46
-  HouseInitiativeFavor: 66
-  HousingItem: 64
-  ItemCollections: 17
-  Items: 47
-  LgVendorPurchase: 59
-  LoadWowlabs: 44
-  Mapping: 56
-  Mounts: 6
-  OutstandingRpc: 43
-  PerkItemHold: 39
-  PerkPastRewards: 41
-  PerkPendingRewards: 40
-  PerkTransaction: 42
-  PlayerDataElements: 52
-  Productitem: 21
-  Profile: 61
-  ProxyCreateAccountHonor: 34
-  ProxyForwarder: 0
-  ProxyGenerateBpayID: 37
-  ProxyGmSetHonor: 36
-  ProxyHonorInitialConversion: 33
-  ProxyValidateAccountHonor: 35
-  Purchase: 1
-  Purchases: 8
-  QuestCriteria: 24
-  QuestLog: 12
-  RafActivity: 31
-  RafFriendMonth: 28
-  RafRecruiterAcceptances: 27
-  RafReward: 29
-  SaveWarbandGroups: 60
-  Settings: 14
-  TransmogOutfitCollection: 65
-  TrialBoostHistories: 23
-  TrialBoostHistory: 22
-  UpgradeAccount: 45
-  VasTransaction: 20
-  WarbandGroups: 55
-  WarbandSceneCollection: 62
+  values:
+    AccountCurrencies: 26
+    AccountNotifications: 38
+    AccountStore: 54
+    Achievements: 4
+    AddLicense: 16
+    ArchivedPurchases: 9
+    AuctionableToken: 18
+    BankTab: 48
+    BattlenetAccount: 25
+    Battlepet: 3
+    BitVectors: 50
+    CharacterDataMerge: 53
+    CharacterItems: 57
+    Characters: 7
+    CombinedQuestLog: 51
+    ConsumableToken: 19
+    CreateOrderInfo: 32
+    Criteria: 5
+    CriteriaNotif: 13
+    CurrencyCaps: 11
+    CurrencyTransferLog: 58
+    Distribution: 2
+    Distributions: 10
+    DynamicCriteria: 30
+    EventRecords: 63
+    Factions: 49
+    FixedLicense: 15
+    GetOrderStatusByPurchaseID: 46
+    HouseInitiativeFavor: 66
+    HousingItem: 64
+    ItemCollections: 17
+    Items: 47
+    LgVendorPurchase: 59
+    LoadWowlabs: 44
+    Mapping: 56
+    Mounts: 6
+    OutstandingRpc: 43
+    PerkItemHold: 39
+    PerkPastRewards: 41
+    PerkPendingRewards: 40
+    PerkTransaction: 42
+    PlayerDataElements: 52
+    Productitem: 21
+    Profile: 61
+    ProxyCreateAccountHonor: 34
+    ProxyForwarder: 0
+    ProxyGenerateBpayID: 37
+    ProxyGmSetHonor: 36
+    ProxyHonorInitialConversion: 33
+    ProxyValidateAccountHonor: 35
+    Purchase: 1
+    Purchases: 8
+    QuestCriteria: 24
+    QuestLog: 12
+    RafActivity: 31
+    RafFriendMonth: 28
+    RafRecruiterAcceptances: 27
+    RafReward: 29
+    SaveWarbandGroups: 60
+    Settings: 14
+    TransmogOutfitCollection: 65
+    TrialBoostHistories: 23
+    TrialBoostHistory: 22
+    UpgradeAccount: 45
+    VasTransaction: 20
+    WarbandGroups: 55
+    WarbandSceneCollection: 62
 ActionBarOrientation:
-  Horizontal: 0
-  Vertical: 1
+  values:
+    Horizontal: 0
+    Vertical: 1
 ActionBarVisibleSetting:
-  Always: 0
-  Hidden: 3
-  InCombat: 1
-  OutOfCombat: 2
+  values:
+    Always: 0
+    Hidden: 3
+    InCombat: 1
+    OutOfCombat: 2
 AddOnEnableState:
-  All: 2
-  None: 0
-  Some: 1
+  values:
+    All: 2
+    None: 0
+    Some: 1
 AddOnPerformanceMessageType:
-  OverallAddOnErrorDialog: 2
-  SpecificAddOnChatWarning: 0
-  SpecificAddOnErrorDialog: 1
+  values:
+    OverallAddOnErrorDialog: 2
+    SpecificAddOnChatWarning: 0
+    SpecificAddOnErrorDialog: 1
 AddOnProfilerMetric:
-  CountTimeOver1000Ms: 11
-  CountTimeOver100Ms: 9
-  CountTimeOver10Ms: 7
-  CountTimeOver1Ms: 5
-  CountTimeOver500Ms: 10
-  CountTimeOver50Ms: 8
-  CountTimeOver5Ms: 6
-  EncounterAverageTime: 2
-  LastTime: 3
-  PeakTime: 4
-  RecentAverageTime: 1
-  SessionAverageTime: 0
+  values:
+    CountTimeOver1000Ms: 11
+    CountTimeOver100Ms: 9
+    CountTimeOver10Ms: 7
+    CountTimeOver1Ms: 5
+    CountTimeOver500Ms: 10
+    CountTimeOver50Ms: 8
+    CountTimeOver5Ms: 6
+    EncounterAverageTime: 2
+    LastTime: 3
+    PeakTime: 4
+    RecentAverageTime: 1
+    SessionAverageTime: 0
 AddOnRestrictionState:
-  Activating: 1
-  Active: 2
-  Inactive: 0
+  values:
+    Activating: 1
+    Active: 2
+    Inactive: 0
 AddOnRestrictionType:
-  ChallengeMode: 2
-  Chat: 5
-  Combat: 0
-  Encounter: 1
-  Map: 4
-  PvPMatch: 3
+  values:
+    ChallengeMode: 2
+    Chat: 5
+    Combat: 0
+    Encounter: 1
+    Map: 4
+    PvPMatch: 3
 AddOnSecurityStatus:
-  Banned: 2
-  Insecure: 1
-  NotAvailable: 3
-  Secure: 0
+  values:
+    Banned: 2
+    Insecure: 1
+    NotAvailable: 3
+    Secure: 0
 ArrowCalloutDirection:
-  Down: 1
-  Left: 2
-  Right: 3
-  Up: 0
+  values:
+    Down: 1
+    Left: 2
+    Right: 3
+    Up: 0
 ArrowCalloutType:
-  Generic: 1
-  None: 0
-  Tutorial: 3
-  WidgetContainerNoBorder: 4
-  WorldLootObject: 2
+  values:
+    Generic: 1
+    None: 0
+    Tutorial: 3
+    WidgetContainerNoBorder: 4
+    WorldLootObject: 2
 AssistActionType:
-  CapturedBuff: 6
-  GraveMarker: 2
-  LoungingPlayer: 1
-  None: 0
-  PlacedVo: 3
-  PlayerGuardian: 4
-  PlayerSlayer: 5
+  values:
+    CapturedBuff: 6
+    GraveMarker: 2
+    LoungingPlayer: 1
+    None: 0
+    PlacedVo: 3
+    PlayerGuardian: 4
+    PlayerSlayer: 5
 AuctionHouseCommoditySortOrder:
-  Quantity: 1
-  UnitPrice: 0
+  values:
+    Quantity: 1
+    UnitPrice: 0
 AuctionHouseError:
-  BidIncrement: 2
-  BidOwn: 3
-  BoundItem: 16
-  ConjuredItem: 17
-  DatabaseError: 10
-  DoubleBid: 23
-  EquippedBag: 20
-  FavoritesMaxed: 24
-  HasRestriction: 6
-  HigherBid: 1
-  IsBag: 19
-  IsBusy: 7
-  ItemBoundToAccountUntilEquip: 26
-  ItemHasQuote: 9
-  ItemNotAvailable: 25
-  ItemNotFound: 4
-  LimitedDurationItem: 18
-  LootItem: 22
-  MinBid: 11
-  NotEnoughItems: 12
-  NotEnoughMoney: 0
-  QuestItem: 15
-  RepairItem: 13
-  RestrictedAccountTrial: 5
-  Unavailable: 8
-  UsedCharges: 14
-  WrappedItem: 21
+  values:
+    BidIncrement: 2
+    BidOwn: 3
+    BoundItem: 16
+    ConjuredItem: 17
+    DatabaseError: 10
+    DoubleBid: 23
+    EquippedBag: 20
+    FavoritesMaxed: 24
+    HasRestriction: 6
+    HigherBid: 1
+    IsBag: 19
+    IsBusy: 7
+    ItemBoundToAccountUntilEquip: 26
+    ItemHasQuote: 9
+    ItemNotAvailable: 25
+    ItemNotFound: 4
+    LimitedDurationItem: 18
+    LootItem: 22
+    MinBid: 11
+    NotEnoughItems: 12
+    NotEnoughMoney: 0
+    QuestItem: 15
+    RepairItem: 13
+    RestrictedAccountTrial: 5
+    Unavailable: 8
+    UsedCharges: 14
+    WrappedItem: 21
 AuctionHouseFilter:
-  ArtifactQuality: 12
-  CommonQuality: 7
-  CurrentExpansionOnly: 3
-  EpicQuality: 10
-  ExactMatch: 5
-  LegendaryCraftedItemOnly: 13
-  LegendaryQuality: 11
-  None: 0
-  PoorQuality: 6
-  RareQuality: 9
-  UncollectedOnly: 1
-  UncommonQuality: 8
-  UpgradesOnly: 4
-  UsableOnly: 2
+  values:
+    ArtifactQuality: 12
+    CommonQuality: 7
+    CurrentExpansionOnly: 3
+    EpicQuality: 10
+    ExactMatch: 5
+    LegendaryCraftedItemOnly: 13
+    LegendaryQuality: 11
+    None: 0
+    PoorQuality: 6
+    RareQuality: 9
+    UncollectedOnly: 1
+    UncommonQuality: 8
+    UpgradesOnly: 4
+    UsableOnly: 2
 AuctionHouseItemSortOrder:
-  Bid: 0
-  Buyout: 1
+  values:
+    Bid: 0
+    Buyout: 1
 AuctionHouseNotification:
-  AuctionExpired: 5
-  AuctionOutbid: 3
-  AuctionRemoved: 1
-  AuctionSold: 4
-  AuctionWon: 2
-  BidPlaced: 0
+  values:
+    AuctionExpired: 5
+    AuctionOutbid: 3
+    AuctionRemoved: 1
+    AuctionSold: 4
+    AuctionWon: 2
+    BidPlaced: 0
 AuctionHouseSortOrder:
-  Bid: 3
-  Buyout: 4
-  Level: 2
-  Name: 1
-  Price: 0
-  TimeRemaining: 5
+  values:
+    Bid: 3
+    Buyout: 4
+    Level: 2
+    Name: 1
+    Price: 0
+    TimeRemaining: 5
 AuctionHouseTimeLeftBand:
-  Long: 2
-  Medium: 1
-  Short: 0
-  VeryLong: 3
+  values:
+    Long: 2
+    Medium: 1
+    Short: 0
+    VeryLong: 3
 AuctionStatus:
-  Active: 0
-  Sold: 1
+  values:
+    Active: 0
+    Sold: 1
 AuraFrameIconDirection:
-  Down: 0
-  Left: 0
-  Right: 1
-  Up: 1
+  values:
+    Down: 0
+    Left: 0
+    Right: 1
+    Up: 1
 AuraFrameIconWrap:
-  Down: 0
-  Left: 0
-  Right: 1
-  Up: 1
+  values:
+    Down: 0
+    Left: 0
+    Right: 1
+    Up: 1
 AuraFrameOrientation:
-  Horizontal: 0
-  Vertical: 1
+  values:
+    Horizontal: 0
+    Vertical: 1
 AuraFrameVisibleSetting:
-  Always: 0
-  Hidden: 2
-  InCombat: 1
+  values:
+    Always: 0
+    Hidden: 2
+    InCombat: 1
 AutoCompleteEntryFlag:
-  AccountCharacter: 128
-  Bnet: 8
-  Friend: 4
-  InAOI: 64
-  InGroup: 1
-  InGuild: 2
-  InteractedWith: 16
-  Online: 32
-  RecentPlayer: 256
+  values:
+    AccountCharacter: 128
+    Bnet: 8
+    Friend: 4
+    InAOI: 64
+    InGroup: 1
+    InGuild: 2
+    InteractedWith: 16
+    Online: 32
+    RecentPlayer: 256
 AutoCompletePriority:
-  AccountCharacter: 5
-  AccountCharacterSameRealm: 6
-  Friend: 4
-  Guild: 3
-  InGroup: 2
-  Interacted: 1
-  Other: 0
+  values:
+    AccountCharacter: 5
+    AccountCharacterSameRealm: 6
+    Friend: 4
+    Guild: 3
+    InGroup: 2
+    Interacted: 1
+    Other: 0
 AvgItemLevelCategories:
-  Base: 0
-  EquippedBase: 1
-  EquippedEffective: 2
-  EquippedEffectiveWeighted: 5
-  PvP: 3
-  PvPWeighted: 4
+  values:
+    Base: 0
+    EquippedBase: 1
+    EquippedEffective: 2
+    EquippedEffectiveWeighted: 5
+    PvP: 3
+    PvPWeighted: 4
 AzeriteEssenceSlot:
-  MainSlot: 0
-  PassiveOneSlot: 1
-  PassiveThreeSlot: 3
-  PassiveTwoSlot: 2
+  values:
+    MainSlot: 0
+    PassiveOneSlot: 1
+    PassiveThreeSlot: 3
+    PassiveTwoSlot: 2
 AzeritePowerLevel:
-  Base: 0
-  Downgraded: 2
-  Upgraded: 1
+  values:
+    Base: 0
+    Downgraded: 2
+    Upgraded: 1
 BagFlag:
-  AllowBagsInNonBagSlots: 1024
-  AllowBuyback: 65536
-  AllowPartialStack: 16384
-  AllowSoulboundItemInAccountBank: 134217728
-  AlreadyBound: 4
-  AlreadyOwner: 2
-  AsymmetricSwap: 1048576
-  BagIsEmpty: 16
-  DontFindStack: 1
-  HasRefund: 33554432
-  IgnoreBankcheck: 512
-  IgnoreBoundItemCheck: 64
-  IgnoreExisting: 8192
-  IgnorePetBankcheck: 131072
-  IgnoreReagentBags: 8388608
-  IgnoreSoulbound: 4194304
-  LookInAccountBankOnly: 16777216
-  LookInBankOnly: 32768
-  LookInInventory: 32
-  PreferNeutralPriorityBags: 524288
-  PreferPriorityBags: 262144
-  PreferQuivers: 2048
-  PreferReagentBags: 2097152
-  RecurseQuivers: 256
-  SkipValidCountCheck: 67108864
-  StackOnly: 128
-  Swap: 8
-  SwapBags: 4096
+  values:
+    AllowBagsInNonBagSlots: 1024
+    AllowBuyback: 65536
+    AllowPartialStack: 16384
+    AllowSoulboundItemInAccountBank: 134217728
+    AlreadyBound: 4
+    AlreadyOwner: 2
+    AsymmetricSwap: 1048576
+    BagIsEmpty: 16
+    DontFindStack: 1
+    HasRefund: 33554432
+    IgnoreBankcheck: 512
+    IgnoreBoundItemCheck: 64
+    IgnoreExisting: 8192
+    IgnorePetBankcheck: 131072
+    IgnoreReagentBags: 8388608
+    IgnoreSoulbound: 4194304
+    LookInAccountBankOnly: 16777216
+    LookInBankOnly: 32768
+    LookInInventory: 32
+    PreferNeutralPriorityBags: 524288
+    PreferPriorityBags: 262144
+    PreferQuivers: 2048
+    PreferReagentBags: 2097152
+    RecurseQuivers: 256
+    SkipValidCountCheck: 67108864
+    StackOnly: 128
+    Swap: 8
+    SwapBags: 4096
 BagIndex:
-  Accountbanktab: -5
-  AccountBankTab_1: 13
-  AccountBankTab_2: 14
-  AccountBankTab_3: 15
-  AccountBankTab_4: 16
-  AccountBankTab_5: 17
-  Backpack: 0
-  Bag_1: 1
-  Bag_2: 2
-  Bag_3: 3
-  Bag_4: 4
-  Bank: -1
-  Bankbag: -4
-  BankBag_1: 6
-  BankBag_2: 7
-  BankBag_3: 8
-  BankBag_4: 9
-  BankBag_5: 10
-  BankBag_6: 11
-  BankBag_7: 12
-  Keyring: -2
-  ReagentBag: 5
-  Reagentbank: -3
+  values:
+    Accountbanktab: -5
+    AccountBankTab_1: 13
+    AccountBankTab_2: 14
+    AccountBankTab_3: 15
+    AccountBankTab_4: 16
+    AccountBankTab_5: 17
+    Backpack: 0
+    Bag_1: 1
+    Bag_2: 2
+    Bag_3: 3
+    Bag_4: 4
+    Bank: -1
+    Bankbag: -4
+    BankBag_1: 6
+    BankBag_2: 7
+    BankBag_3: 8
+    BankBag_4: 9
+    BankBag_5: 10
+    BankBag_6: 11
+    BankBag_7: 12
+    Keyring: -2
+    ReagentBag: 5
+    Reagentbank: -3
 BagsDirection:
-  Down: 1
-  Left: 0
-  Right: 1
-  Up: 0
+  values:
+    Down: 1
+    Left: 0
+    Right: 1
+    Up: 0
 BagSlotFlags:
-  ClassConsumables: 4
-  ClassEquipment: 2
-  ClassJunk: 16
-  ClassProfessionGoods: 8
-  ClassQuestItems: 32
-  ClassReagents: 128
-  DisableAutoSort: 1
-  ExcludeJunkSell: 64
-  ExpansionCurrent: 256
-  ExpansionLegacy: 512
+  values:
+    ClassConsumables: 4
+    ClassEquipment: 2
+    ClassJunk: 16
+    ClassProfessionGoods: 8
+    ClassQuestItems: 32
+    ClassReagents: 128
+    DisableAutoSort: 1
+    ExcludeJunkSell: 64
+    ExpansionCurrent: 256
+    ExpansionLegacy: 512
 BagsOrientation:
-  Horizontal: 0
-  Vertical: 1
+  values:
+    Horizontal: 0
+    Vertical: 1
 BalanceType:
-  Eclipse: 0
-  None: -1
+  values:
+    Eclipse: 0
+    None: -1
 BankLockedReason:
-  BankConversionFailed: 3
-  BankDisabled: 2
-  NoAccountInventoryLock: 1
-  None: 0
+  values:
+    BankConversionFailed: 3
+    BankDisabled: 2
+    NoAccountInventoryLock: 1
+    None: 0
 BankType:
-  Account: 2
-  Character: 0
-  Guild: 1
+  values:
+    Account: 2
+    Character: 0
+    Guild: 1
 Base64Variant:
-  Standard: 0
-  StandardUrlSafe: 1
+  values:
+    Standard: 0
+    StandardUrlSafe: 1
 BattlepayBannerType:
-  Discount: 1
-  Featured: 2
-  New: 3
-  None: 0
+  values:
+    Discount: 1
+    Featured: 2
+    New: 3
+    None: 0
 BattlepayDisplayFlags:
-  CardAlwaysShowsTexture: 4
-  CardDoesNotShowModel: 2
-  Deprecated1: 32
-  Deprecated2: 64
-  Expansion: 1
-  HiddenPrice: 8
-  HideWhenOwned: 256
-  RafReward: 512
-  ShowFancyToast: 1024
-  UseHorizontalLayoutForFullCard: 16
-  UseIconBorderWithOverrideTexture: 2048
-  UseSquareIconBorder: 128
+  values:
+    CardAlwaysShowsTexture: 4
+    CardDoesNotShowModel: 2
+    Deprecated1: 32
+    Deprecated2: 64
+    Expansion: 1
+    HiddenPrice: 8
+    HideWhenOwned: 256
+    RafReward: 512
+    ShowFancyToast: 1024
+    UseHorizontalLayoutForFullCard: 16
+    UseIconBorderWithOverrideTexture: 2048
+    UseSquareIconBorder: 128
 BattlepayGroupDisplayType:
-  ActiveTimeOnly: 2
-  Everyone: 0
-  TrialAndVeteranOnly: 1
+  values:
+    ActiveTimeOnly: 2
+    Everyone: 0
+    TrialAndVeteranOnly: 1
 BattlepayLicenseSynthesisFlags:
-  ForceToGameAccount: 1
+  values:
+    ForceToGameAccount: 1
 BattlepayProductChoiceType:
-  ChoiceNone: 0
-  ChoiceOne: 1
-  SpecAndFaction: 2
-  VasCharacter: 3
-  VasCharacterAndName: 4
+  values:
+    ChoiceNone: 0
+    ChoiceOne: 1
+    SpecAndFaction: 2
+    VasCharacter: 3
+    VasCharacterAndName: 4
 BattlepayProductDecorator:
-  Boost: 0
-  Expansion: 1
-  VasService: 3
-  WoWToken: 2
+  values:
+    Boost: 0
+    Expansion: 1
+    VasService: 3
+    WoWToken: 2
 BattlepayProductGroupFlags:
-  DisableOwnedProducts: 4
-  EnabledForTrial: 2
-  EnabledForVeteran: 8
-  HideOwnedProducts: 1
-  None: 0
-  TrialAndVeteranOnly: 16
+  values:
+    DisableOwnedProducts: 4
+    EnabledForTrial: 2
+    EnabledForVeteran: 8
+    HideOwnedProducts: 1
+    None: 0
+    TrialAndVeteranOnly: 16
 BattlepayShopEntryBannerType:
-  Discount: 1
-  Featured: 0
-  New: 2
+  values:
+    Discount: 1
+    Featured: 0
+    New: 2
 BattlepayShopEntryFlags:
-  None: 0
+  values:
+    None: 0
 BattlePetAction:
-  Ability: 1
-  None: 0
-  Skip: 4
-  SwitchPet: 2
-  Trap: 3
+  values:
+    Ability: 1
+    None: 0
+    Skip: 4
+    SwitchPet: 2
+    Trap: 3
 BattlePetBreedQuality:
-  Common: 1
-  Epic: 4
-  Legendary: 5
-  Poor: 0
-  Rare: 3
-  Uncommon: 2
+  values:
+    Common: 1
+    Epic: 4
+    Legendary: 5
+    Poor: 0
+    Rare: 3
+    Uncommon: 2
 BattlePetOwner:
-  Ally: 1
-  Enemy: 2
-  Weather: 0
+  values:
+    Ally: 1
+    Enemy: 2
+    Weather: 0
 BattlePetSources:
-  Achievement: 5
-  Discovery: 10
-  Drop: 0
-  PetStore: 9
-  Profession: 3
-  Promotion: 7
-  Quest: 1
-  Tcg: 8
-  TradingPost: 11
-  Vendor: 2
-  WildPet: 4
-  WorldEvent: 6
+  values:
+    Achievement: 5
+    Discovery: 10
+    Drop: 0
+    PetStore: 9
+    Profession: 3
+    Promotion: 7
+    Quest: 1
+    Tcg: 8
+    TradingPost: 11
+    Vendor: 2
+    WildPet: 4
+    WorldEvent: 6
 BindingContext:
-  HousingEditor: 1
-  HousingEditorBasicAndExpertDecorMode: 7
-  HousingEditorBasicDecorMode: 2
-  HousingEditorCleanupMode: 5
-  HousingEditorCustomizeMode: 4
-  HousingEditorExpertDecorMode: 3
-  HousingEditorExteriorCustomizationMode: 8
-  HousingEditorLayoutMode: 6
-  None: 0
-  ReservedFutureFeatureBinding01: 9
+  values:
+    HousingEditor: 1
+    HousingEditorBasicAndExpertDecorMode: 7
+    HousingEditorBasicDecorMode: 2
+    HousingEditorCleanupMode: 5
+    HousingEditorCustomizeMode: 4
+    HousingEditorExpertDecorMode: 3
+    HousingEditorExteriorCustomizationMode: 8
+    HousingEditorLayoutMode: 6
+    None: 0
+    ReservedFutureFeatureBinding01: 9
 BindingSet:
-  Account: 1
-  Character: 2
-  Current: 3
-  Default: 0
+  values:
+    Account: 1
+    Character: 2
+    Current: 3
+    Default: 0
 BnetAccountFlag:
-  AccountQuestBitFixUp: 64
-  AchievementsToBi: 128
-  BattlePetTrainer: 1
-  CanBuyAhGameTimeTokens: 32768
-  CataLegendaryMountChecked: 262144
-  CataLegendaryMountObtained: 524288
-  DarkRealmLightCopy: 2048
-  Employee: 16
-  EmployeeFlagIsManual: 32
-  GdprErased: 1024
-  InvalidTransmogsFixUp: 256
-  InvalidTransmogsFixUp2: 512
-  IsLegacy: 131072
-  LockedForExport: 16384
-  MopQuestLogFlagsFixUp: 1048576
-  None: 0
-  PetAchievementFixUp: 65536
-  QuestLogFlagsFixUp: 4096
-  RafVeteranNotified: 2
-  TwitterHasTempSecret: 8
-  TwitterLinked: 4
-  WasSecured: 8192
+  values:
+    AccountQuestBitFixUp: 64
+    AchievementsToBi: 128
+    BattlePetTrainer: 1
+    CanBuyAhGameTimeTokens: 32768
+    CataLegendaryMountChecked: 262144
+    CataLegendaryMountObtained: 524288
+    DarkRealmLightCopy: 2048
+    Employee: 16
+    EmployeeFlagIsManual: 32
+    GdprErased: 1024
+    InvalidTransmogsFixUp: 256
+    InvalidTransmogsFixUp2: 512
+    IsLegacy: 131072
+    LockedForExport: 16384
+    MopQuestLogFlagsFixUp: 1048576
+    None: 0
+    PetAchievementFixUp: 65536
+    QuestLogFlagsFixUp: 4096
+    RafVeteranNotified: 2
+    TwitterHasTempSecret: 8
+    TwitterLinked: 4
+    WasSecured: 8192
 BonusStatIndex:
-  Agility: 3
-  AgilityOrIntellect: 73
-  AgilityOrStrength: 72
-  AgilityOrStrengthOrIntellect: 71
-  ArcaneResistance: 56
-  ArmorPenetrationRating: 44
-  AttackPower: 38
-  BlockRating: 15
-  BlockValue: 48
-  CombatRatingAvoidance: 63
-  CombatRatingLifesteal: 62
-  CombatRatingSpeed: 61
-  CombatRatingSturdiness: 64
-  CombatRatingUnused_0: 58
-  CombatRatingUnused_10: 68
-  CombatRatingUnused_11: 69
-  CombatRatingUnused_12: 70
-  CombatRatingUnused_2: 59
-  CombatRatingUnused_27: 66
-  CombatRatingUnused_3: 60
-  CombatRatingUnused_7: 65
-  CombatRatingUnused_9: 67
-  CritMeleeRating: 19
-  CritRangedRating: 20
-  CritRating: 32
-  CritSpellRating: 21
-  CritTakenMeleeRatingObsolete: 25
-  CritTakenRangedRatingObsolete: 26
-  CritTakenRatingObsolete: 34
-  CritTakenSpellRatingObsolete: 27
-  DefenseSkillRating: 12
-  DodgeRating: 13
-  Endurance: 2
-  Energy: 8
-  ExpertiseRating: 37
-  ExtraArmor: 50
-  FireResistance: 51
-  Focus: 10
-  FrostResistance: 52
-  HasteMeleeRatingObsolete: 28
-  HasteRangedRatingObsolete: 29
-  HasteRating: 36
-  HasteSpellRatingObsolete: 30
-  Health: 1
-  HealthRegen: 46
-  HitMeleeRating: 16
-  HitRangedRating: 17
-  HitRating: 31
-  HitSpellRating: 18
-  HitTakenMeleeRatingObsolete: 22
-  HitTakenRangedRatingObsolete: 23
-  HitTakenRatingObsolete: 33
-  HitTakenSpellRatingObsolete: 24
-  HolyResistance: 53
-  Intellect: 5
-  Mana: 0
-  ManaRegeneration: 43
-  MasteryRating: 49
-  NatureResistance: 55
-  ParryRating: 14
-  ProfessionCraftingSpeed: 80
-  ProfessionDeftness: 78
-  ProfessionFinesse: 77
-  ProfessionIngenuity: 82
-  ProfessionInspiration: 75
-  ProfessionMulticraft: 81
-  ProfessionPerception: 79
-  ProfessionResourcefulness: 76
-  PvPPower: 57
-  Rage: 9
-  RangedAttackPower: 39
-  ResilienceRating: 35
-  ShadowResistance: 54
-  SpellDamageDone: 42
-  SpellHealingDone: 41
-  SpellPenetration: 47
-  SpellPower: 45
-  Spirit: 6
-  Stamina: 7
-  Strength: 4
-  StrengthOrIntellect: 74
-  Versatility: 40
-  WeaponSkillRating: 11
+  values:
+    Agility: 3
+    AgilityOrIntellect: 73
+    AgilityOrStrength: 72
+    AgilityOrStrengthOrIntellect: 71
+    ArcaneResistance: 56
+    ArmorPenetrationRating: 44
+    AttackPower: 38
+    BlockRating: 15
+    BlockValue: 48
+    CombatRatingAvoidance: 63
+    CombatRatingLifesteal: 62
+    CombatRatingSpeed: 61
+    CombatRatingSturdiness: 64
+    CombatRatingUnused_0: 58
+    CombatRatingUnused_10: 68
+    CombatRatingUnused_11: 69
+    CombatRatingUnused_12: 70
+    CombatRatingUnused_2: 59
+    CombatRatingUnused_27: 66
+    CombatRatingUnused_3: 60
+    CombatRatingUnused_7: 65
+    CombatRatingUnused_9: 67
+    CritMeleeRating: 19
+    CritRangedRating: 20
+    CritRating: 32
+    CritSpellRating: 21
+    CritTakenMeleeRatingObsolete: 25
+    CritTakenRangedRatingObsolete: 26
+    CritTakenRatingObsolete: 34
+    CritTakenSpellRatingObsolete: 27
+    DefenseSkillRating: 12
+    DodgeRating: 13
+    Endurance: 2
+    Energy: 8
+    ExpertiseRating: 37
+    ExtraArmor: 50
+    FireResistance: 51
+    Focus: 10
+    FrostResistance: 52
+    HasteMeleeRatingObsolete: 28
+    HasteRangedRatingObsolete: 29
+    HasteRating: 36
+    HasteSpellRatingObsolete: 30
+    Health: 1
+    HealthRegen: 46
+    HitMeleeRating: 16
+    HitRangedRating: 17
+    HitRating: 31
+    HitSpellRating: 18
+    HitTakenMeleeRatingObsolete: 22
+    HitTakenRangedRatingObsolete: 23
+    HitTakenRatingObsolete: 33
+    HitTakenSpellRatingObsolete: 24
+    HolyResistance: 53
+    Intellect: 5
+    Mana: 0
+    ManaRegeneration: 43
+    MasteryRating: 49
+    NatureResistance: 55
+    ParryRating: 14
+    ProfessionCraftingSpeed: 80
+    ProfessionDeftness: 78
+    ProfessionFinesse: 77
+    ProfessionIngenuity: 82
+    ProfessionInspiration: 75
+    ProfessionMulticraft: 81
+    ProfessionPerception: 79
+    ProfessionResourcefulness: 76
+    PvPPower: 57
+    Rage: 9
+    RangedAttackPower: 39
+    ResilienceRating: 35
+    ShadowResistance: 54
+    SpellDamageDone: 42
+    SpellHealingDone: 41
+    SpellPenetration: 47
+    SpellPower: 45
+    Spirit: 6
+    Stamina: 7
+    Strength: 4
+    StrengthOrIntellect: 74
+    Versatility: 40
+    WeaponSkillRating: 11
 BrawlType:
-  Arena: 2
-  Battleground: 1
-  LFG: 3
-  None: 0
-  SoloRbg: 5
-  SoloShuffle: 4
+  values:
+    Arena: 2
+    Battleground: 1
+    LFG: 3
+    None: 0
+    SoloRbg: 5
+    SoloShuffle: 4
 BulkPurchaseResult:
-  ResultFailed: 3
-  ResultInProgress: 1
-  ResultInsufficientFunds: 6
-  ResultOk: 0
-  ResultPartialSuccess: 2
-  ResultPurchaseTimeout: 7
-  ResultSystemDisabled: 5
-  ResultTooManyProducts: 4
+  values:
+    ResultFailed: 3
+    ResultInProgress: 1
+    ResultInsufficientFunds: 6
+    ResultOk: 0
+    ResultPartialSuccess: 2
+    ResultPurchaseTimeout: 7
+    ResultSystemDisabled: 5
+    ResultTooManyProducts: 4
 BulkPurchaseStatus:
-  Done: 3
-  Failed: 4
-  FetchEntitlements: 2
-  PlacingOrders: 0
-  PurchasesPending: 1
+  values:
+    Done: 3
+    Failed: 4
+    FetchEntitlements: 2
+    PlacingOrders: 0
+    PurchasesPending: 1
 BulkRefundResult:
-  ResultFailed: 1
-  ResultInvalidRequest: 2
-  ResultOk: 0
-  ResultRefundWindowExpired: 3
-  ResultSystemDisabled: 4
-  ResultTimeout: 5
+  values:
+    ResultFailed: 1
+    ResultInvalidRequest: 2
+    ResultOk: 0
+    ResultRefundWindowExpired: 3
+    ResultSystemDisabled: 4
+    ResultTimeout: 5
 CachedRewardType:
-  Currency: 2
-  Item: 1
-  None: 0
-  Quest: 3
+  values:
+    Currency: 2
+    Item: 1
+    None: 0
+    Quest: 3
 CalendarCommandType:
-  Complain: 10
-  Create: 0
-  GetCalendar: 7
-  GetEvent: 8
-  Invite: 1
-  ModeratorStatus: 6
-  Notes: 11
-  RemoveEvent: 4
-  RemoveInvite: 3
-  Rsvp: 2
-  Status: 5
-  UpdateEvent: 9
+  values:
+    Complain: 10
+    Create: 0
+    GetCalendar: 7
+    GetEvent: 8
+    Invite: 1
+    ModeratorStatus: 6
+    Notes: 11
+    RemoveEvent: 4
+    RemoveInvite: 3
+    Rsvp: 2
+    Status: 5
+    UpdateEvent: 9
 CalendarErrorType:
-  ArenaEventsExceeded: 27
-  CalendarDisabled: 25
-  CommunityEventsExceeded: 1
-  ComplaintAdded: 50
-  ComplaintDisabled: 31
-  ComplaintGm: 34
-  ComplaintLimit: 35
-  ComplaintNotFound: 36
-  ComplaintSameGuild: 33
-  ComplaintSelf: 32
-  CreatorNotFound: 46
-  DataAlreadySet: 24
-  DeleteCreatorFailed: 23
-  EventInvalid: 6
-  EventLocked: 22
-  EventPassed: 21
-  EventsExceeded: 2
-  EventThrottled: 47
-  EventWrongServer: 37
-  Ignored: 14
-  Internal: 49
-  InvalidClub: 45
-  InvalidDate: 17
-  InvalidDescription: 44
-  InvalidMaxSize: 16
-  InvalidNotes: 42
-  InvalidSignup: 39
-  InvalidTime: 18
-  InvalidTitle: 43
-  InvitesExceeded: 15
-  InviteThrottled: 48
-  ModeratorRestricted: 41
-  NameNotFound: 12
-  NeedsTitle: 20
-  NoCommunityInvites: 38
-  NoInvite: 30
-  NoInvites: 19
-  NoModerator: 40
-  NoPermission: 5
-  NotInCommunity: 10
-  NotInGuild: 9
-  NotInvited: 7
-  OtherInvitesExceeded: 4
-  RestrictedAccount: 26
-  RestrictedLevel: 28
-  SelfInvitesExceeded: 3
-  Squelched: 29
-  Success: 0
-  TargetAlreadyInvited: 11
-  UnknownError: 8
-  WrongFaction: 13
+  values:
+    ArenaEventsExceeded: 27
+    CalendarDisabled: 25
+    CommunityEventsExceeded: 1
+    ComplaintAdded: 50
+    ComplaintDisabled: 31
+    ComplaintGm: 34
+    ComplaintLimit: 35
+    ComplaintNotFound: 36
+    ComplaintSameGuild: 33
+    ComplaintSelf: 32
+    CreatorNotFound: 46
+    DataAlreadySet: 24
+    DeleteCreatorFailed: 23
+    EventInvalid: 6
+    EventLocked: 22
+    EventPassed: 21
+    EventsExceeded: 2
+    EventThrottled: 47
+    EventWrongServer: 37
+    Ignored: 14
+    Internal: 49
+    InvalidClub: 45
+    InvalidDate: 17
+    InvalidDescription: 44
+    InvalidMaxSize: 16
+    InvalidNotes: 42
+    InvalidSignup: 39
+    InvalidTime: 18
+    InvalidTitle: 43
+    InvitesExceeded: 15
+    InviteThrottled: 48
+    ModeratorRestricted: 41
+    NameNotFound: 12
+    NeedsTitle: 20
+    NoCommunityInvites: 38
+    NoInvite: 30
+    NoInvites: 19
+    NoModerator: 40
+    NoPermission: 5
+    NotInCommunity: 10
+    NotInGuild: 9
+    NotInvited: 7
+    OtherInvitesExceeded: 4
+    RestrictedAccount: 26
+    RestrictedLevel: 28
+    SelfInvitesExceeded: 3
+    Squelched: 29
+    Success: 0
+    TargetAlreadyInvited: 11
+    UnknownError: 8
+    WrongFaction: 13
 CalendarEventBits:
-  ArenaDeprecated: 256
-  AutoApprove: 32
-  CantComplain: 3788
-  CommunityAnnouncement: 64
-  CommunitySignup: 1024
-  CommunityWide: 3136
-  GuildDeprecated: 2
-  GuildSignup: 2048
-  Holiday: 8
-  Locked: 16
-  Player: 1
-  PlayerCreated: 3395
-  RaidLockout: 128
-  RaidReset: 512
-  System: 4
+  values:
+    ArenaDeprecated: 256
+    AutoApprove: 32
+    CantComplain: 3788
+    CommunityAnnouncement: 64
+    CommunitySignup: 1024
+    CommunityWide: 3136
+    GuildDeprecated: 2
+    GuildSignup: 2048
+    Holiday: 8
+    Locked: 16
+    Player: 1
+    PlayerCreated: 3395
+    RaidLockout: 128
+    RaidReset: 512
+    System: 4
 CalendarEventRepeatOptions:
-  Biweekly: 2
-  Monthly: 3
-  Never: 0
-  Weekly: 1
+  values:
+    Biweekly: 2
+    Monthly: 3
+    Never: 0
+    Weekly: 1
 CalendarEventType:
-  Dungeon: 1
-  HeroicDeprecated: 5
-  Meeting: 3
-  Other: 4
-  PvP: 2
-  Raid: 0
+  values:
+    Dungeon: 1
+    HeroicDeprecated: 5
+    Meeting: 3
+    Other: 4
+    PvP: 2
+    Raid: 0
 CalendarFilterFlags:
-  Battleground: 4
-  Darkmoon: 2
-  RaidLockout: 8
-  RaidReset: 16
-  WeeklyHoliday: 1
+  values:
+    Battleground: 4
+    Darkmoon: 2
+    RaidLockout: 8
+    RaidReset: 16
+    WeeklyHoliday: 1
 CalendarGetEventType:
-  Add: 1
-  Copy: 2
-  Get: 0
+  values:
+    Add: 1
+    Copy: 2
+    Get: 0
 CalendarHolidayFilterType:
-  Battleground: 2
-  Darkmoon: 1
-  Weekly: 0
+  values:
+    Battleground: 2
+    Darkmoon: 1
+    Weekly: 0
 CalendarInviteBits:
-  Creator: 4
-  Moderator: 2
-  None: 0
-  PendingInvite: 1
-  Signup: 8
+  values:
+    Creator: 4
+    Moderator: 2
+    None: 0
+    PendingInvite: 1
+    Signup: 8
 CalendarInviteSortType:
-  Class: 2
-  Level: 1
-  Name: 0
-  Notes: 5
-  Party: 4
-  Status: 3
+  values:
+    Class: 2
+    Level: 1
+    Name: 0
+    Notes: 5
+    Party: 4
+    Status: 3
 CalendarInviteType:
-  Normal: 0
-  Signup: 1
+  values:
+    Normal: 0
+    Signup: 1
 CalendarModeratorStatus:
-  Creator: 2
-  Moderator: 1
-  None: 0
+  values:
+    Creator: 2
+    Moderator: 1
+    None: 0
 CalendarStatus:
-  Available: 1
-  Confirmed: 3
-  Declined: 2
-  Invited: 0
-  NotSignedup: 7
-  Out: 4
-  Signedup: 6
-  Standby: 5
-  Tentative: 8
+  values:
+    Available: 1
+    Confirmed: 3
+    Declined: 2
+    Invited: 0
+    NotSignedup: 7
+    Out: 4
+    Signedup: 6
+    Standby: 5
+    Tentative: 8
 CalendarTexturesType:
-  Dungeons: 0
-  Raid: 1
+  values:
+    Dungeons: 0
+    Raid: 1
 CalendarType:
-  Community: 1
-  Holiday: 4
-  HolidayBattleground: 7
-  HolidayDarkmoon: 6
-  HolidayWeekly: 5
-  Player: 0
-  RaidLockout: 2
-  RaidReset: 3
+  values:
+    Community: 1
+    Holiday: 4
+    HolidayBattleground: 7
+    HolidayDarkmoon: 6
+    HolidayWeekly: 5
+    Player: 0
+    RaidLockout: 2
+    RaidReset: 3
 CalendarWebActionType:
-  Accept: 0
-  Decline: 1
-  Remove: 2
-  ReportSpam: 3
-  Signup: 4
-  Tentative: 5
-  TentativeSignup: 6
+  values:
+    Accept: 0
+    Decline: 1
+    Remove: 2
+    ReportSpam: 3
+    Signup: 4
+    Tentative: 5
+    TentativeSignup: 6
 CameraModeAspectRatio:
-  Cinemascope_2_Dot_4_X_1: 3
-  Default: 0
-  HighDefinition_16_X_9: 2
-  LegacyLetterbox: 1
+  values:
+    Cinemascope_2_Dot_4_X_1: 3
+    Default: 0
+    HighDefinition_16_X_9: 2
+    LegacyLetterbox: 1
 CanRedeemTokenForBalanceResult:
-  FailureCap: 1
-  Ok: 0
+  values:
+    FailureCap: 1
+    Ok: 0
 CaptureBarWidgetFillDirectionType:
-  LeftToRight: 1
-  RightToLeft: 0
+  values:
+    LeftToRight: 1
+    RightToLeft: 0
 Causeofdeath:
-  Creature: 3
-  Drowning: 5
-  Falling: 4
-  Fatigue: 6
-  Fire: 9
-  Lava: 8
-  None: 0
-  PlayerDuel: 2
-  PlayerPvP: 1
-  Slime: 7
+  values:
+    Creature: 3
+    Drowning: 5
+    Falling: 4
+    Fatigue: 6
+    Fire: 9
+    Lava: 8
+    None: 0
+    PlayerDuel: 2
+    PlayerPvP: 1
+    Slime: 7
 CauseofdeathFlags:
-  CreatureNameNeeded: 2
-  NoneNeeded: 0
-  PlayerNameNeeded: 1
-  ZoneNameNeeded: 4
+  values:
+    CreatureNameNeeded: 2
+    NoneNeeded: 0
+    PlayerNameNeeded: 1
+    ZoneNameNeeded: 4
 ChallengeModeHistoryFlags:
-  ConfirmedLeaver: 1
-  None: 0
+  values:
+    ConfirmedLeaver: 1
+    None: 0
 ChallengeModeHistoryResult:
-  Leaver: 1
-  Successful: 0
+  values:
+    Leaver: 1
+    Successful: 0
 ChallengeModeHistoryStatus:
-  Leaver: 1
-  Normal: 0
+  values:
+    Leaver: 1
+    Normal: 0
 ChannelPlayerFlags:
-  ChannelPlayerHidden: 8
-  ChannelPlayerModerator: 2
-  ChannelPlayerNone: 0
-  ChannelPlayerOwner: 1
-  ChannelPlayerTextAllow: 4
+  values:
+    ChannelPlayerHidden: 8
+    ChannelPlayerModerator: 2
+    ChannelPlayerNone: 0
+    ChannelPlayerOwner: 1
+    ChannelPlayerTextAllow: 4
 CharacterServiceInfoFlag:
-  AllowMaxLevelBoost: 2
-  RestrictToRecommendedSpecs: 1
+  values:
+    AllowMaxLevelBoost: 2
+    RestrictToRecommendedSpecs: 1
 CharCustomizationType:
-  CustomOptionFacewear: 7
-  CustomOptionHorn: 6
-  CustomOptionTattoo: 5
-  CustomOptionTattooColor: 8
-  Face: 1
-  FacialHair: 4
-  Hair: 2
-  HairColor: 3
-  Skin: 0
+  values:
+    CustomOptionFacewear: 7
+    CustomOptionHorn: 6
+    CustomOptionTattoo: 5
+    CustomOptionTattooColor: 8
+    Face: 1
+    FacialHair: 4
+    Hair: 2
+    HairColor: 3
+    Skin: 0
 ChatChannelRuleset:
-  ChromieTimeBuringCrusade: 4
-  ChromieTimeCataclysm: 3
-  ChromieTimeLegion: 8
-  ChromieTimeMists: 6
-  ChromieTimeWoD: 7
-  ChromieTimeWrath: 5
-  Disabled: 2
-  Mentor: 1
-  None: 0
+  values:
+    ChromieTimeBuringCrusade: 4
+    ChromieTimeCataclysm: 3
+    ChromieTimeLegion: 8
+    ChromieTimeMists: 6
+    ChromieTimeWoD: 7
+    ChromieTimeWrath: 5
+    Disabled: 2
+    Mentor: 1
+    None: 0
 ChatChannelType:
-  Communities: 4
-  Custom: 1
-  None: 0
-  PrivateParty: 2
-  PublicParty: 3
+  values:
+    Communities: 4
+    Custom: 1
+    None: 0
+    PrivateParty: 2
+    PublicParty: 3
 ChatToxityFilterOptOut:
-  ExcludeFilterAll: 4294967295
-  ExcludeFilterFriend: 1
-  ExcludeFilterGuild: 2
-  FilterAll: 0
+  values:
+    ExcludeFilterAll: 4294967295
+    ExcludeFilterFriend: 1
+    ExcludeFilterGuild: 2
+    FilterAll: 0
 ChatWhisperTargetStatus:
-  CanWhisper: 0
-  CanWhisperGuild: 1
-  Offline: 2
-  WrongFaction: 3
+  values:
+    CanWhisper: 0
+    CanWhisperGuild: 1
+    Offline: 2
+    WrongFaction: 3
 ChrCustomizationCategoryFlag:
-  Subcategory: 2
-  UndressModel: 1
+  values:
+    Subcategory: 2
+    UndressModel: 1
 ChrCustomizationOptionType:
-  Checkbox: 1
-  Dropdown: 0
-  Slider: 2
+  values:
+    Checkbox: 1
+    Dropdown: 0
+    Slider: 2
 ChrModelFeatureFlags:
-  Deprecated0: 8
-  Forms: 2
-  HunterPets: 32
-  Identity: 4
-  Mounts: 16
-  None: 0
-  Players: 64
-  Summons: 1
+  values:
+    Deprecated0: 8
+    Forms: 2
+    HunterPets: 32
+    Identity: 4
+    Mounts: 16
+    None: 0
+    Players: 64
+    Summons: 1
 ChrRacesAllianceType:
-  Alliance: 0
-  Horde: 1
-  NeutralOrNpc: 2
+  values:
+    Alliance: 0
+    Horde: 1
+    NeutralOrNpc: 2
 CinematicType:
-  GameCinematicSequence: 3
-  GameClientScene: 2
-  GameMovie: 1
-  GlueMovie: 0
+  values:
+    GameCinematicSequence: 3
+    GameClientScene: 2
+    GameMovie: 1
+    GlueMovie: 0
 ClientPlatformType:
-  Macintosh: 1
-  Windows: 0
+  values:
+    Macintosh: 1
+    Windows: 0
 ClientSceneType:
-  DefaultSceneType: 0
-  MinigameSceneType: 1
+  values:
+    DefaultSceneType: 0
+    MinigameSceneType: 1
 ClientSettingsConfigFlag:
-  ClientSettingsConfigBeta: 64
-  ClientSettingsConfigBetaRetail: 128
-  ClientSettingsConfigDebug: 1
-  ClientSettingsConfigGm: 8
-  ClientSettingsConfigInternal: 2
-  ClientSettingsConfigPerf: 4
-  ClientSettingsConfigRetail: 256
-  ClientSettingsConfigTest: 16
-  ClientSettingsConfigTestRetail: 32
+  values:
+    ClientSettingsConfigBeta: 64
+    ClientSettingsConfigBetaRetail: 128
+    ClientSettingsConfigDebug: 1
+    ClientSettingsConfigGm: 8
+    ClientSettingsConfigInternal: 2
+    ClientSettingsConfigPerf: 4
+    ClientSettingsConfigRetail: 256
+    ClientSettingsConfigTest: 16
+    ClientSettingsConfigTestRetail: 32
 ClubActionType:
-  ErrorClubActionAcceptInvitation: 13
-  ErrorClubActionAddBan: 22
-  ErrorClubActionCreate: 1
-  ErrorClubActionCreateMessage: 24
-  ErrorClubActionCreateStream: 15
-  ErrorClubActionCreateTicket: 5
-  ErrorClubActionDeclineInvitation: 14
-  ErrorClubActionDestroy: 3
-  ErrorClubActionDestroyMessage: 26
-  ErrorClubActionDestroyStream: 17
-  ErrorClubActionDestroyTicket: 6
-  ErrorClubActionEdit: 2
-  ErrorClubActionEditMember: 19
-  ErrorClubActionEditMemberNote: 20
-  ErrorClubActionEditMessage: 25
-  ErrorClubActionEditStream: 16
-  ErrorClubActionGetBans: 10
-  ErrorClubActionGetInvitations: 11
-  ErrorClubActionGetTicket: 8
-  ErrorClubActionGetTickets: 9
-  ErrorClubActionInviteMember: 18
-  ErrorClubActionKickMember: 21
-  ErrorClubActionLeave: 4
-  ErrorClubActionRedeemTicket: 7
-  ErrorClubActionRemoveBan: 23
-  ErrorClubActionRevokeInvitation: 12
-  ErrorClubActionSubscribe: 0
+  values:
+    ErrorClubActionAcceptInvitation: 13
+    ErrorClubActionAddBan: 22
+    ErrorClubActionCreate: 1
+    ErrorClubActionCreateMessage: 24
+    ErrorClubActionCreateStream: 15
+    ErrorClubActionCreateTicket: 5
+    ErrorClubActionDeclineInvitation: 14
+    ErrorClubActionDestroy: 3
+    ErrorClubActionDestroyMessage: 26
+    ErrorClubActionDestroyStream: 17
+    ErrorClubActionDestroyTicket: 6
+    ErrorClubActionEdit: 2
+    ErrorClubActionEditMember: 19
+    ErrorClubActionEditMemberNote: 20
+    ErrorClubActionEditMessage: 25
+    ErrorClubActionEditStream: 16
+    ErrorClubActionGetBans: 10
+    ErrorClubActionGetInvitations: 11
+    ErrorClubActionGetTicket: 8
+    ErrorClubActionGetTickets: 9
+    ErrorClubActionInviteMember: 18
+    ErrorClubActionKickMember: 21
+    ErrorClubActionLeave: 4
+    ErrorClubActionRedeemTicket: 7
+    ErrorClubActionRemoveBan: 23
+    ErrorClubActionRevokeInvitation: 12
+    ErrorClubActionSubscribe: 0
 ClubErrorType:
-  ErrorClubAlreadyMember: 19
-  ErrorClubBanAlreadyExists: 35
-  ErrorClubBanCountAtMax: 36
-  ErrorClubDoesntAllowCrossFaction: 40
-  ErrorClubEditHasCrossFactionMembers: 41
-  ErrorClubFull: 16
-  ErrorClubInsufficientPrivileges: 24
-  ErrorClubInvalidRoleID: 23
-  ErrorClubInvitationAlreadyExists: 22
-  ErrorClubMemberHasRequiredRole: 31
-  ErrorClubNoClub: 17
-  ErrorClubNoSuchInvitation: 21
-  ErrorClubNoSuchMember: 20
-  ErrorClubNotMember: 18
-  ErrorClubReceivedInvitationCountAtMax: 33
-  ErrorClubSentInvitationCountAtMax: 32
-  ErrorClubStreamCountAtMax: 30
-  ErrorClubStreamCountAtMin: 29
-  ErrorClubStreamInvalidName: 28
-  ErrorClubStreamNoStream: 27
-  ErrorClubTargetIsBanned: 34
-  ErrorClubTicketCountAtMax: 37
-  ErrorClubTicketHasConsumedAllowedRedeemCount: 39
-  ErrorClubTicketNoSuchTicket: 38
-  ErrorClubTooManyClubsJoined: 25
-  ErrorClubVoiceFull: 26
-  ErrorCommunitiesBadTarget: 4
-  ErrorCommunitiesChatMute: 15
-  ErrorCommunitiesGuild: 8
-  ErrorCommunitiesIgnored: 7
-  ErrorCommunitiesMissingShortName: 11
-  ErrorCommunitiesNeutralFaction: 2
-  ErrorCommunitiesNone: 0
-  ErrorCommunitiesProfanity: 12
-  ErrorCommunitiesRestricted: 6
-  ErrorCommunitiesTrial: 13
-  ErrorCommunitiesUnknown: 1
-  ErrorCommunitiesUnknownRealm: 3
-  ErrorCommunitiesUnknownTicket: 10
-  ErrorCommunitiesVeteranTrial: 14
-  ErrorCommunitiesWrongFaction: 5
-  ErrorCommunitiesWrongRegion: 9
+  values:
+    ErrorClubAlreadyMember: 19
+    ErrorClubBanAlreadyExists: 35
+    ErrorClubBanCountAtMax: 36
+    ErrorClubDoesntAllowCrossFaction: 40
+    ErrorClubEditHasCrossFactionMembers: 41
+    ErrorClubFull: 16
+    ErrorClubInsufficientPrivileges: 24
+    ErrorClubInvalidRoleID: 23
+    ErrorClubInvitationAlreadyExists: 22
+    ErrorClubMemberHasRequiredRole: 31
+    ErrorClubNoClub: 17
+    ErrorClubNoSuchInvitation: 21
+    ErrorClubNoSuchMember: 20
+    ErrorClubNotMember: 18
+    ErrorClubReceivedInvitationCountAtMax: 33
+    ErrorClubSentInvitationCountAtMax: 32
+    ErrorClubStreamCountAtMax: 30
+    ErrorClubStreamCountAtMin: 29
+    ErrorClubStreamInvalidName: 28
+    ErrorClubStreamNoStream: 27
+    ErrorClubTargetIsBanned: 34
+    ErrorClubTicketCountAtMax: 37
+    ErrorClubTicketHasConsumedAllowedRedeemCount: 39
+    ErrorClubTicketNoSuchTicket: 38
+    ErrorClubTooManyClubsJoined: 25
+    ErrorClubVoiceFull: 26
+    ErrorCommunitiesBadTarget: 4
+    ErrorCommunitiesChatMute: 15
+    ErrorCommunitiesGuild: 8
+    ErrorCommunitiesIgnored: 7
+    ErrorCommunitiesMissingShortName: 11
+    ErrorCommunitiesNeutralFaction: 2
+    ErrorCommunitiesNone: 0
+    ErrorCommunitiesProfanity: 12
+    ErrorCommunitiesRestricted: 6
+    ErrorCommunitiesTrial: 13
+    ErrorCommunitiesUnknown: 1
+    ErrorCommunitiesUnknownRealm: 3
+    ErrorCommunitiesUnknownTicket: 10
+    ErrorCommunitiesVeteranTrial: 14
+    ErrorCommunitiesWrongFaction: 5
+    ErrorCommunitiesWrongRegion: 9
 ClubFieldType:
-  ClubBroadcast: 3
-  ClubDescription: 2
-  ClubName: 0
-  ClubShortName: 1
-  ClubStreamName: 4
-  ClubStreamSubject: 5
-  NumTypes: 6
+  values:
+    ClubBroadcast: 3
+    ClubDescription: 2
+    ClubName: 0
+    ClubShortName: 1
+    ClubStreamName: 4
+    ClubStreamSubject: 5
+    NumTypes: 6
 ClubFinderApplicationUpdateType:
-  AcceptInvite: 1
-  Cancel: 3
-  DeclineInvite: 2
-  None: 0
+  values:
+    AcceptInvite: 1
+    Cancel: 3
+    DeclineInvite: 2
+    None: 0
 ClubFinderClubPostingStatusFlags:
-  Banned: 5
-  FakePost: 6
-  ForceDescriptionChange: 2
-  ForceNameChange: 3
-  NeedsCacheUpdate: 1
-  None: 0
-  PendingDelete: 7
-  PostDelisted: 8
-  UnderReview: 4
+  values:
+    Banned: 5
+    FakePost: 6
+    ForceDescriptionChange: 2
+    ForceNameChange: 3
+    NeedsCacheUpdate: 1
+    None: 0
+    PendingDelete: 7
+    PostDelisted: 8
+    UnderReview: 4
 ClubFinderDisableReason:
-  Muted: 0
-  Silenced: 1
-  VeteranTrial: 2
+  values:
+    Muted: 0
+    Silenced: 1
+    VeteranTrial: 2
 ClubFinderPostingReportType:
-  ApplicantsName: 3
-  ClubName: 1
-  JoinNote: 4
-  PostersName: 0
-  PostingDescription: 2
+  values:
+    ApplicantsName: 3
+    ClubName: 1
+    JoinNote: 4
+    PostersName: 0
+    PostingDescription: 2
 ClubFinderRequestType:
-  All: 3
-  Community: 2
-  Guild: 1
-  None: 0
+  values:
+    All: 3
+    Community: 2
+    Guild: 1
+    None: 0
 ClubFinderSettingFlags:
-  AutoAccept: 14
-  Damage: 11
-  Dungeons: 1
-  EnableListing: 12
-  FactionAlliance: 16
-  FactionHorde: 15
-  FactionNeutral: 17
-  Healer: 10
-  LanguageReserved1: 21
-  LanguageReserved2: 22
-  LanguageReserved3: 23
-  LanguageReserved4: 24
-  LanguageReserved5: 25
-  Large: 8
-  MaxLevelOnly: 13
-  Medium: 7
-  None: 0
-  PvP: 3
-  Raids: 2
-  RP: 4
-  Small: 6
-  Social: 5
-  SortMemberCount: 19
-  SortNewest: 20
-  SortRelevance: 18
-  Tank: 9
+  values:
+    AutoAccept: 14
+    Damage: 11
+    Dungeons: 1
+    EnableListing: 12
+    FactionAlliance: 16
+    FactionHorde: 15
+    FactionNeutral: 17
+    Healer: 10
+    LanguageReserved1: 21
+    LanguageReserved2: 22
+    LanguageReserved3: 23
+    LanguageReserved4: 24
+    LanguageReserved5: 25
+    Large: 8
+    MaxLevelOnly: 13
+    Medium: 7
+    None: 0
+    PvP: 3
+    Raids: 2
+    RP: 4
+    Small: 6
+    Social: 5
+    SortMemberCount: 19
+    SortNewest: 20
+    SortRelevance: 18
+    Tank: 9
 ClubInvitationCandidateStatus:
-  AlreadyMember: 2
-  Available: 0
-  InvitePending: 1
+  values:
+    AlreadyMember: 2
+    Available: 0
+    InvitePending: 1
 ClubMemberPresence:
-  Away: 4
-  Busy: 5
-  Offline: 3
-  Online: 1
-  OnlineMobile: 2
-  Unknown: 0
+  values:
+    Away: 4
+    Busy: 5
+    Offline: 3
+    Online: 1
+    OnlineMobile: 2
+    Unknown: 0
 ClubRemovedReason:
-  Banned: 1
-  ClubDestroyed: 3
-  None: 0
-  Removed: 2
+  values:
+    Banned: 1
+    ClubDestroyed: 3
+    None: 0
+    Removed: 2
 ClubRestrictionReason:
-  None: 0
-  Unavailable: 1
+  values:
+    None: 0
+    Unavailable: 1
 ClubRoleIdentifier:
-  Leader: 2
-  Member: 4
-  Moderator: 3
-  Owner: 1
+  values:
+    Leader: 2
+    Member: 4
+    Moderator: 3
+    Owner: 1
 ClubStreamNotificationFilter:
-  All: 2
-  Mention: 1
-  None: 0
+  values:
+    All: 2
+    Mention: 1
+    None: 0
 ClubStreamType:
-  General: 0
-  Guild: 1
-  Officer: 2
-  Other: 3
+  values:
+    General: 0
+    Guild: 1
+    Officer: 2
+    Other: 3
 ClubType:
-  BattleNet: 0
-  Character: 1
-  Guild: 2
-  Other: 3
+  values:
+    BattleNet: 0
+    Character: 1
+    Guild: 2
+    Other: 3
 ColorOverride:
-  ItemQualityAccount: 7
-  ItemQualityArtifact: 6
-  ItemQualityCommon: 1
-  ItemQualityEpic: 4
-  ItemQualityLegendary: 5
-  ItemQualityPoor: 0
-  ItemQualityRare: 3
-  ItemQualityUncommon: 2
+  values:
+    ItemQualityAccount: 7
+    ItemQualityArtifact: 6
+    ItemQualityCommon: 1
+    ItemQualityEpic: 4
+    ItemQualityLegendary: 5
+    ItemQualityPoor: 0
+    ItemQualityRare: 3
+    ItemQualityUncommon: 2
 CombatAudioAlertCastState:
-  Off: 0
-  OnCastEnd: 2
-  OnCastStart: 1
+  values:
+    Off: 0
+    OnCastEnd: 2
+    OnCastStart: 1
 CombatAudioAlertCategory:
-  General: 0
-  PartyHealth: 7
-  PlayerCast: 3
-  PlayerDebuffs: 8
-  PlayerHealth: 1
-  PlayerResource1: 5
-  PlayerResource2: 6
-  TargetCast: 4
-  TargetHealth: 2
+  values:
+    General: 0
+    PartyHealth: 7
+    PlayerCast: 3
+    PlayerDebuffs: 8
+    PlayerHealth: 1
+    PlayerResource1: 5
+    PlayerResource2: 6
+    TargetCast: 4
+    TargetHealth: 2
 CombatAudioAlertDebuffSelfAlertValues:
-  DispelType: 1
-  Off: 0
+  values:
+    DispelType: 1
+    Off: 0
 CombatAudioAlertPartyPercentValues:
-  Off: 0
-  Under100Percent: 1
-  Under10Percent: 10
-  Under20Percent: 9
-  Under30Percent: 8
-  Under40Percent: 7
-  Under50Percent: 6
-  Under60Percent: 5
-  Under70Percent: 4
-  Under80Percent: 3
-  Under90Percent: 2
+  values:
+    Off: 0
+    Under100Percent: 1
+    Under10Percent: 10
+    Under20Percent: 9
+    Under30Percent: 8
+    Under40Percent: 7
+    Under50Percent: 6
+    Under60Percent: 5
+    Under70Percent: 4
+    Under80Percent: 3
+    Under90Percent: 2
 CombatAudioAlertPercentValues:
-  Every10Percent: 1
-  Every20Percent: 2
-  Every30Percent: 3
-  Every40Percent: 4
-  Every50Percent: 5
-  Off: 0
+  values:
+    Every10Percent: 1
+    Every20Percent: 2
+    Every30Percent: 3
+    Every40Percent: 4
+    Every50Percent: 5
+    Off: 0
 CombatAudioAlertPlayerCastFormatValues:
-  Cast: 3
-  Casting: 2
-  CastingSpellname: 0
-  CastSpellname: 1
-  Spellname: 4
+  values:
+    Cast: 3
+    Casting: 2
+    CastingSpellname: 0
+    CastSpellname: 1
+    Spellname: 4
 CombatAudioAlertPlayerDebuffFormatValues:
-  Full: 0
-  NoSpellname: 1
+  values:
+    Full: 0
+    NoSpellname: 1
 CombatAudioAlertPlayerHealthFormatValues:
-  HealthFull: 0
-  HealthNoPercent: 1
-  HealthNoPercentDiv10: 2
-  NoHealthFull: 3
-  NoHealthNoPercent: 4
-  NoHealthNoPercentDiv10: 5
+  values:
+    HealthFull: 0
+    HealthNoPercent: 1
+    HealthNoPercentDiv10: 2
+    NoHealthFull: 3
+    NoHealthNoPercent: 4
+    NoHealthNoPercentDiv10: 5
 CombatAudioAlertPlayerResourceFormatValues:
-  NoResourceFull: 3
-  NoResourceNoPercent: 4
-  NoResourceNoPercentDiv10: 5
-  ResourceFull: 0
-  ResourceNoPercent: 1
-  ResourceNoPercentDiv10: 2
+  values:
+    NoResourceFull: 3
+    NoResourceNoPercent: 4
+    NoResourceNoPercentDiv10: 5
+    ResourceFull: 0
+    ResourceNoPercent: 1
+    ResourceNoPercentDiv10: 2
 CombatAudioAlertSayIfTargetedType:
-  Aggro: 1
-  None: 0
-  Targeted: 2
-  TargetedBy: 3
+  values:
+    Aggro: 1
+    None: 0
+    Targeted: 2
+    TargetedBy: 3
 CombatAudioAlertSpecSetting:
-  Resource1Format: 1
-  Resource1Percent: 0
-  Resource1Voice: 2
-  Resource1Volume: 3
-  Resource2Format: 5
-  Resource2Percent: 4
-  Resource2Voice: 6
-  Resource2Volume: 7
-  SayIfTargeted: 8
+  values:
+    Resource1Format: 1
+    Resource1Percent: 0
+    Resource1Voice: 2
+    Resource1Volume: 3
+    Resource2Format: 5
+    Resource2Percent: 4
+    Resource2Voice: 6
+    Resource2Volume: 7
+    SayIfTargeted: 8
 CombatAudioAlertTargetCastFormatValues:
-  Cast: 5
-  Casting: 4
-  CastingSpellname: 2
-  CastSpellname: 3
-  Spellname: 6
-  TargetCastingSpellname: 0
-  TargetCastSpellname: 1
+  values:
+    Cast: 5
+    Casting: 4
+    CastingSpellname: 2
+    CastSpellname: 3
+    Spellname: 6
+    TargetCastingSpellname: 0
+    TargetCastSpellname: 1
 CombatAudioAlertTargetDeathBehavior:
-  Default: 0
-  SayTargetDead: 1
+  values:
+    Default: 0
+    SayTargetDead: 1
 CombatAudioAlertTargetHealthFormatValues:
-  HealthFull: 3
-  HealthNoPercent: 4
-  HealthNoPercentDiv10: 5
-  NoHealthFull: 0
-  NoHealthNoPercent: 1
-  NoHealthNoPercentDiv10: 2
-  TargetFull: 6
-  TargetNoPercent: 7
-  TargetNoPercentDiv10: 8
+  values:
+    HealthFull: 3
+    HealthNoPercent: 4
+    HealthNoPercentDiv10: 5
+    NoHealthFull: 0
+    NoHealthNoPercent: 1
+    NoHealthNoPercentDiv10: 2
+    TargetFull: 6
+    TargetNoPercent: 7
+    TargetNoPercentDiv10: 8
 CombatAudioAlertThrottle:
-  PlayerCast: 3
-  PlayerHealth: 1
-  PlayerHealthSamePercent: 7
-  PlayerResource1: 5
-  PlayerResource1SamePercent: 9
-  PlayerResource2: 6
-  PlayerResource2SamePercent: 10
-  Sample: 0
-  TargetCast: 4
-  TargetHealth: 2
-  TargetHealthSamePercent: 8
+  values:
+    PlayerCast: 3
+    PlayerHealth: 1
+    PlayerHealthSamePercent: 7
+    PlayerResource1: 5
+    PlayerResource1SamePercent: 9
+    PlayerResource2: 6
+    PlayerResource2SamePercent: 10
+    Sample: 0
+    TargetCast: 4
+    TargetHealth: 2
+    TargetHealthSamePercent: 8
 CombatAudioAlertType:
-  Cast: 1
-  Health: 0
+  values:
+    Cast: 1
+    Health: 0
 CombatAudioAlertUnit:
-  Player: 0
-  Target: 1
+  values:
+    Player: 0
+    Target: 1
 CombatLogMessageOrder:
-  Newest: 0
-  Oldest: 1
+  values:
+    Newest: 0
+    Oldest: 1
 CombatLogObject:
-  AffiliationMine: 1
-  AffiliationOutsider: 8
-  AffiliationParty: 2
-  AffiliationRaid: 4
-  ControlNpc: 512
-  ControlPlayer: 256
-  Empty: 0
-  Focus: 131072
-  Mainassist: 524288
-  Maintank: 262144
-  None: 2147483648
-  ReactionFriendly: 16
-  ReactionHostile: 64
-  ReactionNeutral: 32
-  Target: 65536
-  TypeGuardian: 8192
-  TypeNpc: 2048
-  TypeObject: 16384
-  TypePet: 4096
-  TypePlayer: 1024
+  values:
+    AffiliationMine: 1
+    AffiliationOutsider: 8
+    AffiliationParty: 2
+    AffiliationRaid: 4
+    ControlNpc: 512
+    ControlPlayer: 256
+    Empty: 0
+    Focus: 131072
+    Mainassist: 524288
+    Maintank: 262144
+    None: 2147483648
+    ReactionFriendly: 16
+    ReactionHostile: 64
+    ReactionNeutral: 32
+    Target: 65536
+    TypeGuardian: 8192
+    TypeNpc: 2048
+    TypeObject: 16384
+    TypePet: 4096
+    TypePlayer: 1024
 CombatLogObjectTarget:
-  RaidNone: 2147483648
-  Raidtarget1: 1
-  Raidtarget2: 2
-  Raidtarget3: 4
-  Raidtarget4: 8
-  Raidtarget5: 16
-  Raidtarget6: 32
-  Raidtarget7: 64
-  Raidtarget8: 128
+  values:
+    RaidNone: 2147483648
+    Raidtarget1: 1
+    Raidtarget2: 2
+    Raidtarget3: 4
+    Raidtarget4: 8
+    Raidtarget5: 16
+    Raidtarget6: 32
+    Raidtarget7: 64
+    Raidtarget8: 128
 CombinedQuestLogStatus:
-  Available: 0
-  Complete: 1
-  CompleteDaily: 2
-  CompleteGameReset: 6
-  CompleteMonthly: 4
-  CompleteWeekly: 3
-  CompleteYearly: 5
-  Reset: 7
+  values:
+    Available: 0
+    Complete: 1
+    CompleteDaily: 2
+    CompleteGameReset: 6
+    CompleteMonthly: 4
+    CompleteWeekly: 3
+    CompleteYearly: 5
+    Reset: 7
 CombinedQuestStatus:
-  Completed: 1
-  Invalid: 0
-  NotCompleted: 2
+  values:
+    Completed: 1
+    Invalid: 0
+    NotCompleted: 2
 CommunicationMode:
-  OpenMic: 1
-  PushToTalk: 0
+  values:
+    OpenMic: 1
+    PushToTalk: 0
 CompanionConfigSlotTypes:
-  Combat: 2
-  Role: 0
-  Utility: 1
+  values:
+    Combat: 2
+    Role: 0
+    Utility: 1
 CompressionLevel:
-  Default: 0
-  OptimizeForSize: 2
-  OptimizeForSpeed: 1
+  values:
+    Default: 0
+    OptimizeForSize: 2
+    OptimizeForSpeed: 1
 CompressionMethod:
-  Deflate: 0
-  Gzip: 2
-  Zlib: 1
+  values:
+    Deflate: 0
+    Gzip: 2
+    Zlib: 1
 ConfirmationPromptUIType:
-  BonusRoll: 1
-  SimpleWarning: 2
-  SimpleWarningAlert: 4
-  StaticText: 0
-  StaticTextAlert: 3
+  values:
+    BonusRoll: 1
+    SimpleWarning: 2
+    SimpleWarningAlert: 4
+    StaticText: 0
+    StaticTextAlert: 3
 ConsoleCategory:
-  Combat: 3
-  Console: 2
-  Debug: 0
-  Default: 5
-  Game: 4
-  Gm: 8
-  Graphics: 1
-  Net: 6
-  None: 10
-  Reveal: 9
-  Sound: 7
+  values:
+    Combat: 3
+    Console: 2
+    Debug: 0
+    Default: 5
+    Game: 4
+    Gm: 8
+    Graphics: 1
+    Net: 6
+    None: 10
+    Reveal: 9
+    Sound: 7
 ConsoleColorType:
-  AdminColor: 6
-  BackgroundColor: 8
-  ClickbufferColor: 9
-  DefaultColor: 0
-  DefaultGreen: 11
-  EchoColor: 2
-  ErrorColor: 3
-  GlobalColor: 5
-  HighlightColor: 7
-  InputColor: 1
-  PrivateColor: 10
-  WarningColor: 4
+  values:
+    AdminColor: 6
+    BackgroundColor: 8
+    ClickbufferColor: 9
+    DefaultColor: 0
+    DefaultGreen: 11
+    EchoColor: 2
+    ErrorColor: 3
+    GlobalColor: 5
+    HighlightColor: 7
+    InputColor: 1
+    PrivateColor: 10
+    WarningColor: 4
 ConsoleCommandType:
-  Command: 1
-  Cvar: 0
-  Macro: 2
-  Script: 3
+  values:
+    Command: 1
+    Cvar: 0
+    Macro: 2
+    Script: 3
 ContentTrackingError:
-  AlreadyTracked: 2
-  MaxTracked: 1
-  Untrackable: 0
+  values:
+    AlreadyTracked: 2
+    MaxTracked: 1
+    Untrackable: 0
 ContentTrackingResult:
-  DataPending: 1
-  Failure: 2
-  Success: 0
+  values:
+    DataPending: 1
+    Failure: 2
+    Success: 0
 ContentTrackingStopType:
-  Collected: 1
-  Invalidated: 0
-  Manual: 2
+  values:
+    Collected: 1
+    Invalidated: 0
+    Manual: 2
 ContentTrackingTargetType:
-  Achievement: 2
-  JournalEncounter: 0
-  Profession: 3
-  Quest: 4
-  Vendor: 1
+  values:
+    Achievement: 2
+    JournalEncounter: 0
+    Profession: 3
+    Quest: 4
+    Vendor: 1
 ContentTrackingType:
-  Achievement: 2
-  Appearance: 0
-  Decor: 3
-  Mount: 1
+  values:
+    Achievement: 2
+    Appearance: 0
+    Decor: 3
+    Mount: 1
 ContributionAppearanceFlags:
-  TooltipUseTimeRemaining: 0
+  values:
+    TooltipUseTimeRemaining: 0
 ContributionResult:
-  FailedConditionCheck: 5
-  IncorrectState: 2
-  InternalError: 7
-  InvalidID: 3
-  MustBeNearNpc: 1
-  QuestDataMissing: 4
-  Success: 0
-  UnableToCompleteTurnIn: 6
+  values:
+    FailedConditionCheck: 5
+    IncorrectState: 2
+    InternalError: 7
+    InvalidID: 3
+    MustBeNearNpc: 1
+    QuestDataMissing: 4
+    Success: 0
+    UnableToCompleteTurnIn: 6
 ContributionState:
-  Active: 2
-  Building: 1
-  Destroyed: 4
-  None: 0
-  UnderAttack: 3
+  values:
+    Active: 2
+    Building: 1
+    Destroyed: 4
+    None: 0
+    UnderAttack: 3
 CooldownSetLinkedSpellFlags:
-  UseAsTooltip: 1
+  values:
+    UseAsTooltip: 1
 CooldownSetSpellFlags:
-  HideAura: 1
-  HideByDefault: 2
+  values:
+    HideAura: 1
+    HideByDefault: 2
 CooldownViewerAddAlertStatus:
-  DuplicateAlert: 3
-  InvalidAlertType: 1
-  InvalidEventType: 2
-  Success: 0
+  values:
+    DuplicateAlert: 3
+    InvalidAlertType: 1
+    InvalidEventType: 2
+    Success: 0
 CooldownViewerAlertEventType:
-  Available: 1
-  ChargeGained: 4
-  OnAuraApplied: 5
-  OnAuraRemoved: 6
-  OnCooldown: 3
-  PandemicTime: 2
+  values:
+    Available: 1
+    ChargeGained: 4
+    OnAuraApplied: 5
+    OnAuraRemoved: 6
+    OnCooldown: 3
+    PandemicTime: 2
 CooldownViewerAlertType:
-  Sound: 1
-  Visual: 2
+  values:
+    Sound: 1
+    Visual: 2
 CooldownViewerBarContent:
-  IconAndName: 0
-  IconOnly: 1
-  NameOnly: 2
+  values:
+    IconAndName: 0
+    IconOnly: 1
+    NameOnly: 2
 CooldownViewerCategory:
-  Essential: 0
-  TrackedBar: 3
-  TrackedBuff: 2
-  Utility: 1
+  values:
+    Essential: 0
+    TrackedBar: 3
+    TrackedBuff: 2
+    Utility: 1
 CooldownViewerIconDirection:
-  Left: 0
-  Right: 1
+  values:
+    Left: 0
+    Right: 1
 CooldownViewerOrientation:
-  Horizontal: 0
-  Vertical: 1
+  values:
+    Horizontal: 0
+    Vertical: 1
 CooldownViewerVisibleSetting:
-  Always: 0
-  Hidden: 2
-  InCombat: 1
+  values:
+    Always: 0
+    Hidden: 2
+    InCombat: 1
 CornerstonePurchaseMode:
-  Basic: 0
-  Import: 1
-  Move: 2
+  values:
+    Basic: 0
+    Import: 1
+    Move: 2
 CovenantSkill:
-  Kyrian: 2730
-  Necrolord: 2733
-  NightFae: 2732
-  Venthyr: 2731
+  values:
+    Kyrian: 2730
+    Necrolord: 2733
+    NightFae: 2732
+    Venthyr: 2731
 CovenantType:
-  Kyrian: 1
-  Necrolord: 4
-  NightFae: 3
-  None: 0
-  Venthyr: 2
+  values:
+    Kyrian: 1
+    Necrolord: 4
+    NightFae: 3
+    None: 0
+    Venthyr: 2
 CraftingOrderDuration:
-  Long: 2
-  Medium: 1
-  Short: 0
+  values:
+    Long: 2
+    Medium: 1
+    Short: 0
 CraftingOrderFlags:
-  HasAllReagents: 8
-  HasNoneReagents: 2
-  HasSomeReagents: 4
-  IsFulfillable: 16
-  IsRecraft: 1
-  None: 0
+  values:
+    HasAllReagents: 8
+    HasNoneReagents: 2
+    HasSomeReagents: 4
+    IsFulfillable: 16
+    IsRecraft: 1
+    None: 0
 CraftingOrderItemFlags:
-  HasEnchantmentData: 2
-  None: 0
-  NpcProvided: 1
+  values:
+    HasEnchantmentData: 2
+    None: 0
+    NpcProvided: 1
 CraftingOrderItemType:
-  CraftedResult: 2
-  Currency: 5
-  Deprecated: 4
-  Item: 0
-  Recraft: 1
-  RemoveReagent: 3
+  values:
+    CraftedResult: 2
+    Currency: 5
+    Deprecated: 4
+    Item: 0
+    Recraft: 1
+    RemoveReagent: 3
 CraftingOrderReagentSource:
-  Any: 0
-  Crafter: 2
-  Customer: 1
-  None: 3
+  values:
+    Any: 0
+    Crafter: 2
+    Customer: 1
+    None: 3
 CraftingOrderResult:
-  Aborted: 1
-  AlreadyClaimed: 2
-  AlreadyCrafted: 3
-  CannotBeOrdered: 4
-  CannotCancel: 5
-  CannotClaim: 6
-  CannotClaimOwnOrder: 7
-  CannotCraft: 8
-  CannotCreate: 9
-  CannotFulfill: 10
-  CannotRecraft: 11
-  CannotReject: 12
-  CannotRelease: 13
-  CrafterIsIgnored: 14
-  DatabaseError: 15
-  Expired: 16
-  InvalidDuration: 18
-  InvalidMinQuality: 19
-  InvalidNotes: 20
-  InvalidReagent: 21
-  InvalidRealm: 22
-  InvalidRecipe: 23
-  InvalidRecraftItem: 24
-  InvalidSort: 25
-  InvalidTarget: 26
-  InvalidType: 27
-  Locked: 17
-  MaxOrdersReached: 28
-  MissingCraftingTable: 29
-  MissingCurrency: 30
-  MissingItem: 31
-  MissingNpc: 32
-  MissingOrder: 33
-  MissingRecraftItem: 34
-  NoAccountItems: 35
-  NotClaimed: 36
-  NotCrafted: 37
-  NotInGuild: 38
-  NotYetImplemented: 39
-  Ok: 0
-  OutOfPublicOrderCapacity: 40
-  ServerIsNotAvailable: 41
-  TargetCannotCraft: 43
-  TargetLocked: 44
-  ThrottleViolation: 42
-  Timeout: 45
-  TooManyCurrencies: 46
-  TooManyItems: 47
-  WrongVersion: 48
+  values:
+    Aborted: 1
+    AlreadyClaimed: 2
+    AlreadyCrafted: 3
+    CannotBeOrdered: 4
+    CannotCancel: 5
+    CannotClaim: 6
+    CannotClaimOwnOrder: 7
+    CannotCraft: 8
+    CannotCreate: 9
+    CannotFulfill: 10
+    CannotRecraft: 11
+    CannotReject: 12
+    CannotRelease: 13
+    CrafterIsIgnored: 14
+    DatabaseError: 15
+    Expired: 16
+    InvalidDuration: 18
+    InvalidMinQuality: 19
+    InvalidNotes: 20
+    InvalidReagent: 21
+    InvalidRealm: 22
+    InvalidRecipe: 23
+    InvalidRecraftItem: 24
+    InvalidSort: 25
+    InvalidTarget: 26
+    InvalidType: 27
+    Locked: 17
+    MaxOrdersReached: 28
+    MissingCraftingTable: 29
+    MissingCurrency: 30
+    MissingItem: 31
+    MissingNpc: 32
+    MissingOrder: 33
+    MissingRecraftItem: 34
+    NoAccountItems: 35
+    NotClaimed: 36
+    NotCrafted: 37
+    NotInGuild: 38
+    NotYetImplemented: 39
+    Ok: 0
+    OutOfPublicOrderCapacity: 40
+    ServerIsNotAvailable: 41
+    TargetCannotCraft: 43
+    TargetLocked: 44
+    ThrottleViolation: 42
+    Timeout: 45
+    TooManyCurrencies: 46
+    TooManyItems: 47
+    WrongVersion: 48
 CraftingOrderSortType:
-  AveTip: 1
-  ItemName: 0
-  MaxTip: 2
-  Quantity: 3
-  Reagents: 4
-  Status: 7
-  TimeRemaining: 6
-  Tip: 5
+  values:
+    AveTip: 1
+    ItemName: 0
+    MaxTip: 2
+    Quantity: 3
+    Reagents: 4
+    Status: 7
+    TimeRemaining: 6
+    Tip: 5
 CraftingOrderState:
-  Canceled: 13
-  Canceling: 12
-  Claimed: 4
-  Claiming: 3
-  Crafting: 8
-  Created: 2
-  Creating: 1
-  Expired: 15
-  Expiring: 14
-  Fulfilled: 11
-  Fulfilling: 10
-  None: 0
-  Recrafting: 9
-  Rejected: 6
-  Rejecting: 5
-  Releasing: 7
+  values:
+    Canceled: 13
+    Canceling: 12
+    Claimed: 4
+    Claiming: 3
+    Crafting: 8
+    Created: 2
+    Creating: 1
+    Expired: 15
+    Expiring: 14
+    Fulfilled: 11
+    Fulfilling: 10
+    None: 0
+    Recrafting: 9
+    Rejected: 6
+    Rejecting: 5
+    Releasing: 7
 CraftingOrderType:
-  Guild: 1
-  Npc: 3
-  Personal: 2
-  Public: 0
+  values:
+    Guild: 1
+    Npc: 3
+    Personal: 2
+    Public: 0
 CraftingReagentItemFlag:
-  TooltipShowsAsStatModifications: 1
+  values:
+    TooltipShowsAsStatModifications: 1
 CraftingReagentType:
-  Automatic: 3
-  Basic: 1
-  Finishing: 2
-  Modifying: 0
+  values:
+    Automatic: 3
+    Basic: 1
+    Finishing: 2
+    Modifying: 0
 CreateAllAccountData:
-  AccountCurrenciesDone: '0x0000000000200000'
-  AccountDynamicCriteriaDone: '0x0000000001000000'
-  AccountFactionsDone: '0x0000000200000000'
-  AccountItemsDone: '0x0000000400000000'
-  AccountMappingDone: '0x0000008000000000'
-  AccountNotificationsDone: '0x0000000008000000'
-  AccountStateHousingData: '0x0000080000000000'
-  AchievementsDone: '0x0000000000000001'
-  ArchivedPurchasesDone: '0x0000000000000200'
-  AuctionableTokensDone: '0x0000000000002000'
-  BanktabSettingsDone: '0x0000004000000000'
-  BattlepetsDone: '0x0000000000000008'
-  BitVectorsDone: '0x0000000100000000'
-  BpayAddLicenseObjectsDone: '0x0000000000000800'
-  BpayDistributionObjectsDone: '0x0000000000000100'
-  BpayProductitemObjectsDone: '0x0000000000020000'
-  CharacterItemsDone: '0x0000010000000000'
-  CharactersDone: '0x0000000000000040'
-  CombinedQuestLogEntriesDone: '0x0000000800000000'
-  ConsumableTokensDone: '0x0000000000004000'
-  CriteriaDone: '0x0000000000000002'
-  CurrencycapsDone: '0x0000000000000010'
-  CurrencyTransferLogDone: '0x0000020000000000'
-  DataElementsDone: '0x0000001000000000'
-  EventRecordsDone: '0x0000200000000000'
-  ItemCollectionItemsDone: '0x0000000000001000'
-  LgVendorPurchaseDone: '0x0000040000000000'
-  MountsDone: '0x0000000000000004'
-  None: '0x0000000000000000'
-  Object: '0x0000000000100000'
-  PerkHeldItemsDone: '0x0000000040000000'
-  PerkPastRewardsDone: '0x0000000000008000'
-  PerkPendingPurchasesDone: '0x0000000010000000'
-  PerkPendingRewardsDone: '0x0000000080000000'
-  PurchasesDone: '0x0000000000000080'
-  QuestCriteriaDone: '0x0000000000080000'
-  QuestLogDone: '0x0000000000000020'
-  RafActivitiesDone: '0x0000000002000000'
-  RafBalanceDone: '0x0000000000400000'
-  RafRewardsDone: '0x0000000000800000'
-  RevokedRafRewardsDone: '0x0000000004000000'
-  SettingsDone: '0x0000000000000400'
-  TransmogOutfitsLoadedDone: '0x0000400000000000'
-  TrialBoostHistoryDone: '0x0000000000040000'
-  VasTransactionsDone: '0x0000000000010000'
-  WarbandGroupsDone: '0x0000002000000000'
-  WarbandScenesLoadedDone: '0x0000100000000000'
-  WowlabsDataDone: '0x0000000020000000'
+  values:
+    AccountCurrenciesDone: '0x0000000000200000'
+    AccountDynamicCriteriaDone: '0x0000000001000000'
+    AccountFactionsDone: '0x0000000200000000'
+    AccountItemsDone: '0x0000000400000000'
+    AccountMappingDone: '0x0000008000000000'
+    AccountNotificationsDone: '0x0000000008000000'
+    AccountStateHousingData: '0x0000080000000000'
+    AchievementsDone: '0x0000000000000001'
+    ArchivedPurchasesDone: '0x0000000000000200'
+    AuctionableTokensDone: '0x0000000000002000'
+    BanktabSettingsDone: '0x0000004000000000'
+    BattlepetsDone: '0x0000000000000008'
+    BitVectorsDone: '0x0000000100000000'
+    BpayAddLicenseObjectsDone: '0x0000000000000800'
+    BpayDistributionObjectsDone: '0x0000000000000100'
+    BpayProductitemObjectsDone: '0x0000000000020000'
+    CharacterItemsDone: '0x0000010000000000'
+    CharactersDone: '0x0000000000000040'
+    CombinedQuestLogEntriesDone: '0x0000000800000000'
+    ConsumableTokensDone: '0x0000000000004000'
+    CriteriaDone: '0x0000000000000002'
+    CurrencycapsDone: '0x0000000000000010'
+    CurrencyTransferLogDone: '0x0000020000000000'
+    DataElementsDone: '0x0000001000000000'
+    EventRecordsDone: '0x0000200000000000'
+    ItemCollectionItemsDone: '0x0000000000001000'
+    LgVendorPurchaseDone: '0x0000040000000000'
+    MountsDone: '0x0000000000000004'
+    None: '0x0000000000000000'
+    Object: '0x0000000000100000'
+    PerkHeldItemsDone: '0x0000000040000000'
+    PerkPastRewardsDone: '0x0000000000008000'
+    PerkPendingPurchasesDone: '0x0000000010000000'
+    PerkPendingRewardsDone: '0x0000000080000000'
+    PurchasesDone: '0x0000000000000080'
+    QuestCriteriaDone: '0x0000000000080000'
+    QuestLogDone: '0x0000000000000020'
+    RafActivitiesDone: '0x0000000002000000'
+    RafBalanceDone: '0x0000000000400000'
+    RafRewardsDone: '0x0000000000800000'
+    RevokedRafRewardsDone: '0x0000000004000000'
+    SettingsDone: '0x0000000000000400'
+    TransmogOutfitsLoadedDone: '0x0000400000000000'
+    TrialBoostHistoryDone: '0x0000000000040000'
+    VasTransactionsDone: '0x0000000000010000'
+    WarbandGroupsDone: '0x0000002000000000'
+    WarbandScenesLoadedDone: '0x0000100000000000'
+    WowlabsDataDone: '0x0000000020000000'
 CreateNeighborhoodErrorType:
-  None: 0
-  OversizedGuild: 3
-  Profanity: 1
-  UndersizedGuild: 2
+  values:
+    None: 0
+    OversizedGuild: 3
+    Profanity: 1
+    UndersizedGuild: 2
 CurioRarity:
-  Common: 1
-  Epic: 4
-  Rare: 3
-  Uncommon: 2
+  values:
+    Common: 1
+    Epic: 4
+    Rare: 3
+    Uncommon: 2
 CurrencyConversionResult:
-  Conversion: 1
-  NoConversion: 0
-  SkippedAccountCurrency: 2
+  values:
+    Conversion: 1
+    NoConversion: 0
+    SkippedAccountCurrency: 2
 CurrencyDestroyReason:
-  BonusRoll: 9
-  Capped: 6
-  Cheat: 0
-  DroppedToCorpse: 8
-  Garrison: 7
-  LegacyConversion: 10
-  QuestTurnin: 3
-  Spell: 1
-  Trade: 5
-  Vendor: 4
-  VersionUpdate: 2
+  values:
+    BonusRoll: 9
+    Capped: 6
+    Cheat: 0
+    DroppedToCorpse: 8
+    Garrison: 7
+    LegacyConversion: 10
+    QuestTurnin: 3
+    Spell: 1
+    Trade: 5
+    Vendor: 4
+    VersionUpdate: 2
 CurrencyFlags:
-  Currency_100_Scaler: 8
-  CurrencyAccountWide: 16777216
-  CurrencyAllowOverflowMailer: 33554432
-  CurrencyAppearsInLootWindow: 2
-  CurrencyComputedWeeklyMaximum: 4
-  CurrencyDeprecated: 131072
-  CurrencyDestroyExtraOnLoot: 2097152
-  CurrencyDoNotCompressChat: 8192
-  CurrencyDoNotLogAcquisitionToBi: 16384
-  CurrencyDoNotToast: 1048576
-  CurrencyDontCoalesceInLootWindow: 8388608
-  CurrencyDontShowTotalInTooltip: 4194304
-  CurrencyDynamicMaximum: 262144
-  CurrencyHasWarmodeBonus: 134217728
-  CurrencyHasWeeklyCatchup: 4096
-  CurrencyHideAsReward: 67108864
-  CurrencyIgnoreMaxQtyOnLoad: 32
-  CurrencyIsAllianceOnly: 268435456
-  CurrencyIsHordeOnly: 536870912
-  CurrencyLimitWarmodeBonusOncePerTooltip: 1073741824
-  CurrencyLogOnWorldChange: 64
-  CurrencyNoLowLevelDrop: 16
-  CurrencyNoRaidDrop: 32768
-  CurrencyNotPersistent: 65536
-  CurrencyResetTrackedQuantity: 256
-  CurrencySingleDropInLoot: 2048
-  CurrencySuppressChatMessageOnVersionChange: 1024
-  CurrencySuppressChatMessages: 524288
-  CurrencyTrackQuantity: 128
-  CurrencyTradable: 1
-  CurrencyUpdateVersionIgnoreMax: 512
-  CurrencyUsesLedgerBalance: 2147483648
+  values:
+    Currency_100_Scaler: 8
+    CurrencyAccountWide: 16777216
+    CurrencyAllowOverflowMailer: 33554432
+    CurrencyAppearsInLootWindow: 2
+    CurrencyComputedWeeklyMaximum: 4
+    CurrencyDeprecated: 131072
+    CurrencyDestroyExtraOnLoot: 2097152
+    CurrencyDoNotCompressChat: 8192
+    CurrencyDoNotLogAcquisitionToBi: 16384
+    CurrencyDoNotToast: 1048576
+    CurrencyDontCoalesceInLootWindow: 8388608
+    CurrencyDontShowTotalInTooltip: 4194304
+    CurrencyDynamicMaximum: 262144
+    CurrencyHasWarmodeBonus: 134217728
+    CurrencyHasWeeklyCatchup: 4096
+    CurrencyHideAsReward: 67108864
+    CurrencyIgnoreMaxQtyOnLoad: 32
+    CurrencyIsAllianceOnly: 268435456
+    CurrencyIsHordeOnly: 536870912
+    CurrencyLimitWarmodeBonusOncePerTooltip: 1073741824
+    CurrencyLogOnWorldChange: 64
+    CurrencyNoLowLevelDrop: 16
+    CurrencyNoRaidDrop: 32768
+    CurrencyNotPersistent: 65536
+    CurrencyResetTrackedQuantity: 256
+    CurrencySingleDropInLoot: 2048
+    CurrencySuppressChatMessageOnVersionChange: 1024
+    CurrencySuppressChatMessages: 524288
+    CurrencyTrackQuantity: 128
+    CurrencyTradable: 1
+    CurrencyUpdateVersionIgnoreMax: 512
+    CurrencyUsesLedgerBalance: 2147483648
 CurrencyFlagsB:
-  CurrencyBAllowReductionByResourcefulness: 1024
-  CurrencyBBattlenetVirtualCurrency: 8
-  CurrencyBDontDisplayIfZero: 32
-  CurrencyBForceMaxQuantityOnConversion: 256
-  CurrencyBNoBonusXP: 2048
-  CurrencyBNoNotificationMailOnOfflineProgress: 4
-  CurrencyBScaleMaxQuantityBySeasonWeeks: 64
-  CurrencyBScaleMaxQuantityByWeeksSinceStart: 128
-  CurrencyBShowQuestXPGainInTooltip: 2
-  CurrencyBUnearnableBeforeMaxQuantityStart: 512
-  CurrencyBUseTotalEarnedForEarned: 1
-  FutureCurrencyFlag: 16
+  values:
+    CurrencyBAllowReductionByResourcefulness: 1024
+    CurrencyBBattlenetVirtualCurrency: 8
+    CurrencyBDontDisplayIfZero: 32
+    CurrencyBForceMaxQuantityOnConversion: 256
+    CurrencyBNoBonusXP: 2048
+    CurrencyBNoNotificationMailOnOfflineProgress: 4
+    CurrencyBScaleMaxQuantityBySeasonWeeks: 64
+    CurrencyBScaleMaxQuantityByWeeksSinceStart: 128
+    CurrencyBShowQuestXPGainInTooltip: 2
+    CurrencyBUnearnableBeforeMaxQuantityStart: 512
+    CurrencyBUseTotalEarnedForEarned: 1
+    FutureCurrencyFlag: 16
 CurrencyGainFlags:
-  Autotracking: 8
-  BonusAward: 1
-  DroppedFromDeath: 2
-  FromAccountServer: 4
-  None: 0
+  values:
+    Autotracking: 8
+    BonusAward: 1
+    DroppedFromDeath: 2
+    FromAccountServer: 4
+    None: 0
 CurrencySource:
-  AccountCopy: 37
-  AccountServerConversion: 46
-  Arena: 17
-  ArenaPoints: 38
-  AuctionDeposit: 41
-  AzeriteRespec: 34
-  Barbershop: 42
-  BonusRoll: 33
-  ChallengeModeDungeon: 44
-  Cheat: 4
-  ConvertOldItem: 0
-  ConvertOldPvPCurrency: 1
-  ExceededMaxQty: 18
-  GarrisonBuilding: 23
-  GarrisonBuildingRefund: 26
-  GarrisonFollowerActivation: 25
-  GarrisonMissionReward: 27
-  GarrisonResourceOverTime: 28
-  GarrisonTalent: 30
-  GarrisonWorldQuestBonus: 31
-  GuildBankWithdrawal: 21
-  InitiativeReward: 45
-  ItemDeletion: 14
-  ItemRefund: 2
-  LFGReward: 11
-  Loot: 9
-  Pushloot: 22
-  PvPCompletionBonus: 19
-  PvPDrop: 24
-  PvPHonorQuestReward: 40
-  PvPHonorReward: 32
-  PvPKillCredit: 6
-  PvPMetaCredit: 7
-  PvPScriptedAward: 8
-  PvPTeamContribution: 39
-  QuestReward: 3
-  QuestRewardIgnoreCaps: 29
-  RandomBattleground: 16
-  RatedBattleground: 15
-  Script: 20
-  SimulateLoot: 43
-  Spell: 13
-  Trade: 12
-  UpdatingVersion: 10
-  Vendor: 5
-  WorldQuestReward: 35
-  WorldQuestRewardIgnoreCaps: 36
+  values:
+    AccountCopy: 37
+    AccountServerConversion: 46
+    Arena: 17
+    ArenaPoints: 38
+    AuctionDeposit: 41
+    AzeriteRespec: 34
+    Barbershop: 42
+    BonusRoll: 33
+    ChallengeModeDungeon: 44
+    Cheat: 4
+    ConvertOldItem: 0
+    ConvertOldPvPCurrency: 1
+    ExceededMaxQty: 18
+    GarrisonBuilding: 23
+    GarrisonBuildingRefund: 26
+    GarrisonFollowerActivation: 25
+    GarrisonMissionReward: 27
+    GarrisonResourceOverTime: 28
+    GarrisonTalent: 30
+    GarrisonWorldQuestBonus: 31
+    GuildBankWithdrawal: 21
+    InitiativeReward: 45
+    ItemDeletion: 14
+    ItemRefund: 2
+    LFGReward: 11
+    Loot: 9
+    Pushloot: 22
+    PvPCompletionBonus: 19
+    PvPDrop: 24
+    PvPHonorQuestReward: 40
+    PvPHonorReward: 32
+    PvPKillCredit: 6
+    PvPMetaCredit: 7
+    PvPScriptedAward: 8
+    PvPTeamContribution: 39
+    QuestReward: 3
+    QuestRewardIgnoreCaps: 29
+    RandomBattleground: 16
+    RatedBattleground: 15
+    Script: 20
+    SimulateLoot: 43
+    Spell: 13
+    Trade: 12
+    UpdatingVersion: 10
+    Vendor: 5
+    WorldQuestReward: 35
+    WorldQuestRewardIgnoreCaps: 36
 CurrencyTokenCategoryFlags:
-  FlagPlayerItemAssignment: 2
-  FlagSortLast: 1
-  Hidden: 4
-  StartsCollapsed: 16
-  Virtual: 8
+  values:
+    FlagPlayerItemAssignment: 2
+    FlagSortLast: 1
+    Hidden: 4
+    StartsCollapsed: 16
+    Virtual: 8
 CurrencyType:
-  Copper: 0
-  Gold: 2
-  Silver: 1
+  values:
+    Copper: 0
+    Gold: 2
+    Silver: 1
 Cursormode:
-  AttackCursor: 4
-  AttackErrorCursor: 50
-  BroomCursor: 42
-  BroomErrorCursor: 88
-  BuyCursor: 3
-  BuyErrorCursor: 49
-  CampaignQuestCursor: 23
-  CampaignQuestErrorCursor: 69
-  CampaignQuestTurninCursor: 24
-  CampaignQuestTurninErrorCursor: 70
-  CastCursor: 2
-  CastErrorCursor: 48
-  CustomCursor: 91
-  EnchantCursor: 39
-  EnchantErrorCursor: 85
-  GatherCursor: 13
-  GatherErrorCursor: 59
-  GrabbingHandCursor: 44
-  GrabbingHandErrorCursor: 90
-  HoldingHandCursor: 43
-  HoldingHandErrorCursor: 89
-  InnkeeperCursor: 22
-  InnkeeperErrorCursor: 68
-  InspectCursor: 7
-  InspectErrorCursor: 53
-  InteractCursor: 5
-  InteractErrorCursor: 51
-  ItemCursor: 19
-  ItemErrorCursor: 65
-  LockCursor: 14
-  LockErrorCursor: 60
-  LootAllCursor: 16
-  LootAllErrorCursor: 62
-  MailCursor: 15
-  MailErrorCursor: 61
-  MapPinCursor: 37
-  MapPinErrorCursor: 83
-  MineCursor: 11
-  MineErrorCursor: 57
-  NoCursor: 0
-  PaletteCursor: 41
-  PaletteErrorCursor: 87
-  PickupCursor: 8
-  PickupErrorCursor: 54
-  PingCursor: 38
-  PingErrorCursor: 84
-  PointCursor: 1
-  PointErrorCursor: 47
-  QuestCursor: 25
-  QuestErrorCursor: 71
-  QuestImportantCursor: 30
-  QuestImportantErrorCursor: 76
-  QuestImportantTurninCursor: 31
-  QuestImportantTurninErrorCursor: 77
-  QuestLegendaryCursor: 28
-  QuestLegendaryErrorCursor: 74
-  QuestLegendaryTurninCursor: 29
-  QuestLegendaryTurninErrorCursor: 75
-  QuestMetaCursor: 32
-  QuestMetaErrorCursor: 78
-  QuestMetaTurninCursor: 33
-  QuestMetaTurninErrorCursor: 79
-  QuestRecurringCursor: 34
-  QuestRecurringErrorCursor: 80
-  QuestRecurringTurninCursor: 35
-  QuestRecurringTurninErrorCursor: 81
-  QuestRepeatableCursor: 26
-  QuestRepeatableErrorCursor: 72
-  QuestTurninCursor: 27
-  QuestTurninErrorCursor: 73
-  RepairCursor: 17
-  RepairErrorCursor: 63
-  RepairnpcCursor: 18
-  RepairnpcErrorCursor: 64
-  SkinAllianceCursor: 21
-  SkinAllianceErrorCursor: 67
-  SkinCursor: 12
-  SkinErrorCursor: 58
-  SkinHordeCursor: 20
-  SkinHordeErrorCursor: 66
-  SpeakCursor: 6
-  SpeakErrorCursor: 52
-  StablemasterCursor: 40
-  StablemasterErrorCursor: 86
-  TaxiCursor: 9
-  TaxiErrorCursor: 55
-  TrainerCursor: 10
-  TrainerErrorCursor: 56
-  UIMoveCursor: 45
-  UIResizeCursor: 46
-  VehicleCursor: 36
-  VehicleErrorCursor: 82
+  values:
+    AttackCursor: 4
+    AttackErrorCursor: 50
+    BroomCursor: 42
+    BroomErrorCursor: 88
+    BuyCursor: 3
+    BuyErrorCursor: 49
+    CampaignQuestCursor: 23
+    CampaignQuestErrorCursor: 69
+    CampaignQuestTurninCursor: 24
+    CampaignQuestTurninErrorCursor: 70
+    CastCursor: 2
+    CastErrorCursor: 48
+    CustomCursor: 91
+    EnchantCursor: 39
+    EnchantErrorCursor: 85
+    GatherCursor: 13
+    GatherErrorCursor: 59
+    GrabbingHandCursor: 44
+    GrabbingHandErrorCursor: 90
+    HoldingHandCursor: 43
+    HoldingHandErrorCursor: 89
+    InnkeeperCursor: 22
+    InnkeeperErrorCursor: 68
+    InspectCursor: 7
+    InspectErrorCursor: 53
+    InteractCursor: 5
+    InteractErrorCursor: 51
+    ItemCursor: 19
+    ItemErrorCursor: 65
+    LockCursor: 14
+    LockErrorCursor: 60
+    LootAllCursor: 16
+    LootAllErrorCursor: 62
+    MailCursor: 15
+    MailErrorCursor: 61
+    MapPinCursor: 37
+    MapPinErrorCursor: 83
+    MineCursor: 11
+    MineErrorCursor: 57
+    NoCursor: 0
+    PaletteCursor: 41
+    PaletteErrorCursor: 87
+    PickupCursor: 8
+    PickupErrorCursor: 54
+    PingCursor: 38
+    PingErrorCursor: 84
+    PointCursor: 1
+    PointErrorCursor: 47
+    QuestCursor: 25
+    QuestErrorCursor: 71
+    QuestImportantCursor: 30
+    QuestImportantErrorCursor: 76
+    QuestImportantTurninCursor: 31
+    QuestImportantTurninErrorCursor: 77
+    QuestLegendaryCursor: 28
+    QuestLegendaryErrorCursor: 74
+    QuestLegendaryTurninCursor: 29
+    QuestLegendaryTurninErrorCursor: 75
+    QuestMetaCursor: 32
+    QuestMetaErrorCursor: 78
+    QuestMetaTurninCursor: 33
+    QuestMetaTurninErrorCursor: 79
+    QuestRecurringCursor: 34
+    QuestRecurringErrorCursor: 80
+    QuestRecurringTurninCursor: 35
+    QuestRecurringTurninErrorCursor: 81
+    QuestRepeatableCursor: 26
+    QuestRepeatableErrorCursor: 72
+    QuestTurninCursor: 27
+    QuestTurninErrorCursor: 73
+    RepairCursor: 17
+    RepairErrorCursor: 63
+    RepairnpcCursor: 18
+    RepairnpcErrorCursor: 64
+    SkinAllianceCursor: 21
+    SkinAllianceErrorCursor: 67
+    SkinCursor: 12
+    SkinErrorCursor: 58
+    SkinHordeCursor: 20
+    SkinHordeErrorCursor: 66
+    SpeakCursor: 6
+    SpeakErrorCursor: 52
+    StablemasterCursor: 40
+    StablemasterErrorCursor: 86
+    TaxiCursor: 9
+    TaxiErrorCursor: 55
+    TrainerCursor: 10
+    TrainerErrorCursor: 56
+    UIMoveCursor: 45
+    UIResizeCursor: 46
+    VehicleCursor: 36
+    VehicleErrorCursor: 82
 CursorStyle:
-  Crosshair: 1
-  Mouse: 0
+  values:
+    Crosshair: 1
+    Mouse: 0
 CustomBindingType:
-  VoicePushToTalk: 0
+  values:
+    VoicePushToTalk: 0
 Damageclass:
-  All: 127
-  AllMagical: 126
-  AllPhysical: 1
-  Arcane: 6
-  Fire: 2
-  FirstResist: 2
-  Frost: 4
-  Holy: 1
-  LastResist: 6
-  MaskArcane: 64
-  MaskChaos: 124
-  MaskChromatic: 62
-  MaskCosmic: 106
-  MaskDivine: 66
-  MaskElemental: 28
-  MaskFire: 4
-  MaskFirestorm: 12
-  MaskFlamestrike: 5
-  MaskFrost: 16
-  MaskFrostfire: 20
-  MaskFroststorm: 24
-  MaskFroststrike: 17
-  MaskHoly: 2
-  MaskHolyfire: 6
-  MaskHolyfrost: 18
-  MaskHolystorm: 10
-  MaskHolystrike: 3
-  MaskMagical: 126
-  MaskNature: 8
-  MaskNone: 0
-  MaskPhysical: 1
-  MaskShadow: 32
-  MaskShadowflame: 36
-  MaskShadowfrost: 48
-  MaskShadowstorm: 40
-  MaskShadowstrike: 33
-  MaskSpellfire: 68
-  MaskSpellfrost: 80
-  MaskSpellshadow: 96
-  MaskSpellstorm: 72
-  MaskSpellstrike: 65
-  MaskStormstrike: 9
-  MaskTwilight: 34
-  Nature: 3
-  Physical: 0
-  Shadow: 5
+  values:
+    All: 127
+    AllMagical: 126
+    AllPhysical: 1
+    Arcane: 6
+    Fire: 2
+    FirstResist: 2
+    Frost: 4
+    Holy: 1
+    LastResist: 6
+    MaskArcane: 64
+    MaskChaos: 124
+    MaskChromatic: 62
+    MaskCosmic: 106
+    MaskDivine: 66
+    MaskElemental: 28
+    MaskFire: 4
+    MaskFirestorm: 12
+    MaskFlamestrike: 5
+    MaskFrost: 16
+    MaskFrostfire: 20
+    MaskFroststorm: 24
+    MaskFroststrike: 17
+    MaskHoly: 2
+    MaskHolyfire: 6
+    MaskHolyfrost: 18
+    MaskHolystorm: 10
+    MaskHolystrike: 3
+    MaskMagical: 126
+    MaskNature: 8
+    MaskNone: 0
+    MaskPhysical: 1
+    MaskShadow: 32
+    MaskShadowflame: 36
+    MaskShadowfrost: 48
+    MaskShadowstorm: 40
+    MaskShadowstrike: 33
+    MaskSpellfire: 68
+    MaskSpellfrost: 80
+    MaskSpellshadow: 96
+    MaskSpellstorm: 72
+    MaskSpellstrike: 65
+    MaskStormstrike: 9
+    MaskTwilight: 34
+    Nature: 3
+    Physical: 0
+    Shadow: 5
 DamageclassType:
-  Magical: 1
-  Physical: 0
+  values:
+    Magical: 1
+    Physical: 0
 DamageMeterCombineSessionType:
-  Arena: 2
-  ArenaMultiRound: 3
-  ChallengeMode: 1
-  None: 0
+  values:
+    Arena: 2
+    ArenaMultiRound: 3
+    ChallengeMode: 1
+    None: 0
 DamageMeterNumbers:
-  Compact: 1
-  Complete: 2
-  Minimal: 0
+  values:
+    Compact: 1
+    Complete: 2
+    Minimal: 0
 DamageMeterOverrideType:
-  AllowFriendlyFire: 1
-  Ignore: 0
-  IgnoreForAbsorbSpell: 4
-  RedirectSourceToAuraCaster: 3
-  RedirectSourceToOwner: 2
+  values:
+    AllowFriendlyFire: 1
+    Ignore: 0
+    IgnoreForAbsorbSpell: 4
+    RedirectSourceToAuraCaster: 3
+    RedirectSourceToOwner: 2
 DamageMeterSessionType:
-  Current: 1
-  Expired: 2
-  Overall: 0
+  values:
+    Current: 1
+    Expired: 2
+    Overall: 0
 DamageMeterSourceDisplayType:
-  Ally: 1
-  Enemy: 2
-  None: 0
+  values:
+    Ally: 1
+    Enemy: 2
+    None: 0
 DamageMeterSpellDetailsDisplayType:
-  Deaths: 3
-  EnemyDamageTaken: 4
-  SpellAffected: 2
-  SpellCasted: 0
-  UnitSpecificSpellCasted: 1
+  values:
+    Deaths: 3
+    EnemyDamageTaken: 4
+    SpellAffected: 2
+    SpellCasted: 0
+    UnitSpecificSpellCasted: 1
 DamageMeterStorageType:
-  Absorbs: 2
-  AvoidableDamageTaken: 6
-  Damage: 0
-  DamageTaken: 5
-  Deaths: 7
-  Dispels: 4
-  EnemyDamageTaken: 8
-  HealingAndAbsorbs: 1
-  Interrupts: 3
+  values:
+    Absorbs: 2
+    AvoidableDamageTaken: 6
+    Damage: 0
+    DamageTaken: 5
+    Deaths: 7
+    Dispels: 4
+    EnemyDamageTaken: 8
+    HealingAndAbsorbs: 1
+    Interrupts: 3
 DamageMeterStyle:
-  Bordered: 2
-  Default: 0
-  FullBackground: 3
-  Thin: 1
+  values:
+    Bordered: 2
+    Default: 0
+    FullBackground: 3
+    Thin: 1
 DamageMeterType:
-  Absorbs: 4
-  AvoidableDamageTaken: 8
-  DamageDone: 0
-  DamageTaken: 7
-  Deaths: 9
-  Dispels: 6
-  Dps: 1
-  EnemyDamageTaken: 10
-  HealingDone: 2
-  Hps: 3
-  Interrupts: 5
+  values:
+    Absorbs: 4
+    AvoidableDamageTaken: 8
+    DamageDone: 0
+    DamageTaken: 7
+    Deaths: 9
+    Dispels: 6
+    Dps: 1
+    EnemyDamageTaken: 10
+    HealingDone: 2
+    Hps: 3
+    Interrupts: 5
 DamageMeterVisibility:
-  Always: 0
-  Hidden: 2
-  InCombat: 1
-  InGroup: 3
+  values:
+    Always: 0
+    Hidden: 2
+    InCombat: 1
+    InGroup: 3
 DeveloperLogAssertDomain:
-  Art: 1
-  Design: 2
-  Engineering: 4
-  LiveOperations: 64
-  Performance: 32
-  Sound: 8
-  Tools: 16
+  values:
+    Art: 1
+    Design: 2
+    Engineering: 4
+    LiveOperations: 64
+    Performance: 32
+    Sound: 8
+    Tools: 16
 DeveloperLogErrorDomain:
-  Assert: 0
-  AssertData: 1
-  Frame: 2
-  TestSuite: 3
+  values:
+    Assert: 0
+    AssertData: 1
+    Frame: 2
+    TestSuite: 3
 DeveloperLogTrafficType:
-  ClientToServer: 1
-  GameEvent: 2
-  LuaToClient: 3
-  ServerToClient: 0
+  values:
+    ClientToServer: 1
+    GameEvent: 2
+    LuaToClient: 3
+    ServerToClient: 0
 DisableAccountProfilesFlags:
-  DecorsCollections: 32
-  Document: 1
-  ItemsCollections: 16
-  MountsCollections: 4
-  None: 0
-  PetsCollections: 8
-  SharedCollections: 2
+  values:
+    DecorsCollections: 32
+    Document: 1
+    ItemsCollections: 16
+    MountsCollections: 4
+    None: 0
+    PetsCollections: 8
+    SharedCollections: 2
 DurationTextBindingProperty:
-  ElapsedDuration: 2
-  ElapsedPercent: 3
-  EndTime: 6
-  RemainingDuration: 0
-  RemainingPercent: 1
-  StartTime: 5
-  TotalDuration: 4
+  values:
+    ElapsedDuration: 2
+    ElapsedPercent: 3
+    EndTime: 6
+    RemainingDuration: 0
+    RemainingPercent: 1
+    StartTime: 5
+    TotalDuration: 4
 DurationTimeModifier:
-  BaseTime: 1
-  RealTime: 0
+  values:
+    BaseTime: 1
+    RealTime: 0
 EditModeAccountSetting:
-  DeprecatedShowDebuffFrame: 11
-  EnableAdvancedOptions: 23
-  EnableSnap: 22
-  GridSpacing: 1
-  SettingsExpanded: 2
-  ShowArchaeologyBar: 27
-  ShowArenaFrames: 17
-  ShowBossFrames: 16
-  ShowBuffsAndDebuffs: 10
-  ShowCastBar: 7
-  ShowCooldownViewer: 28
-  ShowDamageMeter: 31
-  ShowDurabilityFrame: 21
-  ShowEncounterBar: 8
-  ShowEncounterEvents: 30
-  ShowExternalDefensives: 32
-  ShowExtraAbilities: 9
-  ShowGrid: 0
-  ShowHudTooltip: 19
-  ShowLootFrame: 18
-  ShowPartyFrames: 12
-  ShowPersonalResourceDisplay: 29
-  ShowPetActionBar: 5
-  ShowPetFrame: 24
-  ShowPossessActionBar: 6
-  ShowRaidFrames: 13
-  ShowStanceBar: 4
-  ShowStatusTrackingBar2: 20
-  ShowTalkingHeadFrame: 14
-  ShowTargetAndFocus: 3
-  ShowTimerBars: 25
-  ShowTotemActionBar: 33
-  ShowVehicleLeaveButton: 15
-  ShowVehicleSeatIndicator: 26
+  values:
+    DeprecatedShowDebuffFrame: 11
+    EnableAdvancedOptions: 23
+    EnableSnap: 22
+    GridSpacing: 1
+    SettingsExpanded: 2
+    ShowArchaeologyBar: 27
+    ShowArenaFrames: 17
+    ShowBossFrames: 16
+    ShowBuffsAndDebuffs: 10
+    ShowCastBar: 7
+    ShowCooldownViewer: 28
+    ShowDamageMeter: 31
+    ShowDurabilityFrame: 21
+    ShowEncounterBar: 8
+    ShowEncounterEvents: 30
+    ShowExternalDefensives: 32
+    ShowExtraAbilities: 9
+    ShowGrid: 0
+    ShowHudTooltip: 19
+    ShowLootFrame: 18
+    ShowPartyFrames: 12
+    ShowPersonalResourceDisplay: 29
+    ShowPetActionBar: 5
+    ShowPetFrame: 24
+    ShowPossessActionBar: 6
+    ShowRaidFrames: 13
+    ShowStanceBar: 4
+    ShowStatusTrackingBar2: 20
+    ShowTalkingHeadFrame: 14
+    ShowTargetAndFocus: 3
+    ShowTimerBars: 25
+    ShowTotemActionBar: 33
+    ShowVehicleLeaveButton: 15
+    ShowVehicleSeatIndicator: 26
 EditModeActionBarSetting:
-  AlwaysShowButtons: 9
-  DeprecatedSnapToSide: 7
-  HideBarArt: 6
-  HideBarScrolling: 8
-  IconPadding: 4
-  IconSize: 3
-  NumIcons: 2
-  NumRows: 1
-  Orientation: 0
-  VisibleSetting: 5
+  values:
+    AlwaysShowButtons: 9
+    DeprecatedSnapToSide: 7
+    HideBarArt: 6
+    HideBarScrolling: 8
+    IconPadding: 4
+    IconSize: 3
+    NumIcons: 2
+    NumRows: 1
+    Orientation: 0
+    VisibleSetting: 5
 EditModeActionBarSystemIndices:
-  Bar2: 2
-  Bar3: 3
-  ExtraBar1: 6
-  ExtraBar2: 7
-  ExtraBar3: 8
-  MainBar: 1
-  PetActionBar: 12
-  PossessActionBar: 13
-  RightBar1: 4
-  RightBar2: 5
-  StanceBar: 11
+  values:
+    Bar2: 2
+    Bar3: 3
+    ExtraBar1: 6
+    ExtraBar2: 7
+    ExtraBar3: 8
+    MainBar: 1
+    PetActionBar: 12
+    PossessActionBar: 13
+    RightBar1: 4
+    RightBar2: 5
+    StanceBar: 11
 EditModeArchaeologyBarSetting:
-  Size: 0
+  values:
+    Size: 0
 EditModeAuraFrameSetting:
-  DeprecatedShowFull: 7
-  IconDirection: 2
-  IconLimitBuffFrame: 3
-  IconLimitDebuffFrame: 4
-  IconPadding: 6
-  IconSize: 5
-  IconWrap: 1
-  Opacity: 9
-  Orientation: 0
-  ShowDispelType: 10
-  VisibleSetting: 8
+  values:
+    DeprecatedShowFull: 7
+    IconDirection: 2
+    IconLimitBuffFrame: 3
+    IconLimitDebuffFrame: 4
+    IconPadding: 6
+    IconSize: 5
+    IconWrap: 1
+    Opacity: 9
+    Orientation: 0
+    ShowDispelType: 10
+    VisibleSetting: 8
 EditModeAuraFrameSystemIndices:
-  BuffFrame: 1
-  DebuffFrame: 2
-  ExternalDefensivesFrame: 3
+  values:
+    BuffFrame: 1
+    DebuffFrame: 2
+    ExternalDefensivesFrame: 3
 EditModeBagsSetting:
-  BagSlotPadding: 3
-  Direction: 1
-  Orientation: 0
-  Size: 2
+  values:
+    BagSlotPadding: 3
+    Direction: 1
+    Orientation: 0
+    Size: 2
 EditModeCastBarSetting:
-  BarSize: 0
-  LockToPlayerFrame: 1
-  ShowCastTime: 2
+  values:
+    BarSize: 0
+    LockToPlayerFrame: 1
+    ShowCastTime: 2
 EditModeChatFrameSetting:
-  HeightHundreds: 2
-  HeightTensAndOnes: 3
-  WidthHundreds: 0
-  WidthTensAndOnes: 1
+  values:
+    HeightHundreds: 2
+    HeightTensAndOnes: 3
+    WidthHundreds: 0
+    WidthTensAndOnes: 1
 EditModeCooldownViewerSetting:
-  BarContent: 7
-  BarWidthScale: 11
-  HideWhenInactive: 8
-  IconDirection: 2
-  IconLimit: 1
-  IconPadding: 4
-  IconSize: 3
-  Opacity: 5
-  Orientation: 0
-  ShowTimer: 9
-  ShowTooltips: 10
-  VisibleSetting: 6
+  values:
+    BarContent: 7
+    BarWidthScale: 11
+    HideWhenInactive: 8
+    IconDirection: 2
+    IconLimit: 1
+    IconPadding: 4
+    IconSize: 3
+    Opacity: 5
+    Orientation: 0
+    ShowTimer: 9
+    ShowTooltips: 10
+    VisibleSetting: 6
 EditModeCooldownViewerSystemIndices:
-  BuffBar: 4
-  BuffIcon: 3
-  Essential: 1
-  Utility: 2
+  values:
+    BuffBar: 4
+    BuffIcon: 3
+    Essential: 1
+    Utility: 2
 EditModeDamageMeterSetting:
-  BackgroundTransparency: 12
-  BarHeight: 10
-  FrameHeight: 4
-  FrameWidth: 3
-  Numbers: 2
-  ObsoleteReuse1: 7
-  Padding: 5
-  ShowClassColor: 9
-  ShowSpecIcon: 8
-  Style: 1
-  TextSize: 11
-  Transparency: 6
-  Visibility: 0
+  values:
+    BackgroundTransparency: 12
+    BarHeight: 10
+    FrameHeight: 4
+    FrameWidth: 3
+    Numbers: 2
+    ObsoleteReuse1: 7
+    Padding: 5
+    ShowClassColor: 9
+    ShowSpecIcon: 8
+    Style: 1
+    TextSize: 11
+    Transparency: 6
+    Visibility: 0
 EditModeDurabilityFrameSetting:
-  Size: 0
+  values:
+    Size: 0
 EditModeEncounterEventsSetting:
-  BackgroundTransparency: 5
-  BarWidth: 12
-  FlipHorizontally: 11
-  IconDirection: 1
-  IconSize: 3
-  Orientation: 0
-  OverallSize: 4
-  Padding: 13
-  ShowSpellName: 2
-  ShowTimer: 9
-  TooltipAnchor: 8
-  Transparency: 6
-  ViewType: 10
-  Visibility: 7
+  values:
+    BackgroundTransparency: 5
+    BarWidth: 12
+    FlipHorizontally: 11
+    IconDirection: 1
+    IconSize: 3
+    Orientation: 0
+    OverallSize: 4
+    Padding: 13
+    ShowSpellName: 2
+    ShowTimer: 9
+    TooltipAnchor: 8
+    Transparency: 6
+    ViewType: 10
+    Visibility: 7
 EditModeEncounterEventsSystemIndices:
-  CriticalWarnings: 2
-  MediumWarnings: 3
-  NormalWarnings: 4
-  Timeline: 1
+  values:
+    CriticalWarnings: 2
+    MediumWarnings: 3
+    NormalWarnings: 4
+    Timeline: 1
 EditModeLayoutType:
-  Account: 1
-  Character: 2
-  Override: 3
-  Preset: 0
+  values:
+    Account: 1
+    Character: 2
+    Override: 3
+    Preset: 0
 EditModeMicroMenuSetting:
-  EyeSize: 3
-  Order: 1
-  Orientation: 0
-  Size: 2
+  values:
+    EyeSize: 3
+    Order: 1
+    Orientation: 0
+    Size: 2
 EditModeMinimapSetting:
-  HeaderUnderneath: 0
-  RotateMinimap: 1
-  Size: 2
+  values:
+    HeaderUnderneath: 0
+    RotateMinimap: 1
+    Size: 2
 EditModeObjectiveTrackerSetting:
-  Height: 0
-  Opacity: 1
-  TextSize: 2
+  values:
+    Height: 0
+    Opacity: 1
+    TextSize: 2
 EditModePersonalResourceDisplaySetting:
-  BarWidth: 12
-  DeprecatedOnlyShowInCombat: 1
-  HealthBarHeight: 4
-  HideAltPower: 14
-  HideClassInfo: 3
-  HideClassInfoOnPlayerFrame: 10
-  HideHealth: 0
-  HidePower: 2
-  Opacity: 7
-  Padding: 6
-  PowerBarHeight: 5
-  ShowBarText: 13
-  ShowClassColor: 11
-  Size: 9
-  VisibleSetting: 8
+  values:
+    BarWidth: 12
+    DeprecatedOnlyShowInCombat: 1
+    HealthBarHeight: 4
+    HideAltPower: 14
+    HideClassInfo: 3
+    HideClassInfoOnPlayerFrame: 10
+    HideHealth: 0
+    HidePower: 2
+    Opacity: 7
+    Padding: 6
+    PowerBarHeight: 5
+    ShowBarText: 13
+    ShowClassColor: 11
+    Size: 9
+    VisibleSetting: 8
 EditModePresetLayouts:
-  Classic: 1
-  Modern: 0
+  values:
+    Classic: 1
+    Modern: 0
 EditModeSettingDisplayType:
-  Checkbox: 1
-  Dropdown: 0
-  Slider: 2
+  values:
+    Checkbox: 1
+    Dropdown: 0
+    Slider: 2
 EditModeStatusTrackingBarSetting:
-  Height: 0
-  Size: 3
-  TextSize: 2
-  Width: 1
+  values:
+    Height: 0
+    Size: 3
+    TextSize: 2
+    Width: 1
 EditModeStatusTrackingBarSystemIndices:
-  StatusTrackingBar1: 1
-  StatusTrackingBar2: 2
+  values:
+    StatusTrackingBar1: 1
+    StatusTrackingBar2: 2
 EditModeSystem:
-  ActionBar: 0
-  ArchaeologyBar: 19
-  AuraFrame: 6
-  Bags: 14
-  CastBar: 1
-  ChatFrame: 8
-  CooldownViewer: 20
-  DamageMeter: 23
-  DurabilityFrame: 16
-  EncounterBar: 4
-  EncounterEvents: 22
-  ExtraAbilities: 5
-  HudTooltip: 11
-  LootFrame: 10
-  MicroMenu: 13
-  Minimap: 2
-  ObjectiveTracker: 12
-  PersonalResourceDisplay: 21
-  StatusTrackingBar: 15
-  TalkingHeadFrame: 7
-  TimerBars: 17
-  TotemActionBar: 24
-  UnitFrame: 3
-  VehicleLeaveButton: 9
-  VehicleSeatIndicator: 18
+  values:
+    ActionBar: 0
+    ArchaeologyBar: 19
+    AuraFrame: 6
+    Bags: 14
+    CastBar: 1
+    ChatFrame: 8
+    CooldownViewer: 20
+    DamageMeter: 23
+    DurabilityFrame: 16
+    EncounterBar: 4
+    EncounterEvents: 22
+    ExtraAbilities: 5
+    HudTooltip: 11
+    LootFrame: 10
+    MicroMenu: 13
+    Minimap: 2
+    ObjectiveTracker: 12
+    PersonalResourceDisplay: 21
+    StatusTrackingBar: 15
+    TalkingHeadFrame: 7
+    TimerBars: 17
+    TotemActionBar: 24
+    UnitFrame: 3
+    VehicleLeaveButton: 9
+    VehicleSeatIndicator: 18
 EditModeTimerBarsSetting:
-  Size: 0
+  values:
+    Size: 0
 EditModeUnitFrameSetting:
-  AuraOrganizationType: 18
-  BigDefensiveIconSize: 21
-  BuffsOnTop: 2
-  CastBarOnSide: 7
-  CastBarUnderneath: 1
-  DisplayBorder: 12
-  FrameHeight: 11
-  FrameSize: 16
-  FrameWidth: 10
-  HidePortrait: 0
-  IconSize: 19
-  Opacity: 20
-  RaidGroupDisplayType: 13
-  RowSize: 15
-  ShowCastTime: 8
-  ShowPartyFrameBackground: 5
-  SortPlayersBy: 14
-  UseHorizontalGroups: 6
-  UseLargerFrame: 3
-  UseRaidStylePartyFrames: 4
-  ViewArenaSize: 17
-  ViewRaidSize: 9
+  values:
+    AuraOrganizationType: 18
+    BigDefensiveIconSize: 21
+    BuffsOnTop: 2
+    CastBarOnSide: 7
+    CastBarUnderneath: 1
+    DisplayBorder: 12
+    FrameHeight: 11
+    FrameSize: 16
+    FrameWidth: 10
+    HidePortrait: 0
+    IconSize: 19
+    Opacity: 20
+    RaidGroupDisplayType: 13
+    RowSize: 15
+    ShowCastTime: 8
+    ShowPartyFrameBackground: 5
+    SortPlayersBy: 14
+    UseHorizontalGroups: 6
+    UseLargerFrame: 3
+    UseRaidStylePartyFrames: 4
+    ViewArenaSize: 17
+    ViewRaidSize: 9
 EditModeUnitFrameSystemIndices:
-  Arena: 7
-  Boss: 6
-  Focus: 3
-  Party: 4
-  Pet: 8
-  Player: 1
-  Raid: 5
-  Target: 2
+  values:
+    Arena: 7
+    Boss: 6
+    Focus: 3
+    Party: 4
+    Pet: 8
+    Player: 1
+    Raid: 5
+    Target: 2
 EditModeVehicleSeatIndicatorSetting:
-  Size: 0
+  values:
+    Size: 0
 EncounterEventCastState:
-  Casting: 1
-  Expired: 3
-  NotCasting: 2
+  values:
+    Casting: 1
+    Expired: 3
+    NotCasting: 2
 EncounterEventColorTrigger:
-  TextWarning: 0
-  TimelineEvent: 1
-  TimelineEventHighlight: 2
+  values:
+    TextWarning: 0
+    TimelineEvent: 1
+    TimelineEventHighlight: 2
 EncounterEventIconmask:
-  BleedEffect: 4
-  CurseEffect: 32
-  DeadlyEffect: 1
-  DiseaseEffect: 16
-  DpsRole: 512
-  EnrageEffect: 2
-  HealerRole: 256
-  MagicEffect: 8
-  PoisonEffect: 64
-  TankRole: 128
+  values:
+    BleedEffect: 4
+    CurseEffect: 32
+    DeadlyEffect: 1
+    DiseaseEffect: 16
+    DpsRole: 512
+    EnrageEffect: 2
+    HealerRole: 256
+    MagicEffect: 8
+    PoisonEffect: 64
+    TankRole: 128
 EncounterEventSeverity:
-  High: 2
-  Low: 0
-  Medium: 1
+  values:
+    High: 2
+    Low: 0
+    Medium: 1
 EncounterEventsIconDirection:
-  Bottom: 1
-  Left: 0
-  Right: 1
-  Top: 0
+  values:
+    Bottom: 1
+    Left: 0
+    Right: 1
+    Top: 0
 EncounterEventsOrientation:
-  Horizontal: 0
-  Vertical: 1
+  values:
+    Horizontal: 0
+    Vertical: 1
 EncounterEventSoundTrigger:
-  OnTextWarningShown: 0
-  OnTimelineEventFinished: 1
-  OnTimelineEventHighlight: 2
+  values:
+    OnTextWarningShown: 0
+    OnTimelineEventFinished: 1
+    OnTimelineEventHighlight: 2
 EncounterEventsTooltipAnchor:
-  Cursor: 2
-  Default: 1
-  Hidden: 0
+  values:
+    Cursor: 2
+    Default: 1
+    Hidden: 0
 EncounterEventsViewType:
-  Bars: 1
-  Timeline: 0
+  values:
+    Bars: 1
+    Timeline: 0
 EncounterEventsVisibility:
-  Always: 0
-  DeprecatedHidden: 2
-  InEncounter: 1
+  values:
+    Always: 0
+    DeprecatedHidden: 2
+    InEncounter: 1
 EncounterTimelineEventSortDirection:
-  Ascending: 1
-  Descending: 0
+  values:
+    Ascending: 1
+    Descending: 0
 EncounterTimelineEventSource:
-  EditMode: 2
-  Encounter: 0
-  Script: 1
+  values:
+    EditMode: 2
+    Encounter: 0
+    Script: 1
 EncounterTimelineEventState:
-  Active: 0
-  Canceled: 3
-  Finished: 2
-  Paused: 1
+  values:
+    Active: 0
+    Canceled: 3
+    Finished: 2
+    Paused: 1
 EncounterTimelineIconSet:
-  DamageAlert: 3
-  Deadly: 4
-  Dispel: 5
-  Enrage: 6
-  HealerAlert: 2
-  TankAlert: 1
+  values:
+    DamageAlert: 3
+    Deadly: 4
+    Dispel: 5
+    Enrage: 6
+    HealerAlert: 2
+    TankAlert: 1
 EncounterTimelineTrack:
-  Indeterminate: 4
-  Long: 3
-  Medium: 2
-  Queued: 0
-  Short: 1
+  values:
+    Indeterminate: 4
+    Long: 3
+    Medium: 2
+    Queued: 0
+    Short: 1
 EncounterTimelineTrackType:
-  Hidden: 0
-  Linear: 2
-  Sorted: 1
+  values:
+    Hidden: 0
+    Linear: 2
+    Sorted: 1
 EncounterTimelineViewType:
-  Bars: 2
-  None: 0
-  Timeline: 1
+  values:
+    Bars: 2
+    None: 0
+    Timeline: 1
 EndOfMatchType:
-  None: 0
-  Plunderstorm: 1
+  values:
+    None: 0
+    Plunderstorm: 1
 EnvironmentalDamageFlags:
-  DmgIsPct: 2
-  OneTime: 1
+  values:
+    DmgIsPct: 2
+    OneTime: 1
 Environmentaldamagetype:
-  Drowning: 1
-  Falling: 2
-  Fatigue: 0
-  Fire: 5
-  Lava: 3
-  Slime: 4
+  values:
+    Drowning: 1
+    Falling: 2
+    Fatigue: 0
+    Fire: 5
+    Lava: 3
+    Slime: 4
 EventRealmQueues:
-  None: 0
-  PlunderstormDuo: 2
-  PlunderstormSolo: 1
-  PlunderstormTraining: 8
-  PlunderstormTrio: 4
+  values:
+    None: 0
+    PlunderstormDuo: 2
+    PlunderstormSolo: 1
+    PlunderstormTraining: 8
+    PlunderstormTrio: 4
 EventToastDisplayType:
-  CapstoneUnlocked: 12
-  ChallengeMode: 7
-  FlightpointDiscovered: 11
-  HouseUpgradeAvailable: 15
-  LargeTextWithIcon: 4
-  NormalBlockText: 1
-  NormalSingleLine: 0
-  NormalTextWithIcon: 3
-  NormalTextWithIconAndRarity: 5
-  NormalTitleAndSubTitle: 2
-  Scenario: 6
-  ScenarioClickExpand: 8
-  Scoreboard: 14
-  SingleLineWithIcon: 13
-  WeeklyRewardUnlock: 9
-  WeeklyRewardUpgrade: 10
+  values:
+    CapstoneUnlocked: 12
+    ChallengeMode: 7
+    FlightpointDiscovered: 11
+    HouseUpgradeAvailable: 15
+    LargeTextWithIcon: 4
+    NormalBlockText: 1
+    NormalSingleLine: 0
+    NormalTextWithIcon: 3
+    NormalTextWithIconAndRarity: 5
+    NormalTitleAndSubTitle: 2
+    Scenario: 6
+    ScenarioClickExpand: 8
+    Scoreboard: 14
+    SingleLineWithIcon: 13
+    WeeklyRewardUnlock: 9
+    WeeklyRewardUpgrade: 10
 EventToastEventType:
-  BattlePetLevelChanged: 8
-  BattlePetLevelUpAbility: 9
-  CriteriaUpdated: 19
-  FlightpointDiscovered: 25
-  HouseUpgradeAvailable: 26
-  LevelUp: 0
-  LevelUpDungeon: 2
-  LevelUpOther: 15
-  LevelUpPvP: 4
-  LevelUpRaid: 3
-  LevelUpSpell: 1
-  MythicPlusWeeklyRecord: 11
-  PetBattleCapture: 7
-  PetBattleFinalRound: 6
-  PetBattleNewAbility: 5
-  PlayerAuraAdded: 16
-  PlayerAuraRemoved: 17
-  PvPTierUpdate: 20
-  QuestBossEmote: 10
-  QuestTurnedIn: 12
-  Scenario: 14
-  SpellLearned: 21
-  SpellScript: 18
-  TreasureItem: 22
-  WeeklyRewardUnlock: 23
-  WeeklyRewardUpgrade: 24
-  WorldStateChange: 13
+  values:
+    BattlePetLevelChanged: 8
+    BattlePetLevelUpAbility: 9
+    CriteriaUpdated: 19
+    FlightpointDiscovered: 25
+    HouseUpgradeAvailable: 26
+    LevelUp: 0
+    LevelUpDungeon: 2
+    LevelUpOther: 15
+    LevelUpPvP: 4
+    LevelUpRaid: 3
+    LevelUpSpell: 1
+    MythicPlusWeeklyRecord: 11
+    PetBattleCapture: 7
+    PetBattleFinalRound: 6
+    PetBattleNewAbility: 5
+    PlayerAuraAdded: 16
+    PlayerAuraRemoved: 17
+    PvPTierUpdate: 20
+    QuestBossEmote: 10
+    QuestTurnedIn: 12
+    Scenario: 14
+    SpellLearned: 21
+    SpellScript: 18
+    TreasureItem: 22
+    WeeklyRewardUnlock: 23
+    WeeklyRewardUpgrade: 24
+    WorldStateChange: 13
 EventToastFlags:
-  DisableRightClickDismiss: 1
+  values:
+    DisableRightClickDismiss: 1
 ExcludedCensorSources:
-  All: 255
-  Friends: 1
-  Guild: 2
-  None: 0
-  Reserve1: 4
-  Reserve2: 8
-  Reserve3: 16
-  Reserve4: 32
-  Reserve5: 64
-  Reserve6: 128
+  values:
+    All: 255
+    Friends: 1
+    Guild: 2
+    None: 0
+    Reserve1: 4
+    Reserve2: 8
+    Reserve3: 16
+    Reserve4: 32
+    Reserve5: 64
+    Reserve6: 128
 ExpansionLandingPageType:
-  Midnight: 1
-  None: 0
+  values:
+    Midnight: 1
+    None: 0
 ExpansionLevel:
-  BattleForAzeroth: 7
-  BurningCrusade: 1
-  Cataclysm: 3
-  Draenor: 5
-  Dragonflight: 9
-  LastTitan: 12
-  Legion: 6
-  Midnight: 11
-  MistsOfPandaria: 4
-  None: 0
-  Northrend: 2
-  Shadowlands: 8
-  WarWithin: 10
+  values:
+    BattleForAzeroth: 7
+    BurningCrusade: 1
+    Cataclysm: 3
+    Draenor: 5
+    Dragonflight: 9
+    LastTitan: 12
+    Legion: 6
+    Midnight: 11
+    MistsOfPandaria: 4
+    None: 0
+    Northrend: 2
+    Shadowlands: 8
+    WarWithin: 10
 FlightPathFaction:
-  Alliance: 2
-  Horde: 1
-  Neutral: 0
+  values:
+    Alliance: 2
+    Horde: 1
+    Neutral: 0
 FlightPathState:
-  Current: 0
-  Reachable: 1
-  Unreachable: 2
+  values:
+    Current: 0
+    Reachable: 1
+    Unreachable: 2
 FollowerAbilityCastResult:
-  AlreadyAtMaxDurability: 13
-  CannotTargetLimitedUseFollower: 11
-  CannotTargetNonAutoMissionFollower: 14
-  Failure: 1
-  InvalidFollowerSpell: 4
-  InvalidFollowerType: 9
-  InvalidTarget: 3
-  MustBeUnique: 10
-  MustTargetFollower: 7
-  MustTargetLimitedUseFollower: 12
-  MustTargetTrait: 8
-  NoPendingCast: 2
-  RerollNotAllowed: 5
-  SingleMissionDuration: 6
-  Success: 0
+  values:
+    AlreadyAtMaxDurability: 13
+    CannotTargetLimitedUseFollower: 11
+    CannotTargetNonAutoMissionFollower: 14
+    Failure: 1
+    InvalidFollowerSpell: 4
+    InvalidFollowerType: 9
+    InvalidTarget: 3
+    MustBeUnique: 10
+    MustTargetFollower: 7
+    MustTargetLimitedUseFollower: 12
+    MustTargetTrait: 8
+    NoPendingCast: 2
+    RerollNotAllowed: 5
+    SingleMissionDuration: 6
+    Success: 0
 FontStringScaleAnimationMode:
-  FontSize: 0
-  Vertex: 1
+  values:
+    FontSize: 0
+    Vertex: 1
 FragmentID:
-  Actor: 15
-  CgObject: 2
-  ClientObservablesData: 6
-  DeferredMessages: 9
-  EntityPosition: 1
-  FHousingDecor: 20
-  FHousingDecorActor: 28
-  FHousingDecorProxy: 26
-  FHousingFixture: 34
-  FHousingHouseDecorSet: 24
-  FHousingHouseFixtureSet: 35
-  FHousingHouseRoomSet: 25
-  FHousingPlayerHouse: 23
-  FHousingPlotAreaTrigger: 29
-  FHousingRoom: 21
-  FHousingRoomComponentMesh: 22
-  FHousingStorageMirrorData: 33
-  FJamHousingCornerstone: 27
-  FLootObjectList: 12
-  FMeshObjectData: 19
-  FMirroredPositionData: 31
-  FNeighborhoodMirrorData: 30
-  FNeighborhoodStateData: 38
-  FPathingDoor: 41
-  FPathingDynamicLinks: 40
-  FPersistableJamServers: 10
-  FPhaseShiftData: 16
-  FPlayerHouseInfo: 32
-  FPlayerInitiativeInfo: 37
-  FPlayerJamServers: 11
-  FPlayerOwnershipLink: 13
-  FTransportLink: 5
-  FUnitAIGroupLink: 39
-  FUnitAreaTriggerLink: 14
-  FVendor: 17
-  HeartbeatData: 4
-  JamDispatcher: 3
-  MirroredObjectC: 18
-  MirrorState: 0
-  ReservedArchetypeSeparator: 255
-  TagActiveClientS: 216
-  TagActiveObjectC: 217
-  TagActivePlayer: 215
-  TagAIGroup: 212
-  TagAreaTrigger: 209
-  TagAzeriteEmpoweredItem: 202
-  TagAzeriteItem: 203
-  TagContainer: 201
-  TagConversation: 211
-  TagCorpse: 208
-  TagDynamicObject: 207
-  TagGameObject: 206
-  TagHouseExteriorPiece: 224
-  TagHouseExteriorRoot: 225
-  TagHousingDecorProxyGameObject: 226
-  TagHousingPoolObject: 223
-  TagHousingRoom: 220
-  TagHousingSubdivisionObject: 222
-  TagItem: 200
-  TagLootObject: 214
-  TagMeshObject: 221
-  TagPlayer: 205
-  TagScenario: 213
-  TagSceneObject: 210
-  TagUnit: 204
-  TagUnitVehicle: 219
-  TagVisibleObjectC: 218
-  TestFragment_1: 250
-  TestFragment_2: 251
-  TestFragment_3: 252
-  TestFragment_4: 253
-  TestFragment_5: 254
-  Timer: 36
-  TimerQueues: 7
-  TransferSuspensionData: 8
+  values:
+    Actor: 15
+    CgObject: 2
+    ClientObservablesData: 6
+    DeferredMessages: 9
+    EntityPosition: 1
+    FHousingDecor: 20
+    FHousingDecorActor: 28
+    FHousingDecorProxy: 26
+    FHousingFixture: 34
+    FHousingHouseDecorSet: 24
+    FHousingHouseFixtureSet: 35
+    FHousingHouseRoomSet: 25
+    FHousingPlayerHouse: 23
+    FHousingPlotAreaTrigger: 29
+    FHousingRoom: 21
+    FHousingRoomComponentMesh: 22
+    FHousingStorageMirrorData: 33
+    FJamHousingCornerstone: 27
+    FLootObjectList: 12
+    FMeshObjectData: 19
+    FMirroredPositionData: 31
+    FNeighborhoodMirrorData: 30
+    FNeighborhoodStateData: 38
+    FPathingDoor: 41
+    FPathingDynamicLinks: 40
+    FPersistableJamServers: 10
+    FPhaseShiftData: 16
+    FPlayerHouseInfo: 32
+    FPlayerInitiativeInfo: 37
+    FPlayerJamServers: 11
+    FPlayerOwnershipLink: 13
+    FTransportLink: 5
+    FUnitAIGroupLink: 39
+    FUnitAreaTriggerLink: 14
+    FVendor: 17
+    HeartbeatData: 4
+    JamDispatcher: 3
+    MirroredObjectC: 18
+    MirrorState: 0
+    ReservedArchetypeSeparator: 255
+    TagActiveClientS: 216
+    TagActiveObjectC: 217
+    TagActivePlayer: 215
+    TagAIGroup: 212
+    TagAreaTrigger: 209
+    TagAzeriteEmpoweredItem: 202
+    TagAzeriteItem: 203
+    TagContainer: 201
+    TagConversation: 211
+    TagCorpse: 208
+    TagDynamicObject: 207
+    TagGameObject: 206
+    TagHouseExteriorPiece: 224
+    TagHouseExteriorRoot: 225
+    TagHousingDecorProxyGameObject: 226
+    TagHousingPoolObject: 223
+    TagHousingRoom: 220
+    TagHousingSubdivisionObject: 222
+    TagItem: 200
+    TagLootObject: 214
+    TagMeshObject: 221
+    TagPlayer: 205
+    TagScenario: 213
+    TagSceneObject: 210
+    TagUnit: 204
+    TagUnitVehicle: 219
+    TagVisibleObjectC: 218
+    TestFragment_1: 250
+    TestFragment_2: 251
+    TestFragment_3: 252
+    TestFragment_4: 253
+    TestFragment_5: 254
+    Timer: 36
+    TimerQueues: 7
+    TransferSuspensionData: 8
 FrameTutorialAccount:
-  AccountWideReputation: 9
-  AssistedCombatRotationActionButton: 22
-  AssistedCombatRotationDragSpell: 21
-  BindToAccountUntilEquip: 11
-  CompletedQuestsFilter: 12
-  CompletedQuestsFilterSeen: 13
-  ConcentrationCurrency: 14
-  EditModeManager: 3
-  EnconterJournalTutorialsTabSeen: 33
-  EventSchedulerTabSeen: 20
-  HeirloomJournalLevel: 7
-  HousingCleanupMode: 40
-  HousingDecorCleanup: 23
-  HousingDecorClippingGrid: 25
-  HousingDecorCustomization: 26
-  HousingDecorLayout: 27
-  HousingDecorPlace: 24
-  HousingEndeavorsTabSeen: 48
-  HousingExpertMode: 39
-  HousingHouseFinderMap: 28
-  HousingHouseFinderVisitHouse: 29
-  HousingInvalidCollision: 37
-  HousingItemAcquisition: 30
-  HousingMarketTab: 34
-  HousingModesUnlocked: 38
-  HousingNewPip: 31
-  HousingTeleportButton: 35
-  HudRevampBagChanges: 1
-  LFGList: 6
-  LocalStoriesFilterSeen: 19
-  MapLegendOpened: 15
-  MountCollectionDragonriding: 5
-  NpcCraftingOrderCreateButton: 17
-  NpcCraftingOrders: 16
-  NpcCraftingOrderTabNew: 18
-  PerksProgramActivitiesIntro: 2
-  PerksProgramActivitiesOpen: 32
-  RPETalentStarterBuild: 36
-  RunesOfPower: 49
-  TimerunnersAdvantage: 8
-  TransferableCurrencies: 10
-  TransmogCustomSets: 43
-  TransmogCustomSetsMigration: 47
-  TransmogOutfits: 41
-  TransmogSets: 42
-  TransmogSetsTab: 4
-  TransmogSituations: 44
-  TransmogTrialOfStyle: 46
-  TransmogWeaponOptions: 45
+  values:
+    AccountWideReputation: 9
+    AssistedCombatRotationActionButton: 22
+    AssistedCombatRotationDragSpell: 21
+    BindToAccountUntilEquip: 11
+    CompletedQuestsFilter: 12
+    CompletedQuestsFilterSeen: 13
+    ConcentrationCurrency: 14
+    EditModeManager: 3
+    EnconterJournalTutorialsTabSeen: 33
+    EventSchedulerTabSeen: 20
+    HeirloomJournalLevel: 7
+    HousingCleanupMode: 40
+    HousingDecorCleanup: 23
+    HousingDecorClippingGrid: 25
+    HousingDecorCustomization: 26
+    HousingDecorLayout: 27
+    HousingDecorPlace: 24
+    HousingEndeavorsTabSeen: 48
+    HousingExpertMode: 39
+    HousingHouseFinderMap: 28
+    HousingHouseFinderVisitHouse: 29
+    HousingInvalidCollision: 37
+    HousingItemAcquisition: 30
+    HousingMarketTab: 34
+    HousingModesUnlocked: 38
+    HousingNewPip: 31
+    HousingTeleportButton: 35
+    HudRevampBagChanges: 1
+    LFGList: 6
+    LocalStoriesFilterSeen: 19
+    MapLegendOpened: 15
+    MountCollectionDragonriding: 5
+    NpcCraftingOrderCreateButton: 17
+    NpcCraftingOrders: 16
+    NpcCraftingOrderTabNew: 18
+    PerksProgramActivitiesIntro: 2
+    PerksProgramActivitiesOpen: 32
+    RPETalentStarterBuild: 36
+    RunesOfPower: 49
+    TimerunnersAdvantage: 8
+    TransferableCurrencies: 10
+    TransmogCustomSets: 43
+    TransmogCustomSetsMigration: 47
+    TransmogOutfits: 41
+    TransmogSets: 42
+    TransmogSetsTab: 4
+    TransmogSituations: 44
+    TransmogTrialOfStyle: 46
+    TransmogWeaponOptions: 45
 GameMode:
-  Plunderstorm: 2
-  Standard: 1
-  WoWHack: 3
+  values:
+    Plunderstorm: 2
+    Standard: 1
+    WoWHack: 3
 GamePadPowerLevel:
-  Critical: 0
-  High: 3
-  Low: 1
-  Medium: 2
-  Unknown: 5
-  Wired: 4
+  values:
+    Critical: 0
+    High: 3
+    Low: 1
+    Medium: 2
+    Unknown: 5
+    Wired: 4
 GameRule:
-  AchievementsPanelDisabled: 40
-  ActionbarIconIntroDisabled: 60
-  ActionButtonTypeOverlayStrategy: 165
-  ActionCombatTargetLockEnabled: 87
-  AfterDeathSpectatingUI: 49
-  AllPlayersAreFastMovers: 53
-  AlwaysAllowAlliedRaces: 59
-  AutoAttacksDisabled: 103
-  BagSpaceOverride: 172
-  BagsUIDisabled: 64
-  BlockWhileSheathedAllowed: 88
-  CharacterCreateUseFixedBackgroundModel: 55
-  CharacterlessLogin: 14
-  CharacterPanelDisabled: 37
-  CharNameReservationEnabled: 2
-  CharReservationsPerRealmReopenThreshold: 8
-  ChatLinkLevelToastsDisabled: 63
-  ClearMailOnRealmTransfer: 92
-  CollectionsPanelDisabled: 36
-  CommunitiesPanelDisabled: 41
-  CompactRaidFrameManagerDisabled: 81
-  CustomActionbarOverlayHeightOffset: 33
-  DeleteItemConfirmationDisabled: 62
-  DisableCampsites: 114
-  DisableHonorDecay: 23
-  DisablePct: 9
-  DisableQuickJoin: 162
-  DisableRaidGroups: 163
-  DisableRealmSelection: 113
-  DisableVas: 119
-  DoesNotCountTowardAccountCharacterMax: 142
-  EditModeDisabled: 82
-  EjDungeonsDisabled: 149
-  EjItemSetsDisabled: 151
-  EjJourneysDisabled: 156
-  EjRaidsDisabled: 150
-  EjSuggestedContentDisabled: 148
-  EncounterJournalDisabled: 42
-  EtaRealmLaunchTime: 5
-  ExperienceBarDisabled: 159
-  FastAreaTriggerTick: 52
-  FinderPanelDisabled: 43
-  ForceAlteredFormsOn: 56
-  ForcedChatLanguage: 34
-  ForcedMultiActionBarSetting: 133
-  ForcedPartyFrameScale: 32
-  FrontEndChat: 50
-  FullCharacterCreateDisabled: 84
-  GameMode: 13
-  GdapiCharacterProfileDisabled: 153
-  GroupFinderCapabilities: 98
-  GuildsDisabled: 46
-  HardcoreRuleset: 10
-  HelpPanelDisabled: 45
-  HideAllMultiActionBars: 135
-  HideFaction: 116
-  HideTransmogZeroCost: 161
-  HideUnavailableTransmogSlots: 160
-  HousingDashboardDisabled: 102
-  HousingEnabled: 154
-  IgnoreChrclassDisabledFlag: 54
-  IngameCalendarDisabled: 75
-  IngameFriendsListDisabled: 79
-  IngameMailNotificationDisabled: 74
-  IngameTrackingDisabled: 76
-  IngameWhoListDisabled: 77
-  InstanceDifficultyBannerDisabled: 83
-  LandingPageFactionID: 35
-  LootMethodStyle: 157
-  MacrosDisabled: 80
-  MailGameRule: 132
-  MapPlunderstormCircle: 48
-  MaxAccountCharReservationsPerContentset: 4
-  MaxCharactersPerContentSet: 139
-  MaxCharReservationsPerRealm: 3
-  MaximizeWorldMapDisabled: 67
-  MaxLootDropLevel: 25
-  MaxNameplateDistance: 28
-  MaxUnitNameDistance: 27
-  MerchantFilterDisabled: 101
-  MicrobarScale: 26
-  MinimapDisabled: 146
-  MinUndeleteLevelRequired: 140
-  NameplateCastBarDisabled: 107
-  NoDebuffLimit: 1
-  NonPlayerNameplateScale: 31
-  ObjectiveTrackerDisabled: 104
-  PerksProgramActivityTrackingDisabled: 66
-  PersonalResourceDisplayDisabled: 129
-  PetBattlesDisabled: 65
-  PlayerCastBarDisabled: 105
-  PlayerFrameDisabled: 131
-  PlayerNameplateAlternateHealthColor: 58
-  PlayerNameplateDifficultyIcon: 57
-  PlunderstormAreaSelection: 94
-  PremadeGroupFinderStyle: 93
-  PvPInitialRatingOverride: 190
-  QuestLogMicrobuttonDisabled: 47
-  QuestLogPanelDisabled: 71
-  QuestLogSuperTrackingDisabled: 72
-  RaceAlteredFormsDisabled: 78
-  RecommendLeastPopulatedRealm: 169
-  ReleaseSpiritGhostDisabled: 61
-  RepairArmorDisabled: 147
-  ReplaceAbsentGmSeconds: 11
-  ReplaceGmRankLastOnlineSeconds: 12
-  RestrictedAchievementCategoryID: 155
-  Runecarving: 17
-  SelfFoundAllowed: 22
-  SpellbookPanelDisabled: 38
-  StoreDisabled: 44
-  SummoningStones: 108
-  TalentRespecCostMax: 19
-  TalentRespecCostMin: 18
-  TalentRespecCostStep: 20
-  TalentsPanelDisabled: 39
-  TargetCastBarDisabled: 106
-  TargetFrameBuffsDisabled: 85
-  TargetFrameDisabled: 130
-  TimerunningAllowed: 137
-  TransmogEnabled: 109
-  TrivialGroupXPPercent: 7
-  TutorialFrameDisabled: 73
-  UnflaggedPlayersCanAttackPvPFlaggedPlayers: 173
-  UnitFramePvPContextualDisabled: 86
-  UniversalNameplateOcclusion: 51
-  UseGameTableVariation: 164
-  UserAddonsDisabled: 29
-  UserScriptsDisabled: 30
-  UseSimpleCharacterSelectList: 115
-  VanillaAccountMailInstant: 91
-  VanillaNpcKnockback: 16
-  VanillaRageGenerationModifier: 21
-  WorldMapDisabled: 145
-  WorldMapFrameStrata: 100
-  WorldMapHelpPlateDisabled: 70
-  WorldMapLegendDisabled: 99
-  WorldMapTrackingOptionsDisabled: 68
-  WorldMapTrackingPinDisabled: 69
+  values:
+    AchievementsPanelDisabled: 40
+    ActionbarIconIntroDisabled: 60
+    ActionButtonTypeOverlayStrategy: 165
+    ActionCombatTargetLockEnabled: 87
+    AfterDeathSpectatingUI: 49
+    AllPlayersAreFastMovers: 53
+    AlwaysAllowAlliedRaces: 59
+    AutoAttacksDisabled: 103
+    BagSpaceOverride: 172
+    BagsUIDisabled: 64
+    BlockWhileSheathedAllowed: 88
+    CharacterCreateUseFixedBackgroundModel: 55
+    CharacterlessLogin: 14
+    CharacterPanelDisabled: 37
+    CharNameReservationEnabled: 2
+    CharReservationsPerRealmReopenThreshold: 8
+    ChatLinkLevelToastsDisabled: 63
+    ClearMailOnRealmTransfer: 92
+    CollectionsPanelDisabled: 36
+    CommunitiesPanelDisabled: 41
+    CompactRaidFrameManagerDisabled: 81
+    CustomActionbarOverlayHeightOffset: 33
+    DeleteItemConfirmationDisabled: 62
+    DisableCampsites: 114
+    DisableHonorDecay: 23
+    DisablePct: 9
+    DisableQuickJoin: 162
+    DisableRaidGroups: 163
+    DisableRealmSelection: 113
+    DisableVas: 119
+    DoesNotCountTowardAccountCharacterMax: 142
+    EditModeDisabled: 82
+    EjDungeonsDisabled: 149
+    EjItemSetsDisabled: 151
+    EjJourneysDisabled: 156
+    EjRaidsDisabled: 150
+    EjSuggestedContentDisabled: 148
+    EncounterJournalDisabled: 42
+    EtaRealmLaunchTime: 5
+    ExperienceBarDisabled: 159
+    FastAreaTriggerTick: 52
+    FinderPanelDisabled: 43
+    ForceAlteredFormsOn: 56
+    ForcedChatLanguage: 34
+    ForcedMultiActionBarSetting: 133
+    ForcedPartyFrameScale: 32
+    FrontEndChat: 50
+    FullCharacterCreateDisabled: 84
+    GameMode: 13
+    GdapiCharacterProfileDisabled: 153
+    GroupFinderCapabilities: 98
+    GuildsDisabled: 46
+    HardcoreRuleset: 10
+    HelpPanelDisabled: 45
+    HideAllMultiActionBars: 135
+    HideFaction: 116
+    HideTransmogZeroCost: 161
+    HideUnavailableTransmogSlots: 160
+    HousingDashboardDisabled: 102
+    HousingEnabled: 154
+    IgnoreChrclassDisabledFlag: 54
+    IngameCalendarDisabled: 75
+    IngameFriendsListDisabled: 79
+    IngameMailNotificationDisabled: 74
+    IngameTrackingDisabled: 76
+    IngameWhoListDisabled: 77
+    InstanceDifficultyBannerDisabled: 83
+    LandingPageFactionID: 35
+    LootMethodStyle: 157
+    MacrosDisabled: 80
+    MailGameRule: 132
+    MapPlunderstormCircle: 48
+    MaxAccountCharReservationsPerContentset: 4
+    MaxCharactersPerContentSet: 139
+    MaxCharReservationsPerRealm: 3
+    MaximizeWorldMapDisabled: 67
+    MaxLootDropLevel: 25
+    MaxNameplateDistance: 28
+    MaxUnitNameDistance: 27
+    MerchantFilterDisabled: 101
+    MicrobarScale: 26
+    MinimapDisabled: 146
+    MinUndeleteLevelRequired: 140
+    NameplateCastBarDisabled: 107
+    NoDebuffLimit: 1
+    NonPlayerNameplateScale: 31
+    ObjectiveTrackerDisabled: 104
+    PerksProgramActivityTrackingDisabled: 66
+    PersonalResourceDisplayDisabled: 129
+    PetBattlesDisabled: 65
+    PlayerCastBarDisabled: 105
+    PlayerFrameDisabled: 131
+    PlayerNameplateAlternateHealthColor: 58
+    PlayerNameplateDifficultyIcon: 57
+    PlunderstormAreaSelection: 94
+    PremadeGroupFinderStyle: 93
+    PvPInitialRatingOverride: 190
+    QuestLogMicrobuttonDisabled: 47
+    QuestLogPanelDisabled: 71
+    QuestLogSuperTrackingDisabled: 72
+    RaceAlteredFormsDisabled: 78
+    RecommendLeastPopulatedRealm: 169
+    ReleaseSpiritGhostDisabled: 61
+    RepairArmorDisabled: 147
+    ReplaceAbsentGmSeconds: 11
+    ReplaceGmRankLastOnlineSeconds: 12
+    RestrictedAchievementCategoryID: 155
+    Runecarving: 17
+    SelfFoundAllowed: 22
+    SpellbookPanelDisabled: 38
+    StoreDisabled: 44
+    SummoningStones: 108
+    TalentRespecCostMax: 19
+    TalentRespecCostMin: 18
+    TalentRespecCostStep: 20
+    TalentsPanelDisabled: 39
+    TargetCastBarDisabled: 106
+    TargetFrameBuffsDisabled: 85
+    TargetFrameDisabled: 130
+    TimerunningAllowed: 137
+    TransmogEnabled: 109
+    TrivialGroupXPPercent: 7
+    TutorialFrameDisabled: 73
+    UnflaggedPlayersCanAttackPvPFlaggedPlayers: 173
+    UnitFramePvPContextualDisabled: 86
+    UniversalNameplateOcclusion: 51
+    UseGameTableVariation: 164
+    UserAddonsDisabled: 29
+    UserScriptsDisabled: 30
+    UseSimpleCharacterSelectList: 115
+    VanillaAccountMailInstant: 91
+    VanillaNpcKnockback: 16
+    VanillaRageGenerationModifier: 21
+    WorldMapDisabled: 145
+    WorldMapFrameStrata: 100
+    WorldMapHelpPlateDisabled: 70
+    WorldMapLegendDisabled: 99
+    WorldMapTrackingOptionsDisabled: 68
+    WorldMapTrackingPinDisabled: 69
 GameRuleFlags:
-  AllowClient: 1
-  None: 0
-  RequiresDefault: 2
+  values:
+    AllowClient: 1
+    None: 0
+    RequiresDefault: 2
 GameRuleType:
-  Bool: 2
-  Float: 1
-  Int: 0
+  values:
+    Bool: 2
+    Float: 1
+    Int: 0
 GarrAutoBoardIndex:
-  AllyCenterFront: 3
-  AllyLeftBack: 0
-  AllyLeftFront: 2
-  AllyRightBack: 1
-  AllyRightFront: 4
-  EnemyCenterLeftBack: 10
-  EnemyCenterLeftFront: 6
-  EnemyCenterRightBack: 11
-  EnemyCenterRightFront: 7
-  EnemyLeftBack: 9
-  EnemyLeftFront: 5
-  EnemyRightBack: 12
-  EnemyRightFront: 8
-  None: -1
+  values:
+    AllyCenterFront: 3
+    AllyLeftBack: 0
+    AllyLeftFront: 2
+    AllyRightBack: 1
+    AllyRightFront: 4
+    EnemyCenterLeftBack: 10
+    EnemyCenterLeftFront: 6
+    EnemyCenterRightBack: 11
+    EnemyCenterRightFront: 7
+    EnemyLeftBack: 9
+    EnemyLeftFront: 5
+    EnemyRightBack: 12
+    EnemyRightFront: 8
+    None: -1
 GarrAutoCombatantRole:
-  HealSupport: 4
-  Melee: 1
-  None: 0
-  RangedMagic: 3
-  RangedPhysical: 2
-  Tank: 5
+  values:
+    HealSupport: 4
+    Melee: 1
+    None: 0
+    RangedMagic: 3
+    RangedPhysical: 2
+    Tank: 5
 GarrAutoCombatSpellTutorialFlag:
-  All: 4
-  Column: 2
-  None: 0
-  Row: 3
-  Single: 1
+  values:
+    All: 4
+    Column: 2
+    None: 0
+    Row: 3
+    Single: 1
 GarrAutoCombatTutorial:
-  AttackAll: 256
-  AttackColumn: 64
-  AttackRow: 128
-  AttackSingle: 32
-  BeneficialEffect: 16
-  EnvironmentalEffect: 1024
-  HealCompanion: 4
-  LevelHeal: 8
-  PlaceCompanion: 2
-  SelectMission: 1
-  TroopTutorial: 512
+  values:
+    AttackAll: 256
+    AttackColumn: 64
+    AttackRow: 128
+    AttackSingle: 32
+    BeneficialEffect: 16
+    EnvironmentalEffect: 1024
+    HealCompanion: 4
+    LevelHeal: 8
+    PlaceCompanion: 2
+    SelectMission: 1
+    TroopTutorial: 512
 GarrAutoEventFlags:
-  AutoAttack: 1
-  Environment: 4
-  None: 0
-  Passive: 2
+  values:
+    AutoAttack: 1
+    Environment: 4
+    None: 0
+    Passive: 2
 GarrAutoMissionEventType:
-  ApplyAura: 7
-  Died: 9
-  Heal: 4
-  MeleeDamage: 0
-  PeriodicDamage: 5
-  PeriodicHeal: 6
-  RangeDamage: 1
-  RemoveAura: 8
-  SpellMeleeDamage: 2
-  SpellRangeDamage: 3
+  values:
+    ApplyAura: 7
+    Died: 9
+    Heal: 4
+    MeleeDamage: 0
+    PeriodicDamage: 5
+    PeriodicHeal: 6
+    RangeDamage: 1
+    RemoveAura: 8
+    SpellMeleeDamage: 2
+    SpellRangeDamage: 3
 GarrAutoPreviewTargetType:
-  Buff: 4
-  Damage: 1
-  Debuff: 8
-  Heal: 2
-  None: 0
+  values:
+    Buff: 4
+    Damage: 1
+    Debuff: 8
+    Heal: 2
+    None: 0
 GarrFollowerMissionCompleteState:
-  Alive: 0
-  KilledByMissionFailure: 1
-  OutOfDurability: 3
-  SavedByPreventDeath: 2
+  values:
+    Alive: 0
+    KilledByMissionFailure: 1
+    OutOfDurability: 3
+    SavedByPreventDeath: 2
 GarrFollowerQuality:
-  Common: 1
-  Epic: 4
-  Legendary: 5
-  None: 0
-  Rare: 3
-  Title: 6
-  Uncommon: 2
+  values:
+    Common: 1
+    Epic: 4
+    Legendary: 5
+    None: 0
+    Rare: 3
+    Title: 6
+    Uncommon: 2
 GarrisonFollowerType:
-  FollowerType_6_0_Boat: 2
-  FollowerType_6_0_GarrisonFollower: 1
-  FollowerType_7_0_GarrisonFollower: 4
-  FollowerType_8_0_GarrisonFollower: 22
-  FollowerType_9_0_GarrisonFollower: 123
+  values:
+    FollowerType_6_0_Boat: 2
+    FollowerType_6_0_GarrisonFollower: 1
+    FollowerType_7_0_GarrisonFollower: 4
+    FollowerType_8_0_GarrisonFollower: 22
+    FollowerType_9_0_GarrisonFollower: 123
 GarrisonTalentAvailability:
-  Available: 0
-  Unavailable: 1
-  UnavailableAlreadyHave: 7
-  UnavailableAnotherIsResearching: 2
-  UnavailableNotEnoughGold: 4
-  UnavailableNotEnoughResources: 3
-  UnavailablePlayerCondition: 6
-  UnavailableRequiresPrerequisiteTalent: 8
-  UnavailableTierUnavailable: 5
+  values:
+    Available: 0
+    Unavailable: 1
+    UnavailableAlreadyHave: 7
+    UnavailableAnotherIsResearching: 2
+    UnavailableNotEnoughGold: 4
+    UnavailableNotEnoughResources: 3
+    UnavailablePlayerCondition: 6
+    UnavailableRequiresPrerequisiteTalent: 8
+    UnavailableTierUnavailable: 5
 GarrisonType:
-  Type_6_0_Garrison: 2
-  Type_7_0_Garrison: 3
-  Type_8_0_Garrison: 9
-  Type_9_0_Garrison: 111
+  values:
+    Type_6_0_Garrison: 2
+    Type_7_0_Garrison: 3
+    Type_8_0_Garrison: 9
+    Type_9_0_Garrison: 111
 GarrTalentCostType:
-  Initial: 0
-  MakePermanent: 2
-  Respec: 1
-  TreeReset: 3
+  values:
+    Initial: 0
+    MakePermanent: 2
+    Respec: 1
+    TreeReset: 3
 GarrTalentFeatureSubtype:
-  Ardenweald: 3
-  Bastion: 1
-  Generic: 0
-  Maldraxxus: 4
-  Revendreth: 2
+  values:
+    Ardenweald: 3
+    Bastion: 1
+    Generic: 0
+    Maldraxxus: 4
+    Revendreth: 2
 GarrTalentFeatureType:
-  Adventures: 3
-  AnimaDiversion: 1
-  AnimaDiversionMap: 7
-  Cyphers: 8
-  Generic: 0
-  ReservoirUpgrades: 4
-  SanctumUnique: 5
-  SoulBinds: 6
-  TravelPortals: 2
+  values:
+    Adventures: 3
+    AnimaDiversion: 1
+    AnimaDiversionMap: 7
+    Cyphers: 8
+    Generic: 0
+    ReservoirUpgrades: 4
+    SanctumUnique: 5
+    SoulBinds: 6
+    TravelPortals: 2
 GarrTalentResearchCostSource:
-  Talent: 0
-  Tree: 1
+  values:
+    Talent: 0
+    Tree: 1
 GarrTalentSocketType:
-  Conduit: 2
-  None: 0
-  Spell: 1
+  values:
+    Conduit: 2
+    None: 0
+    Spell: 1
 GarrTalentTreeType:
-  Classic: 1
-  Tiers: 0
+  values:
+    Classic: 1
+    Tiers: 0
 GarrTalentType:
-  Major: 2
-  Minor: 1
-  Socket: 3
-  Standard: 0
+  values:
+    Major: 2
+    Minor: 1
+    Socket: 3
+    Standard: 0
 GarrTalentUI:
-  AnimaDiversionMap: 3
-  CovenantSanctum: 1
-  Generic: 0
-  SoulBinds: 2
+  values:
+    AnimaDiversionMap: 3
+    CovenantSanctum: 1
+    Generic: 0
+    SoulBinds: 2
 GossipNpcOption:
-  AccountBanker: 57
-  AdventureMap: 31
-  ArtifactRespec: 21
-  Auctioneer: 10
-  AzeriteRespec: 35
-  Banker: 6
-  BarbersChoice: 52
-  Battlemaster: 9
-  Binder: 5
-  BlackMarketAuctionHouse: 46
-  CemeterySelect: 22
-  CharacterBanker: 56
-  ChromieTimeNpc: 40
-  ContributionCollector: 33
-  CovenantPreviewNpc: 41
-  CovenantRenownNpc: 45
-  DisableXPGain: 16
-  EnableXPGain: 17
-  ForgeMaster: 55
-  GarrisonArchitect: 26
-  GarrisonMissionNpc: 27
-  GarrisonRecruitment: 30
-  GarrisonTalent: 32
-  GarrisonTradeskillNpc: 29
-  GlyphMaster: 24
-  GuildBanker: 14
-  GuildRename: 62
-  GuildTabardVendor: 8
-  HouseFinder: 65
-  HousingCreateGuildNeighborhood: 60
-  HousingGetNeighborhoodCharter: 61
-  HousingOpenCharterConfirmation: 63
-  IslandsMissionNpc: 36
-  ItemUpgrade: 64
-  LFGDungeon: 20
-  Mailbox: 18
-  MajorFactionRenown: 53
-  NewPlayerGuide: 43
-  None: 0
-  PerksProgramVendor: 47
-  PersonalTabardVendor: 54
-  PetitionVendor: 7
-  PetUntrainer: 13
-  ProfessionRespec: 58
-  ProfessionsCraftingOrder: 48
-  ProfessionsCustomerOrder: 50
-  ProfessionsOpen: 49
-  QueueScenario: 25
-  RenameNeighborhood: 59
-  RuneforgeLegendaryCrafting: 42
-  RuneforgeLegendaryUpgrade: 44
-  ShipmentCrafter: 28
-  Soulbind: 39
-  SpecializationMaster: 23
-  Spellclick: 15
-  SpiritHealer: 4
-  Stablemaster: 12
-  TalentMaster: 11
-  Taxinode: 2
-  TieredEntrance: 66
-  Trainer: 3
-  TraitSystem: 51
-  Transmogrify: 34
-  UIItemInteraction: 37
-  Vendor: 1
-  WorldMap: 38
-  WorldPvPQueue: 19
+  values:
+    AccountBanker: 57
+    AdventureMap: 31
+    ArtifactRespec: 21
+    Auctioneer: 10
+    AzeriteRespec: 35
+    Banker: 6
+    BarbersChoice: 52
+    Battlemaster: 9
+    Binder: 5
+    BlackMarketAuctionHouse: 46
+    CemeterySelect: 22
+    CharacterBanker: 56
+    ChromieTimeNpc: 40
+    ContributionCollector: 33
+    CovenantPreviewNpc: 41
+    CovenantRenownNpc: 45
+    DisableXPGain: 16
+    EnableXPGain: 17
+    ForgeMaster: 55
+    GarrisonArchitect: 26
+    GarrisonMissionNpc: 27
+    GarrisonRecruitment: 30
+    GarrisonTalent: 32
+    GarrisonTradeskillNpc: 29
+    GlyphMaster: 24
+    GuildBanker: 14
+    GuildRename: 62
+    GuildTabardVendor: 8
+    HouseFinder: 65
+    HousingCreateGuildNeighborhood: 60
+    HousingGetNeighborhoodCharter: 61
+    HousingOpenCharterConfirmation: 63
+    IslandsMissionNpc: 36
+    ItemUpgrade: 64
+    LFGDungeon: 20
+    Mailbox: 18
+    MajorFactionRenown: 53
+    NewPlayerGuide: 43
+    None: 0
+    PerksProgramVendor: 47
+    PersonalTabardVendor: 54
+    PetitionVendor: 7
+    PetUntrainer: 13
+    ProfessionRespec: 58
+    ProfessionsCraftingOrder: 48
+    ProfessionsCustomerOrder: 50
+    ProfessionsOpen: 49
+    QueueScenario: 25
+    RenameNeighborhood: 59
+    RuneforgeLegendaryCrafting: 42
+    RuneforgeLegendaryUpgrade: 44
+    ShipmentCrafter: 28
+    Soulbind: 39
+    SpecializationMaster: 23
+    Spellclick: 15
+    SpiritHealer: 4
+    Stablemaster: 12
+    TalentMaster: 11
+    Taxinode: 2
+    TieredEntrance: 66
+    Trainer: 3
+    TraitSystem: 51
+    Transmogrify: 34
+    UIItemInteraction: 37
+    Vendor: 1
+    WorldMap: 38
+    WorldPvPQueue: 19
 GossipNpcOptionDisplayFlags:
-  ForceInteractionOnSingleChoice: 1
+  values:
+    ForceInteractionOnSingleChoice: 1
 GossipOptionRecFlags:
-  HideOptionIDFromClient: 2
-  PlayMovieLabelPrepend: 4
-  QuestLabelPrepend: 1
+  values:
+    HideOptionIDFromClient: 2
+    PlayMovieLabelPrepend: 4
+    QuestLabelPrepend: 1
 GossipOptionStatus:
-  AlreadyComplete: 3
-  Available: 0
-  Locked: 2
-  Unavailable: 1
+  values:
+    AlreadyComplete: 3
+    Available: 0
+    Locked: 2
+    Unavailable: 1
 GraphicsValidationResult:
-  AmdGpuUnsupported: 36
-  AppleGpuUnsupported: 35
-  CompatMode: 41
-  CpuMem_2: 6
-  CpuMem_4: 7
-  CpuMem_8: 8
-  DualCore: 4
-  Dx11Unsupported: 30
-  Dx12Win7Unsupported: 31
-  GpuDriver: 40
-  Graphics: 3
-  Illegal: 1
-  IntelGpuUnsupported: 37
-  LegacyUnsupported: 29
-  MacOsUnsupported: 27
-  Needs_5_0: 9
-  Needs_6_0: 10
-  NeedsAmdGpu: 15
-  NeedsAppleGpu: 14
-  NeedsDx12: 12
-  NeedsDx12Vrs2: 13
-  NeedsIntelGpu: 16
-  NeedsMacOs_10_13: 19
-  NeedsMacOs_10_14: 20
-  NeedsMacOs_10_15: 21
-  NeedsMacOs_11_0: 22
-  NeedsMacOs_12_0: 23
-  NeedsMacOs_13_0: 24
-  NeedsNvidiaGpu: 17
-  NeedsQualcommGpu: 18
-  NeedsRt: 11
-  NeedsWindows_10: 25
-  NeedsWindows_11: 26
-  NvapiWineUnsupported: 34
-  NvidiaGpuUnsupported: 38
-  QuadCore: 5
-  QualcommGpuUnsupported: 39
-  RemoteDesktopUnsupported: 32
-  Supported: 0
-  Unknown: 42
-  Unsupported: 2
-  WindowsUnsupported: 28
-  WineUnsupported: 33
+  values:
+    AmdGpuUnsupported: 36
+    AppleGpuUnsupported: 35
+    CompatMode: 41
+    CpuMem_2: 6
+    CpuMem_4: 7
+    CpuMem_8: 8
+    DualCore: 4
+    Dx11Unsupported: 30
+    Dx12Win7Unsupported: 31
+    GpuDriver: 40
+    Graphics: 3
+    Illegal: 1
+    IntelGpuUnsupported: 37
+    LegacyUnsupported: 29
+    MacOsUnsupported: 27
+    Needs_5_0: 9
+    Needs_6_0: 10
+    NeedsAmdGpu: 15
+    NeedsAppleGpu: 14
+    NeedsDx12: 12
+    NeedsDx12Vrs2: 13
+    NeedsIntelGpu: 16
+    NeedsMacOs_10_13: 19
+    NeedsMacOs_10_14: 20
+    NeedsMacOs_10_15: 21
+    NeedsMacOs_11_0: 22
+    NeedsMacOs_12_0: 23
+    NeedsMacOs_13_0: 24
+    NeedsNvidiaGpu: 17
+    NeedsQualcommGpu: 18
+    NeedsRt: 11
+    NeedsWindows_10: 25
+    NeedsWindows_11: 26
+    NvapiWineUnsupported: 34
+    NvidiaGpuUnsupported: 38
+    QuadCore: 5
+    QualcommGpuUnsupported: 39
+    RemoteDesktopUnsupported: 32
+    Supported: 0
+    Unknown: 42
+    Unsupported: 2
+    WindowsUnsupported: 28
+    WineUnsupported: 33
 GuildErrorType:
-  AlreadyInGuild: 2
-  BadItem: 29
-  BankNotFound: 43
-  BankTabFull: 28
-  BankTabLocked: 35
-  Busy: 20
-  CantInviteSelf: 41
-  DeleteNoAppropriateLeader: 47
-  GuildBankNotAvailable: 45
-  GuildRepTooLow: 40
-  HasRestriction: 42
-  HousingEvictError: 51
-  Ignored: 19
-  InCooldown: 49
-  InvalidBankTab: 24
-  InvitedToGuild: 4
-  LockedForMove: 39
-  NameAlreadyExists: 7
-  NameInvalid: 6
-  NewLeaderWrongFaction: 44
-  NewLeaderWrongRealm: 46
-  NoPermisson: 8
-  NotEnoughMoney: 26
-  NotInGuild: 9
-  PlayerNotFound: 11
-  RankInUse: 18
-  RankRequiresAuthenticator: 34
-  RanksLocked: 17
-  RealmMismatch: 48
-  ReservationExpired: 50
-  Success: 0
-  TargetAlreadyInGuild: 3
-  TargetInvitedToGuild: 5
-  TargetLevelTooHigh: 22
-  TargetLevelTooLow: 21
-  TargetNotInGuild: 10
-  TargetTooHigh: 13
-  TargetTooLow: 14
-  TeamNotFound: 27
-  TeamsLocked: 30
-  Throttled: 52
-  TooFewRanks: 16
-  TooManyCreate: 33
-  TooManyMembers: 23
-  TooManyRanks: 15
-  TooMuchMoney: 31
-  TrialAccount: 36
-  UndeletableDueToLevel: 38
-  UnknownError: 1
-  VeteranAccount: 37
-  WithdrawLimit: 25
-  WrongBankTab: 32
-  WrongFaction: 12
+  values:
+    AlreadyInGuild: 2
+    BadItem: 29
+    BankNotFound: 43
+    BankTabFull: 28
+    BankTabLocked: 35
+    Busy: 20
+    CantInviteSelf: 41
+    DeleteNoAppropriateLeader: 47
+    GuildBankNotAvailable: 45
+    GuildRepTooLow: 40
+    HasRestriction: 42
+    HousingEvictError: 51
+    Ignored: 19
+    InCooldown: 49
+    InvalidBankTab: 24
+    InvitedToGuild: 4
+    LockedForMove: 39
+    NameAlreadyExists: 7
+    NameInvalid: 6
+    NewLeaderWrongFaction: 44
+    NewLeaderWrongRealm: 46
+    NoPermisson: 8
+    NotEnoughMoney: 26
+    NotInGuild: 9
+    PlayerNotFound: 11
+    RankInUse: 18
+    RankRequiresAuthenticator: 34
+    RanksLocked: 17
+    RealmMismatch: 48
+    ReservationExpired: 50
+    Success: 0
+    TargetAlreadyInGuild: 3
+    TargetInvitedToGuild: 5
+    TargetLevelTooHigh: 22
+    TargetLevelTooLow: 21
+    TargetNotInGuild: 10
+    TargetTooHigh: 13
+    TargetTooLow: 14
+    TeamNotFound: 27
+    TeamsLocked: 30
+    Throttled: 52
+    TooFewRanks: 16
+    TooManyCreate: 33
+    TooManyMembers: 23
+    TooManyRanks: 15
+    TooMuchMoney: 31
+    TrialAccount: 36
+    UndeletableDueToLevel: 38
+    UnknownError: 1
+    VeteranAccount: 37
+    WithdrawLimit: 25
+    WrongBankTab: 32
+    WrongFaction: 12
 HolidayCalendarFlags:
-  Alliance: 1
-  Horde: 2
+  values:
+    Alliance: 1
+    Horde: 2
 HolidayFlags:
-  BeginEventOnlyOnStageChange: 64
-  DontDisplayBanner: 8
-  DontDisplayEnd: 4
-  DontShowInCalendar: 2
-  DurationUseMinutes: 32
-  IsRegionwide: 1
-  NotAvailableClientSide: 16
+  values:
+    BeginEventOnlyOnStageChange: 64
+    DontDisplayBanner: 8
+    DontDisplayEnd: 4
+    DontShowInCalendar: 2
+    DurationUseMinutes: 32
+    IsRegionwide: 1
+    NotAvailableClientSide: 16
 HouseEditingContext:
-  Decor: 1
-  Fixture: 3
-  None: 0
-  Room: 2
+  values:
+    Decor: 1
+    Fixture: 3
+    None: 0
+    Room: 2
 HouseEditorMode:
-  BasicDecor: 1
-  Cleanup: 5
-  Customize: 4
-  ExpertDecor: 2
-  ExteriorCustomization: 6
-  Layout: 3
-  None: 0
+  values:
+    BasicDecor: 1
+    Cleanup: 5
+    Customize: 4
+    ExpertDecor: 2
+    ExteriorCustomization: 6
+    Layout: 3
+    None: 0
 HouseExteriorWMODataFlags:
-  AllowedInAllianceNeighborhoods: 4
-  AllowedInHordeNeighborhoods: 2
-  HiddenUnlessOwned: 8
-  None: 0
-  UnlockedByDefault: 1
+  values:
+    AllowedInAllianceNeighborhoods: 4
+    AllowedInHordeNeighborhoods: 2
+    HiddenUnlessOwned: 8
+    None: 0
+    UnlockedByDefault: 1
 HouseFinderSuggestionReason:
-  BNetFriends: 8
-  CharterInvite: 2
-  Guild: 4
-  HomeOwner: 64
-  None: 0
-  Owner: 1
-  PartySync: 16
-  Random: 32
+  values:
+    BNetFriends: 8
+    CharterInvite: 2
+    Guild: 4
+    HomeOwner: 64
+    None: 0
+    Owner: 1
+    PartySync: 16
+    Random: 32
 HouseLevelRewardType:
-  Object: 1
-  Value: 0
+  values:
+    Object: 1
+    Value: 0
 HouseLevelRewardValueType:
-  ExteriorDecor: 0
-  Fixtures: 3
-  InteriorDecor: 1
-  Rooms: 2
+  values:
+    ExteriorDecor: 0
+    Fixtures: 3
+    InteriorDecor: 1
+    Rooms: 2
 HouseOwnerError:
-  Faction: 1
-  GenericPermission: 3
-  Guild: 2
-  None: 0
+  values:
+    Faction: 1
+    GenericPermission: 3
+    Guild: 2
+    None: 0
 HouseSettingFlags:
-  HouseAccessAnyone: 1
-  HouseAccessFriends: 8
-  HouseAccessGuild: 4
-  HouseAccessNeighbors: 2
-  HouseAccessParty: 16
-  None: 0
-  PlotAccessAnyone: 32
-  PlotAccessFriends: 256
-  PlotAccessGuild: 128
-  PlotAccessNeighbors: 64
-  PlotAccessParty: 512
+  values:
+    HouseAccessAnyone: 1
+    HouseAccessFriends: 8
+    HouseAccessGuild: 4
+    HouseAccessNeighbors: 2
+    HouseAccessParty: 16
+    None: 0
+    PlotAccessAnyone: 32
+    PlotAccessFriends: 256
+    PlotAccessGuild: 128
+    PlotAccessNeighbors: 64
+    PlotAccessParty: 512
 HouseVisitType:
-  Friend: 1
-  Guild: 2
-  Party: 3
-  Unknown: 0
+  values:
+    Friend: 1
+    Guild: 2
+    Party: 3
+    Unknown: 0
 HousingBasicModeTargetType:
-  Decor: 1
-  House: 2
-  None: 0
+  values:
+    Decor: 1
+    House: 2
+    None: 0
 HousingCatalogEntryModelScenePresets:
-  DecorCeiling: 1338
-  DecorDefault: 1317
-  DecorFlat: 1318
-  DecorHorizontalSurface: 1452
-  DecorHuge: 1337
-  DecorLarge: 1336
-  DecorMedium: 1335
-  DecorSmall: 1334
-  DecorTiny: 1333
-  DecorWall: 1339
+  values:
+    DecorCeiling: 1338
+    DecorDefault: 1317
+    DecorFlat: 1318
+    DecorHorizontalSurface: 1452
+    DecorHuge: 1337
+    DecorLarge: 1336
+    DecorMedium: 1335
+    DecorSmall: 1334
+    DecorTiny: 1333
+    DecorWall: 1339
 HousingCatalogEntrySize:
-  Huge: 69
-  Large: 68
-  Medium: 67
-  None: 0
-  Small: 66
-  Tiny: 65
+  values:
+    Huge: 69
+    Large: 68
+    Medium: 67
+    None: 0
+    Small: 66
+    Tiny: 65
 HousingCatalogEntryType:
-  Decor: 1
-  Invalid: 0
-  Room: 2
+  values:
+    Decor: 1
+    Invalid: 0
+    Room: 2
 HousingCatalogSortType:
-  Alphabetical: 1
-  DateAdded: 0
+  values:
+    Alphabetical: 1
+    DateAdded: 0
 HousingCleanupModeTargetType:
-  Decor: 1
-  HouseExterior: 2
-  None: 0
+  values:
+    Decor: 1
+    HouseExterior: 2
+    None: 0
 HousingCustomizeModeTargetType:
-  Decor: 1
-  ExteriorHouse: 3
-  None: 0
-  RoomComponent: 2
+  values:
+    Decor: 1
+    ExteriorHouse: 3
+    None: 0
+    RoomComponent: 2
 HousingDecorActionFlags:
-  Add: 1
-  ClickTarget: 16
-  DragMove: 4
-  HoverTarget: 32
-  IncludeTargetChildren: 512
-  MaintainLastTarget: 256
-  None: 0
-  PrecisionMove: 8
-  PreviewDecor: 2048
-  Remove: 2
-  TargetHouseExterior: 128
-  TargetRoomComponents: 64
-  UsePlacedDecorList: 1024
+  values:
+    Add: 1
+    ClickTarget: 16
+    DragMove: 4
+    HoverTarget: 32
+    IncludeTargetChildren: 512
+    MaintainLastTarget: 256
+    None: 0
+    PrecisionMove: 8
+    PreviewDecor: 2048
+    Remove: 2
+    TargetHouseExterior: 128
+    TargetRoomComponents: 64
+    UsePlacedDecorList: 1024
 HousingDecorModelType:
-  M2: 1
-  None: 0
-  WMO: 2
+  values:
+    M2: 1
+    None: 0
+    WMO: 2
 HousingDecorPlacementRestriction:
-  ChildOutsideBounds: 8
-  InvalidCollision: 32
-  InvalidLightOverlap: 64
-  InvalidTarget: 16
-  OutsidePlotBounds: 4
-  OutsideRoomBounds: 2
-  TooFarAway: 1
+  values:
+    ChildOutsideBounds: 8
+    InvalidCollision: 32
+    InvalidLightOverlap: 64
+    InvalidTarget: 16
+    OutsidePlotBounds: 4
+    OutsideRoomBounds: 2
+    TooFarAway: 1
 HousingDecorTheme:
-  BloodElf: 5
-  Folk: 1
-  Generic: 3
-  NightElf: 4
-  None: 0
-  Rugged: 2
+  values:
+    BloodElf: 5
+    Folk: 1
+    Generic: 3
+    NightElf: 4
+    None: 0
+    Rugged: 2
 HousingDecorType:
-  Ceiling: 3
-  Floor: 1
-  Flooring: 4
-  None: 0
-  Wall: 2
+  values:
+    Ceiling: 3
+    Floor: 1
+    Flooring: 4
+    None: 0
+    Wall: 2
 HousingExpertModeTargetType:
-  Decor: 1
-  House: 2
-  None: 0
+  values:
+    Decor: 1
+    House: 2
+    None: 0
 HousingExpertSubmodeRestriction:
-  NoHouseExteriorScale: 2
-  None: 0
-  NotInExpertMode: 1
-  NoWMOScale: 3
+  values:
+    NoHouseExteriorScale: 2
+    None: 0
+    NotInExpertMode: 1
+    NoWMOScale: 3
 HousingFavorUpdateSource:
-  DecorCollection: 1
-  DeferredRewards: 2
-  InitiativeChest: 6
-  InitiativeTask: 5
-  NewHouseDecorFavor: 4
-  Quest: 7
-  RetroactiveDecor: 3
-  Unknown: 0
+  values:
+    DecorCollection: 1
+    DeferredRewards: 2
+    InitiativeChest: 6
+    InitiativeTask: 5
+    NewHouseDecorFavor: 4
+    Quest: 7
+    RetroactiveDecor: 3
+    Unknown: 0
 HousingFavorUpdateType:
-  Add: 0
-  InitiativeAdd: 1
-  Set: 2
+  values:
+    Add: 0
+    InitiativeAdd: 1
+    Set: 2
 HousingFixtureDecorAction:
-  Detach: 1
-  Store: 0
+  values:
+    Detach: 1
+    Store: 0
 HousingFixtureFlags:
-  IsDefaultFixture: 1
-  None: 0
-  UnlockedByDefault: 2
+  values:
+    IsDefaultFixture: 1
+    None: 0
+    UnlockedByDefault: 2
 HousingFixtureSize:
-  Any: 1
-  Large: 4
-  Medium: 3
-  None: 0
-  Small: 2
+  values:
+    Any: 1
+    Large: 4
+    Medium: 3
+    None: 0
+    Small: 2
 HousingFixtureType:
-  Base: 9
-  Chimney: 16
-  Door: 11
-  None: 0
-  Roof: 10
-  RoofDetail: 13
-  RoofWindow: 14
-  Tower: 15
-  Window: 12
+  values:
+    Base: 9
+    Chimney: 16
+    Door: 11
+    None: 0
+    Roof: 10
+    RoofDetail: 13
+    RoofWindow: 14
+    Tower: 15
+    Window: 12
 HousingIncrementType:
-  Back: 8
-  Down: 32
-  Forward: 4
-  Left: 1
-  Right: 2
-  RotateLeft: 64
-  RotateRight: 128
-  ScaleDown: 512
-  ScaleUp: 256
-  Up: 16
+  values:
+    Back: 8
+    Down: 32
+    Forward: 4
+    Left: 1
+    Right: 2
+    RotateLeft: 64
+    RotateRight: 128
+    ScaleDown: 512
+    ScaleUp: 256
+    Up: 16
 HousingItemToastType:
-  Customization: 2
-  Decor: 3
-  Fixture: 1
-  HouseType: 4
-  Room: 0
+  values:
+    Customization: 2
+    Decor: 3
+    Fixture: 1
+    HouseType: 4
+    Room: 0
 HousingLayoutCameraDirection:
-  Down: 2
-  Left: 4
-  None: 0
-  Right: 8
-  Up: 1
+  values:
+    Down: 2
+    Left: 4
+    None: 0
+    Right: 8
+    Up: 1
 HousingLayoutPinType:
-  Door: 0
-  Room: 1
+  values:
+    Door: 0
+    Room: 1
 HousingLayoutRestriction:
-  IsBaseRoom: 4
-  LastRoom: 7
-  None: 0
-  NotHouseOwner: 3
-  NotInsideHouse: 2
-  RoomNotFound: 1
-  RoomNotLeaf: 5
-  SingleDoor: 9
-  StairwellConnection: 6
-  UnreachableRoom: 8
+  values:
+    IsBaseRoom: 4
+    LastRoom: 7
+    None: 0
+    NotHouseOwner: 3
+    NotInsideHouse: 2
+    RoomNotFound: 1
+    RoomNotLeaf: 5
+    SingleDoor: 9
+    StairwellConnection: 6
+    UnreachableRoom: 8
 HousingLayoutStairDirection:
-  Down: 1
-  Up: 0
+  values:
+    Down: 1
+    Up: 0
 HousingPlotOwnerType:
-  Friend: 2
-  None: 0
-  Self: 3
-  Stranger: 1
+  values:
+    Friend: 2
+    None: 0
+    Self: 3
+    Stranger: 1
 HousingPrecisionSubmode:
-  Rotate: 1
-  Scale: 2
-  Translate: 0
+  values:
+    Rotate: 1
+    Scale: 2
+    Translate: 0
 HousingResult:
-  ActionLockedByCombat: 1
-  BoundsFailureChildren: 2
-  BoundsFailurePlot: 3
-  BoundsFailureRoom: 4
-  BoundToStartingArea: 5
-  CannotAfford: 6
-  CharterComplete: 7
-  CollisionInvalid: 8
-  DbError: 9
-  DecorCannotBeRedeemed: 10
-  DecorItemNotDestroyable: 11
-  DecorNotFound: 12
-  DecorNotFoundInStorage: 13
-  DuplicateCharterSignature: 14
-  FilterRejected: 15
-  FixtureCantDeleteDoor: 16
-  FixtureHookEmpty: 17
-  FixtureHookOccupied: 18
-  FixtureHouseTypeMismatch: 19
-  FixtureNotFound: 20
-  FixtureSizeMismatch: 21
-  FixtureTypeMismatch: 22
-  GenericFailure: 23
-  GuildMoreAccountsNeeded: 24
-  GuildMoreActivePlayersNeeded: 25
-  GuildNotLoaded: 26
-  HookNotChildOfFixture: 35
-  HouseEditLockFailed: 27
-  HouseExteriorAlreadyThatSize: 28
-  HouseExteriorAlreadyThatType: 29
-  HouseExteriorRootNotFound: 30
-  HouseExteriorSizeNotAvailable: 34
-  HouseExteriorTypeNeighborhoodMismatch: 31
-  HouseExteriorTypeNotFound: 32
-  HouseExteriorTypeSizeMismatch: 33
-  HouseNotFound: 36
-  IncorrectFaction: 37
-  InvalidDecorItem: 38
-  InvalidDistance: 39
-  InvalidGuild: 40
-  InvalidHouse: 41
-  InvalidInstance: 42
-  InvalidInteraction: 43
-  InvalidLightOverlap: 44
-  InvalidMap: 45
-  InvalidNeighborhoodName: 46
-  InvalidRoomLayout: 47
-  LockedByOtherPlayer: 48
-  LockOperationFailed: 49
-  MaxDecorReached: 50
-  MaxPreviewDecorReached: 51
-  MissingCoreFixture: 52
-  MissingDye: 53
-  MissingExpansionAccess: 54
-  MissingFactionMap: 55
-  MissingPrivateNeighborhoodInvite: 56
-  MoreHouseSlotsNeeded: 57
-  MoreSignaturesNeeded: 58
-  NeighborhoodNotFound: 59
-  NoNeighborhoodOwnershipRequests: 60
-  NotInDecorEditMode: 61
-  NotInFixtureEditMode: 62
-  NotInLayoutEditMode: 63
-  NotInsideHouse: 64
-  NotOnOwnedPlot: 65
-  OperationAborted: 66
-  OwnerNotInGuild: 67
-  PermissionDenied: 68
-  PlacementTargetInvalid: 69
-  PlayerNotFound: 70
-  PlayerNotInInstance: 71
-  PlotNotFound: 72
-  PlotNotVacant: 73
-  PlotReservationCooldown: 74
-  PlotReserved: 75
-  RoomNotFound: 76
-  RoomUpdateFailed: 77
-  RpcFailure: 78
-  ServiceNotAvailable: 79
-  StaticDataNotFound: 80
-  Success: 0
-  TimeoutLimit: 81
-  TimerunningNotAllowed: 82
-  TokenRequired: 83
-  TooManyRequests: 84
-  TransactionFailure: 85
-  UncollectedExteriorFixture: 86
-  UncollectedHouseType: 87
-  UncollectedRoom: 88
-  UncollectedRoomMaterial: 89
-  UncollectedRoomTheme: 90
-  UnlockOperationFailed: 91
+  values:
+    ActionLockedByCombat: 1
+    BoundsFailureChildren: 2
+    BoundsFailurePlot: 3
+    BoundsFailureRoom: 4
+    BoundToStartingArea: 5
+    CannotAfford: 6
+    CharterComplete: 7
+    CollisionInvalid: 8
+    DbError: 9
+    DecorCannotBeRedeemed: 10
+    DecorItemNotDestroyable: 11
+    DecorNotFound: 12
+    DecorNotFoundInStorage: 13
+    DuplicateCharterSignature: 14
+    FilterRejected: 15
+    FixtureCantDeleteDoor: 16
+    FixtureHookEmpty: 17
+    FixtureHookOccupied: 18
+    FixtureHouseTypeMismatch: 19
+    FixtureNotFound: 20
+    FixtureSizeMismatch: 21
+    FixtureTypeMismatch: 22
+    GenericFailure: 23
+    GuildMoreAccountsNeeded: 24
+    GuildMoreActivePlayersNeeded: 25
+    GuildNotLoaded: 26
+    HookNotChildOfFixture: 35
+    HouseEditLockFailed: 27
+    HouseExteriorAlreadyThatSize: 28
+    HouseExteriorAlreadyThatType: 29
+    HouseExteriorRootNotFound: 30
+    HouseExteriorSizeNotAvailable: 34
+    HouseExteriorTypeNeighborhoodMismatch: 31
+    HouseExteriorTypeNotFound: 32
+    HouseExteriorTypeSizeMismatch: 33
+    HouseNotFound: 36
+    IncorrectFaction: 37
+    InvalidDecorItem: 38
+    InvalidDistance: 39
+    InvalidGuild: 40
+    InvalidHouse: 41
+    InvalidInstance: 42
+    InvalidInteraction: 43
+    InvalidLightOverlap: 44
+    InvalidMap: 45
+    InvalidNeighborhoodName: 46
+    InvalidRoomLayout: 47
+    LockedByOtherPlayer: 48
+    LockOperationFailed: 49
+    MaxDecorReached: 50
+    MaxPreviewDecorReached: 51
+    MissingCoreFixture: 52
+    MissingDye: 53
+    MissingExpansionAccess: 54
+    MissingFactionMap: 55
+    MissingPrivateNeighborhoodInvite: 56
+    MoreHouseSlotsNeeded: 57
+    MoreSignaturesNeeded: 58
+    NeighborhoodNotFound: 59
+    NoNeighborhoodOwnershipRequests: 60
+    NotInDecorEditMode: 61
+    NotInFixtureEditMode: 62
+    NotInLayoutEditMode: 63
+    NotInsideHouse: 64
+    NotOnOwnedPlot: 65
+    OperationAborted: 66
+    OwnerNotInGuild: 67
+    PermissionDenied: 68
+    PlacementTargetInvalid: 69
+    PlayerNotFound: 70
+    PlayerNotInInstance: 71
+    PlotNotFound: 72
+    PlotNotVacant: 73
+    PlotReservationCooldown: 74
+    PlotReserved: 75
+    RoomNotFound: 76
+    RoomUpdateFailed: 77
+    RpcFailure: 78
+    ServiceNotAvailable: 79
+    StaticDataNotFound: 80
+    Success: 0
+    TimeoutLimit: 81
+    TimerunningNotAllowed: 82
+    TokenRequired: 83
+    TooManyRequests: 84
+    TransactionFailure: 85
+    UncollectedExteriorFixture: 86
+    UncollectedHouseType: 87
+    UncollectedRoom: 88
+    UncollectedRoomMaterial: 89
+    UncollectedRoomTheme: 90
+    UnlockOperationFailed: 91
 HousingRoomComponentCeilingType:
-  Flat: 0
-  Vaulted: 1
+  values:
+    Flat: 0
+    Vaulted: 1
 HousingRoomComponentDoorType:
-  Doorway: 1
-  None: 0
-  Threshold: 2
+  values:
+    Doorway: 1
+    None: 0
+    Threshold: 2
 HousingRoomComponentFlags:
-  HiddenInLayoutMode: 1
-  None: 0
+  values:
+    HiddenInLayoutMode: 1
+    None: 0
 HousingRoomComponentFloorType:
-  Floor: 0
+  values:
+    Floor: 0
 HousingRoomComponentOptionFlags:
-  IsDefault: 1
-  None: 0
+  values:
+    IsDefault: 1
+    None: 0
 HousingRoomComponentOptionType:
-  Cosmetic: 0
-  Doorway: 2
-  DoorwayWall: 1
+  values:
+    Cosmetic: 0
+    Doorway: 2
+    DoorwayWall: 1
 HousingRoomComponentStairType:
-  MiddleToEnd: 4
-  MiddleToMiddle: 3
-  None: 0
-  StartToEnd: 1
-  StartToMiddle: 2
+  values:
+    MiddleToEnd: 4
+    MiddleToMiddle: 3
+    None: 0
+    StartToEnd: 1
+    StartToMiddle: 2
 HousingRoomComponentTextureFlags:
-  None: 0
-  UnlockedByDefault: 1
+  values:
+    None: 0
+    UnlockedByDefault: 1
 HousingRoomComponentType:
-  Ceiling: 3
-  Doorway: 7
-  DoorwayWall: 6
-  Floor: 2
-  None: 0
-  Pillar: 5
-  Stairs: 4
-  Wall: 1
+  values:
+    Ceiling: 3
+    Doorway: 7
+    DoorwayWall: 6
+    Floor: 2
+    None: 0
+    Pillar: 5
+    Stairs: 4
+    Wall: 1
 HousingRoomFlags:
-  BaseRoom: 1
-  HasCustomGeometry: 8
-  HasStairs: 2
-  None: 0
-  UnlockedByDefault: 4
+  values:
+    BaseRoom: 1
+    HasCustomGeometry: 8
+    HasStairs: 2
+    None: 0
+    UnlockedByDefault: 4
 HousingTeleportReason:
-  Booted: 3
-  Cheat: 1
-  ExitingHouse: 9
-  Friend: 6
-  GuildMember: 7
-  Homestone: 4
-  None: 0
-  PartyMember: 8
-  Portal: 10
-  Tutorial: 11
-  UnspecifiedSpellcast: 2
-  Visit: 5
+  values:
+    Booted: 3
+    Cheat: 1
+    ExitingHouse: 9
+    Friend: 6
+    GuildMember: 7
+    Homestone: 4
+    None: 0
+    PartyMember: 8
+    Portal: 10
+    Tutorial: 11
+    UnspecifiedSpellcast: 2
+    Visit: 5
 HousingThemeFlags:
-  None: 0
-  ShowInStyleSelector: 2
-  UnlockedByDefault: 1
+  values:
+    None: 0
+    ShowInStyleSelector: 2
+    UnlockedByDefault: 1
 HousingThrottleType:
-  Decoration: 1
-  General: 0
+  values:
+    Decoration: 1
+    General: 0
 IconAndTextShiftTextType:
-  None: 0
-  ShiftText: 1
+  values:
+    None: 0
+    ShiftText: 1
 IconAndTextWidgetState:
-  Hidden: 0
-  Shown: 1
-  ShownWithDynamicIconFlashing: 2
-  ShownWithDynamicIconNotFlashing: 3
+  values:
+    Hidden: 0
+    Shown: 1
+    ShownWithDynamicIconFlashing: 2
+    ShownWithDynamicIconNotFlashing: 3
 IconState:
-  Hidden: 0
-  ShowState1: 1
-  ShowState2: 2
+  values:
+    Hidden: 0
+    ShowState1: 1
+    ShowState2: 2
 ImageSharingResult:
-  AccountDataRequestFailure: 6
-  EncryptionFailure: 11
-  EncryptionSecretNotSet: 14
-  FailedToCreateHeader: 10
-  Failure: 0
-  GetAccountDataRequestFailure: 7
-  InvalidOAuthExpiration: 12
-  InvalidRefreshExpiration: 13
-  MissingFieldApiError: 5
-  NotConfigured: 2
-  PlatformApiError: 4
-  RefreshTokenExpired: 9
-  RetrievedExisting: 3
-  SetAccountDataRequestFailure: 8
-  Success: 1
+  values:
+    AccountDataRequestFailure: 6
+    EncryptionFailure: 11
+    EncryptionSecretNotSet: 14
+    FailedToCreateHeader: 10
+    Failure: 0
+    GetAccountDataRequestFailure: 7
+    InvalidOAuthExpiration: 12
+    InvalidRefreshExpiration: 13
+    MissingFieldApiError: 5
+    NotConfigured: 2
+    PlatformApiError: 4
+    RefreshTokenExpired: 9
+    RetrievedExisting: 3
+    SetAccountDataRequestFailure: 8
+    Success: 1
 InitiativeMilestoneFlags:
-  FinalMilestone: 1
+  values:
+    FinalMilestone: 1
 InitiativeRewardFlags:
-  PermanentWorldState: 1
+  values:
+    PermanentWorldState: 1
 InputContext:
-  GamePad: 3
-  Keyboard: 1
-  Mouse: 2
-  None: 0
+  values:
+    GamePad: 3
+    Keyboard: 1
+    Mouse: 2
+    None: 0
 InvalidPlotScreenshotReason:
-  Facing: 2
-  NoActivePlayer: 4
-  None: 0
-  NoNeighborhoodFound: 3
-  OutOfBounds: 1
+  values:
+    Facing: 2
+    NoActivePlayer: 4
+    None: 0
+    NoNeighborhoodFound: 3
+    OutOfBounds: 1
 InventoryType:
-  Index2HweaponType: 17
-  IndexAmmoType: 24
-  IndexBagType: 18
-  IndexBodyType: 4
-  IndexChestType: 5
-  IndexCloakType: 16
-  IndexEquipablespellDefensiveType: 33
-  IndexEquipablespellOffensiveType: 31
-  IndexEquipablespellUtilityType: 32
-  IndexEquipablespellWeaponType: 34
-  IndexFeetType: 8
-  IndexFingerType: 11
-  IndexHandType: 10
-  IndexHeadType: 1
-  IndexHoldableType: 23
-  IndexLegsType: 7
-  IndexNeckType: 2
-  IndexNonEquipType: 0
-  IndexProfessionGearType: 30
-  IndexProfessionToolType: 29
-  IndexQuiverType: 27
-  IndexRangedrightType: 26
-  IndexRangedType: 15
-  IndexRelicType: 28
-  IndexRobeType: 20
-  IndexShieldType: 14
-  IndexShoulderType: 3
-  IndexTabardType: 19
-  IndexThrownType: 25
-  IndexTrinketType: 12
-  IndexWaistType: 6
-  IndexWeaponmainhandType: 21
-  IndexWeaponoffhandType: 22
-  IndexWeaponType: 13
-  IndexWristType: 9
+  values:
+    Index2HweaponType: 17
+    IndexAmmoType: 24
+    IndexBagType: 18
+    IndexBodyType: 4
+    IndexChestType: 5
+    IndexCloakType: 16
+    IndexEquipablespellDefensiveType: 33
+    IndexEquipablespellOffensiveType: 31
+    IndexEquipablespellUtilityType: 32
+    IndexEquipablespellWeaponType: 34
+    IndexFeetType: 8
+    IndexFingerType: 11
+    IndexHandType: 10
+    IndexHeadType: 1
+    IndexHoldableType: 23
+    IndexLegsType: 7
+    IndexNeckType: 2
+    IndexNonEquipType: 0
+    IndexProfessionGearType: 30
+    IndexProfessionToolType: 29
+    IndexQuiverType: 27
+    IndexRangedrightType: 26
+    IndexRangedType: 15
+    IndexRelicType: 28
+    IndexRobeType: 20
+    IndexShieldType: 14
+    IndexShoulderType: 3
+    IndexTabardType: 19
+    IndexThrownType: 25
+    IndexTrinketType: 12
+    IndexWaistType: 6
+    IndexWeaponmainhandType: 21
+    IndexWeaponoffhandType: 22
+    IndexWeaponType: 13
+    IndexWristType: 9
 ItemArmorSubclass:
-  Cloth: 1
-  Cosmetic: 5
-  Generic: 0
-  Idol: 8
-  Leather: 2
-  Libram: 7
-  Mail: 3
-  Plate: 4
-  Relic: 11
-  Shield: 6
-  Sigil: 10
-  Totem: 9
+  values:
+    Cloth: 1
+    Cosmetic: 5
+    Generic: 0
+    Idol: 8
+    Leather: 2
+    Libram: 7
+    Mail: 3
+    Plate: 4
+    Relic: 11
+    Shield: 6
+    Sigil: 10
+    Totem: 9
 ItemBind:
-  Multi: 6
-  None: 0
-  OnAcquire: 1
-  OnEquip: 2
-  OnUse: 3
-  Quest: 4
-  QuestMulti: 5
-  ToBnetAccount: 8
-  ToBnetAccountUntilEquipped: 9
-  ToWoWAccount: 7
+  values:
+    Multi: 6
+    None: 0
+    OnAcquire: 1
+    OnEquip: 2
+    OnUse: 3
+    Quest: 4
+    QuestMulti: 5
+    ToBnetAccount: 8
+    ToBnetAccountUntilEquipped: 9
+    ToWoWAccount: 7
 ItemClass:
-  Armor: 4
-  Battlepet: 17
-  Consumable: 0
-  Container: 1
-  CurrencyTokenObsolete: 10
-  Gem: 3
-  Glyph: 16
-  Housing: 20
-  ItemEnhancement: 8
-  Key: 13
-  Miscellaneous: 15
-  PermanentObsolete: 14
-  Profession: 19
-  Projectile: 6
-  Questitem: 12
-  Quiver: 11
-  Reagent: 5
-  Recipe: 9
-  Tradegoods: 7
-  Weapon: 2
-  WoWToken: 18
+  values:
+    Armor: 4
+    Battlepet: 17
+    Consumable: 0
+    Container: 1
+    CurrencyTokenObsolete: 10
+    Gem: 3
+    Glyph: 16
+    Housing: 20
+    ItemEnhancement: 8
+    Key: 13
+    Miscellaneous: 15
+    PermanentObsolete: 14
+    Profession: 19
+    Projectile: 6
+    Questitem: 12
+    Quiver: 11
+    Reagent: 5
+    Recipe: 9
+    Tradegoods: 7
+    Weapon: 2
+    WoWToken: 18
 Itemclassfilterflags:
-  Armor: 16
-  Battlepet: 131072
-  Consumable: 1
-  Container: 2
-  CurrencyTokenObsolete: 1024
-  Gem: 8
-  Glyph: 65536
-  ItemEnhancement: 256
-  Key: 8192
-  Miscellaneous: 32768
-  PermanentObsolete: 16384
-  Projectile: 64
-  Questitemclassfilterflags: 4096
-  Quiver: 2048
-  Reagent: 32
-  Recipe: 512
-  Tradegoods: 128
-  Weapon: 4
+  values:
+    Armor: 16
+    Battlepet: 131072
+    Consumable: 1
+    Container: 2
+    CurrencyTokenObsolete: 1024
+    Gem: 8
+    Glyph: 65536
+    ItemEnhancement: 256
+    Key: 8192
+    Miscellaneous: 32768
+    PermanentObsolete: 16384
+    Projectile: 64
+    Questitemclassfilterflags: 4096
+    Quiver: 2048
+    Reagent: 32
+    Recipe: 512
+    Tradegoods: 128
+    Weapon: 4
 ItemCollectionType:
-  ExteriorFixture: 9
-  Heirloom: 2
-  HouseType: 13
-  None: 0
-  Room: 8
-  RoomMaterial: 11
-  RoomTheme: 10
-  RuneforgeLegendaryAbility: 5
-  Toy: 1
-  Transmog: 3
-  TransmogIllusion: 6
-  TransmogOutfit: 12
-  TransmogSetFavorite: 4
-  WarbandScene: 7
+  values:
+    ExteriorFixture: 9
+    Heirloom: 2
+    HouseType: 13
+    None: 0
+    Room: 8
+    RoomMaterial: 11
+    RoomTheme: 10
+    RuneforgeLegendaryAbility: 5
+    Toy: 1
+    Transmog: 3
+    TransmogIllusion: 6
+    TransmogOutfit: 12
+    TransmogSetFavorite: 4
+    WarbandScene: 7
 ItemConsumableSubclass:
-  Bandage: 7
-  CombatCurio: 11
-  Elixir: 2
-  Flasksphials: 3
-  Fooddrink: 5
-  Generic: 0
-  Itemenhancement: 6
-  Other: 8
-  Potion: 1
-  Relic: 12
-  Scroll: 4
-  UtilityCurio: 10
-  VantusRune: 9
+  values:
+    Bandage: 7
+    CombatCurio: 11
+    Elixir: 2
+    Flasksphials: 3
+    Fooddrink: 5
+    Generic: 0
+    Itemenhancement: 6
+    Other: 8
+    Potion: 1
+    Relic: 12
+    Scroll: 4
+    UtilityCurio: 10
+    VantusRune: 9
 ItemCreationContext:
-  BlackMarket: 15
-  ChallengeMode_1: 16
-  ChallengeMode_2: 33
-  ChallengeMode_3: 34
-  ChallengeMode_4: 87
-  ChallengeModeJackpot: 35
-  CharacterBoost_1: 61
-  CharacterBoost_2: 62
-  CharacterBoost_3: 86
-  CorpseRecovery: 80
-  Delves_1: 104
-  Delves_2: 106
-  Delves_3: 107
-  DelvesBonus_1: 129
-  DelvesBonus_10: 138
-  DelvesBonus_2: 130
-  DelvesBonus_3: 131
-  DelvesBonus_4: 132
-  DelvesBonus_5: 133
-  DelvesBonus_6: 134
-  DelvesBonus_7: 135
-  DelvesBonus_8: 136
-  DelvesBonus_9: 137
-  DelvesBounty_1: 117
-  DelvesBounty_2: 118
-  DelvesBounty_3: 119
-  DelvesBounty_4: 120
-  DelvesBounty_5: 121
-  DelvesBounty_6: 122
-  DelvesBounty_7: 123
-  DelvesBounty_8: 124
-  DelvesJackpot: 108
-  DelvesKey_1: 109
-  DelvesKey_2: 110
-  DelvesKey_3: 111
-  DelvesKey_4: 112
-  DelvesKey_5: 113
-  DelvesKey_6: 114
-  DelvesKey_7: 115
-  DelvesKey_8: 116
-  DelvesLevelUp_1: 125
-  DelvesLevelUp_2: 126
-  DelvesLevelUp_3: 127
-  DelvesLevelUp_4: 128
-  DungeonBonus_1: 139
-  DungeonBonus_10: 148
-  DungeonBonus_2: 140
-  DungeonBonus_3: 141
-  DungeonBonus_4: 142
-  DungeonBonus_5: 143
-  DungeonBonus_6: 144
-  DungeonBonus_7: 145
-  DungeonBonus_8: 146
-  DungeonBonus_9: 147
-  DungeonHardMode_1: 159
-  DungeonHardMode_2: 160
-  DungeonHardMode_3: 161
-  DungeonHeroic: 2
-  DungeonHeroicJackpot: 102
-  DungeonLevelUp_1: 17
-  DungeonLevelUp_2: 18
-  DungeonLevelUp_3: 19
-  DungeonLevelUp_4: 20
-  DungeonMythic: 23
-  DungeonMythicJackpot: 103
-  DungeonNormal: 1
-  DungeonNormalJackpot: 101
-  Endeavors: 185
-  ForceNone: 21
-  LegendaryCrafting_1: 63
-  LegendaryCrafting_2: 64
-  LegendaryCrafting_3: 65
-  LegendaryCrafting_4: 66
-  LegendaryCrafting_5: 67
-  LegendaryCrafting_6: 68
-  LegendaryCrafting_7: 69
-  LegendaryCrafting_8: 70
-  LegendaryCrafting_9: 71
-  LegendaryForge: 59
-  MissionReward_1: 31
-  MissionReward_2: 32
-  NewCharacter: 75
-  None: 0
-  PvPBrawl_1: 77
-  PvPBrawl_2: 78
-  PvPHonorReward: 24
-  PvPRanked_1: 8
-  PvPRanked_2: 38
-  PvPRanked_3: 39
-  PvPRanked_4: 40
-  PvPRanked_5: 44
-  PvPRanked_6: 45
-  PvPRanked_7: 46
-  PvPRanked_8: 52
-  PvPRanked_9: 88
-  PvPRankedJackpot: 56
-  PvPUnranked_1: 7
-  PvPUnranked_2: 41
-  PvPUnranked_3: 47
-  PvPUnranked_4: 48
-  PvPUnranked_5: 49
-  PvPUnranked_6: 50
-  PvPUnranked_7: 51
-  QuestBonusLoot: 60
-  QuestReward: 11
-  RaidBonus_1: 149
-  RaidBonus_10: 158
-  RaidBonus_2: 150
-  RaidBonus_3: 151
-  RaidBonus_4: 152
-  RaidBonus_5: 153
-  RaidBonus_6: 154
-  RaidBonus_7: 155
-  RaidBonus_8: 156
-  RaidBonus_9: 157
-  RaidFinder: 4
-  RaidFinderExtended: 83
-  RaidFinderExtended_2: 90
-  RaidFinderExtended_3: 94
-  RaidHeroic: 5
-  RaidHeroicExtended: 84
-  RaidHeroicExtended_2: 91
-  RaidHeroicExtended_3: 95
-  RaidMythic: 6
-  RaidMythicExtended: 85
-  RaidMythicExtended_2: 92
-  RaidMythicExtended_3: 96
-  RaidNormal: 3
-  RaidNormalExtended: 82
-  RaidNormalExtended_2: 89
-  RaidNormalExtended_3: 93
-  Relinquished: 58
-  ScenarioHeroic: 10
-  ScenarioNormal: 9
-  Store: 12
-  TemplateCharacter_1: 97
-  TemplateCharacter_2: 98
-  TemplateCharacter_3: 99
-  TemplateCharacter_4: 100
-  Timerunning: 105
-  TimewalkerLevelUp: 22
-  TimewalkerMaxLevel: 186
-  Torghast: 79
-  TournamentRealm_1: 57
-  TournamentRealm_2: 162
-  TournamentRealm_3: 163
-  TournamentRealm_4: 164
-  TradeSkill: 13
-  Vendor: 14
-  Warbound_1: 165
-  Warbound_10: 174
-  Warbound_11: 175
-  Warbound_12: 176
-  Warbound_13: 177
-  Warbound_14: 178
-  Warbound_15: 179
-  Warbound_16: 180
-  Warbound_17: 181
-  Warbound_18: 182
-  Warbound_19: 183
-  Warbound_2: 166
-  Warbound_20: 184
-  Warbound_3: 167
-  Warbound_4: 168
-  Warbound_5: 169
-  Warbound_6: 170
-  Warbound_7: 171
-  Warbound_8: 172
-  Warbound_9: 173
-  WarMode: 76
-  WeeklyRewardsAdditional: 72
-  WeeklyRewardsConcession: 73
-  WorldBoss: 81
-  WorldQuest_1: 25
-  WorldQuest_10: 43
-  WorldQuest_11: 53
-  WorldQuest_12: 54
-  WorldQuest_13: 55
-  WorldQuest_2: 26
-  WorldQuest_3: 27
-  WorldQuest_4: 28
-  WorldQuest_5: 29
-  WorldQuest_6: 30
-  WorldQuest_7: 36
-  WorldQuest_8: 37
-  WorldQuest_9: 42
-  WorldQuestJackpot: 74
+  values:
+    BlackMarket: 15
+    ChallengeMode_1: 16
+    ChallengeMode_2: 33
+    ChallengeMode_3: 34
+    ChallengeMode_4: 87
+    ChallengeModeJackpot: 35
+    CharacterBoost_1: 61
+    CharacterBoost_2: 62
+    CharacterBoost_3: 86
+    CorpseRecovery: 80
+    Delves_1: 104
+    Delves_2: 106
+    Delves_3: 107
+    DelvesBonus_1: 129
+    DelvesBonus_10: 138
+    DelvesBonus_2: 130
+    DelvesBonus_3: 131
+    DelvesBonus_4: 132
+    DelvesBonus_5: 133
+    DelvesBonus_6: 134
+    DelvesBonus_7: 135
+    DelvesBonus_8: 136
+    DelvesBonus_9: 137
+    DelvesBounty_1: 117
+    DelvesBounty_2: 118
+    DelvesBounty_3: 119
+    DelvesBounty_4: 120
+    DelvesBounty_5: 121
+    DelvesBounty_6: 122
+    DelvesBounty_7: 123
+    DelvesBounty_8: 124
+    DelvesJackpot: 108
+    DelvesKey_1: 109
+    DelvesKey_2: 110
+    DelvesKey_3: 111
+    DelvesKey_4: 112
+    DelvesKey_5: 113
+    DelvesKey_6: 114
+    DelvesKey_7: 115
+    DelvesKey_8: 116
+    DelvesLevelUp_1: 125
+    DelvesLevelUp_2: 126
+    DelvesLevelUp_3: 127
+    DelvesLevelUp_4: 128
+    DungeonBonus_1: 139
+    DungeonBonus_10: 148
+    DungeonBonus_2: 140
+    DungeonBonus_3: 141
+    DungeonBonus_4: 142
+    DungeonBonus_5: 143
+    DungeonBonus_6: 144
+    DungeonBonus_7: 145
+    DungeonBonus_8: 146
+    DungeonBonus_9: 147
+    DungeonHardMode_1: 159
+    DungeonHardMode_2: 160
+    DungeonHardMode_3: 161
+    DungeonHeroic: 2
+    DungeonHeroicJackpot: 102
+    DungeonLevelUp_1: 17
+    DungeonLevelUp_2: 18
+    DungeonLevelUp_3: 19
+    DungeonLevelUp_4: 20
+    DungeonMythic: 23
+    DungeonMythicJackpot: 103
+    DungeonNormal: 1
+    DungeonNormalJackpot: 101
+    Endeavors: 185
+    ForceNone: 21
+    LegendaryCrafting_1: 63
+    LegendaryCrafting_2: 64
+    LegendaryCrafting_3: 65
+    LegendaryCrafting_4: 66
+    LegendaryCrafting_5: 67
+    LegendaryCrafting_6: 68
+    LegendaryCrafting_7: 69
+    LegendaryCrafting_8: 70
+    LegendaryCrafting_9: 71
+    LegendaryForge: 59
+    MissionReward_1: 31
+    MissionReward_2: 32
+    NewCharacter: 75
+    None: 0
+    PvPBrawl_1: 77
+    PvPBrawl_2: 78
+    PvPHonorReward: 24
+    PvPRanked_1: 8
+    PvPRanked_2: 38
+    PvPRanked_3: 39
+    PvPRanked_4: 40
+    PvPRanked_5: 44
+    PvPRanked_6: 45
+    PvPRanked_7: 46
+    PvPRanked_8: 52
+    PvPRanked_9: 88
+    PvPRankedJackpot: 56
+    PvPUnranked_1: 7
+    PvPUnranked_2: 41
+    PvPUnranked_3: 47
+    PvPUnranked_4: 48
+    PvPUnranked_5: 49
+    PvPUnranked_6: 50
+    PvPUnranked_7: 51
+    QuestBonusLoot: 60
+    QuestReward: 11
+    RaidBonus_1: 149
+    RaidBonus_10: 158
+    RaidBonus_2: 150
+    RaidBonus_3: 151
+    RaidBonus_4: 152
+    RaidBonus_5: 153
+    RaidBonus_6: 154
+    RaidBonus_7: 155
+    RaidBonus_8: 156
+    RaidBonus_9: 157
+    RaidFinder: 4
+    RaidFinderExtended: 83
+    RaidFinderExtended_2: 90
+    RaidFinderExtended_3: 94
+    RaidHeroic: 5
+    RaidHeroicExtended: 84
+    RaidHeroicExtended_2: 91
+    RaidHeroicExtended_3: 95
+    RaidMythic: 6
+    RaidMythicExtended: 85
+    RaidMythicExtended_2: 92
+    RaidMythicExtended_3: 96
+    RaidNormal: 3
+    RaidNormalExtended: 82
+    RaidNormalExtended_2: 89
+    RaidNormalExtended_3: 93
+    Relinquished: 58
+    ScenarioHeroic: 10
+    ScenarioNormal: 9
+    Store: 12
+    TemplateCharacter_1: 97
+    TemplateCharacter_2: 98
+    TemplateCharacter_3: 99
+    TemplateCharacter_4: 100
+    Timerunning: 105
+    TimewalkerLevelUp: 22
+    TimewalkerMaxLevel: 186
+    Torghast: 79
+    TournamentRealm_1: 57
+    TournamentRealm_2: 162
+    TournamentRealm_3: 163
+    TournamentRealm_4: 164
+    TradeSkill: 13
+    Vendor: 14
+    Warbound_1: 165
+    Warbound_10: 174
+    Warbound_11: 175
+    Warbound_12: 176
+    Warbound_13: 177
+    Warbound_14: 178
+    Warbound_15: 179
+    Warbound_16: 180
+    Warbound_17: 181
+    Warbound_18: 182
+    Warbound_19: 183
+    Warbound_2: 166
+    Warbound_20: 184
+    Warbound_3: 167
+    Warbound_4: 168
+    Warbound_5: 169
+    Warbound_6: 170
+    Warbound_7: 171
+    Warbound_8: 172
+    Warbound_9: 173
+    WarMode: 76
+    WeeklyRewardsAdditional: 72
+    WeeklyRewardsConcession: 73
+    WorldBoss: 81
+    WorldQuest_1: 25
+    WorldQuest_10: 43
+    WorldQuest_11: 53
+    WorldQuest_12: 54
+    WorldQuest_13: 55
+    WorldQuest_2: 26
+    WorldQuest_3: 27
+    WorldQuest_4: 28
+    WorldQuest_5: 29
+    WorldQuest_6: 30
+    WorldQuest_7: 36
+    WorldQuest_8: 37
+    WorldQuest_9: 42
+    WorldQuestJackpot: 74
 ItemDisplayTextDisplayStyle:
-  ItemNameAndInfoText: 1
-  ItemNameOnlyCentered: 2
-  PlayerChoiceReward: 3
-  WorldQuestReward: 0
+  values:
+    ItemNameAndInfoText: 1
+    ItemNameOnlyCentered: 2
+    PlayerChoiceReward: 3
+    WorldQuestReward: 0
 ItemDisplayTooltipEnabledType:
-  Disabled: 1
-  Enabled: 0
+  values:
+    Disabled: 1
+    Enabled: 0
 ItemGemColor:
-  Arcane: 1024
-  Blood: 128
-  Blue: 8
-  Cogwheel: 32
-  Cypher: 8388608
-  DominationBlood: 1048576
-  DominationFrost: 2097152
-  DominationUnholy: 4194304
-  Fel: 512
-  Fiber: 1073741824
-  Fire: 4096
-  Fragrance: 67108864
-  Frost: 2048
-  Holy: 65536
-  Hydraulic: 16
-  Iron: 64
-  Life: 16384
-  Meta: 1
-  Primordial: 33554432
-  PunchcardBlue: 524288
-  PunchcardRed: 131072
-  PunchcardYellow: 262144
-  Red: 2
-  Shadow: 256
-  SingingSea: 268435456
-  SingingThunder: 134217728
-  SingingWind: 536870912
-  Tinker: 16777216
-  Water: 8192
-  Wind: 32768
-  Yellow: 4
+  values:
+    Arcane: 1024
+    Blood: 128
+    Blue: 8
+    Cogwheel: 32
+    Cypher: 8388608
+    DominationBlood: 1048576
+    DominationFrost: 2097152
+    DominationUnholy: 4194304
+    Fel: 512
+    Fiber: 1073741824
+    Fire: 4096
+    Fragrance: 67108864
+    Frost: 2048
+    Holy: 65536
+    Hydraulic: 16
+    Iron: 64
+    Life: 16384
+    Meta: 1
+    Primordial: 33554432
+    PunchcardBlue: 524288
+    PunchcardRed: 131072
+    PunchcardYellow: 262144
+    Red: 2
+    Shadow: 256
+    SingingSea: 268435456
+    SingingThunder: 134217728
+    SingingWind: 536870912
+    Tinker: 16777216
+    Water: 8192
+    Wind: 32768
+    Yellow: 4
 ItemGemSubclass:
-  Blue: 1
-  Green: 4
-  Meta: 6
-  Orange: 5
-  Prismatic: 8
-  Purple: 3
-  Red: 0
-  Simple: 7
-  Yellow: 2
+  values:
+    Blue: 1
+    Green: 4
+    Meta: 6
+    Orange: 5
+    Prismatic: 8
+    Purple: 3
+    Red: 0
+    Simple: 7
+    Yellow: 2
 ItemHousingSubclass:
-  Decor: 0
-  Dye: 1
-  ExteriorCustomization: 4
-  Room: 2
-  RoomCustomization: 3
-  ServiceItem: 5
+  values:
+    Decor: 0
+    Dye: 1
+    ExteriorCustomization: 4
+    Room: 2
+    RoomCustomization: 3
+    ServiceItem: 5
 ItemMiscellaneousSubclass:
-  CompanionPet: 2
-  Holiday: 3
-  Junk: 0
-  Mount: 5
-  MountEquipment: 6
-  Other: 4
-  Reagent: 1
+  values:
+    CompanionPet: 2
+    Holiday: 3
+    Junk: 0
+    Mount: 5
+    MountEquipment: 6
+    Other: 4
+    Reagent: 1
 ItemModification:
-  ArtifactAppearanceID: 8
-  ArtifactTier: 24
-  BattlePetBreed: 4
-  BattlePetCreaturedisplayid: 6
-  BattlePetLevel: 5
-  BattlePetSpecies: 3
-  ChangeModifiedCraftingStat_1: 29
-  ChangeModifiedCraftingStat_2: 30
-  ContentTuningID: 28
-  CraftingDataID: 40
-  CraftingQualityID: 38
-  CraftingReagentSlot_0: 43
-  CraftingReagentSlot_1: 44
-  CraftingReagentSlot_10: 53
-  CraftingReagentSlot_11: 54
-  CraftingReagentSlot_12: 55
-  CraftingReagentSlot_13: 56
-  CraftingReagentSlot_14: 57
-  CraftingReagentSlot_2: 45
-  CraftingReagentSlot_3: 46
-  CraftingReagentSlot_4: 47
-  CraftingReagentSlot_5: 48
-  CraftingReagentSlot_6: 49
-  CraftingReagentSlot_7: 50
-  CraftingReagentSlot_8: 51
-  CraftingReagentSlot_9: 52
-  CraftingSkillLineAbilityID: 39
-  CraftingSkillReagents: 41
-  CraftingSkillWatermark: 42
-  CurrencyWalletID: 61
-  CurrencyWalletQuantity: 62
-  CurrencyWalletVersion: 63
-  DbidHigh: 59
-  DbidLow: 60
-  IncrementLevel: 2
-  KeystoneAffix0: 19
-  KeystoneAffix01: 20
-  KeystoneAffix02: 21
-  KeystoneAffix03: 22
-  KeystoneMapChallengeModeID: 17
-  KeystonePowerLevel: 18
-  LegionArtifactKnowledgeObsolete: 23
-  PvPRating: 26
-  RedirectedBaseStats: 64
-  Reforge: 58
-  SoulbindConduitRank: 37
-  TimewalkerLevel: 9
-  TransmogrifyItemModifiedAppearanceIDSpec_0: 1
-  TransmogrifyItemModifiedAppearanceIDSpec_1: 11
-  TransmogrifyItemModifiedAppearanceIDSpec_2: 13
-  TransmogrifyItemModifiedAppearanceIDSpec_3: 15
-  TransmogrifyItemModifiedAppearanceIDSpec_4: 25
-  TransmogrifyItemModifiedAppearanceIDSpecAll: 0
-  TransmogrifyOverrideEnchantVisualIDSpec_0: 10
-  TransmogrifyOverrideEnchantVisualIDSpec_1: 12
-  TransmogrifyOverrideEnchantVisualIDSpec_2: 14
-  TransmogrifyOverrideEnchantVisualIDSpec_3: 16
-  TransmogrifyOverrideEnchantVisualIDSpec_4: 27
-  TransmogrifyOverrideEnchantVisualIDSpecAll: 7
-  TransmogrifySecondaryItemModifiedAppearanceIDSpec_0: 32
-  TransmogrifySecondaryItemModifiedAppearanceIDSpec_1: 33
-  TransmogrifySecondaryItemModifiedAppearanceIDSpec_2: 34
-  TransmogrifySecondaryItemModifiedAppearanceIDSpec_3: 35
-  TransmogrifySecondaryItemModifiedAppearanceIDSpec_4: 36
-  TransmogrifySecondaryItemModifiedAppearanceIDSpecAll: 31
+  values:
+    ArtifactAppearanceID: 8
+    ArtifactTier: 24
+    BattlePetBreed: 4
+    BattlePetCreaturedisplayid: 6
+    BattlePetLevel: 5
+    BattlePetSpecies: 3
+    ChangeModifiedCraftingStat_1: 29
+    ChangeModifiedCraftingStat_2: 30
+    ContentTuningID: 28
+    CraftingDataID: 40
+    CraftingQualityID: 38
+    CraftingReagentSlot_0: 43
+    CraftingReagentSlot_1: 44
+    CraftingReagentSlot_10: 53
+    CraftingReagentSlot_11: 54
+    CraftingReagentSlot_12: 55
+    CraftingReagentSlot_13: 56
+    CraftingReagentSlot_14: 57
+    CraftingReagentSlot_2: 45
+    CraftingReagentSlot_3: 46
+    CraftingReagentSlot_4: 47
+    CraftingReagentSlot_5: 48
+    CraftingReagentSlot_6: 49
+    CraftingReagentSlot_7: 50
+    CraftingReagentSlot_8: 51
+    CraftingReagentSlot_9: 52
+    CraftingSkillLineAbilityID: 39
+    CraftingSkillReagents: 41
+    CraftingSkillWatermark: 42
+    CurrencyWalletID: 61
+    CurrencyWalletQuantity: 62
+    CurrencyWalletVersion: 63
+    DbidHigh: 59
+    DbidLow: 60
+    IncrementLevel: 2
+    KeystoneAffix0: 19
+    KeystoneAffix01: 20
+    KeystoneAffix02: 21
+    KeystoneAffix03: 22
+    KeystoneMapChallengeModeID: 17
+    KeystonePowerLevel: 18
+    LegionArtifactKnowledgeObsolete: 23
+    PvPRating: 26
+    RedirectedBaseStats: 64
+    Reforge: 58
+    SoulbindConduitRank: 37
+    TimewalkerLevel: 9
+    TransmogrifyItemModifiedAppearanceIDSpec_0: 1
+    TransmogrifyItemModifiedAppearanceIDSpec_1: 11
+    TransmogrifyItemModifiedAppearanceIDSpec_2: 13
+    TransmogrifyItemModifiedAppearanceIDSpec_3: 15
+    TransmogrifyItemModifiedAppearanceIDSpec_4: 25
+    TransmogrifyItemModifiedAppearanceIDSpecAll: 0
+    TransmogrifyOverrideEnchantVisualIDSpec_0: 10
+    TransmogrifyOverrideEnchantVisualIDSpec_1: 12
+    TransmogrifyOverrideEnchantVisualIDSpec_2: 14
+    TransmogrifyOverrideEnchantVisualIDSpec_3: 16
+    TransmogrifyOverrideEnchantVisualIDSpec_4: 27
+    TransmogrifyOverrideEnchantVisualIDSpecAll: 7
+    TransmogrifySecondaryItemModifiedAppearanceIDSpec_0: 32
+    TransmogrifySecondaryItemModifiedAppearanceIDSpec_1: 33
+    TransmogrifySecondaryItemModifiedAppearanceIDSpec_2: 34
+    TransmogrifySecondaryItemModifiedAppearanceIDSpec_3: 35
+    TransmogrifySecondaryItemModifiedAppearanceIDSpec_4: 36
+    TransmogrifySecondaryItemModifiedAppearanceIDSpecAll: 31
 ItemProfessionSubclass:
-  Alchemy: 2
-  Archaeology: 13
-  Blacksmithing: 0
-  Cooking: 4
-  Enchanting: 8
-  Engineering: 7
-  Fishing: 9
-  Herbalism: 3
-  Inscription: 12
-  Jewelcrafting: 11
-  Leatherworking: 1
-  Mining: 5
-  Skinning: 10
-  Tailoring: 6
+  values:
+    Alchemy: 2
+    Archaeology: 13
+    Blacksmithing: 0
+    Cooking: 4
+    Enchanting: 8
+    Engineering: 7
+    Fishing: 9
+    Herbalism: 3
+    Inscription: 12
+    Jewelcrafting: 11
+    Leatherworking: 1
+    Mining: 5
+    Skinning: 10
+    Tailoring: 6
 ItemQuality:
-  Artifact: 6
-  Epic: 4
-  Good: 2
-  Heirloom: 7
-  Legendary: 5
-  Poor: 0
-  Rare: 3
-  Standard: 1
-  WoWToken: 8
+  values:
+    Artifact: 6
+    Epic: 4
+    Good: 2
+    Heirloom: 7
+    Legendary: 5
+    Poor: 0
+    Rare: 3
+    Standard: 1
+    WoWToken: 8
 ItemReagentSubclass:
-  ContextToken: 2
-  Keystone: 1
-  Reagent: 0
+  values:
+    ContextToken: 2
+    Keystone: 1
+    Reagent: 0
 ItemRecipeSubclass:
-  Alchemy: 6
-  Blacksmithing: 4
-  Book: 0
-  Cooking: 5
-  Enchanting: 8
-  Engineering: 3
-  FirstAid: 7
-  Fishing: 9
-  Inscription: 11
-  Jewelcrafting: 10
-  Leatherworking: 1
-  Tailoring: 2
+  values:
+    Alchemy: 6
+    Blacksmithing: 4
+    Book: 0
+    Cooking: 5
+    Enchanting: 8
+    Engineering: 3
+    FirstAid: 7
+    Fishing: 9
+    Inscription: 11
+    Jewelcrafting: 10
+    Leatherworking: 1
+    Tailoring: 2
 ItemRecraftFlags:
-  Invalid: 1
+  values:
+    Invalid: 1
 Itemsetflags:
-  Legacy: 1
-  RequiresPvPTalentsActive: 4
-  UseItemHistorySetSlots: 2
+  values:
+    Legacy: 1
+    RequiresPvPTalentsActive: 4
+    UseItemHistorySetSlots: 2
 ItemSlotFilterType:
-  Chest: 4
-  Cloak: 3
-  Feet: 9
-  Finger: 12
-  Hand: 6
-  Head: 0
-  Legs: 8
-  MainHand: 10
-  Neck: 1
-  NoFilter: 15
-  OffHand: 11
-  Other: 14
-  Shoulder: 2
-  Trinket: 13
-  Waist: 7
-  Wrist: 5
+  values:
+    Chest: 4
+    Cloak: 3
+    Feet: 9
+    Finger: 12
+    Hand: 6
+    Head: 0
+    Legs: 8
+    MainHand: 10
+    Neck: 1
+    NoFilter: 15
+    OffHand: 11
+    Other: 14
+    Shoulder: 2
+    Trinket: 13
+    Waist: 7
+    Wrist: 5
 ItemSocketInfoUIType:
-  Default: 0
+  values:
+    Default: 0
 ItemSocketType:
-  Arcane: 12
-  Blood: 9
-  Blue: 4
-  Cogwheel: 6
-  Cypher: 23
-  Domination: 22
-  Fel: 11
-  Fiber: 30
-  Fire: 14
-  Fragrance: 26
-  Frost: 13
-  Holy: 18
-  Hydraulic: 5
-  Iron: 8
-  Life: 16
-  Meta: 1
-  None: 0
-  Primordial: 25
-  Prismatic: 7
-  PunchcardBlue: 21
-  PunchcardRed: 19
-  PunchcardYellow: 20
-  Red: 2
-  Shadow: 10
-  SingingSea: 28
-  SingingThunder: 27
-  SingingWind: 29
-  Tinker: 24
-  Water: 15
-  Wind: 17
-  Yellow: 3
+  values:
+    Arcane: 12
+    Blood: 9
+    Blue: 4
+    Cogwheel: 6
+    Cypher: 23
+    Domination: 22
+    Fel: 11
+    Fiber: 30
+    Fire: 14
+    Fragrance: 26
+    Frost: 13
+    Holy: 18
+    Hydraulic: 5
+    Iron: 8
+    Life: 16
+    Meta: 1
+    None: 0
+    Primordial: 25
+    Prismatic: 7
+    PunchcardBlue: 21
+    PunchcardRed: 19
+    PunchcardYellow: 20
+    Red: 2
+    Shadow: 10
+    SingingSea: 28
+    SingingThunder: 27
+    SingingWind: 29
+    Tinker: 24
+    Water: 15
+    Wind: 17
+    Yellow: 3
 ItemSoundType:
-  Close: 3
-  Drop: 1
-  Pickup: 0
-  Use: 2
+  values:
+    Close: 3
+    Drop: 1
+    Pickup: 0
+    Use: 2
 ItemSubclassDisplay:
-  HideSubclassInAuction: 2
-  HideSubclassInTooltips: 1
-  ShowItemCount: 4
+  values:
+    HideSubclassInAuction: 2
+    HideSubclassInTooltips: 1
+    ShowItemCount: 4
 ItemSubclassFlag:
-  ArmorsubclassLfgscalingarmor: 1024
-  ItemsubclassQuivernotrequired: 64
-  ItemsubclassUsesInvtype: 512
-  WeaponsubclassCanparry: 1
-  WeaponsubclassDeprecatedReuseMe: 256
-  WeaponsubclassIsrifle: 8
-  WeaponsubclassIsthrown: 16
-  WeaponsubclassIsunarmed: 4
-  WeaponsubclassRanged: 128
-  WeaponsubclassRighthandRanged: 32
-  WeaponsubclassSetfingerseq: 2
+  values:
+    ArmorsubclassLfgscalingarmor: 1024
+    ItemsubclassQuivernotrequired: 64
+    ItemsubclassUsesInvtype: 512
+    WeaponsubclassCanparry: 1
+    WeaponsubclassDeprecatedReuseMe: 256
+    WeaponsubclassIsrifle: 8
+    WeaponsubclassIsthrown: 16
+    WeaponsubclassIsunarmed: 4
+    WeaponsubclassRanged: 128
+    WeaponsubclassRighthandRanged: 32
+    WeaponsubclassSetfingerseq: 2
 ItemTryOnReason:
-  DataPending: 3
-  NotEquippable: 2
-  Success: 0
-  WrongRace: 1
+  values:
+    DataPending: 3
+    NotEquippable: 2
+    Success: 0
+    WrongRace: 1
 ItemWeaponSubclass:
-  Axe1H: 0
-  Axe2H: 1
-  Bearclaw: 11
-  Bows: 2
-  Catclaw: 12
-  Crossbow: 18
-  Dagger: 15
-  Fishingpole: 20
-  Generic: 14
-  Guns: 3
-  Mace1H: 4
-  Mace2H: 5
-  Obsolete3: 17
-  Polearm: 6
-  Staff: 10
-  Sword1H: 7
-  Sword2H: 8
-  Thrown: 16
-  Unarmed: 13
-  Wand: 19
-  Warglaive: 9
+  values:
+    Axe1H: 0
+    Axe2H: 1
+    Bearclaw: 11
+    Bows: 2
+    Catclaw: 12
+    Crossbow: 18
+    Dagger: 15
+    Fishingpole: 20
+    Generic: 14
+    Guns: 3
+    Mace1H: 4
+    Mace2H: 5
+    Obsolete3: 17
+    Polearm: 6
+    Staff: 10
+    Sword1H: 7
+    Sword2H: 8
+    Thrown: 16
+    Unarmed: 13
+    Wand: 19
+    Warglaive: 9
 JailersTowerType:
-  AdamantVaults: 11
-  ArkobanHall: 7
-  BossRush: 14
-  Coldheart: 4
-  ForgottenCatacombs: 12
-  FractureChambers: 2
-  Mortregar: 5
-  Ossuary: 13
-  SkoldusHalls: 1
-  Soulforges: 3
-  TormentChamberAnduin: 10
-  TormentChamberJaina: 8
-  TormentChamberThrall: 9
-  TwistingCorridors: 0
-  UpperReaches: 6
+  values:
+    AdamantVaults: 11
+    ArkobanHall: 7
+    BossRush: 14
+    Coldheart: 4
+    ForgottenCatacombs: 12
+    FractureChambers: 2
+    Mortregar: 5
+    Ossuary: 13
+    SkoldusHalls: 1
+    Soulforges: 3
+    TormentChamberAnduin: 10
+    TormentChamberJaina: 8
+    TormentChamberThrall: 9
+    TwistingCorridors: 0
+    UpperReaches: 6
 JournalEncounterFlags:
-  AllianceOnly: 4
-  DoNotDisplayEncounter: 64
-  HordeOnly: 8
-  InternalOnly: 32
-  LimitDifficulties: 2
-  NoMap: 16
-  Obsolete: 1
+  values:
+    AllianceOnly: 4
+    DoNotDisplayEncounter: 64
+    HordeOnly: 8
+    InternalOnly: 32
+    LimitDifficulties: 2
+    NoMap: 16
+    Obsolete: 1
 JournalEncounterIconFlags:
-  Bleed: 8192
-  Curse: 256
-  Deadly: 16
-  Disease: 1024
-  Dps: 2
-  Enrage: 2048
-  Healer: 4
-  Heroic: 8
-  Important: 32
-  Interruptible: 64
-  Magic: 128
-  Mythic: 4096
-  Poison: 512
-  Tank: 1
+  values:
+    Bleed: 8192
+    Curse: 256
+    Deadly: 16
+    Disease: 1024
+    Dps: 2
+    Enrage: 2048
+    Healer: 4
+    Heroic: 8
+    Important: 32
+    Interruptible: 64
+    Magic: 128
+    Mythic: 4096
+    Poison: 512
+    Tank: 1
 JournalEncounterItemFlags:
-  DisplayAsExtremelyRare: 16
-  DisplayAsPerPlayerLoot: 4
-  DisplayAsVeryRare: 8
-  LimitDifficulties: 2
-  Obsolete: 1
+  values:
+    DisplayAsExtremelyRare: 16
+    DisplayAsPerPlayerLoot: 4
+    DisplayAsVeryRare: 8
+    LimitDifficulties: 2
+    Obsolete: 1
 JournalEncounterLocFlags:
-  Primary: 1
+  values:
+    Primary: 1
 JournalEncounterSectionFlags:
-  LimitDifficulties: 2
-  StartExpanded: 1
+  values:
+    LimitDifficulties: 2
+    StartExpanded: 1
 JournalEncounterSecTypes:
-  Ability: 2
-  Creature: 1
-  Generic: 0
-  Overview: 3
+  values:
+    Ability: 2
+    Creature: 1
+    Generic: 0
+    Overview: 3
 JournalInstanceFlags:
-  DoNotDisplayInstance: 4
-  HideUserSelectableDifficulty: 2
-  Timewalker: 1
+  values:
+    DoNotDisplayInstance: 4
+    HideUserSelectableDifficulty: 2
+    Timewalker: 1
 JournalLinkTypes:
-  Encounter: 1
-  Instance: 0
-  Section: 2
-  Tier: 3
+  values:
+    Encounter: 1
+    Instance: 0
+    Section: 2
+    Tier: 3
 LanguageFlag:
-  HiddenFromPlayer: 2
-  HideLanguageNameInChat: 4
-  IsExotic: 1
+  values:
+    HiddenFromPlayer: 2
+    HideLanguageNameInChat: 4
+    IsExotic: 1
 LeavePartyConfirmReason:
-  QuestSync: 0
-  RestrictedChallengeMode: 1
+  values:
+    QuestSync: 0
+    RestrictedChallengeMode: 1
 LFGEntryGeneralPlaystyle:
-  Expert: 4
-  FunRelaxed: 2
-  FunSerious: 3
-  Learning: 1
-  None: 0
+  values:
+    Expert: 4
+    FunRelaxed: 2
+    FunSerious: 3
+    Learning: 1
+    None: 0
 LFGEntryPlaystyle:
-  Casual: 2
-  Hardcore: 3
-  None: 0
-  Standard: 1
+  values:
+    Casual: 2
+    Hardcore: 3
+    None: 0
+    Standard: 1
 LFGListDisplayType:
-  ClassEnumerate: 2
-  Comment: 5
-  HideAll: 3
-  PlayerCount: 4
-  RoleCount: 0
-  RoleEnumerate: 1
+  values:
+    ClassEnumerate: 2
+    Comment: 5
+    HideAll: 3
+    PlayerCount: 4
+    RoleCount: 0
+    RoleEnumerate: 1
 LFGListFilter:
-  CurrentExpansion: 32
-  CurrentSeason: 64
-  NotCurrentSeason: 128
-  NotRecommended: 2
-  PvE: 4
-  PvP: 8
-  Recommended: 1
-  Timerunning: 16
+  values:
+    CurrentExpansion: 32
+    CurrentSeason: 64
+    NotCurrentSeason: 128
+    NotRecommended: 2
+    PvE: 4
+    PvP: 8
+    Recommended: 1
+    Timerunning: 16
 LFGRole:
-  Damage: 2
-  Healer: 1
-  Tank: 0
+  values:
+    Damage: 2
+    Healer: 1
+    Tank: 0
 LFGSlotInvalidReason:
-  AreaNotExplored: 9
-  CannotRunAnyChildDungeon: 14
-  ChromieTime: 16
-  EngagedInPvP: 12
-  ExpansionTooLow: 1
-  GearTooHigh: 5
-  GearTooLow: 4
-  LevelTargetTooHigh: 8
-  LevelTargetTooLow: 7
-  LevelTooHigh: 3
-  LevelTooLow: 2
-  None: 0
-  NoSpec: 13
-  NoValidRoles: 11
-  Npe: 17
-  PlayerConditionFailed: 19
-  RaidLocked: 6
-  Restricted: 15
-  Timerunning: 18
-  WrongFaction: 10
+  values:
+    AreaNotExplored: 9
+    CannotRunAnyChildDungeon: 14
+    ChromieTime: 16
+    EngagedInPvP: 12
+    ExpansionTooLow: 1
+    GearTooHigh: 5
+    GearTooLow: 4
+    LevelTargetTooHigh: 8
+    LevelTargetTooLow: 7
+    LevelTooHigh: 3
+    LevelTooLow: 2
+    None: 0
+    NoSpec: 13
+    NoValidRoles: 11
+    Npe: 17
+    PlayerConditionFailed: 19
+    RaidLocked: 6
+    Restricted: 15
+    Timerunning: 18
+    WrongFaction: 10
 LgVendorPurchaseSettlementState:
-  NotSettled: 1
-  Settled: 0
+  values:
+    NotSettled: 1
+    Settled: 0
 LgVendorPurchaseSqlResults:
-  AlreadyOwned: 102
-  Failed: 0
-  InsufficientFunds: 101
-  InsufficientSpent: 103
-  InvalidState: 107
-  NoRecord: 106
-  NotOwned: 104
-  RefundExpired: 105
-  Success: 100
+  values:
+    AlreadyOwned: 102
+    Failed: 0
+    InsufficientFunds: 101
+    InsufficientSpent: 103
+    InvalidState: 107
+    NoRecord: 106
+    NotOwned: 104
+    RefundExpired: 105
+    Success: 100
 LgVendorPurchaseState:
-  NotOwned: 0
-  Owned: 1
+  values:
+    NotOwned: 0
+    Owned: 1
 LightRadiusIndicatorType:
-  Always: 0
-  Never: 2
-  Overlap: 1
+  values:
+    Always: 0
+    Never: 2
+    Overlap: 1
 LimitedInputType:
-  MouseDown: 1
-  MouseMove: 0
-  MouseUp: 2
-  MouseWheel: 3
+  values:
+    MouseDown: 1
+    MouseMove: 0
+    MouseUp: 2
+    MouseWheel: 3
 LinkedCurrencyFlags:
-  AddIgnoresMax: 8
-  IgnoreAdd: 1
-  IgnoreSubtract: 2
-  SuppressChatLog: 4
+  values:
+    AddIgnoresMax: 8
+    IgnoreAdd: 1
+    IgnoreSubtract: 2
+    SuppressChatLog: 4
 LogicLogicop:
-  And: 1
-  None: 0
-  Or: 2
-  Xor: 3
+  values:
+    And: 1
+    None: 0
+    Or: 2
+    Xor: 3
 LogicMathop:
-  Div: 4
-  Minus: 2
-  Mod: 5
-  None: 0
-  Plus: 1
-  Times: 3
+  values:
+    Div: 4
+    Minus: 2
+    Mod: 5
+    None: 0
+    Plus: 1
+    Times: 3
 LogicRelop:
-  Equal: 1
-  Gt: 5
-  Gteq: 6
-  Lt: 3
-  Lteq: 4
-  None: 0
-  Notequal: 2
+  values:
+    Equal: 1
+    Gt: 5
+    Gteq: 6
+    Lt: 3
+    Lteq: 4
+    None: 0
+    Notequal: 2
 LogPriority:
-  Debug: 30
-  Error: 2
-  Fatal: 1
-  Normal: 10
-  Spam: 40
-  Warning: 3
+  values:
+    Debug: 30
+    Error: 2
+    Fatal: 1
+    Normal: 10
+    Spam: 40
+    Warning: 3
 LootMethod:
-  Freeforall: 0
-  Group: 3
-  Masterlooter: 2
-  Needbeforegreed: 4
-  Personal: 5
-  Roundrobin: 1
+  values:
+    Freeforall: 0
+    Group: 3
+    Masterlooter: 2
+    Needbeforegreed: 4
+    Personal: 5
+    Roundrobin: 1
 LootMethodStyles:
-  Mainline: 0
-  Vanilla: 1
+  values:
+    Mainline: 0
+    Vanilla: 1
 LootSlotType:
-  Currency: 3
-  Item: 1
-  Money: 2
-  None: 0
+  values:
+    Currency: 3
+    Item: 1
+    Money: 2
+    None: 0
 LuaCurveType:
-  Cosine: 2
-  Cubic: 3
-  Linear: 0
-  Step: 1
+  values:
+    Cosine: 2
+    Cubic: 3
+    Linear: 0
+    Step: 1
 ManipulatorEventType:
-  Complete: 2
-  Delete: 3
-  Move: 1
-  Start: 0
+  values:
+    Complete: 2
+    Delete: 3
+    Move: 1
+    Start: 0
 MapCanvasPosition:
-  BottomLeft: 1
-  BottomRight: 2
-  None: 0
-  TopLeft: 3
-  TopRight: 4
+  values:
+    BottomLeft: 1
+    BottomRight: 2
+    None: 0
+    TopLeft: 3
+    TopRight: 4
 MapIconUIWidgetSetType:
-  AdventureMapDetails: 2
-  BehindIcon: 1
-  Tooltip: 0
+  values:
+    AdventureMapDetails: 2
+    BehindIcon: 1
+    Tooltip: 0
 MapobjEventTypes:
-  PlayAnim: 0
-  SetAnimSpeed: 1
+  values:
+    PlayAnim: 0
+    SetAnimSpeed: 1
 MapPinAnimationType:
-  None: 0
-  Pulse: 1
+  values:
+    None: 0
+    Pulse: 1
 MatchDetailType:
-  Kills: 1
-  Placement: 0
-  PlunderAcquired: 2
+  values:
+    Kills: 1
+    Placement: 0
+    PlunderAcquired: 2
 MicroMenuOrder:
-  Default: 0
-  Reverse: 1
+  values:
+    Default: 0
+    Reverse: 1
 MicroMenuOrientation:
-  Horizontal: 0
-  Vertical: 1
+  values:
+    Horizontal: 0
+    Vertical: 1
 MinimapTrackingFilter:
-  AccountBanker: 4194304
-  AccountCompletedQuests: 2097152
-  Auctioneer: 1
-  Banker: 2
-  Battlemaster: 4
-  Digsites: 131072
-  Focus: 32768
-  Innkeeper: 32
-  Mailbox: 64
-  POI: 8192
-  QuestPOIs: 65536
-  Repair: 512
-  Stablemaster: 2048
-  Target: 16384
-  TaxiNode: 8
-  TrainerClass: 262144
-  TrainerProfession: 128
-  Transmogrifier: 4096
-  TrivialQuests: 1024
-  Unfiltered: 0
-  VenderFood: 16
-  VendorAmmo: 524288
-  VendorPoison: 1048576
-  VendorReagent: 256
+  values:
+    AccountBanker: 4194304
+    AccountCompletedQuests: 2097152
+    Auctioneer: 1
+    Banker: 2
+    Battlemaster: 4
+    Digsites: 131072
+    Focus: 32768
+    Innkeeper: 32
+    Mailbox: 64
+    POI: 8192
+    QuestPOIs: 65536
+    Repair: 512
+    Stablemaster: 2048
+    Target: 16384
+    TaxiNode: 8
+    TrainerClass: 262144
+    TrainerProfession: 128
+    Transmogrifier: 4096
+    TrivialQuests: 1024
+    Unfiltered: 0
+    VenderFood: 16
+    VendorAmmo: 524288
+    VendorPoison: 1048576
+    VendorReagent: 256
 ModelBlendOperation:
-  Anim: 1
-  None: 0
+  values:
+    Anim: 1
+    None: 0
 ModelLightType:
-  Directional: 0
-  Point: 1
+  values:
+    Directional: 0
+    Point: 1
 ModelSceneSetting:
-  AlignLightToOrbitDelta: 1
+  values:
+    AlignLightToOrbitDelta: 1
 ModelSceneType:
-  ArtifactRelicTalentEffect: 9
-  ArtifactTier2: 5
-  ArtifactTier2ForgingScene: 6
-  ArtifactTier2SlamEffect: 7
-  AzeriteItemLevelUpToast: 13
-  AzeritePowers: 14
-  AzeriteRewardGlow: 15
-  CommentatorVictoryFanfare: 8
-  EncounterJournal: 3
-  MountJournal: 0
-  PartyPose: 12
-  PetJournalCard: 1
-  PetJournalLoadout: 4
-  PvPWarModeFire: 11
-  PvPWarModeOrb: 10
-  ShopCard: 2
+  values:
+    ArtifactRelicTalentEffect: 9
+    ArtifactTier2: 5
+    ArtifactTier2ForgingScene: 6
+    ArtifactTier2SlamEffect: 7
+    AzeriteItemLevelUpToast: 13
+    AzeritePowers: 14
+    AzeriteRewardGlow: 15
+    CommentatorVictoryFanfare: 8
+    EncounterJournal: 3
+    MountJournal: 0
+    PartyPose: 12
+    PetJournalCard: 1
+    PetJournalLoadout: 4
+    PvPWarModeFire: 11
+    PvPWarModeOrb: 10
+    ShopCard: 2
 ModelSoundOverrideType:
-  Mute: 2
-  UseOverride: 1
-  UseParent: 0
+  values:
+    Mute: 2
+    UseOverride: 1
+    UseParent: 0
 ModelSoundTagType:
-  Looping: 2
-  Oneshot: 1
+  values:
+    Looping: 2
+    Oneshot: 1
 MountType:
-  Aquatic: 2
-  Dragonriding: 3
-  Flying: 1
-  Ground: 0
-  RideAlong: 4
+  values:
+    Aquatic: 2
+    Dragonriding: 3
+    Flying: 1
+    Ground: 0
+    RideAlong: 4
 MountTypeFlag:
-  IsAquaticMount: 2
-  IsDragonRidingMount: 4
-  IsFlyingMount: 1
-  IsRideAlongMount: 8
+  values:
+    IsAquaticMount: 2
+    IsDragonRidingMount: 4
+    IsFlyingMount: 1
+    IsRideAlongMount: 8
 NamePlateCastBarDisplay:
-  HighlightImportantCasts: 4
-  HighlightWhenCastTarget: 5
-  None: 0
-  SpellIcon: 2
-  SpellName: 1
-  SpellTarget: 3
+  values:
+    HighlightImportantCasts: 4
+    HighlightWhenCastTarget: 5
+    None: 0
+    SpellIcon: 2
+    SpellName: 1
+    SpellTarget: 3
 NamePlateEnemyNpcAuraDisplay:
-  Buffs: 1
-  CrowdControl: 3
-  Debuffs: 2
-  None: 0
+  values:
+    Buffs: 1
+    CrowdControl: 3
+    Debuffs: 2
+    None: 0
 NamePlateEnemyPlayerAuraDisplay:
-  Buffs: 1
-  Debuffs: 2
-  LossOfControl: 3
-  None: 0
+  values:
+    Buffs: 1
+    Debuffs: 2
+    LossOfControl: 3
+    None: 0
 NamePlateFriendlyPlayerAuraDisplay:
-  Buffs: 1
-  Debuffs: 2
-  LossOfControl: 3
-  None: 0
+  values:
+    Buffs: 1
+    Debuffs: 2
+    LossOfControl: 3
+    None: 0
 NamePlateInfoDisplay:
-  CurrentHealthPercent: 1
-  CurrentHealthValue: 2
-  None: 0
-  RarityIcon: 3
+  values:
+    CurrentHealthPercent: 1
+    CurrentHealthValue: 2
+    None: 0
+    RarityIcon: 3
 NamePlateSimplifiedType:
-  FriendlyNpc: 4
-  FriendlyPlayer: 3
-  Minion: 1
-  MinusMob: 2
-  None: 0
+  values:
+    FriendlyNpc: 4
+    FriendlyPlayer: 3
+    Minion: 1
+    MinusMob: 2
+    None: 0
 NamePlateSize:
-  ExtraLarge: 4
-  Huge: 5
-  Large: 3
-  Medium: 2
-  Small: 1
+  values:
+    ExtraLarge: 4
+    Huge: 5
+    Large: 3
+    Medium: 2
+    Small: 1
 NamePlateStackType:
-  Enemy: 1
-  Friendly: 2
-  None: 0
+  values:
+    Enemy: 1
+    Friendly: 2
+    None: 0
 NamePlateStyle:
-  Block: 2
-  CastFocus: 4
-  Classic: 6
-  HealthFocus: 3
-  Legacy: 5
-  Modern: 0
-  Thin: 1
+  values:
+    Block: 2
+    CastFocus: 4
+    Classic: 6
+    HealthFocus: 3
+    Legacy: 5
+    Modern: 0
+    Thin: 1
 NamePlateThreatDisplay:
-  Flash: 2
-  HealthBarColor: 3
-  None: 0
-  Progressive: 1
+  values:
+    Flash: 2
+    HealthBarColor: 3
+    None: 0
+    Progressive: 1
 NamePlateType:
-  Enemy: 1
-  Friendly: 0
+  values:
+    Enemy: 1
+    Friendly: 0
 NeighborhoodFlags:
-  None: 0
-  OpenToPublic: 2
-  PoolParent: 1
+  values:
+    None: 0
+    OpenToPublic: 2
+    PoolParent: 1
 NeighborhoodInitiativeChestResult:
-  NiNoHouseFound: 2
-  NiNoRewards: 3
-  NiServiceDisabled: 5
-  NiSuccess: 0
-  NiThrottled: 4
-  NiUnspecifiedFailure: 1
+  values:
+    NiNoHouseFound: 2
+    NiNoRewards: 3
+    NiServiceDisabled: 5
+    NiSuccess: 0
+    NiThrottled: 4
+    NiUnspecifiedFailure: 1
 NeighborhoodInitiativeFlags:
-  Disabled: 1
-  NoAbandon: 2
-  NoRepeat: 4
+  values:
+    Disabled: 1
+    NoAbandon: 2
+    NoRepeat: 4
 NeighborhoodInitiativeNeighborhoodTypes:
-  NiNeighborhoodTypePool: 1
-  NiNeighborhoodTypeSingleton: 0
+  values:
+    NiNeighborhoodTypePool: 1
+    NiNeighborhoodTypeSingleton: 0
 NeighborhoodInitiativesCompletionStates:
-  NiCompletionStateNotCompleted: 0
-  NiCompletionStatePlayerCompleted: 1
-  NiCompletionStateSystemAbandoned: 2
+  values:
+    NiCompletionStateNotCompleted: 0
+    NiCompletionStatePlayerCompleted: 1
+    NiCompletionStateSystemAbandoned: 2
 NeighborhoodInitiativeTaskType:
-  RepeatableFinite: 1
-  RepeatableInfinite: 2
-  Single: 0
+  values:
+    RepeatableFinite: 1
+    RepeatableInfinite: 2
+    Single: 0
 NeighborhoodInitiativeUpdateStatus:
-  Completed: 2
-  Failed: 3
-  MilestoneCompleted: 1
-  Started: 0
+  values:
+    Completed: 2
+    Failed: 3
+    MilestoneCompleted: 1
+    Started: 0
 NeighborhoodInviteResult:
-  AlreadyInNeighborhood: 11
-  DbError: 1
-  Faction: 5
-  GenericFailure: 3
-  InviteLimit: 7
-  NotEnoughPlots: 8
-  NotFound: 9
-  PendingInvitation: 6
-  Permission: 4
-  RpcFailure: 2
-  Success: 0
-  TooManyRequests: 10
+  values:
+    AlreadyInNeighborhood: 11
+    DbError: 1
+    Faction: 5
+    GenericFailure: 3
+    InviteLimit: 7
+    NotEnoughPlots: 8
+    NotFound: 9
+    PendingInvitation: 6
+    Permission: 4
+    RpcFailure: 2
+    Success: 0
+    TooManyRequests: 10
 NeighborhoodMapFlags:
-  AlliancePurchasable: 1
-  CanSystemGenerate: 4
-  HordePurchasable: 2
-  None: 0
+  values:
+    AlliancePurchasable: 1
+    CanSystemGenerate: 4
+    HordePurchasable: 2
+    None: 0
 NeighborhoodOwnerType:
-  Charter: 2
-  Guild: 1
-  None: 0
+  values:
+    Charter: 2
+    Guild: 1
+    None: 0
 NeighborhoodType:
-  Open: 0
-  Private: 1
-  Public: 2
+  values:
+    Open: 0
+    Private: 1
+    Public: 2
 NewCharGear:
-  Preview: 1
-  Start: 0
+  values:
+    Preview: 1
+    Start: 0
 NodeOpFailureReason:
-  AccountDataNoMatch: 25
-  DataError: 13
-  EntryNotFound: 19
-  HasMutuallyExclusiveEdge: 4
-  LevelTooLow: 22
-  MaxRank: 12
-  MissingAchievement: 8
-  MissingEdgeConnection: 1
-  MissingQuest: 9
-  MissingRequiredEdge: 3
-  NodeNeverPurchasable: 24
-  NodeNotFound: 18
-  None: 0
-  NotEnoughCurrency: 15
-  NotEnoughCurrencySpent: 6
-  NotEnoughGold: 16
-  NotEnoughGoldSpent: 7
-  NotEnoughRanksInEntry: 26
-  NotEnoughSourcedCurrency: 14
-  NotEnoughSourcedCurrencySpent: 5
-  RequiredForCondition: 20
-  RequiredForEdge: 2
-  SameSelection: 17
-  TreeFlaggedNoRefund: 23
-  WrongSelection: 11
-  WrongSpec: 10
-  WrongTreeID: 21
+  values:
+    AccountDataNoMatch: 25
+    DataError: 13
+    EntryNotFound: 19
+    HasMutuallyExclusiveEdge: 4
+    LevelTooLow: 22
+    MaxRank: 12
+    MissingAchievement: 8
+    MissingEdgeConnection: 1
+    MissingQuest: 9
+    MissingRequiredEdge: 3
+    NodeNeverPurchasable: 24
+    NodeNotFound: 18
+    None: 0
+    NotEnoughCurrency: 15
+    NotEnoughCurrencySpent: 6
+    NotEnoughGold: 16
+    NotEnoughGoldSpent: 7
+    NotEnoughRanksInEntry: 26
+    NotEnoughSourcedCurrency: 14
+    NotEnoughSourcedCurrencySpent: 5
+    RequiredForCondition: 20
+    RequiredForEdge: 2
+    SameSelection: 17
+    TreeFlaggedNoRefund: 23
+    WrongSelection: 11
+    WrongSpec: 10
+    WrongTreeID: 21
 NoRPEReason:
-  BNetToken: 8
-  FactionOrRaceChange: 7
-  HasRPE: 0
-  IneligibleMap: 3
-  LowLevel: 1
-  PlayerLocked: 9
-  RecentlyActive: 4
-  RecentlyBoosted: 5
-  Timerunner: 2
-  UpgradeInProgress: 6
+  values:
+    BNetToken: 8
+    FactionOrRaceChange: 7
+    HasRPE: 0
+    IneligibleMap: 3
+    LowLevel: 1
+    PlayerLocked: 9
+    RecentlyActive: 4
+    RecentlyBoosted: 5
+    Timerunner: 2
+    UpgradeInProgress: 6
 NpcCraftingOrderSetFlags:
-  AllowDuplicate: 2
-  AllowMultiple: 1
+  values:
+    AllowDuplicate: 2
+    AllowMultiple: 1
 NumericRuleFormatRounding:
-  Down: 2
-  Nearest: 0
-  Up: 1
+  values:
+    Down: 2
+    Nearest: 0
+    Up: 1
 PartyPlaylistEntry:
-  DuoGameMode: 1
-  SoloGameMode: 0
-  TrainingGameMode: 3
-  TrioGameMode: 2
+  values:
+    DuoGameMode: 1
+    SoloGameMode: 0
+    TrainingGameMode: 3
+    TrioGameMode: 2
 PartyPoseFlags:
-  HideLeaveInstanceButton: 1
+  values:
+    HideLeaveInstanceButton: 1
 PartyRequestJoinRelation:
-  Club: 3
-  Friend: 1
-  Guild: 2
-  None: 0
-  RecentAllies: 4
+  values:
+    Club: 3
+    Friend: 1
+    Guild: 2
+    None: 0
+    RecentAllies: 4
 PerksVendorCategoryType:
-  Achievement: 23
-  Activity: 21
-  GmAdjustment: 22
-  Illusion: 7
-  Mount: 2
-  Pet: 3
-  RefundUnused: 24
-  Stipend: 20
-  Toy: 5
-  Transmog: 1
-  Transmogset: 8
-  WarbandScene: 9
+  values:
+    Achievement: 23
+    Activity: 21
+    GmAdjustment: 22
+    Illusion: 7
+    Mount: 2
+    Pet: 3
+    RefundUnused: 24
+    Stipend: 20
+    Toy: 5
+    Transmog: 1
+    Transmogset: 8
+    WarbandScene: 9
 PermanentChatChannelType:
-  Communities: 2
-  Custom: 3
-  None: 0
-  Zone: 1
+  values:
+    Communities: 2
+    Custom: 3
+    None: 0
+    Zone: 1
 PersonalResourceDisplayVisibleSetting:
-  Always: 0
-  Hidden: 2
-  InCombat: 1
+  values:
+    Always: 0
+    Hidden: 2
+    InCombat: 1
 PetActionbuttonType:
-  Max: 18
-  Mode: 6
-  None: 0
-  Orders: 7
-  Slot1: 8
-  Slot10: 17
-  Slot1Obsolete: 2
-  Slot2: 9
-  Slot2Obsolete: 3
-  Slot3: 10
-  Slot3Obsolete: 4
-  Slot4: 11
-  Slot4Obsolete: 5
-  Slot5: 12
-  Slot6: 13
-  Slot7: 14
-  Slot8: 15
-  Slot9: 16
-  Spell: 1
-  VehicleAction: 19
+  values:
+    Max: 18
+    Mode: 6
+    None: 0
+    Orders: 7
+    Slot1: 8
+    Slot10: 17
+    Slot1Obsolete: 2
+    Slot2: 9
+    Slot2Obsolete: 3
+    Slot3: 10
+    Slot3Obsolete: 4
+    Slot4: 11
+    Slot4Obsolete: 5
+    Slot5: 12
+    Slot6: 13
+    Slot7: 14
+    Slot8: 15
+    Slot9: 16
+    Spell: 1
+    VehicleAction: 19
 PetActionFeedback:
-  Dead: 1
-  FriendlyTarget: 3
-  InvalidTarget: 2
-  NoPath: 4
-  Success: 0
+  values:
+    Dead: 1
+    FriendlyTarget: 3
+    InvalidTarget: 2
+    NoPath: 4
+    Success: 0
 PetBattleQueueStatus:
-  AlreadyQueued: 3
-  InBattle: 20
-  JoinFailed: 4
-  JoinFailedJournalLock: 6
-  JoinFailedNeutral: 7
-  JoinFailedSlots: 5
-  LostConnection: 16
-  MatchAccepted: 8
-  MatchDeclined: 9
-  Matchmaking: 15
-  MatchOpponentDeclined: 10
-  NoBattlingHere: 21
-  None: 0
-  ProposalTimedOut: 11
-  Queued: 1
-  QueuedUpdate: 2
-  Removed: 12
-  RequeuedAfterInternalError: 13
-  RequeuedAfterOpponentRemoved: 14
-  Shutdown: 17
-  Suspended: 18
-  Unsuspended: 19
+  values:
+    AlreadyQueued: 3
+    InBattle: 20
+    JoinFailed: 4
+    JoinFailedJournalLock: 6
+    JoinFailedNeutral: 7
+    JoinFailedSlots: 5
+    LostConnection: 16
+    MatchAccepted: 8
+    MatchDeclined: 9
+    Matchmaking: 15
+    MatchOpponentDeclined: 10
+    NoBattlingHere: 21
+    None: 0
+    ProposalTimedOut: 11
+    Queued: 1
+    QueuedUpdate: 2
+    Removed: 12
+    RequeuedAfterInternalError: 13
+    RequeuedAfterOpponentRemoved: 14
+    Shutdown: 17
+    Suspended: 18
+    Unsuspended: 19
 PetbattleSlot:
-  Slot_0: 0
-  Slot_1: 1
-  Slot_2: 2
+  values:
+    Slot_0: 0
+    Slot_1: 1
+    Slot_2: 2
 PetbattleState:
-  Created: 0
-  CreatedFailed: 4
-  FinalRound: 5
-  Finished: 6
-  RoundInProgress: 2
-  WaitingForFrontPets: 3
-  WaitingPreBattle: 1
+  values:
+    Created: 0
+    CreatedFailed: 4
+    FinalRound: 5
+    Finished: 6
+    RoundInProgress: 2
+    WaitingForFrontPets: 3
+    WaitingPreBattle: 1
 PetJournalError:
-  InvalidFaction: 3
-  JournalIsLocked: 2
-  NoFavoritesToSummon: 4
-  None: 0
-  NoValidRandomSummon: 5
-  PetIsDead: 1
+  values:
+    InvalidFaction: 3
+    JournalIsLocked: 2
+    NoFavoritesToSummon: 4
+    None: 0
+    NoValidRandomSummon: 5
+    PetIsDead: 1
 PetMode:
-  Aggressive: 2
-  Assist: 3
-  Defensive: 1
-  Passive: 0
+  values:
+    Aggressive: 2
+    Assist: 3
+    Defensive: 1
+    Passive: 0
 PetOrders:
-  Attack: 2
-  Dismiss: 3
-  Follow: 1
-  MoveTo: 4
-  Wait: 0
+  values:
+    Attack: 2
+    Dismiss: 3
+    Follow: 1
+    MoveTo: 4
+    Wait: 0
 PetOverride:
-  AICombatControl: 1
-  AICombatPassive: 2
-  None: 0
-  OwnerMounted: 4
+  values:
+    AICombatControl: 1
+    AICombatPassive: 2
+    None: 0
+    OwnerMounted: 4
 Pettameresult:
-  Anothersummonactive: 5
-  Cantcontrolexotic: 12
-  Creaturealreadyowned: 3
-  Dead: 10
-  EliteToohighlevel: 14
-  Internalerror: 8
-  Invalidcreature: 1
-  Invalidslot: 13
-  Nopetavailable: 7
-  Notdead: 11
-  Nottameable: 4
-  Numresults: 15
-  Ok: 0
-  Toohighlevel: 9
-  Toomany: 2
-  Unitscanttame: 6
+  values:
+    Anothersummonactive: 5
+    Cantcontrolexotic: 12
+    Creaturealreadyowned: 3
+    Dead: 10
+    EliteToohighlevel: 14
+    Internalerror: 8
+    Invalidcreature: 1
+    Invalidslot: 13
+    Nopetavailable: 7
+    Notdead: 11
+    Nottameable: 4
+    Numresults: 15
+    Ok: 0
+    Toohighlevel: 9
+    Toomany: 2
+    Unitscanttame: 6
 PhaseReason:
-  ChromieTime: 3
-  Phasing: 0
-  Sharding: 1
-  TimerunningHwt: 4
-  WarMode: 2
+  values:
+    ChromieTime: 3
+    Phasing: 0
+    Sharding: 1
+    TimerunningHwt: 4
+    WarMode: 2
 PhotoSharingStatus:
-  AADCRestricted: 6
-  Configured: 2
-  Disabled: 0
-  Error: 7
-  Expired: 3
-  FailedToClear: 8
-  NotConfigured: 1
-  ParentalControl: 4
-  TrialOrVeteran: 5
+  values:
+    AADCRestricted: 6
+    Configured: 2
+    Disabled: 0
+    Error: 7
+    Expired: 3
+    FailedToClear: 8
+    NotConfigured: 1
+    ParentalControl: 4
+    TrialOrVeteran: 5
 PhotoSharingUploadStatus:
-  CreatePageApiCallFailed: 13
-  CreatePageBadRequest: 14
-  CreatePageForbidden: 16
-  CreatePageGenericFailure: 19
-  CreatePageNoBoardIDFound: 20
-  CreatePageNotFound: 17
-  CreatePageTooManyRequests: 18
-  CreatePageUnauthorized: 15
-  CreatePostApiCallFailed: 21
-  CreatePostBadRequest: 22
-  CreatePostForbidden: 24
-  CreatePostGenericFailure: 27
-  CreatePostNoIDFound: 28
-  CreatePostNotFound: 25
-  CreatePostThrottled: 29
-  CreatePostTooManyRequests: 26
-  CreatePostUnauthorized: 23
-  Disabled: 0
-  Failed: 1
-  ListPagesApiCallFailed: 4
-  ListPagesBadRequest: 5
-  ListPagesEmptyBoardID: 11
-  ListPagesForbidden: 7
-  ListPagesGenericFailure: 10
-  ListPagesInvalidBookmark: 12
-  ListPagesNotFound: 8
-  ListPagesTooManyRequests: 9
-  ListPagesUnauthorized: 6
-  Locked: 3
-  Success: 2
+  values:
+    CreatePageApiCallFailed: 13
+    CreatePageBadRequest: 14
+    CreatePageForbidden: 16
+    CreatePageGenericFailure: 19
+    CreatePageNoBoardIDFound: 20
+    CreatePageNotFound: 17
+    CreatePageTooManyRequests: 18
+    CreatePageUnauthorized: 15
+    CreatePostApiCallFailed: 21
+    CreatePostBadRequest: 22
+    CreatePostForbidden: 24
+    CreatePostGenericFailure: 27
+    CreatePostNoIDFound: 28
+    CreatePostNotFound: 25
+    CreatePostThrottled: 29
+    CreatePostTooManyRequests: 26
+    CreatePostUnauthorized: 23
+    Disabled: 0
+    Failed: 1
+    ListPagesApiCallFailed: 4
+    ListPagesBadRequest: 5
+    ListPagesEmptyBoardID: 11
+    ListPagesForbidden: 7
+    ListPagesGenericFailure: 10
+    ListPagesInvalidBookmark: 12
+    ListPagesNotFound: 8
+    ListPagesTooManyRequests: 9
+    ListPagesUnauthorized: 6
+    Locked: 3
+    Success: 2
 PingSubjectType:
-  AlertNotThreat: 5
-  AlertThreat: 4
-  Assist: 2
-  Attack: 0
-  OnMyWay: 3
-  Warning: 1
+  values:
+    AlertNotThreat: 5
+    AlertThreat: 4
+    Assist: 2
+    Attack: 0
+    OnMyWay: 3
+    Warning: 1
 PingTextureType:
-  Center: 0
-  Expand: 1
-  Rotation: 2
+  values:
+    Center: 0
+    Expand: 1
+    Rotation: 2
 PingTypeFlags:
-  DefaultPing: 1
+  values:
+    DefaultPing: 1
 PlayerClubRequestStatus:
-  Approved: 4
-  AutoApproved: 2
-  Canceled: 7
-  Declined: 3
-  Joined: 5
-  JoinedAnother: 6
-  None: 0
-  Pending: 1
+  values:
+    Approved: 4
+    AutoApproved: 2
+    Canceled: 7
+    Declined: 3
+    Joined: 5
+    JoinedAnother: 6
+    None: 0
+    Pending: 1
 PlayerCompanionInfoFlags:
-  IgnoreSeasonInScenarios: 1
+  values:
+    IgnoreSeasonInScenarios: 1
 PlayerCurrencyFlags:
-  Incremented: 1
-  Loading: 2
+  values:
+    Incremented: 1
+    Loading: 2
 PlayerCurrencyFlagsDbFlags:
-  IgnoreMaxQtyOnload: 1
-  InBackpack: 4
-  Reuse1: 2
-  Reuse2: 16
-  UnusedInUI: 8
+  values:
+    IgnoreMaxQtyOnload: 1
+    InBackpack: 4
+    Reuse1: 2
+    Reuse2: 16
+    UnusedInUI: 8
 PlayerDataElementType:
-  Float: 1
-  Int: 0
+  values:
+    Float: 1
+    Int: 0
 PlayerInteractionType:
-  AccountBanker: 68
-  AdventureJournal: 54
-  AdventureMap: 28
-  AlliedRaceDetailsGiver: 9
-  AnimaDiversion: 47
-  AreaSpiritHealer: 19
-  ArtifactForge: 38
-  Auctioneer: 21
-  AzeriteForge: 56
-  AzeriteRespec: 42
-  Banker: 8
-  BarbersChoice: 62
-  BattleMaster: 23
-  Binder: 20
-  BlackMarketAuctioneer: 27
-  CharacterBanker: 67
-  ChromieTime: 45
-  ContributionCollector: 41
-  CornerstoneInteraction: 70
-  CovenantPreview: 46
-  CovenantSanctum: 51
-  CreateGuildNeighborhood: 74
-  ForgeMaster: 66
-  GarrArchitect: 30
-  GarrMission: 32
-  GarrRecruitment: 34
-  GarrTalent: 35
-  GarrTradeskill: 31
-  Gossip: 3
-  GuildBanker: 10
-  GuildRename: 76
-  GuildTabardVendor: 14
-  HousingBulletinBoard: 72
-  HousingPedestal: 73
-  IslandQueue: 43
-  Item: 2
-  ItemInteraction: 44
-  ItemUpgrade: 53
-  JailersTowerBuffs: 63
-  LegendaryCrafting: 48
-  LFGDungeon: 25
-  MailInfo: 17
-  MajorFactionRenown: 64
-  Merchant: 5
-  NeighborhoodCharter: 75
-  NewPlayerGuide: 52
-  None: 0
-  ObliterumForge: 39
-  OpenHouseFinder: 78
-  OpenNeighborhoodCharterConfirmation: 77
-  PerksProgramVendor: 57
-  PersonalTabardVendor: 65
-  PetitionVendor: 13
-  PlayerChoice: 37
-  ProfessionRespec: 69
-  Professions: 59
-  ProfessionsCraftingOrder: 58
-  ProfessionsCustomerOrder: 60
-  QuestGiver: 4
-  Registrar: 11
-  RenameNeighborhood: 71
-  Renown: 55
-  ScrappingMachine: 40
-  ShipmentCrafter: 33
-  Soulbind: 50
-  SpecializationMaster: 16
-  SpiritHealer: 18
-  StableMaster: 22
-  TalentMaster: 15
-  TaxiNode: 6
-  TieredEntrance: 79
-  TradePartner: 1
-  Trainer: 7
-  TraitSystem: 61
-  Transmogrifier: 24
-  Trophy: 36
-  Vendor: 12
-  VoidStorageBanker: 26
-  WeeklyRewards: 49
-  WorldMap: 29
+  values:
+    AccountBanker: 68
+    AdventureJournal: 54
+    AdventureMap: 28
+    AlliedRaceDetailsGiver: 9
+    AnimaDiversion: 47
+    AreaSpiritHealer: 19
+    ArtifactForge: 38
+    Auctioneer: 21
+    AzeriteForge: 56
+    AzeriteRespec: 42
+    Banker: 8
+    BarbersChoice: 62
+    BattleMaster: 23
+    Binder: 20
+    BlackMarketAuctioneer: 27
+    CharacterBanker: 67
+    ChromieTime: 45
+    ContributionCollector: 41
+    CornerstoneInteraction: 70
+    CovenantPreview: 46
+    CovenantSanctum: 51
+    CreateGuildNeighborhood: 74
+    ForgeMaster: 66
+    GarrArchitect: 30
+    GarrMission: 32
+    GarrRecruitment: 34
+    GarrTalent: 35
+    GarrTradeskill: 31
+    Gossip: 3
+    GuildBanker: 10
+    GuildRename: 76
+    GuildTabardVendor: 14
+    HousingBulletinBoard: 72
+    HousingPedestal: 73
+    IslandQueue: 43
+    Item: 2
+    ItemInteraction: 44
+    ItemUpgrade: 53
+    JailersTowerBuffs: 63
+    LegendaryCrafting: 48
+    LFGDungeon: 25
+    MailInfo: 17
+    MajorFactionRenown: 64
+    Merchant: 5
+    NeighborhoodCharter: 75
+    NewPlayerGuide: 52
+    None: 0
+    ObliterumForge: 39
+    OpenHouseFinder: 78
+    OpenNeighborhoodCharterConfirmation: 77
+    PerksProgramVendor: 57
+    PersonalTabardVendor: 65
+    PetitionVendor: 13
+    PlayerChoice: 37
+    ProfessionRespec: 69
+    Professions: 59
+    ProfessionsCraftingOrder: 58
+    ProfessionsCustomerOrder: 60
+    QuestGiver: 4
+    Registrar: 11
+    RenameNeighborhood: 71
+    Renown: 55
+    ScrappingMachine: 40
+    ShipmentCrafter: 33
+    Soulbind: 50
+    SpecializationMaster: 16
+    SpiritHealer: 18
+    StableMaster: 22
+    TalentMaster: 15
+    TaxiNode: 6
+    TieredEntrance: 79
+    TradePartner: 1
+    Trainer: 7
+    TraitSystem: 61
+    Transmogrifier: 24
+    Trophy: 36
+    Vendor: 12
+    VoidStorageBanker: 26
+    WeeklyRewards: 49
+    WorldMap: 29
 PlayerMentorshipApplicationResult:
-  AlreadyMentor: 1
-  Ineligible: 2
-  Success: 0
+  values:
+    AlreadyMentor: 1
+    Ineligible: 2
+    Success: 0
 PlayerMentorshipStatus:
-  Mentor: 2
-  Newcomer: 1
-  None: 0
+  values:
+    Mentor: 2
+    Newcomer: 1
+    None: 0
 PlunderstormQueueState:
-  None: 0
-  Proposed: 2
-  Queued: 1
-  Suspended: 3
+  values:
+    None: 0
+    Proposed: 2
+    Queued: 1
+    Suspended: 3
 PowerType:
-  Alternate: 10
-  AlternateEncounter: 24
-  AlternateMount: 25
-  AlternateQuest: 23
-  ArcaneCharges: 16
-  Balance: 26
-  BurningEmbers: 14
-  Chi: 12
-  ComboPoints: 4
-  DemonicFury: 15
-  Energy: 3
-  Essence: 19
-  Focus: 2
-  Fury: 17
-  Happiness: 27
-  HolyPower: 9
-  Insanity: 13
-  LunarPower: 8
-  Maelstrom: 11
-  Mana: 0
-  Pain: 18
-  Rage: 1
-  RuneBlood: 20
-  RuneChromatic: 29
-  RuneFrost: 21
-  Runes: 5
-  RuneUnholy: 22
-  RunicPower: 6
-  ShadowOrbs: 28
-  SoulShards: 7
+  values:
+    Alternate: 10
+    AlternateEncounter: 24
+    AlternateMount: 25
+    AlternateQuest: 23
+    ArcaneCharges: 16
+    Balance: 26
+    BurningEmbers: 14
+    Chi: 12
+    ComboPoints: 4
+    DemonicFury: 15
+    Energy: 3
+    Essence: 19
+    Focus: 2
+    Fury: 17
+    Happiness: 27
+    HolyPower: 9
+    Insanity: 13
+    LunarPower: 8
+    Maelstrom: 11
+    Mana: 0
+    Pain: 18
+    Rage: 1
+    RuneBlood: 20
+    RuneChromatic: 29
+    RuneFrost: 21
+    Runes: 5
+    RuneUnholy: 22
+    RunicPower: 6
+    ShadowOrbs: 28
+    SoulShards: 7
 PowerTypeSign:
-  Negative: 1
-  None: -1
-  Positive: 0
+  values:
+    Negative: 1
+    None: -1
+    Positive: 0
 PowerTypeSlot:
-  Slot_0: 0
-  Slot_1: 1
-  Slot_2: 2
-  Slot_3: 3
-  Slot_4: 4
-  Slot_5: 5
-  Slot_6: 6
-  Slot_7: 7
-  Slot_8: 8
-  Slot_9: 9
+  values:
+    Slot_0: 0
+    Slot_1: 1
+    Slot_2: 2
+    Slot_3: 3
+    Slot_4: 4
+    Slot_5: 5
+    Slot_6: 6
+    Slot_7: 7
+    Slot_8: 8
+    Slot_9: 9
 PremadeGroupFinderStyle:
-  Disabled: 0
-  Mainline: 1
-  Vanilla: 2
+  values:
+    Disabled: 0
+    Mainline: 1
+    Vanilla: 2
 PreyHuntProgressState:
-  Cold: 0
-  Final: 3
-  Hot: 2
-  Warm: 1
+  values:
+    Cold: 0
+    Final: 3
+    Hot: 2
+    Warm: 1
 ProceduralSpawnInteractionMode:
-  Manipulate: 2
-  None: 0
-  Paint: 1
+  values:
+    Manipulate: 2
+    None: 0
+    Paint: 1
 ProceduralSpawnVolumeChunkFlags:
-  AllSubChunksSet: 1
-  None: 0
+  values:
+    AllSubChunksSet: 1
+    None: 0
 Profession:
-  Alchemy: 3
-  Archaeology: 14
-  Blacksmithing: 1
-  Cooking: 5
-  Enchanting: 9
-  Engineering: 8
-  FirstAid: 0
-  Fishing: 10
-  Herbalism: 4
-  Inscription: 13
-  Jewelcrafting: 12
-  Leatherworking: 2
-  Mining: 6
-  Skinning: 11
-  Tailoring: 7
+  values:
+    Alchemy: 3
+    Archaeology: 14
+    Blacksmithing: 1
+    Cooking: 5
+    Enchanting: 9
+    Engineering: 8
+    FirstAid: 0
+    Fishing: 10
+    Herbalism: 4
+    Inscription: 13
+    Jewelcrafting: 12
+    Leatherworking: 2
+    Mining: 6
+    Skinning: 11
+    Tailoring: 7
 ProfessionActionType:
-  Craft: 0
-  Gather: 1
+  values:
+    Craft: 0
+    Gather: 1
 ProfessionEffect:
-  AccumulateRanksByLabel: 25
-  ConcentrationRefund: 30
-  DecreaseDifficulty: 22
-  IncreaseDifficulty: 23
-  ModConcentration: 27
-  ModCraftCritSize: 20
-  ModCraftExtraQuantity: 18
-  ModCraftingSpeed: 14
-  ModCraftReductionQuantity: 21
-  ModDeftness: 12
-  ModFinesse: 11
-  ModGatherExtraQuantity: 19
-  ModIngenuity: 29
-  ModInspiration: 9
-  ModMulticraft: 15
-  ModPerception: 13
-  ModResourcefulness: 10
-  ModSkillGain: 24
-  ModUnused_1: 16
-  ModUnused_2: 17
-  Skill: 0
-  StatCraftingSpeed: 6
-  StatDeftness: 4
-  StatFinesse: 3
-  StatIngenuity: 26
-  StatInspiration: 1
-  StatMulticraft: 7
-  StatPerception: 5
-  StatResourcefulness: 2
-  Tokenizer: 28
-  UnlockReagentSlot: 8
+  values:
+    AccumulateRanksByLabel: 25
+    ConcentrationRefund: 30
+    DecreaseDifficulty: 22
+    IncreaseDifficulty: 23
+    ModConcentration: 27
+    ModCraftCritSize: 20
+    ModCraftExtraQuantity: 18
+    ModCraftingSpeed: 14
+    ModCraftReductionQuantity: 21
+    ModDeftness: 12
+    ModFinesse: 11
+    ModGatherExtraQuantity: 19
+    ModIngenuity: 29
+    ModInspiration: 9
+    ModMulticraft: 15
+    ModPerception: 13
+    ModResourcefulness: 10
+    ModSkillGain: 24
+    ModUnused_1: 16
+    ModUnused_2: 17
+    Skill: 0
+    StatCraftingSpeed: 6
+    StatDeftness: 4
+    StatFinesse: 3
+    StatIngenuity: 26
+    StatInspiration: 1
+    StatMulticraft: 7
+    StatPerception: 5
+    StatResourcefulness: 2
+    Tokenizer: 28
+    UnlockReagentSlot: 8
 ProfessionRating:
-  CraftingSpeed: 5
-  Deftness: 3
-  Finesse: 2
-  Ingenuity: 7
-  Inspiration: 0
-  Multicraft: 6
-  Perception: 4
-  Resourcefulness: 1
-  Unused_2: 8
+  values:
+    CraftingSpeed: 5
+    Deftness: 3
+    Finesse: 2
+    Ingenuity: 7
+    Inspiration: 0
+    Multicraft: 6
+    Perception: 4
+    Resourcefulness: 1
+    Unused_2: 8
 ProfessionRatingType:
-  Craft: 0
-  Gather: 1
+  values:
+    Craft: 0
+    Gather: 1
 PurchaseEligibility:
-  ExpansionTooHigh: 4
-  ExpansionTooLow: 3
-  MissingRequiredDeliverable: 5
-  Ok: 0
-  Owned: 2
-  PartiallyOwned: 1
+  values:
+    ExpansionTooHigh: 4
+    ExpansionTooLow: 3
+    MissingRequiredDeliverable: 5
+    Ok: 0
+    Owned: 2
+    PartiallyOwned: 1
 PurchaseHouseDisabledReason:
-  CharterLockout: 7
-  GuildLockout: 6
-  MaxHouses: 8
-  NoExpansion: 4
-  NoGameTimeRemaining: 9
-  None: 0
-  NotInvited: 3
-  Reserved: 5
-  WrongFaction: 1
-  WrongGuild: 2
+  values:
+    CharterLockout: 7
+    GuildLockout: 6
+    MaxHouses: 8
+    NoExpansion: 4
+    NoGameTimeRemaining: 9
+    None: 0
+    NotInvited: 3
+    Reserved: 5
+    WrongFaction: 1
+    WrongGuild: 2
 PurchaseResult:
-  ErrorAuthorizingPayment: 37
-  ErrorBattlepayDisabled: 14
-  ErrorBattlepayTemporarilyUnavailable: 13
-  ErrorBattlepayTimeoutMopAndRisk: 11
-  ErrorBattlepayTimeoutValidatePurchase: 56
-  ErrorBattlepayTimeoutValidationHash: 62
-  ErrorBlockedByParentalControls: 33
-  ErrorBuyingProductNotAllowedInGlueScreen: 27
-  ErrorBuyingProductNotAllowedInWorld: 32
-  ErrorCharacterUpgradeOperationInProgress: 51
-  ErrorClientCheckoutCanceledOrFailed: 63
-  ErrorClientCheckoutTimeout: 60
-  ErrorClientDeclined: 4
-  ErrorClientDeclinedChallenge: 41
-  ErrorClientGone: 9
-  ErrorClientRestricted: 66
-  ErrorClientTimeout: 3
-  ErrorClientTimeoutChallenge: 40
-  ErrorCommerceServerDisabled: 48
-  ErrorCouldNotGetValidationHash: 64
-  ErrorCurrencyInvalidInRegion: 12
-  ErrorDistributionObjectAlreadyAssigned: 20
-  ErrorDistributionObjectExpansionBlocked: 45
-  ErrorDistributionObjectInvalidChoice: 35
-  ErrorDistributionObjectInvalidTarget: 42
-  ErrorDistributionObjectNotFound: 19
-  ErrorDistributionObjectTrialBlocked: 44
-  ErrorDistributionObjectWrongGameAccount: 65
-  ErrorFailedOldPurchaseFlow: 59
-  ErrorFailedToCreatePurchaseRecord: 5
-  ErrorFailedToGetPurchaseID: 6
-  ErrorFailedToSaveClientCheckoutStatus: 58
-  ErrorFailedToSaveMopAndRiskResponse: 8
-  ErrorFailedToSaveMopAndRiskStatus: 7
-  ErrorFailedToSavePlaceOrderStatus: 10
-  ErrorFailedToSaveRedeemTokenStatus: 67
-  ErrorFailedToSaveValidatePurchaseResponse: 55
-  ErrorFailedToSaveValidatePurchaseStatus: 54
-  ErrorFailedToSaveValidationHashStatus: 61
-  ErrorFailedToWriteVasLicenseID: 50
-  ErrorFailedToWriteVasPurchaseID: 49
-  ErrorFixedLicenseProductAlreadyExists: 43
-  ErrorInManualReview: 71
-  ErrorInvalidCreditCardExpiryDate: 36
-  ErrorInvalidDeviceID: 53
-  ErrorInvalidPlatform: 52
-  ErrorInvalidProduct: 16
-  ErrorInvalidPurchaseID: 68
-  ErrorInvalidRegionGroupMask: 17
-  ErrorMopAndRiskAmqpRpcFailed: 22
-  ErrorMopAndRiskNotEnoughBalance: 28
-  ErrorMopAndRiskNoValidPaymentMethods: 25
-  ErrorMopAndRiskRpcErrorFromBattlepay: 23
-  ErrorMopAndRiskUnexpectedResponseFromBattlepay: 24
-  ErrorNoStorePurchaseFlagIsSet: 34
-  ErrorOrderCanceledPriceChange: 26
-  ErrorOrderFailed: 2
-  ErrorOverSpendingLimit: 39
-  ErrorOwnsConsumableToken: 46
-  ErrorPaymentProviderDeniedPayment: 38
-  ErrorPlaceOrderNotEnoughBalance: 29
-  ErrorProductInvalidInRegion: 18
-  ErrorProductNotPurchasable: 57
-  ErrorProgrammerManualFail: 30
-  ErrorRiskDenied: 1
-  ErrorRiskResponseMissingScore: 21
-  ErrorServerRestarted: 15
-  ErrorThrottledByUserServer: 31
-  ErrorTokenRedemptionOrderFailed: 69
-  ErrorTooManyTokens: 47
-  ErrorVasTransactionCreateFailed: 70
-  Ok: 0
+  values:
+    ErrorAuthorizingPayment: 37
+    ErrorBattlepayDisabled: 14
+    ErrorBattlepayTemporarilyUnavailable: 13
+    ErrorBattlepayTimeoutMopAndRisk: 11
+    ErrorBattlepayTimeoutValidatePurchase: 56
+    ErrorBattlepayTimeoutValidationHash: 62
+    ErrorBlockedByParentalControls: 33
+    ErrorBuyingProductNotAllowedInGlueScreen: 27
+    ErrorBuyingProductNotAllowedInWorld: 32
+    ErrorCharacterUpgradeOperationInProgress: 51
+    ErrorClientCheckoutCanceledOrFailed: 63
+    ErrorClientCheckoutTimeout: 60
+    ErrorClientDeclined: 4
+    ErrorClientDeclinedChallenge: 41
+    ErrorClientGone: 9
+    ErrorClientRestricted: 66
+    ErrorClientTimeout: 3
+    ErrorClientTimeoutChallenge: 40
+    ErrorCommerceServerDisabled: 48
+    ErrorCouldNotGetValidationHash: 64
+    ErrorCurrencyInvalidInRegion: 12
+    ErrorDistributionObjectAlreadyAssigned: 20
+    ErrorDistributionObjectExpansionBlocked: 45
+    ErrorDistributionObjectInvalidChoice: 35
+    ErrorDistributionObjectInvalidTarget: 42
+    ErrorDistributionObjectNotFound: 19
+    ErrorDistributionObjectTrialBlocked: 44
+    ErrorDistributionObjectWrongGameAccount: 65
+    ErrorFailedOldPurchaseFlow: 59
+    ErrorFailedToCreatePurchaseRecord: 5
+    ErrorFailedToGetPurchaseID: 6
+    ErrorFailedToSaveClientCheckoutStatus: 58
+    ErrorFailedToSaveMopAndRiskResponse: 8
+    ErrorFailedToSaveMopAndRiskStatus: 7
+    ErrorFailedToSavePlaceOrderStatus: 10
+    ErrorFailedToSaveRedeemTokenStatus: 67
+    ErrorFailedToSaveValidatePurchaseResponse: 55
+    ErrorFailedToSaveValidatePurchaseStatus: 54
+    ErrorFailedToSaveValidationHashStatus: 61
+    ErrorFailedToWriteVasLicenseID: 50
+    ErrorFailedToWriteVasPurchaseID: 49
+    ErrorFixedLicenseProductAlreadyExists: 43
+    ErrorInManualReview: 71
+    ErrorInvalidCreditCardExpiryDate: 36
+    ErrorInvalidDeviceID: 53
+    ErrorInvalidPlatform: 52
+    ErrorInvalidProduct: 16
+    ErrorInvalidPurchaseID: 68
+    ErrorInvalidRegionGroupMask: 17
+    ErrorMopAndRiskAmqpRpcFailed: 22
+    ErrorMopAndRiskNotEnoughBalance: 28
+    ErrorMopAndRiskNoValidPaymentMethods: 25
+    ErrorMopAndRiskRpcErrorFromBattlepay: 23
+    ErrorMopAndRiskUnexpectedResponseFromBattlepay: 24
+    ErrorNoStorePurchaseFlagIsSet: 34
+    ErrorOrderCanceledPriceChange: 26
+    ErrorOrderFailed: 2
+    ErrorOverSpendingLimit: 39
+    ErrorOwnsConsumableToken: 46
+    ErrorPaymentProviderDeniedPayment: 38
+    ErrorPlaceOrderNotEnoughBalance: 29
+    ErrorProductInvalidInRegion: 18
+    ErrorProductNotPurchasable: 57
+    ErrorProgrammerManualFail: 30
+    ErrorRiskDenied: 1
+    ErrorRiskResponseMissingScore: 21
+    ErrorServerRestarted: 15
+    ErrorThrottledByUserServer: 31
+    ErrorTokenRedemptionOrderFailed: 69
+    ErrorTooManyTokens: 47
+    ErrorVasTransactionCreateFailed: 70
+    Ok: 0
 PvPFaction:
-  Alliance: 1
-  Horde: 0
+  values:
+    Alliance: 1
+    Horde: 0
 PvPMatchmakingType:
-  Arena: 1
-  Battleground: 0
+  values:
+    Arena: 1
+    Battleground: 0
 PvPMatchState:
-  Complete: 5
-  Engaged: 3
-  Inactive: 0
-  PostRound: 4
-  StartUp: 2
-  Waiting: 1
+  values:
+    Complete: 5
+    Engaged: 3
+    Inactive: 0
+    PostRound: 4
+    StartUp: 2
+    Waiting: 1
 PvPRanks:
-  Rank_1: 5
-  Rank_10: 14
-  Rank_11: 15
-  Rank_12: 16
-  Rank_13: 17
-  Rank_14: 18
-  Rank_2: 6
-  Rank_3: 7
-  Rank_4: 8
-  Rank_5: 9
-  Rank_6: 10
-  Rank_7: 11
-  Rank_8: 12
-  Rank_9: 13
-  RankDishonored: 4
-  RankExiled: 3
-  RankNone: 0
-  RankOutlaw: 2
-  RankPariah: 1
+  values:
+    Rank_1: 5
+    Rank_10: 14
+    Rank_11: 15
+    Rank_12: 16
+    Rank_13: 17
+    Rank_14: 18
+    Rank_2: 6
+    Rank_3: 7
+    Rank_4: 8
+    Rank_5: 9
+    Rank_6: 10
+    Rank_7: 11
+    Rank_8: 12
+    Rank_9: 13
+    RankDishonored: 4
+    RankExiled: 3
+    RankNone: 0
+    RankOutlaw: 2
+    RankPariah: 1
 PvPUnitClassification:
-  AssassinAlliance: 6
-  AssassinHorde: 5
-  CartRunnerAlliance: 4
-  CartRunnerHorde: 3
-  FlagCarrierAlliance: 1
-  FlagCarrierHorde: 0
-  FlagCarrierNeutral: 2
-  OrbCarrierBlue: 7
-  OrbCarrierGreen: 8
-  OrbCarrierOrange: 9
-  OrbCarrierPurple: 10
+  values:
+    AssassinAlliance: 6
+    AssassinHorde: 5
+    CartRunnerAlliance: 4
+    CartRunnerHorde: 3
+    FlagCarrierAlliance: 1
+    FlagCarrierHorde: 0
+    FlagCarrierNeutral: 2
+    OrbCarrierBlue: 7
+    OrbCarrierGreen: 8
+    OrbCarrierOrange: 9
+    OrbCarrierPurple: 10
 QuestClassification:
-  BonusObjective: 8
-  Calling: 3
-  Campaign: 2
-  Important: 0
-  Legendary: 1
-  Meta: 4
-  Normal: 7
-  Questline: 6
-  Recurring: 5
-  Threat: 9
-  WorldQuest: 10
+  values:
+    BonusObjective: 8
+    Calling: 3
+    Campaign: 2
+    Important: 0
+    Legendary: 1
+    Meta: 4
+    Normal: 7
+    Questline: 6
+    Recurring: 5
+    Threat: 9
+    WorldQuest: 10
 QuestCompleteSpellType:
-  Ability: 3
-  Aura: 4
-  Companion: 7
-  Follower: 1
-  LegacyBehavior: 0
-  PossibleReward: 11
-  QuestlineReward: 9
-  QuestlineUnlock: 8
-  QuestlineUnlockPart: 10
-  Spell: 5
-  Tradeskill: 2
-  Unlock: 6
+  values:
+    Ability: 3
+    Aura: 4
+    Companion: 7
+    Follower: 1
+    LegacyBehavior: 0
+    PossibleReward: 11
+    QuestlineReward: 9
+    QuestlineUnlock: 8
+    QuestlineUnlockPart: 10
+    Spell: 5
+    Tradeskill: 2
+    Unlock: 6
 QuestFrequency:
-  Daily: 1
-  Default: 0
-  ResetByScheduler: 3
-  Weekly: 2
+  values:
+    Daily: 1
+    Default: 0
+    ResetByScheduler: 3
+    Weekly: 2
 QuestLineFloorLocation:
-  Above: 0
-  Below: 1
-  Same: 2
+  values:
+    Above: 0
+    Below: 1
+    Same: 2
 QuestRepeatability:
-  Daily: 1
-  None: 0
-  Turnin: 3
-  Weekly: 2
-  World: 4
+  values:
+    Daily: 1
+    None: 0
+    Turnin: 3
+    Weekly: 2
+    World: 4
 QuestRewardContextFlags:
-  FirstCompletionBonus: 1
-  None: 0
-  RepeatCompletionBonus: 2
+  values:
+    FirstCompletionBonus: 1
+    None: 0
+    RepeatCompletionBonus: 2
 QuestSessionCommand:
-  None: 0
-  SessionActiveNoCommand: 3
-  Start: 1
-  Stop: 2
+  values:
+    None: 0
+    SessionActiveNoCommand: 3
+    Start: 1
+    Stop: 2
 QuestSessionResult:
-  AlreadyActive: 3
-  AlreadyJoined: 20
-  AlreadyMember: 17
-  AlreadyOwner: 19
-  Busy: 22
-  Disabled: 8
-  Empty: 25
-  InCombat: 32
-  InPetBattle: 29
-  InRaid: 5
-  InvalidOwner: 2
-  InvalidPublicParty: 30
-  Joined: 11
-  JoinRejected: 23
-  Left: 12
-  Logout: 24
-  MemberInCombat: 33
-  MemberTimeout: 16
-  NotActive: 4
-  NotInParty: 1
-  NotMember: 21
-  NotOwner: 18
-  Ok: 0
-  OwnerLeft: 13
-  OwnerRefused: 6
-  PartyDestroyed: 15
-  QuestNotCompleted: 26
-  ReadyCheckFailed: 14
-  Restricted: 28
-  RestrictedCrossFaction: 34
-  Resync: 27
-  Started: 9
-  Stopped: 10
-  Timeout: 7
-  Unknown: 31
+  values:
+    AlreadyActive: 3
+    AlreadyJoined: 20
+    AlreadyMember: 17
+    AlreadyOwner: 19
+    Busy: 22
+    Disabled: 8
+    Empty: 25
+    InCombat: 32
+    InPetBattle: 29
+    InRaid: 5
+    InvalidOwner: 2
+    InvalidPublicParty: 30
+    Joined: 11
+    JoinRejected: 23
+    Left: 12
+    Logout: 24
+    MemberInCombat: 33
+    MemberTimeout: 16
+    NotActive: 4
+    NotInParty: 1
+    NotMember: 21
+    NotOwner: 18
+    Ok: 0
+    OwnerLeft: 13
+    OwnerRefused: 6
+    PartyDestroyed: 15
+    QuestNotCompleted: 26
+    ReadyCheckFailed: 14
+    Restricted: 28
+    RestrictedCrossFaction: 34
+    Resync: 27
+    Started: 9
+    Stopped: 10
+    Timeout: 7
+    Unknown: 31
 QuestTag:
-  Account: 102
-  Delve: 288
-  Dungeon: 81
-  Group: 1
-  Heroic: 85
-  Legendary: 83
-  PvP: 41
-  Raid: 62
-  Raid10: 88
-  Raid25: 89
-  Scenario: 98
+  values:
+    Account: 102
+    Delve: 288
+    Dungeon: 81
+    Group: 1
+    Heroic: 85
+    Legendary: 83
+    PvP: 41
+    Raid: 62
+    Raid10: 88
+    Raid25: 89
+    Scenario: 98
 QuestTagType:
-  Bounty: 5
-  Capstone: 17
-  Contribution: 9
-  CovenantCalling: 15
-  DragonRiderRacing: 16
-  Dungeon: 6
-  FactionAssault: 12
-  Invasion: 7
-  InvasionWrapper: 11
-  Islands: 13
-  Normal: 2
-  PetBattle: 4
-  Prey: 19
-  Profession: 1
-  PvP: 3
-  Raid: 8
-  RatedReward: 10
-  Tag: 0
-  Threat: 14
-  WorldBoss: 18
+  values:
+    Bounty: 5
+    Capstone: 17
+    Contribution: 9
+    CovenantCalling: 15
+    DragonRiderRacing: 16
+    Dungeon: 6
+    FactionAssault: 12
+    Invasion: 7
+    InvasionWrapper: 11
+    Islands: 13
+    Normal: 2
+    PetBattle: 4
+    Prey: 19
+    Profession: 1
+    PvP: 3
+    Raid: 8
+    RatedReward: 10
+    Tag: 0
+    Threat: 14
+    WorldBoss: 18
 QuestTreasurePickerType:
-  Hidden: 1
-  Select: 2
-  Visible: 0
+  values:
+    Hidden: 1
+    Select: 2
+    Visible: 0
 RafLinkType:
-  Both: 3
-  Friend: 2
-  None: 0
-  Recruit: 1
+  values:
+    Both: 3
+    Friend: 2
+    None: 0
+    Recruit: 1
 RafRecruitActivityState:
-  Complete: 1
-  Incomplete: 0
-  RewardClaimed: 2
+  values:
+    Complete: 1
+    Incomplete: 0
+    RewardClaimed: 2
 RafRecruitSubStatus:
-  Active: 1
-  Inactive: 2
-  Trial: 0
+  values:
+    Active: 1
+    Inactive: 2
+    Trial: 0
 RafRewardType:
-  Appearance: 2
-  AppearanceSet: 5
-  GameTime: 4
-  Illusion: 6
-  Invalid: 7
-  Mount: 1
-  Pet: 0
-  Title: 3
+  values:
+    Appearance: 2
+    AppearanceSet: 5
+    GameTime: 4
+    Illusion: 6
+    Invalid: 7
+    Mount: 1
+    Pet: 0
+    Title: 3
 RaidAuraOrganizationType:
-  BuffsRightDebuffsLeft: 2
-  BuffsTopDebuffsBottom: 1
-  Legacy: 0
+  values:
+    BuffsRightDebuffsLeft: 2
+    BuffsTopDebuffsBottom: 1
+    Legacy: 0
 RaidDispelDisplayType:
-  Disabled: 0
-  DispellableByMe: 1
-  DisplayAll: 2
+  values:
+    Disabled: 0
+    DispellableByMe: 1
+    DisplayAll: 2
 RaidGroupDisplayType:
-  CombineGroupsHorizontal: 3
-  CombineGroupsVertical: 2
-  SeparateGroupsHorizontal: 1
-  SeparateGroupsVertical: 0
+  values:
+    CombineGroupsHorizontal: 3
+    CombineGroupsVertical: 2
+    SeparateGroupsHorizontal: 1
+    SeparateGroupsVertical: 0
 RcoCloseReason:
-  Cancel: 2
-  CrafterFulfill: 5
-  Expire: 1
-  Fulfill: 0
-  GmCancel: 4
-  Invalid: 6
-  Reject: 3
+  values:
+    Cancel: 2
+    CrafterFulfill: 5
+    Expire: 1
+    Fulfill: 0
+    GmCancel: 4
+    Invalid: 6
+    Reject: 3
 RecentAllyPinResult:
-  ServerError: 1
-  Success: 0
+  values:
+    ServerError: 1
+    Success: 0
 RecruitAFriendRewardsVersion:
-  InvalidVersion: 0
-  UnusedVersionOne: 1
-  VersionThree: 3
-  VersionTwo: 2
+  values:
+    InvalidVersion: 0
+    UnusedVersionOne: 1
+    VersionThree: 3
+    VersionTwo: 2
 ReforgeFailedReason:
-  None: 0
-  ReforgeAlreadyHasDstStat: 3
-  ReforgeInsufficientSrcStat: 2
-  ReforgeItemTooLowLevel: 4
-  ReforgeSrcStatNotFound: 1
+  values:
+    None: 0
+    ReforgeAlreadyHasDstStat: 3
+    ReforgeInsufficientSrcStat: 2
+    ReforgeItemTooLowLevel: 4
+    ReforgeSrcStatNotFound: 1
 RegisterAddonMessagePrefixResult:
-  DuplicatePrefix: 1
-  InvalidPrefix: 2
-  MaxPrefixes: 3
-  Success: 0
+  values:
+    DuplicatePrefix: 1
+    InvalidPrefix: 2
+    MaxPrefixes: 3
+    Success: 0
 RelativeContentDifficulty:
-  Difficult: 3
-  Easy: 1
-  Fair: 2
-  Impossible: 4
-  Trivial: 0
+  values:
+    Difficult: 3
+    Easy: 1
+    Fair: 2
+    Impossible: 4
+    Trivial: 0
 ReleaseType:
-  Classic: 2
-  Original: 1
+  values:
+    Classic: 2
+    Original: 1
 RenownRewardDisplayType:
-  Currency: 9
-  GarrFollower: 8
-  Item: 1
-  Mount: 3
-  None: 0
-  Spell: 2
-  Title: 7
-  Transmog: 4
-  TransmogIllusion: 6
-  TransmogSet: 5
+  values:
+    Currency: 9
+    GarrFollower: 8
+    Item: 1
+    Mount: 3
+    None: 0
+    Spell: 2
+    Title: 7
+    Transmog: 4
+    TransmogIllusion: 6
+    TransmogSet: 5
 RenownRewardsFlags:
-  AccountUnlock: 8
-  Capstone: 2
-  Hidden: 4
-  Milestone: 1
+  values:
+    AccountUnlock: 8
+    Capstone: 2
+    Hidden: 4
+    Milestone: 1
 ReportEvidenceType:
-  HouseLayoutJson: 2
-  HouseScreenshot: 1
-  Invalid: 0
+  values:
+    HouseLayoutJson: 2
+    HouseScreenshot: 1
+    Invalid: 0
 ReportMajorCategory:
-  Cheating: 2
-  GameplaySabotage: 1
-  InappropriateCommunication: 0
-  InappropriateDecor: 4
-  InappropriateName: 3
+  values:
+    Cheating: 2
+    GameplaySabotage: 1
+    InappropriateCommunication: 0
+    InappropriateDecor: 4
+    InappropriateName: 3
 ReportMinorCategory:
-  Advertisement: 256
-  Afk: 8
-  BlockingProgress: 32
-  Boosting: 2
-  Botting: 128
-  BTag: 512
-  CharacterName: 2048
-  ChildSexualExploitationAndAbuse: 262144
-  Description: 8192
-  Disruption: 65536
-  GroupName: 1024
-  GuildName: 4096
-  Hacking: 64
-  HarmfulToMinors: 32768
-  IntentionallyFeeding: 16
-  Name: 16384
-  NeighborhoodName: 524288
-  Spam: 4
-  TerroristAndViolentExtremistContent: 131072
-  TextChat: 1
+  values:
+    Advertisement: 256
+    Afk: 8
+    BlockingProgress: 32
+    Boosting: 2
+    Botting: 128
+    BTag: 512
+    CharacterName: 2048
+    ChildSexualExploitationAndAbuse: 262144
+    Description: 8192
+    Disruption: 65536
+    GroupName: 1024
+    GuildName: 4096
+    Hacking: 64
+    HarmfulToMinors: 32768
+    IntentionallyFeeding: 16
+    Name: 16384
+    NeighborhoodName: 524288
+    Spam: 4
+    TerroristAndViolentExtremistContent: 131072
+    TextChat: 1
 ReportSubComplaintTypes:
-  Advertising: 1
-  Inappropriate: 0
+  values:
+    Advertising: 1
+    Inappropriate: 0
 ReportThrottleType:
-  Expensive: 2
-  General: 1
-  Invalid: 0
+  values:
+    Expensive: 2
+    General: 1
+    Invalid: 0
 ReportType:
-  BattlePet: 10
-  Calendar: 11
-  Chat: 0
-  ClubFinderApplicant: 3
-  ClubFinderPosting: 2
-  ClubMember: 6
-  CraftingOrder: 16
-  Friend: 8
-  GroupFinderApplicant: 5
-  GroupFinderPosting: 4
-  GroupMember: 7
-  HousingDecor: 18
-  InWorld: 1
-  Mail: 12
-  Neighborhood: 19
-  NeighborhoodRoster: 20
-  Pet: 9
-  PvP: 13
-  PvPGroupMember: 15
-  PvPScoreboard: 14
-  RecentAlly: 17
+  values:
+    BattlePet: 10
+    Calendar: 11
+    Chat: 0
+    ClubFinderApplicant: 3
+    ClubFinderPosting: 2
+    ClubMember: 6
+    CraftingOrder: 16
+    Friend: 8
+    GroupFinderApplicant: 5
+    GroupFinderPosting: 4
+    GroupMember: 7
+    HousingDecor: 18
+    InWorld: 1
+    Mail: 12
+    Neighborhood: 19
+    NeighborhoodRoster: 20
+    Pet: 9
+    PvP: 13
+    PvPGroupMember: 15
+    PvPScoreboard: 14
+    RecentAlly: 17
 ReservationFlags:
-  Canceled: 2
-  None: 0
-  Plotless: 4
-  Relinquish: 1
+  values:
+    Canceled: 2
+    None: 0
+    Plotless: 4
+    Relinquish: 1
 ResidentType:
-  Manager: 1
-  Owner: 2
-  Resident: 0
+  values:
+    Manager: 1
+    Owner: 2
+    Resident: 0
 RestrictPingsTo:
-  Assist: 2
-  Lead: 1
-  None: 0
-  TankHealer: 3
+  values:
+    Assist: 2
+    Lead: 1
+    None: 0
+    TankHealer: 3
 RetroactiveDecorRewardFlags:
-  AllCriteriaRequired: 1
-  None: 0
+  values:
+    AllCriteriaRequired: 1
+    None: 0
 RolodexContextLevelType:
-  DelveTier: 3
-  Difficulty: 1
-  KeystoneLevel: 2
-  None: 0
+  values:
+    DelveTier: 3
+    Difficulty: 1
+    KeystoneLevel: 2
+    None: 0
 RolodexType:
-  CompleteArena: 16
-  CompleteBg: 17
-  CompleteDelve: 15
-  CompleteDungeon: 12
-  CreatureKill: 11
-  Duel: 18
-  GuildOrderFilledByOther: 9
-  GuildOrderFilledByYou: 10
-  KillLfrBoss: 14
-  KillRaidBoss: 13
-  None: 0
-  PartyMember: 1
-  PersonalOrderFilledByOther: 7
-  PersonalOrderFilledByYou: 8
-  PetBattle: 19
-  PublicOrderFilledByOther: 5
-  PublicOrderFilledByYou: 6
-  PvPKill: 20
-  RaidMember: 2
-  Trade: 3
-  Whisper: 4
+  values:
+    CompleteArena: 16
+    CompleteBg: 17
+    CompleteDelve: 15
+    CompleteDungeon: 12
+    CreatureKill: 11
+    Duel: 18
+    GuildOrderFilledByOther: 9
+    GuildOrderFilledByYou: 10
+    KillLfrBoss: 14
+    KillRaidBoss: 13
+    None: 0
+    PartyMember: 1
+    PersonalOrderFilledByOther: 7
+    PersonalOrderFilledByYou: 8
+    PetBattle: 19
+    PublicOrderFilledByOther: 5
+    PublicOrderFilledByYou: 6
+    PvPKill: 20
+    RaidMember: 2
+    Trade: 3
+    Whisper: 4
 RolodexTypeFlags:
-  HiddenFromHistory: 1
-  None: 0
+  values:
+    HiddenFromHistory: 1
+    None: 0
 RoomConnectionType:
-  All: 1
-  None: 0
+  values:
+    All: 1
+    None: 0
 ScalingArmorType:
-  Cloth: 0
-  Leather: 1
-  Mail: 2
-  Plate: 3
+  values:
+    Cloth: 0
+    Leather: 1
+    Mail: 2
+    Plate: 3
 ScreenLocationType:
-  Bottom: 4
-  Center: 0
-  Left: 1
-  LeftOutside: 7
-  LeftRight: 9
-  LeftRightOutside: 11
-  Right: 2
-  RightOutside: 8
-  Top: 3
-  TopBottom: 10
-  TopLeft: 5
-  TopRight: 6
+  values:
+    Bottom: 4
+    Center: 0
+    Left: 1
+    LeftOutside: 7
+    LeftRight: 9
+    LeftRightOutside: 11
+    Right: 2
+    RightOutside: 8
+    Top: 3
+    TopBottom: 10
+    TopLeft: 5
+    TopRight: 6
 ScreenshotSource:
-  Automatic: 0
-  Cheat: 2
-  PlayerReport: 1
+  values:
+    Automatic: 0
+    Cheat: 2
+    PlayerReport: 1
 ScriptedAnimationBehavior:
-  None: 0
-  SourceCollideWithTarget: 4
-  SourceRecoil: 3
-  TargetKnockBack: 2
-  TargetShake: 1
-  UIParentShake: 5
+  values:
+    None: 0
+    SourceCollideWithTarget: 4
+    SourceRecoil: 3
+    TargetKnockBack: 2
+    TargetShake: 1
+    UIParentShake: 5
 ScriptedAnimationFlags:
-  UseTargetAsSource: 1
+  values:
+    UseTargetAsSource: 1
 ScriptedAnimationTrajectory:
-  AtSource: 0
-  AtTarget: 1
-  CurveLeft: 3
-  CurveRandom: 5
-  CurveRight: 4
-  HalfwayBetween: 6
-  Straight: 2
+  values:
+    AtSource: 0
+    AtTarget: 1
+    CurveLeft: 3
+    CurveRandom: 5
+    CurveRight: 4
+    HalfwayBetween: 6
+    Straight: 2
 ScrubStringFlags:
-  AllowBarCodes: 2
-  None: 0
-  StripControlCodes: 4
-  TruncateNewLines: 1
+  values:
+    AllowBarCodes: 2
+    None: 0
+    StripControlCodes: 4
+    TruncateNewLines: 1
 SeasonID:
-  Fresh: 11
-  FreshHardcore: 12
-  Hardcore: 3
-  NoSeason: 0
-  SeasonOfDiscovery: 2
-  SeasonOfMastery: 1
+  values:
+    Fresh: 11
+    FreshHardcore: 12
+    Hardcore: 3
+    NoSeason: 0
+    SeasonOfDiscovery: 2
+    SeasonOfMastery: 1
 SecondsFormatterAbbreviation:
-  None: 0
-  OneLetter: 2
-  Truncate: 1
+  values:
+    None: 0
+    OneLetter: 2
+    Truncate: 1
 SecondsFormatterInterval:
-  Days: 3
-  Hours: 2
-  Minutes: 1
-  Seconds: 0
+  values:
+    Days: 3
+    Hours: 2
+    Minutes: 1
+    Seconds: 0
 SecondsFormatterIntervalWhitespace:
-  Preserve: 0
-  Strip: 1
-  StripIgnoreLocale: 2
+  values:
+    Preserve: 0
+    Strip: 1
+    StripIgnoreLocale: 2
 SecrecyLevel:
-  AlwaysSecret: 1
-  ContextuallySecret: 2
-  NeverSecret: 0
+  values:
+    AlwaysSecret: 1
+    ContextuallySecret: 2
+    NeverSecret: 0
 SecretAspect:
-  Alpha: 128
-  Attributes: 1
-  BarValue: 16384
-  ButtonState: 2097152
-  Cooldown: 32768
-  CooldownStyle: 524288
-  Cursor: 1024
-  Desaturation: 4096
-  FrameLevel: 256
-  Hierarchy: 1
-  ID: 2
-  MinimumWidth: 131072
-  ObjectDebug: 1
-  ObjectName: 1
-  ObjectSecrets: 1
-  ObjectSecurity: 1
-  ObjectType: 1
-  Padding: 262144
-  Rotation: 65536
-  Scale: 64
-  ScrollOffset: 4194304
-  ScrollRange: 512
-  SecureText: 16
-  Shown: 32
-  TexCoords: 8192
-  Text: 8
-  TooltipTexture: 1048576
-  Toplevel: 4
-  VertexColor: 2048
+  values:
+    Alpha: 128
+    Attributes: 1
+    BarValue: 16384
+    ButtonState: 2097152
+    Cooldown: 32768
+    CooldownStyle: 524288
+    Cursor: 1024
+    Desaturation: 4096
+    FrameLevel: 256
+    Hierarchy: 1
+    ID: 2
+    MinimumWidth: 131072
+    ObjectDebug: 1
+    ObjectName: 1
+    ObjectSecrets: 1
+    ObjectSecurity: 1
+    ObjectType: 1
+    Padding: 262144
+    Rotation: 65536
+    Scale: 64
+    ScrollOffset: 4194304
+    ScrollRange: 512
+    SecureText: 16
+    Shown: 32
+    TexCoords: 8192
+    Text: 8
+    TooltipTexture: 1048576
+    Toplevel: 4
+    VertexColor: 2048
 SelfResurrectOptionType:
-  Item: 1
-  Spell: 0
+  values:
+    Item: 1
+    Spell: 0
 SendAddonMessageResult:
-  AddOnMessageLockdown: 11
-  AddonMessageThrottle: 3
-  ChannelThrottle: 8
-  GeneralError: 9
-  InvalidChannel: 7
-  InvalidChatType: 4
-  InvalidMessage: 2
-  InvalidPrefix: 1
-  NotInGroup: 5
-  NotInGuild: 10
-  Success: 0
-  TargetOffline: 12
-  TargetRequired: 6
+  values:
+    AddOnMessageLockdown: 11
+    AddonMessageThrottle: 3
+    ChannelThrottle: 8
+    GeneralError: 9
+    InvalidChannel: 7
+    InvalidChatType: 4
+    InvalidMessage: 2
+    InvalidPrefix: 1
+    NotInGroup: 5
+    NotInGuild: 10
+    Success: 0
+    TargetOffline: 12
+    TargetRequired: 6
 SendReportResult:
-  GeneralError: 1
-  RequiresChatLine: 3
-  RequiresChatLineOrVoice: 4
-  RequiresScreenshot: 5
-  Success: 0
-  TooManyReports: 2
+  values:
+    GeneralError: 1
+    RequiresChatLine: 3
+    RequiresChatLineOrVoice: 4
+    RequiresScreenshot: 5
+    Success: 0
+    TooManyReports: 2
 SharedStringFlag:
-  InternalOnly: 1
+  values:
+    InternalOnly: 1
 ShutdownSessionReason:
-  AccountLoginCommand: 4
-  Error: 6
-  ForceLogoutCommand: 2
-  LuaScript: 5
-  RealmSelectCommand: 3
-  RestartSessionCommand: 1
-  SessionEnded: 0
+  values:
+    AccountLoginCommand: 4
+    Error: 6
+    ForceLogoutCommand: 2
+    LuaScript: 5
+    RealmSelectCommand: 3
+    RestartSessionCommand: 1
+    SessionEnded: 0
 Siflag:
-  Affectedbyaltitude: 16
-  Affectedbysanity: 2048
-  AutocreatedByBroadcastText: 4
-  CasterOwnsTargetSound: 128
-  Disablepositionallpf: 1
-  Dontplayindoors: 256
-  Dontplayunderwater: 1024
-  Dontstopondeath: 4096
-  Ignoresuppressors: 64
-  Ignorevopriority: 16384
-  Looping: 512
-  Noduplicates: 32
-  None: 0
-  Onlyplayindoors: 32768
-  Onlyplayunderwater: 65536
-  Playonlyforowner: 8192
-  Playsequential: 8
-  UseModCastSpeed: 2
+  values:
+    Affectedbyaltitude: 16
+    Affectedbysanity: 2048
+    AutocreatedByBroadcastText: 4
+    CasterOwnsTargetSound: 128
+    Disablepositionallpf: 1
+    Dontplayindoors: 256
+    Dontplayunderwater: 1024
+    Dontstopondeath: 4096
+    Ignoresuppressors: 64
+    Ignorevopriority: 16384
+    Looping: 512
+    Noduplicates: 32
+    None: 0
+    Onlyplayindoors: 32768
+    Onlyplayunderwater: 65536
+    Playonlyforowner: 8192
+    Playsequential: 8
+    UseModCastSpeed: 2
 SimpleOrderStatus:
-  Creating: 1
-  Failed: 4
-  InProgress: 2
-  Invalid: 0
-  Success: 3
+  values:
+    Creating: 1
+    Failed: 4
+    InProgress: 2
+    Invalid: 0
+    Success: 3
 SleevesGeoRange:
-  Default: 1
-  Flared: 2
-  None: 0
-  PandaCollar: 4
-  Puffy: 3
+  values:
+    Default: 1
+    Flared: 2
+    None: 0
+    PandaCollar: 4
+    Puffy: 3
 SlotRegion:
-  AccountBank: 5
-  CharacterBank: 4
-  Invalid: 0
-  PlayerBags: 2
-  PlayerEquip: 1
-  PlayerInv: 3
+  values:
+    AccountBank: 5
+    CharacterBank: 4
+    Invalid: 0
+    PlayerBags: 2
+    PlayerEquip: 1
+    PlayerInv: 3
 SlotRegionMask:
-  AccountBank: 64
-  CharacterBank: 16
-  Invalid: 1
-  PlayerBags: 4
-  PlayerEquip: 2
-  PlayerInv: 8
+  values:
+    AccountBank: 64
+    CharacterBank: 16
+    Invalid: 1
+    PlayerBags: 4
+    PlayerEquip: 2
+    PlayerInv: 8
 SocialWhoOrigin:
-  Chat: 2
-  Item: 3
-  Social: 1
-  Unknown: 0
+  values:
+    Chat: 2
+    Item: 3
+    Social: 1
+    Unknown: 0
 SoftTargetEnableFlags:
-  Any: 3
-  Gamepad: 1
-  Kbm: 2
-  None: 0
+  values:
+    Any: 3
+    Gamepad: 1
+    Kbm: 2
+    None: 0
 SortPlayersBy:
-  Alphabetical: 2
-  Group: 1
-  Role: 0
+  values:
+    Alphabetical: 2
+    Group: 1
+    Role: 0
 SoundBusFlag:
-  Disablepositionallpf: 1
+  values:
+    Disablepositionallpf: 1
 SpecializationSystem:
-  ChrSpecialization: 1
-  TalentTab: 0
+  values:
+    ChrSpecialization: 1
+    TalentTab: 0
 SpellAuraVisibilityType:
-  EnemyTarget: 2
-  RaidInCombat: 0
-  RaidOutOfCombat: 1
+  values:
+    EnemyTarget: 2
+    RaidInCombat: 0
+    RaidOutOfCombat: 1
 SpellBookItemType:
-  Flyout: 4
-  FutureSpell: 2
-  None: 0
-  PetAction: 3
-  Spell: 1
+  values:
+    Flyout: 4
+    FutureSpell: 2
+    None: 0
+    PetAction: 3
+    Spell: 1
 SpellBookSpellBank:
-  Pet: 1
-  Player: 0
+  values:
+    Pet: 1
+    Player: 0
 SpellDiminishCategory:
-  AoEKnockback: 3
-  Disarm: 7
-  Disorient: 5
-  Incapacitate: 4
-  Root: 0
-  Silence: 6
-  Stun: 2
-  Taunt: 1
+  values:
+    AoEKnockback: 3
+    Disarm: 7
+    Disorient: 5
+    Incapacitate: 4
+    Root: 0
+    Silence: 6
+    Stun: 2
+    Taunt: 1
 SpellDiminishRuleset:
-  None: 0
-  PvE: 1
-  PvP: 2
+  values:
+    None: 0
+    PvE: 1
+    PvP: 2
 SpellDisplayBorderColor:
-  Black: 1
-  Blue: 8
-  Green: 7
-  None: 0
-  Orange: 5
-  Purple: 6
-  Red: 3
-  White: 2
-  Yellow: 4
+  values:
+    Black: 1
+    Blue: 8
+    Green: 7
+    None: 0
+    Orange: 5
+    Purple: 6
+    Red: 3
+    White: 2
+    Yellow: 4
 SpellDisplayIconDisplayType:
-  Buff: 0
-  Circular: 2
-  Debuff: 1
-  NoBorder: 3
+  values:
+    Buff: 0
+    Circular: 2
+    Debuff: 1
+    NoBorder: 3
 SpellDisplayTextShownStateType:
-  Hidden: 1
-  Shown: 0
+  values:
+    Hidden: 1
+    Shown: 0
 SpellDisplayTint:
-  None: 0
-  Red: 1
+  values:
+    None: 0
+    Red: 1
 SplashScreenType:
-  SeasonRollOver: 1
-  WhatsNew: 0
+  values:
+    SeasonRollOver: 1
+    WhatsNew: 0
 StableResult:
-  AlreadyStabled: 5
-  AlreadySummoned: 6
-  BuySlotSuccess: 14
-  CantControlExotic: 11
-  CheckForLuaHack: 13
-  FavoriteToggle: 15
-  InsufficientFunds: 1
-  InternalError: 12
-  InvalidSlot: 3
-  MaxSlots: 0
-  NoPet: 4
-  NotFound: 7
-  NotStableMaster: 2
-  PetRenamed: 16
-  ReviveSuccess: 10
-  StableSuccess: 8
-  UnstableSuccess: 9
+  values:
+    AlreadyStabled: 5
+    AlreadySummoned: 6
+    BuySlotSuccess: 14
+    CantControlExotic: 11
+    CheckForLuaHack: 13
+    FavoriteToggle: 15
+    InsufficientFunds: 1
+    InternalError: 12
+    InvalidSlot: 3
+    MaxSlots: 0
+    NoPet: 4
+    NotFound: 7
+    NotStableMaster: 2
+    PetRenamed: 16
+    ReviveSuccess: 10
+    StableSuccess: 8
+    UnstableSuccess: 9
 StartTimerType:
-  ChallengeModeCountdown: 1
-  PlayerCountdown: 2
-  PlunderstormCountdown: 3
-  PvPBeginTimer: 0
+  values:
+    ChallengeModeCountdown: 1
+    PlayerCountdown: 2
+    PlunderstormCountdown: 3
+    PvPBeginTimer: 0
 StatusBarColorTintValue:
-  Black: 1
-  Blue: 8
-  Green: 7
-  None: 0
-  Orange: 5
-  Purple: 6
-  Red: 3
-  White: 2
-  Yellow: 4
+  values:
+    Black: 1
+    Blue: 8
+    Green: 7
+    None: 0
+    Orange: 5
+    Purple: 6
+    Red: 3
+    White: 2
+    Yellow: 4
 StatusBarFillStyle:
-  Center: 2
-  Reverse: 3
-  Standard: 0
-  StandardNoRangeFill: 1
+  values:
+    Center: 2
+    Reverse: 3
+    Standard: 0
+    StandardNoRangeFill: 1
 StatusBarInterpolation:
-  ExponentialEaseOut: 1
-  Immediate: 0
+  values:
+    ExponentialEaseOut: 1
+    Immediate: 0
 StatusBarOverrideBarTextShownType:
-  Always: 1
-  Never: 0
-  OnlyNotOnMouseover: 3
-  OnlyOnMouseover: 2
+  values:
+    Always: 1
+    Never: 0
+    OnlyNotOnMouseover: 3
+    OnlyOnMouseover: 2
 StatusBarTimerDirection:
-  ElapsedTime: 0
-  RemainingTime: 1
+  values:
+    ElapsedTime: 0
+    RemainingTime: 1
 StatusBarValueTextType:
-  Hidden: 0
-  Percentage: 1
-  Time: 3
-  TimeShowOneLevelOnly: 4
-  Value: 2
-  ValueOverMax: 5
-  ValueOverMaxNormalized: 6
+  values:
+    Hidden: 0
+    Percentage: 1
+    Time: 3
+    TimeShowOneLevelOnly: 4
+    Value: 2
+    ValueOverMax: 5
+    ValueOverMaxNormalized: 6
 StoreDeliveryType:
-  Battlepet: 2
-  Collection: 3
-  Item: 0
-  Mount: 1
+  values:
+    Battlepet: 2
+    Collection: 3
+    Item: 0
+    Mount: 1
 StoreError:
-  AlreadyOwned: 7
-  BattlepayDisabled: 4
-  ClientRestricted: 13
-  ConsumableTokenOwned: 10
-  InsufficientBalance: 5
-  InvalidPaymentMethod: 1
-  ItemUnavailable: 12
-  Other: 6
-  ParentalControlsNoPurchase: 8
-  PaymentFailed: 2
-  PurchaseDenied: 9
-  Success: 0
-  TooManyTokens: 11
-  WrongCurrency: 3
+  values:
+    AlreadyOwned: 7
+    BattlepayDisabled: 4
+    ClientRestricted: 13
+    ConsumableTokenOwned: 10
+    InsufficientBalance: 5
+    InvalidPaymentMethod: 1
+    ItemUnavailable: 12
+    Other: 6
+    ParentalControlsNoPurchase: 8
+    PaymentFailed: 2
+    PurchaseDenied: 9
+    Success: 0
+    TooManyTokens: 11
+    WrongCurrency: 3
 SubcontainerType:
-  AccountBankTabs: 36
-  Auction: 5
-  Bag: 0
-  Bankbag: 3
-  Bankgeneric: 2
-  BuybackSlots: 26
-  CachedReward: 27
-  CharacterBankTabs: 38
-  Childequipmentstorage: 23
-  CraftingOrder: 34
-  CraftingOrderReagents: 35
-  CreatedImmediately: 25
-  CurrencytokenOboslete: 15
-  CurrencyTransfer: 37
-  Equipablespells: 14
-  Equipped: 1
-  EquippedBags: 28
-  EquippedCooking: 31
-  EquippedFishing: 32
-  EquippedProfession1: 29
-  EquippedProfession2: 30
-  EquippedReagentbag: 33
-  GuildBank0: 7
-  GuildBank1: 8
-  GuildBank10: 20
-  GuildBank11: 21
-  GuildBank2: 9
-  GuildBank3: 10
-  GuildBank4: 11
-  GuildBank5: 12
-  GuildBank6: 16
-  GuildBank7: 17
-  GuildBank8: 18
-  GuildBank9: 19
-  GuildOverflow: 13
-  HousingDecorConversion: 39
-  Keyring: 6
-  Mail: 4
-  Quarantine: 24
-  ReagentbankObsolete: 22
+  values:
+    AccountBankTabs: 36
+    Auction: 5
+    Bag: 0
+    Bankbag: 3
+    Bankgeneric: 2
+    BuybackSlots: 26
+    CachedReward: 27
+    CharacterBankTabs: 38
+    Childequipmentstorage: 23
+    CraftingOrder: 34
+    CraftingOrderReagents: 35
+    CreatedImmediately: 25
+    CurrencytokenOboslete: 15
+    CurrencyTransfer: 37
+    Equipablespells: 14
+    Equipped: 1
+    EquippedBags: 28
+    EquippedCooking: 31
+    EquippedFishing: 32
+    EquippedProfession1: 29
+    EquippedProfession2: 30
+    EquippedReagentbag: 33
+    GuildBank0: 7
+    GuildBank1: 8
+    GuildBank10: 20
+    GuildBank11: 21
+    GuildBank2: 9
+    GuildBank3: 10
+    GuildBank4: 11
+    GuildBank5: 12
+    GuildBank6: 16
+    GuildBank7: 17
+    GuildBank8: 18
+    GuildBank9: 19
+    GuildOverflow: 13
+    HousingDecorConversion: 39
+    Keyring: 6
+    Mail: 4
+    Quarantine: 24
+    ReagentbankObsolete: 22
 SummonReason:
-  Scenario: 1
-  Spell: 0
+  values:
+    Scenario: 1
+    Spell: 0
 SummonStatus:
-  Accepted: 2
-  Declined: 3
-  None: 0
-  Pending: 1
+  values:
+    Accepted: 2
+    Declined: 3
+    None: 0
+    Pending: 1
 SurveyDeliveryFlags:
-  EncounterSucccessOnly: 1
-  None: 0
+  values:
+    EncounterSucccessOnly: 1
+    None: 0
 SurveyDeliveryMoment:
-  ChestLooted: 3
-  EncounterEnd: 5
-  Login: 0
-  MythicPlusCompleted: 4
-  ProfessionTable: 1
-  QuestTurnIn: 2
+  values:
+    ChestLooted: 3
+    EncounterEnd: 5
+    Login: 0
+    MythicPlusCompleted: 4
+    ProfessionTable: 1
+    QuestTurnIn: 2
 TableSecurityOption:
-  DisallowSecretKeys: 1
-  DisallowTaintedAccess: 0
-  SecretWrapContents: 2
+  values:
+    DisallowSecretKeys: 1
+    DisallowTaintedAccess: 0
+    SecretWrapContents: 2
 TieredEntranceType:
-  Delve: 1
-  Invalid: 0
-  Sites: 2
-  WorldTier: 3
+  values:
+    Delve: 1
+    Invalid: 0
+    Sites: 2
+    WorldTier: 3
 TimeEventFlag:
-  GlueScreenShortcut: 1
+  values:
+    GlueScreenShortcut: 1
 TitleIconVersion:
-  Large: 2
-  Medium: 1
-  Small: 0
+  values:
+    Large: 2
+    Medium: 1
+    Small: 0
 TooltipComparisonMethod:
-  Single: 0
-  WithBagMainHandItem: 2
-  WithBagOffHandItem: 3
-  WithBothHands: 1
+  values:
+    Single: 0
+    WithBagMainHandItem: 2
+    WithBagOffHandItem: 3
+    WithBothHands: 1
 TooltipDataItemBinding:
-  Account: 1
-  AccountUntilEquipped: 9
-  BindOnEquip: 7
-  BindOnPickup: 6
-  BindOnUse: 8
-  BindToAccount: 4
-  BindToAccountUntilEquipped: 10
-  BindToBnetAccount: 5
-  BnetAccount: 2
-  Quest: 0
-  Soulbound: 3
+  values:
+    Account: 1
+    AccountUntilEquipped: 9
+    BindOnEquip: 7
+    BindOnPickup: 6
+    BindOnUse: 8
+    BindToAccount: 4
+    BindToAccountUntilEquipped: 10
+    BindToBnetAccount: 5
+    BnetAccount: 2
+    Quest: 0
+    Soulbound: 3
 TooltipDataLineType:
-  AzeriteEssencePower: 5
-  AzeriteEssenceSlot: 4
-  AzeriteItemPowerDescription: 9
-  Blank: 1
-  CurrencyTotal: 14
-  DisabledLine: 42
-  EquipSlot: 21
-  ErrorLine: 41
-  FlavorText: 37
-  GemSocket: 3
-  GemSocketEnchantment: 30
-  ItemBinding: 20
-  ItemEnchantmentPermanent: 15
-  ItemLevel: 31
-  ItemName: 22
-  ItemQuality: 35
-  ItemSpellTriggerLearn: 38
-  ItemUpgradeLevel: 32
-  LearnableSpell: 6
-  LearnTransmogIllusion: 40
-  LearnTransmogSet: 39
-  NestedBlock: 19
-  None: 0
-  ProfessionCraftingQuality: 12
-  QuestObjective: 8
-  QuestPlayer: 18
-  QuestTitle: 17
-  RuneforgeLegendaryPowerDescription: 10
-  SellPrice: 11
-  Separator: 23
-  SpellDescription: 34
-  SpellName: 13
-  SpellPassive: 33
-  ToyDescription: 28
-  ToyDuration: 27
-  ToyEffect: 26
-  ToyName: 24
-  ToySource: 29
-  ToyText: 25
-  TradeTimeRemaining: 36
-  UnitName: 2
-  UnitOwner: 16
-  UnitThreat: 7
-  UsageRequirement: 43
+  values:
+    AzeriteEssencePower: 5
+    AzeriteEssenceSlot: 4
+    AzeriteItemPowerDescription: 9
+    Blank: 1
+    CurrencyTotal: 14
+    DisabledLine: 42
+    EquipSlot: 21
+    ErrorLine: 41
+    FlavorText: 37
+    GemSocket: 3
+    GemSocketEnchantment: 30
+    ItemBinding: 20
+    ItemEnchantmentPermanent: 15
+    ItemLevel: 31
+    ItemName: 22
+    ItemQuality: 35
+    ItemSpellTriggerLearn: 38
+    ItemUpgradeLevel: 32
+    LearnableSpell: 6
+    LearnTransmogIllusion: 40
+    LearnTransmogSet: 39
+    NestedBlock: 19
+    None: 0
+    ProfessionCraftingQuality: 12
+    QuestObjective: 8
+    QuestPlayer: 18
+    QuestTitle: 17
+    RuneforgeLegendaryPowerDescription: 10
+    SellPrice: 11
+    Separator: 23
+    SpellDescription: 34
+    SpellName: 13
+    SpellPassive: 33
+    ToyDescription: 28
+    ToyDuration: 27
+    ToyEffect: 26
+    ToyName: 24
+    ToySource: 29
+    ToyText: 25
+    TradeTimeRemaining: 36
+    UnitName: 2
+    UnitOwner: 16
+    UnitThreat: 7
+    UsageRequirement: 43
 TooltipDataType:
-  Achievement: 12
-  AzeriteEssence: 8
-  BattlePet: 6
-  CompanionPet: 9
-  Corpse: 3
-  CorruptionCleanser: 20
-  Currency: 5
-  Debug: 26
-  EnhancedConduit: 13
-  EquipmentSet: 14
-  Flyout: 22
-  InstanceLock: 15
-  Item: 0
-  Macro: 25
-  MinimapMouseover: 21
-  Mount: 10
-  Object: 4
-  Outfit: 27
-  PetAction: 11
-  PvPBrawl: 16
-  Quest: 23
-  QuestPartyProgress: 24
-  RecipeRankInfo: 17
-  Spell: 1
-  Totem: 18
-  Toy: 19
-  Unit: 2
-  UnitAura: 7
+  values:
+    Achievement: 12
+    AzeriteEssence: 8
+    BattlePet: 6
+    CompanionPet: 9
+    Corpse: 3
+    CorruptionCleanser: 20
+    Currency: 5
+    Debug: 26
+    EnhancedConduit: 13
+    EquipmentSet: 14
+    Flyout: 22
+    InstanceLock: 15
+    Item: 0
+    Macro: 25
+    MinimapMouseover: 21
+    Mount: 10
+    Object: 4
+    Outfit: 27
+    PetAction: 11
+    PvPBrawl: 16
+    Quest: 23
+    QuestPartyProgress: 24
+    RecipeRankInfo: 17
+    Spell: 1
+    Totem: 18
+    Toy: 19
+    Unit: 2
+    UnitAura: 7
 TooltipDataUsageRequirementType:
-  Achievement: 7
-  ArenaRating: 11
-  EarnCurrency: 12
-  EquippedItem: 9
-  Faction: 1
-  Guild: 6
-  Level: 5
-  NotAlreadyKnown: 14
-  NotInArena: 15
-  NotInRatedBg: 16
-  PvPMedal: 3
-  PvPRank: 8
-  RaceClass: 0
-  Reputation: 4
-  ShapeshiftForm: 10
-  Skill: 2
-  Specialization: 13
+  values:
+    Achievement: 7
+    ArenaRating: 11
+    EarnCurrency: 12
+    EquippedItem: 9
+    Faction: 1
+    Guild: 6
+    Level: 5
+    NotAlreadyKnown: 14
+    NotInArena: 15
+    NotInRatedBg: 16
+    PvPMedal: 3
+    PvPRank: 8
+    RaceClass: 0
+    Reputation: 4
+    ShapeshiftForm: 10
+    Skill: 2
+    Specialization: 13
 TooltipSide:
-  Bottom: 3
-  Left: 0
-  Right: 1
-  Top: 2
+  values:
+    Bottom: 3
+    Left: 0
+    Right: 1
+    Top: 2
 TooltipTextureAnchor:
-  All: 6
-  LeftBottom: 2
-  LeftCenter: 1
-  LeftTop: 0
-  RightBottom: 5
-  RightCenter: 4
-  RightTop: 3
+  values:
+    All: 6
+    LeftBottom: 2
+    LeftCenter: 1
+    LeftTop: 0
+    RightBottom: 5
+    RightCenter: 4
+    RightTop: 3
 TooltipTextureRelativeRegion:
-  LeftLine: 0
-  RightLine: 1
+  values:
+    LeftLine: 0
+    RightLine: 1
 TrackedSpellCategory:
-  Debuff: 3
-  Defensive: 2
-  None: 0
-  Offensive: 1
-  RacialAbility: 4
+  values:
+    Debuff: 3
+    Defensive: 2
+    None: 0
+    Offensive: 1
+    RacialAbility: 4
 TradeskillRelativeDifficulty:
-  Easy: 2
-  Medium: 1
-  Optimal: 0
-  Trivial: 3
+  values:
+    Easy: 2
+    Medium: 1
+    Optimal: 0
+    Trivial: 3
 TraitCombatConfigFlags:
-  ActiveForSpec: 1
-  SharedActionBars: 4
-  StarterBuild: 2
+  values:
+    ActiveForSpec: 1
+    SharedActionBars: 4
+    StarterBuild: 2
 TraitCondFlag:
-  IsAlwaysMet: 2
-  IsGate: 1
-  IsSufficient: 4
+  values:
+    IsAlwaysMet: 2
+    IsGate: 1
+    IsSufficient: 4
 TraitConditionType:
-  Available: 0
-  DisplayError: 4
-  Granted: 2
-  Increased: 3
-  RanksAllowed: 5
-  Visible: 1
+  values:
+    Available: 0
+    DisplayError: 4
+    Granted: 2
+    Increased: 3
+    RanksAllowed: 5
+    Visible: 1
 TraitConfigDbState:
-  Created: 1
-  Deleted: 3
-  Ready: 0
-  Removed: 2
+  values:
+    Created: 1
+    Deleted: 3
+    Ready: 0
+    Removed: 2
 TraitConfigType:
-  Combat: 1
-  Generic: 3
-  Invalid: 0
-  Profession: 2
+  values:
+    Combat: 1
+    Generic: 3
+    Invalid: 0
+    Profession: 2
 TraitCurrencyFlag:
-  ShowQuantityAsSpent: 1
-  TraitSourcedShowMax: 2
-  UseClassIcon: 4
-  UseSpecIcon: 8
+  values:
+    ShowQuantityAsSpent: 1
+    TraitSourcedShowMax: 2
+    UseClassIcon: 4
+    UseSpecIcon: 8
 TraitCurrencyType:
-  CurrencyTypesBased: 1
-  Gold: 0
-  TraitSourced: 2
-  TraitSourcedPlayerDataElement: 3
+  values:
+    CurrencyTypesBased: 1
+    Gold: 0
+    TraitSourced: 2
+    TraitSourcedPlayerDataElement: 3
 TraitDefinitionSubType:
-  DragonflightBlack: 4
-  DragonflightBlue: 1
-  DragonflightBronze: 3
-  DragonflightGreen: 2
-  DragonflightRed: 0
+  values:
+    DragonflightBlack: 4
+    DragonflightBlue: 1
+    DragonflightBronze: 3
+    DragonflightGreen: 2
+    DragonflightRed: 0
 TraitEdgeType:
-  DeprecatedRankConnection: 1
-  DeprecatedSelectionOption: 5
-  MutuallyExclusive: 4
-  RequiredForAvailability: 3
-  SufficientForAvailability: 2
-  VisualOnly: 0
+  values:
+    DeprecatedRankConnection: 1
+    DeprecatedSelectionOption: 5
+    MutuallyExclusive: 4
+    RequiredForAvailability: 3
+    SufficientForAvailability: 2
+    VisualOnly: 0
 TraitEdgeVisualStyle:
-  None: 0
-  Straight: 1
+  values:
+    None: 0
+    Straight: 1
 TraitNodeEntryType:
-  ArmorSet: 11
-  DeprecatedSelect: 4
-  DragAndDrop: 5
-  ProfPath: 7
-  ProfPathUnlock: 9
-  ProfPerk: 8
-  RedButton: 10
-  SpendCapstoneCircle: 13
-  SpendCapstoneSquare: 14
-  SpendCircle: 2
-  SpendDiamond: 6
-  SpendHex: 0
-  SpendInfinite: 12
-  SpendSmallCircle: 3
-  SpendSquare: 1
+  values:
+    ArmorSet: 11
+    DeprecatedSelect: 4
+    DragAndDrop: 5
+    ProfPath: 7
+    ProfPathUnlock: 9
+    ProfPerk: 8
+    RedButton: 10
+    SpendCapstoneCircle: 13
+    SpendCapstoneSquare: 14
+    SpendCircle: 2
+    SpendDiamond: 6
+    SpendHex: 0
+    SpendInfinite: 12
+    SpendSmallCircle: 3
+    SpendSquare: 1
 TraitNodeFlag:
-  ActiveAtFirstRank: 16
-  HideMaxRank: 64
-  HighestChosenRank: 128
-  NeverPurchasable: 2
-  ShowExpandedSelection: 32
-  ShowMultipleIcons: 1
-  ShowTierTrack: 256
-  TestGridPositioned: 8
-  TestPositionLocked: 4
+  values:
+    ActiveAtFirstRank: 16
+    HideMaxRank: 64
+    HighestChosenRank: 128
+    NeverPurchasable: 2
+    ShowExpandedSelection: 32
+    ShowMultipleIcons: 1
+    ShowTierTrack: 256
+    TestGridPositioned: 8
+    TestPositionLocked: 4
 TraitNodeGroupFlag:
-  AvailableByDefault: 1
+  values:
+    AvailableByDefault: 1
 TraitNodeType:
-  Selection: 2
-  Single: 0
-  SubTreeSelection: 3
-  Tiered: 1
+  values:
+    Selection: 2
+    Single: 0
+    SubTreeSelection: 3
+    Tiered: 1
 TraitPointsOperationType:
-  Multiply: 1
-  None: -1
-  Set: 0
+  values:
+    Multiply: 1
+    None: -1
+    Set: 0
 TraitSystemFlag:
-  AllowEditInChallengeMode: 8
-  AllowEditInCombat: 4
-  AllowMultipleLoadoutsPerTree: 1
-  ShowSpendConfirmation: 2
+  values:
+    AllowEditInChallengeMode: 8
+    AllowEditInCombat: 4
+    AllowMultipleLoadoutsPerTree: 1
+    ShowSpendConfirmation: 2
 TraitSystemVariationType:
-  None: 0
-  Spec: 1
+  values:
+    None: 0
+    Spec: 1
 TraitTreeFlag:
-  CannotRefund: 1
-  HideSingleRankNumbers: 2
+  values:
+    CannotRefund: 1
+    HideSingleRankNumbers: 2
 TransformManipulatorAxis:
-  X: 1
-  Y: 2
-  Z: 4
+  values:
+    X: 1
+    Y: 2
+    Z: 4
 TransformManipulatorControlState:
-  Default: 0
-  Dimmed: 2
-  ExternallyHighlighted: 3
-  Hidden: 1
-  Hovered: 4
-  Moving: 6
-  Selected: 5
+  values:
+    Default: 0
+    Dimmed: 2
+    ExternallyHighlighted: 3
+    Hidden: 1
+    Hovered: 4
+    Moving: 6
+    Selected: 5
 TransformManipulatorDirection:
-  Negative: 1
-  Positive: 0
+  values:
+    Negative: 1
+    Positive: 0
 TransformManipulatorEvent:
-  Cancel: 3
-  Change: 1
-  Complete: 2
-  Hover: 4
-  MouseDown: 5
-  MouseUp: 6
-  Start: 0
+  values:
+    Cancel: 3
+    Change: 1
+    Complete: 2
+    Hover: 4
+    MouseDown: 5
+    MouseUp: 6
+    Start: 0
 TransformManipulatorMode:
-  Rotate: 1
-  Scale: 2
-  Translate: 0
+  values:
+    Rotate: 1
+    Scale: 2
+    Translate: 0
 TransmogCameraVariation:
-  CloakBackpack: 1
-  None: 0
-  RightShoulder: 1
+  values:
+    CloakBackpack: 1
+    None: 0
+    RightShoulder: 1
 TransmogCollectionType:
-  Back: 3
-  Bow: 25
-  Chest: 4
-  Crossbow: 27
-  Dagger: 16
-  Feet: 11
-  Fist: 17
-  Gun: 26
-  Hands: 8
-  Head: 1
-  Holdable: 19
-  Legs: 10
-  None: 0
-  OneHAxe: 13
-  OneHMace: 15
-  OneHSword: 14
-  Paired: 29
-  Polearm: 24
-  Shield: 18
-  Shirt: 5
-  Shoulder: 2
-  Staff: 23
-  Tabard: 6
-  TwoHAxe: 20
-  TwoHMace: 22
-  TwoHSword: 21
-  Waist: 9
-  Wand: 12
-  Warglaives: 28
-  Wrist: 7
+  values:
+    Back: 3
+    Bow: 25
+    Chest: 4
+    Crossbow: 27
+    Dagger: 16
+    Feet: 11
+    Fist: 17
+    Gun: 26
+    Hands: 8
+    Head: 1
+    Holdable: 19
+    Legs: 10
+    None: 0
+    OneHAxe: 13
+    OneHMace: 15
+    OneHSword: 14
+    Paired: 29
+    Polearm: 24
+    Shield: 18
+    Shirt: 5
+    Shoulder: 2
+    Staff: 23
+    Tabard: 6
+    TwoHAxe: 20
+    TwoHMace: 22
+    TwoHSword: 21
+    Waist: 9
+    Wand: 12
+    Warglaives: 28
+    Wrist: 7
 TransmogIllusionFlags:
-  AllowedRangedShieldsHoldables: 4
-  HideUntilCollected: 1
-  PlayerConditionGrantsOnLogin: 2
+  values:
+    AllowedRangedShieldsHoldables: 4
+    HideUntilCollected: 1
+    PlayerConditionGrantsOnLogin: 2
 TransmogModification:
-  Main: 0
-  Secondary: 1
+  values:
+    Main: 0
+    Secondary: 1
 TransmogOutfitCostModifiersApplied:
-  AuraDiscountApplied: 8
-  DebugOnlyFreeDiscountApplied: 1
-  OutfitCostModifierApplied: 4
-  VoidRacialDiscountApplied: 2
+  values:
+    AuraDiscountApplied: 8
+    DebugOnlyFreeDiscountApplied: 1
+    OutfitCostModifierApplied: 4
+    VoidRacialDiscountApplied: 2
 TransmogOutfitDataFlags:
-  IsCachedLocally: 1
+  values:
+    IsCachedLocally: 1
 TransmogOutfitDisplayType:
-  Assigned: 1
-  Disabled: 4
-  Equipped: 2
-  Hidden: 3
-  Unassigned: 0
+  values:
+    Assigned: 1
+    Disabled: 4
+    Equipped: 2
+    Hidden: 3
+    Unassigned: 0
 TransmogOutfitEntryFlags:
-  AutomaticallyAwardedOnLogin: 1
-  IsDefaultEquipped: 32
-  OnlyAvailableDuringEvent: 4
-  SortedToTopOfList: 8
-  UseOverrideCostModifier: 16
-  UseOverrideName: 2
+  values:
+    AutomaticallyAwardedOnLogin: 1
+    IsDefaultEquipped: 32
+    OnlyAvailableDuringEvent: 4
+    SortedToTopOfList: 8
+    UseOverrideCostModifier: 16
+    UseOverrideName: 2
 TransmogOutfitEntrySource:
-  AutomaticallyAwarded: 1
-  PlayerPurchased: 2
-  StampedSource: 0
+  values:
+    AutomaticallyAwarded: 1
+    PlayerPurchased: 2
+    StampedSource: 0
 TransmogOutfitEquipAction:
-  Equip: 0
-  EquipAndLock: 1
-  Lock: 5
-  Remove: 2
-  RemoveAndLock: 3
-  Unlock: 4
+  values:
+    Equip: 0
+    EquipAndLock: 1
+    Lock: 5
+    Remove: 2
+    RemoveAndLock: 3
+    Unlock: 4
 TransmogOutfitSetType:
-  CustomSet: 2
-  Equipped: 0
-  Outfit: 1
+  values:
+    CustomSet: 2
+    Equipped: 0
+    Outfit: 1
 TransmogOutfitSlot:
-  Back: 3
-  Body: 6
-  Chest: 4
-  Feet: 11
-  Hand: 8
-  Head: 0
-  Legs: 10
-  ShoulderLeft: 2
-  ShoulderRight: 1
-  Tabard: 5
-  Waist: 9
-  WeaponMainHand: 12
-  WeaponOffHand: 13
-  WeaponRanged: 14
-  Wrist: 7
+  values:
+    Back: 3
+    Body: 6
+    Chest: 4
+    Feet: 11
+    Hand: 8
+    Head: 0
+    Legs: 10
+    ShoulderLeft: 2
+    ShoulderRight: 1
+    Tabard: 5
+    Waist: 9
+    WeaponMainHand: 12
+    WeaponOffHand: 13
+    WeaponRanged: 14
+    Wrist: 7
 TransmogOutfitSlotError:
-  CannotUseItem: 10
-  IncompatibleWithMainHand: 14
-  InvalidDestination: 5
-  InvalidItemType: 4
-  InvalidSlotForForm: 13
-  InvalidSlotForRace: 11
-  InvalidSource: 8
-  InvalidSourceQuality: 9
-  Legendary: 3
-  Mismatch: 6
-  NoIllusion: 12
-  NoItem: 1
-  NotSoulbound: 2
-  Ok: 0
-  SameItem: 7
+  values:
+    CannotUseItem: 10
+    IncompatibleWithMainHand: 14
+    InvalidDestination: 5
+    InvalidItemType: 4
+    InvalidSlotForForm: 13
+    InvalidSlotForRace: 11
+    InvalidSource: 8
+    InvalidSourceQuality: 9
+    Legendary: 3
+    Mismatch: 6
+    NoIllusion: 12
+    NoItem: 1
+    NotSoulbound: 2
+    Ok: 0
+    SameItem: 7
 TransmogOutfitSlotFlags:
-  CanHaveIllusions: 2
-  CannotBeHidden: 1
-  IsSecondarySlot: 4
+  values:
+    CanHaveIllusions: 2
+    CannotBeHidden: 1
+    IsSecondarySlot: 4
 TransmogOutfitSlotOption:
-  ArtifactSpecFour: 11
-  ArtifactSpecOne: 8
-  ArtifactSpecThree: 10
-  ArtifactSpecTwo: 9
-  DeprecatedReuseMe: 6
-  FuryTwoHandedWeapon: 7
-  None: 0
-  OffHand: 4
-  OneHandedWeapon: 1
-  RangedWeapon: 3
-  Shield: 5
-  TwoHandedWeapon: 2
+  values:
+    ArtifactSpecFour: 11
+    ArtifactSpecOne: 8
+    ArtifactSpecThree: 10
+    ArtifactSpecTwo: 9
+    DeprecatedReuseMe: 6
+    FuryTwoHandedWeapon: 7
+    None: 0
+    OffHand: 4
+    OneHandedWeapon: 1
+    RangedWeapon: 3
+    Shield: 5
+    TwoHandedWeapon: 2
 TransmogOutfitSlotOptionFlags:
-  DisablesOffhandSlot: 4
-  DynamicOptionName: 2
-  IllusionNotAllowed: 1
+  values:
+    DisablesOffhandSlot: 4
+    DynamicOptionName: 2
+    IllusionNotAllowed: 1
 TransmogOutfitSlotOptionSheatheCategory:
-  Back: 1
-  Default: 0
-  Hide: 3
-  Side: 2
+  values:
+    Back: 1
+    Default: 0
+    Hide: 3
+    Side: 2
 TransmogOutfitSlotPosition:
-  Bottom: 2
-  Left: 0
-  Right: 1
+  values:
+    Bottom: 2
+    Left: 0
+    Right: 1
 TransmogOutfitSlotSaveFlags:
-  AppearanceIsNotValid: 1
+  values:
+    AppearanceIsNotValid: 1
 TransmogOutfitSlotWarning:
-  InvalidEquippedDestinationItem: 1
-  NothingEquipped: 5
-  Ok: 0
-  PendingWeaponChanges: 3
-  WeaponDoesNotSupportIllusions: 4
-  WrongWeaponCategoryEquipped: 2
+  values:
+    InvalidEquippedDestinationItem: 1
+    NothingEquipped: 5
+    Ok: 0
+    PendingWeaponChanges: 3
+    WeaponDoesNotSupportIllusions: 4
+    WrongWeaponCategoryEquipped: 2
 TransmogOutfitTransactionFlags:
-  AddNewOutfitMask: 20
-  AddOutfitAndUpdateSlots: 28
-  CreateAndUpdateOutfitInfoMask: 6
-  CreateOutfitInfo: 4
-  FullOutfitUpdateMask: 27
-  UpdateMetadata: 1
-  UpdateOutfitInfo: 2
-  UpdateSituations: 16
-  UpdateSituationsMask: 18
-  UpdateSlots: 8
+  values:
+    AddNewOutfitMask: 20
+    AddOutfitAndUpdateSlots: 28
+    CreateAndUpdateOutfitInfoMask: 6
+    CreateOutfitInfo: 4
+    FullOutfitUpdateMask: 27
+    UpdateMetadata: 1
+    UpdateOutfitInfo: 2
+    UpdateSituations: 16
+    UpdateSituationsMask: 18
+    UpdateSlots: 8
 TransmogOutfitTransactionType:
-  CreateOutfitInfo: 2
-  UpdateMetadata: 0
-  UpdateOutfitInfo: 1
-  UpdateSituations: 4
-  UpdateSlots: 3
+  values:
+    CreateOutfitInfo: 2
+    UpdateMetadata: 0
+    UpdateOutfitInfo: 1
+    UpdateSituations: 4
+    UpdateSlots: 3
 TransmogPendingType:
-  Apply: 0
-  Revert: 1
-  ToggleOff: 3
-  ToggleOn: 2
+  values:
+    Apply: 0
+    Revert: 1
+    ToggleOff: 3
+    ToggleOn: 2
 TransmogSearchType:
-  BaseSets: 2
-  Items: 1
-  UsableSets: 3
+  values:
+    BaseSets: 2
+    Items: 1
+    UsableSets: 3
 TransmogSituation:
-  AllEquipmentSets: 17
-  AllLocations: 2
-  AllMovement: 12
-  AllRacialForms: 19
-  AllSpecs: 0
-  AllTime: 27
-  AllWeather: 22
-  EquipmentSets: 18
-  FormNative: 20
-  FormNonNative: 21
-  LocationArenas: 10
-  LocationBattlegrounds: 11
-  LocationCharacterSelect: 5
-  LocationDelves: 7
-  LocationDungeons: 8
-  LocationHouse: 4
-  LocationRaids: 9
-  LocationRested: 3
-  LocationWorld: 6
-  MovementFlyingMount: 16
-  MovementGroundMount: 15
-  MovementSwimming: 14
-  MovementUnmounted: 13
-  Spec: 1
-  TimeDay: 29
-  TimeEvening: 30
-  TimeMorning: 28
-  TimeNight: 31
-  WeatherClear: 23
-  WeatherRain: 24
-  WeatherSand: 26
-  WeatherSnow: 25
+  values:
+    AllEquipmentSets: 17
+    AllLocations: 2
+    AllMovement: 12
+    AllRacialForms: 19
+    AllSpecs: 0
+    AllTime: 27
+    AllWeather: 22
+    EquipmentSets: 18
+    FormNative: 20
+    FormNonNative: 21
+    LocationArenas: 10
+    LocationBattlegrounds: 11
+    LocationCharacterSelect: 5
+    LocationDelves: 7
+    LocationDungeons: 8
+    LocationHouse: 4
+    LocationRaids: 9
+    LocationRested: 3
+    LocationWorld: 6
+    MovementFlyingMount: 16
+    MovementGroundMount: 15
+    MovementSwimming: 14
+    MovementUnmounted: 13
+    Spec: 1
+    TimeDay: 29
+    TimeEvening: 30
+    TimeMorning: 28
+    TimeNight: 31
+    WeatherClear: 23
+    WeatherRain: 24
+    WeatherSand: 26
+    WeatherSnow: 25
 TransmogSituationFlags:
-  AllSituation: 4
-  DefaultsToOn: 8
-  DisabledSituation: 64
-  DynamicallyNamed: 16
-  IsPlayerFacing: 1
-  NoneSituation: 32
-  SpecUseTalentLoadout: 2
+  values:
+    AllSituation: 4
+    DefaultsToOn: 8
+    DisabledSituation: 64
+    DynamicallyNamed: 16
+    IsPlayerFacing: 1
+    NoneSituation: 32
+    SpecUseTalentLoadout: 2
 TransmogSituationGroupFlags:
-  DynamicallyCreatesGroups: 1
+  values:
+    DynamicallyCreatesGroups: 1
 TransmogSituationTrigger:
-  EquipmentSet: 6
-  EventOutfit: 8
-  Forms: 7
-  Location: 3
-  Manual: 1
-  Movement: 4
-  None: 0
-  Specialization: 5
-  TimeOfDay: 10
-  TransmogUpdate: 2
-  Weather: 9
+  values:
+    EquipmentSet: 6
+    EventOutfit: 8
+    Forms: 7
+    Location: 3
+    Manual: 1
+    Movement: 4
+    None: 0
+    Specialization: 5
+    TimeOfDay: 10
+    TransmogUpdate: 2
+    Weather: 9
 TransmogSituationTriggerFlags:
-  CanChangeLockedOutfit: 2
-  CanLockOutfit: 1
-  DisabledTrigger: 16
-  IsPlayerFacing: 4
-  SituationsAreExclusive: 8
+  values:
+    CanChangeLockedOutfit: 2
+    CanLockOutfit: 1
+    DisabledTrigger: 16
+    IsPlayerFacing: 4
+    SituationsAreExclusive: 8
 TransmogSituationTriggerType:
-  Automatic: 2
-  Manual: 1
-  None: 0
-  TransmogUpdate: 3
+  values:
+    Automatic: 2
+    Manual: 1
+    None: 0
+    TransmogUpdate: 3
 TransmogSlot:
-  Back: 2
-  Body: 4
-  Chest: 3
-  Feet: 10
-  Hand: 7
-  Head: 0
-  Legs: 9
-  Mainhand: 11
-  Offhand: 12
-  Ranged: 13
-  Shoulder: 1
-  Tabard: 5
-  Waist: 8
-  Wrist: 6
+  values:
+    Back: 2
+    Body: 4
+    Chest: 3
+    Feet: 10
+    Hand: 7
+    Head: 0
+    Legs: 9
+    Mainhand: 11
+    Offhand: 12
+    Ranged: 13
+    Shoulder: 1
+    Tabard: 5
+    Waist: 8
+    Wrist: 6
 TransmogSource:
-  Achievement: 7
-  CantCollect: 6
-  HiddenUntilCollected: 5
-  JournalEncounter: 1
-  None: 0
-  NotValidForTransmog: 9
-  Profession: 8
-  Quest: 2
-  TradingPost: 10
-  Vendor: 3
-  WorldDrop: 4
+  values:
+    Achievement: 7
+    CantCollect: 6
+    HiddenUntilCollected: 5
+    JournalEncounter: 1
+    None: 0
+    NotValidForTransmog: 9
+    Profession: 8
+    Quest: 2
+    TradingPost: 10
+    Vendor: 3
+    WorldDrop: 4
 TransmogTimeOfDayCategory:
-  Evening: 2
-  Midday: 1
-  Morning: 0
-  Night: 3
+  values:
+    Evening: 2
+    Midday: 1
+    Morning: 0
+    Night: 3
 TransmogType:
-  Appearance: 0
-  Illusion: 1
+  values:
+    Appearance: 0
+    Illusion: 1
 TransmogUseErrorType:
-  Ability: 3
-  Class: 7
-  Faction: 9
-  Holiday: 5
-  HotRecheckFailed: 6
-  ItemProficiency: 10
-  None: 0
-  PlayerCondition: 1
-  Race: 8
-  Reputation: 4
-  Skill: 2
+  values:
+    Ability: 3
+    Class: 7
+    Faction: 9
+    Holiday: 5
+    HotRecheckFailed: 6
+    ItemProficiency: 10
+    None: 0
+    PlayerCondition: 1
+    Race: 8
+    Reputation: 4
+    Skill: 2
 TtsBoolSetting:
-  AddCharacterNameToSpeech: 1
-  AlternateSystemVoice: 3
-  NarrateMyMessages: 4
-  PlayActivitySoundWhenNotFocused: 2
-  PlaySoundSeparatingChatLineBreaks: 0
+  values:
+    AddCharacterNameToSpeech: 1
+    AlternateSystemVoice: 3
+    NarrateMyMessages: 4
+    PlayActivitySoundWhenNotFocused: 2
+    PlaySoundSeparatingChatLineBreaks: 0
 TtsVoiceType:
-  Alternate: 1
-  Standard: 0
+  values:
+    Alternate: 1
+    Standard: 0
 TugOfWarMarkerArrowShownState:
-  Always: 1
-  FlashOnMove: 2
-  Never: 0
+  values:
+    Always: 1
+    FlashOnMove: 2
+    Never: 0
 TugOfWarStyleValue:
-  ArchaeologyBrown: 1
-  DefaultYellow: 0
+  values:
+    ArchaeologyBrown: 1
+    DefaultYellow: 0
 TurnStrafeStyle:
-  Custom: 2
-  Legacy: 1
-  Modern: 0
+  values:
+    Custom: 2
+    Legacy: 1
+    Modern: 0
 UIActionType:
-  DefaultAction: 0
-  Reserved1: 2
-  UpdateMapSystem: 1
+  values:
+    DefaultAction: 0
+    Reserved1: 2
+    UpdateMapSystem: 1
 UICovenantDisplayInfoFlags:
-  DisplayCovenantAsJourney: 1
-  UseJourneyRewardTrack: 2
-  UseJourneyUnlockToastText: 3
+  values:
+    DisplayCovenantAsJourney: 1
+    UseJourneyRewardTrack: 2
+    UseJourneyUnlockToastText: 3
 UICursorType:
-  ActionBar: 6
-  Ammo: 8
-  BattlePet: 16
-  ConduitCollectionItem: 19
-  Currency: 13
-  Default: 0
-  EquipmentSet: 12
-  Flyout: 14
-  GuildBank: 10
-  GuildBankMoney: 11
-  Item: 1
-  Macro: 7
-  Merchant: 5
-  Money: 2
-  Mount: 17
-  Outfit: 21
-  PerksProgramVendorItem: 20
-  Pet: 9
-  PetAction: 4
-  Spell: 3
-  Toy: 18
-  VoidItem: 15
+  values:
+    ActionBar: 6
+    Ammo: 8
+    BattlePet: 16
+    ConduitCollectionItem: 19
+    Currency: 13
+    Default: 0
+    EquipmentSet: 12
+    Flyout: 14
+    GuildBank: 10
+    GuildBankMoney: 11
+    Item: 1
+    Macro: 7
+    Merchant: 5
+    Money: 2
+    Mount: 17
+    Outfit: 21
+    PerksProgramVendorItem: 20
+    Pet: 9
+    PetAction: 4
+    Spell: 3
+    Toy: 18
+    VoidItem: 15
 UIItemInteractionFlags:
-  AddCurrency: 16
-  ClickShowsFlyout: 8
-  ConfirmationHasDelay: 2
-  ConversionMode: 4
-  DisplayWithInset: 1
-  UsesCharges: 32
+  values:
+    AddCurrency: 16
+    ClickShowsFlyout: 8
+    ConfirmationHasDelay: 2
+    ConversionMode: 4
+    DisplayWithInset: 1
+    UsesCharges: 32
 UIItemInteractionType:
-  CastSpell: 1
-  CleanseCorruption: 2
-  ItemConversion: 4
-  None: 0
-  RunecarverScrapping: 3
+  values:
+    CastSpell: 1
+    CleanseCorruption: 2
+    ItemConversion: 4
+    None: 0
+    RunecarverScrapping: 3
 UIMapFlag:
-  AlwaysAllowTaxiPathing: 131072
-  AlwaysAllowUserWaypoints: 65536
-  DoNotShowOnNavbar: 524288
-  DoNotTranslateBranches: 512
-  FallbackToParentMap: 16
-  FlightMapAutoZoom: 16384
-  FlightMapShowZoomOut: 8192
-  ForceAllOverlayExplored: 4096
-  ForceAllowMapLinks: 262144
-  ForceOnNavbar: 32768
-  GarrisonMap: 8
-  HideArchaeologyDigs: 256
-  HideIcons: 1024
-  HideVignettes: 2048
-  IgnoreInTranslationsToParent: 2097152
-  IsCityMap: 1048576
-  NoHighlight: 1
-  NoHighlightTexture: 32
-  NoWorldPositions: 128
-  ShowOverlays: 2
-  ShowTaskObjectives: 64
-  ShowTaxiNodes: 4
+  values:
+    AlwaysAllowTaxiPathing: 131072
+    AlwaysAllowUserWaypoints: 65536
+    DoNotShowOnNavbar: 524288
+    DoNotTranslateBranches: 512
+    FallbackToParentMap: 16
+    FlightMapAutoZoom: 16384
+    FlightMapShowZoomOut: 8192
+    ForceAllOverlayExplored: 4096
+    ForceAllowMapLinks: 262144
+    ForceOnNavbar: 32768
+    GarrisonMap: 8
+    HideArchaeologyDigs: 256
+    HideIcons: 1024
+    HideVignettes: 2048
+    IgnoreInTranslationsToParent: 2097152
+    IsCityMap: 1048576
+    NoHighlight: 1
+    NoHighlightTexture: 32
+    NoWorldPositions: 128
+    ShowOverlays: 2
+    ShowTaskObjectives: 64
+    ShowTaxiNodes: 4
 UIMapGroupFlag:
-  ShowIconsAcrossFloors: 1
+  values:
+    ShowIconsAcrossFloors: 1
 UIMapSystem:
-  Adventure: 2
-  Minimap: 3
-  Taxi: 1
-  World: 0
+  values:
+    Adventure: 2
+    Minimap: 3
+    Taxi: 1
+    World: 0
 UIMapType:
-  Continent: 2
-  Cosmic: 0
-  Dungeon: 4
-  Micro: 5
-  Orphan: 6
-  World: 1
-  Zone: 3
+  values:
+    Continent: 2
+    Cosmic: 0
+    Dungeon: 4
+    Micro: 5
+    Orphan: 6
+    World: 1
+    Zone: 3
 UIModelSceneActorFlag:
-  Deprecated1: 1
-  UseCenterForOriginX: 2
-  UseCenterForOriginY: 4
-  UseCenterForOriginZ: 8
+  values:
+    Deprecated1: 1
+    UseCenterForOriginX: 2
+    UseCenterForOriginY: 4
+    UseCenterForOriginZ: 8
 UIModelSceneContext:
-  None: -1
-  PerksProgram: 0
+  values:
+    None: -1
+    PerksProgram: 0
 UIModelSceneFlags:
-  Autodress: 4
-  HideWeapon: 2
-  NoCameraSpin: 8
-  SheatheWeapon: 1
+  values:
+    Autodress: 4
+    HideWeapon: 2
+    NoCameraSpin: 8
+    SheatheWeapon: 1
 UISystemType:
-  InGameNavigation: 0
+  values:
+    InGameNavigation: 0
 UITextureSliceMode:
-  Stretched: 0
-  Tiled: 1
+  values:
+    Stretched: 0
+    Tiled: 1
 UIWidgetBlendModeType:
-  Additive: 1
-  Opaque: 0
+  values:
+    Additive: 1
+    Opaque: 0
 UIWidgetButtonEnabledState:
-  Disabled: 0
-  Enabled: 1
+  values:
+    Disabled: 0
+    Enabled: 1
 UIWidgetButtonIconType:
-  Checkmark: 3
-  Exit: 0
-  RedX: 4
-  Speak: 1
-  Undo: 2
+  values:
+    Checkmark: 3
+    Exit: 0
+    RedX: 4
+    Speak: 1
+    Undo: 2
 UIWidgetFlag:
-  UniversalWidget: 1
+  values:
+    UniversalWidget: 1
 UIWidgetFontType:
-  Normal: 0
-  Outline: 2
-  Shadow: 1
+  values:
+    Normal: 0
+    Outline: 2
+    Shadow: 1
 UIWidgetHorizontalDirection:
-  LeftToRight: 0
-  RightToLeft: 1
+  values:
+    LeftToRight: 0
+    RightToLeft: 1
 UIWidgetLayoutDirection:
-  Default: 0
-  Horizontal: 2
-  HorizontalForceNewRow: 4
-  Overlap: 3
-  Vertical: 1
+  values:
+    Default: 0
+    Horizontal: 2
+    HorizontalForceNewRow: 4
+    Overlap: 3
+    Vertical: 1
 UIWidgetModelSceneLayer:
-  Back: 2
-  Front: 1
-  None: 0
+  values:
+    Back: 2
+    Front: 1
+    None: 0
 UIWidgetMotionType:
-  Instant: 0
-  Smooth: 1
+  values:
+    Instant: 0
+    Smooth: 1
 UIWidgetOverrideState:
-  Active: 1
-  Inactive: 0
+  values:
+    Active: 1
+    Inactive: 0
 UIWidgetRewardShownState:
-  Hidden: 0
-  ShownEarned: 1
-  ShownUnearned: 2
+  values:
+    Hidden: 0
+    ShownEarned: 1
+    ShownUnearned: 2
 UIWidgetScale:
-  Eighty: 2
-  Fifty: 5
-  Ninty: 1
-  OneHundred: 0
-  OneHundredEighty: 13
-  OneHundredFifty: 10
-  OneHundredForty: 9
-  OneHundredNinety: 14
-  OneHundredSeventy: 12
-  OneHundredSixty: 11
-  OneHundredTen: 6
-  OneHundredThirty: 8
-  OneHundredTwenty: 7
-  Seventy: 3
-  Sixty: 4
-  TwoHundred: 15
+  values:
+    Eighty: 2
+    Fifty: 5
+    Ninty: 1
+    OneHundred: 0
+    OneHundredEighty: 13
+    OneHundredFifty: 10
+    OneHundredForty: 9
+    OneHundredNinety: 14
+    OneHundredSeventy: 12
+    OneHundredSixty: 11
+    OneHundredTen: 6
+    OneHundredThirty: 8
+    OneHundredTwenty: 7
+    Seventy: 3
+    Sixty: 4
+    TwoHundred: 15
 UIWidgetSetLayoutDirection:
-  Horizontal: 1
-  Overlap: 2
-  Vertical: 0
+  values:
+    Horizontal: 1
+    Overlap: 2
+    Vertical: 0
 UIWidgetSpellButtonCooldownType:
-  HideCooldown: 0
-  ShowCooldown: 1
-  ShowCooldownAndDisableOnCooldown: 2
+  values:
+    HideCooldown: 0
+    ShowCooldown: 1
+    ShowCooldownAndDisableOnCooldown: 2
 UIWidgetTextFormatType:
-  LeadingZeroesWithSixDigits: 3
-  None: 0
-  TimeOneLevel: 1
-  TimeTwoLevel: 2
+  values:
+    LeadingZeroesWithSixDigits: 3
+    None: 0
+    TimeOneLevel: 1
+    TimeTwoLevel: 2
 UIWidgetTextSizeType:
-  Huge27Pt: 3
-  Large20Pt: 8
-  Large24Pt: 2
-  Medium16Pt: 1
-  Medium18Pt: 7
-  Small10Pt: 5
-  Small11Pt: 6
-  Small12Pt: 0
-  Standard14Pt: 4
+  values:
+    Huge27Pt: 3
+    Large20Pt: 8
+    Large24Pt: 2
+    Medium16Pt: 1
+    Medium18Pt: 7
+    Small10Pt: 5
+    Small11Pt: 6
+    Small12Pt: 0
+    Standard14Pt: 4
 UIWidgetTextureAndTextSizeType:
-  Huge: 3
-  Large: 2
-  Medium: 1
-  Medium2: 5
-  Small: 0
-  Standard: 4
+  values:
+    Huge: 3
+    Large: 2
+    Medium: 1
+    Medium2: 5
+    Small: 0
+    Standard: 4
 UIWidgetTooltipLocation:
-  Bottom: 8
-  BottomLeft: 1
-  BottomRight: 7
-  Default: 0
-  Left: 2
-  Right: 6
-  Top: 4
-  TopLeft: 3
-  TopRight: 5
+  values:
+    Bottom: 8
+    BottomLeft: 1
+    BottomRight: 7
+    Default: 0
+    Left: 2
+    Right: 6
+    Top: 4
+    TopLeft: 3
+    TopRight: 5
 UIWidgetUpdateAnimType:
-  Flash: 1
-  FlashAndAnimateNumber: 2
-  None: 0
+  values:
+    Flash: 1
+    FlashAndAnimateNumber: 2
+    None: 0
 UIWidgetVisualizationType:
-  BulletTextList: 10
-  ButtonHeader: 30
-  CaptureBar: 1
-  CaptureZone: 17
-  DiscreteProgressSteps: 19
-  DoubleIconAndText: 5
-  DoubleStateIconRow: 14
-  DoubleStatusBar: 3
-  FillUpFrames: 24
-  HorizontalCurrencies: 9
-  IconAndText: 0
-  IconTextAndBackground: 4
-  IconTextAndCurrencies: 7
-  ItemDisplay: 27
-  MapPinAnimation: 26
-  PreyHuntProgress: 31
-  ScenarioHeaderCurrenciesAndBackground: 11
-  ScenarioHeaderDelves: 29
-  ScenarioHeaderTimer: 20
-  Spacer: 22
-  SpellDisplay: 13
-  StackedResourceTracker: 6
-  StatusBar: 2
-  TextColumnRow: 21
-  TextureAndText: 12
-  TextureAndTextRow: 15
-  TextureWithAnimation: 18
-  TextWithState: 8
-  TextWithSubtext: 25
-  TugOfWar: 28
-  UnitPowerBar: 23
-  ZoneControl: 16
+  values:
+    BulletTextList: 10
+    ButtonHeader: 30
+    CaptureBar: 1
+    CaptureZone: 17
+    DiscreteProgressSteps: 19
+    DoubleIconAndText: 5
+    DoubleStateIconRow: 14
+    DoubleStatusBar: 3
+    FillUpFrames: 24
+    HorizontalCurrencies: 9
+    IconAndText: 0
+    IconTextAndBackground: 4
+    IconTextAndCurrencies: 7
+    ItemDisplay: 27
+    MapPinAnimation: 26
+    PreyHuntProgress: 31
+    ScenarioHeaderCurrenciesAndBackground: 11
+    ScenarioHeaderDelves: 29
+    ScenarioHeaderTimer: 20
+    Spacer: 22
+    SpellDisplay: 13
+    StackedResourceTracker: 6
+    StatusBar: 2
+    TextColumnRow: 21
+    TextureAndText: 12
+    TextureAndTextRow: 15
+    TextureWithAnimation: 18
+    TextWithState: 8
+    TextWithSubtext: 25
+    TugOfWar: 28
+    UnitPowerBar: 23
+    ZoneControl: 16
 UnitAuraSortDirection:
-  Normal: 0
-  Reverse: 1
+  values:
+    Normal: 0
+    Reverse: 1
 UnitAuraSortRule:
-  BigDefensive: 2
-  Default: 1
-  Expiration: 3
-  ExpirationOnly: 4
-  Name: 5
-  NameOnly: 6
-  Unsorted: 0
+  values:
+    BigDefensive: 2
+    Default: 1
+    Expiration: 3
+    ExpirationOnly: 4
+    Name: 5
+    NameOnly: 6
+    Unsorted: 0
 UnitDamageAbsorbClampMode:
-  MaximumHealth: 2
-  MissingHealth: 0
-  MissingHealthWithoutIncomingHeals: 1
+  values:
+    MaximumHealth: 2
+    MissingHealth: 0
+    MissingHealthWithoutIncomingHeals: 1
 UnitHealAbsorbClampMode:
-  CurrentHealth: 0
-  MaximumHealth: 1
+  values:
+    CurrentHealth: 0
+    MaximumHealth: 1
 UnitHealAbsorbMode:
-  ReducedByIncomingHeals: 0
-  Total: 1
+  values:
+    ReducedByIncomingHeals: 0
+    Total: 1
 UnitIncomingHealClampMode:
-  MaximumHealth: 1
-  MissingHealth: 0
+  values:
+    MaximumHealth: 1
+    MissingHealth: 0
 UnitMaximumHealthMode:
-  Default: 0
-  WithAbsorbs: 1
+  values:
+    Default: 0
+    WithAbsorbs: 1
 UnitMirrorPetFlags:
-  Dismissable: 2
-  ExtraPet: 16
-  RecentlyTamed: 4
-  Renameable: 1
-  Stampede: 8
+  values:
+    Dismissable: 2
+    ExtraPet: 16
+    RecentlyTamed: 4
+    Renameable: 1
+    Stampede: 8
 UnitSex:
-  Both: 3
-  Female: 1
-  Male: 0
-  Neutral: 4
-  None: 2
+  values:
+    Both: 3
+    Female: 1
+    Male: 0
+    Neutral: 4
+    None: 2
 UrlTextureResult:
-  Found: 1
-  NotAllowed: 4
-  NotFound: 2
-  Requested: 3
+  values:
+    Found: 1
+    NotAllowed: 4
+    NotFound: 2
+    Requested: 3
 ValidateNameResult:
-  ConsecutiveSpaces: 13
-  DeclensionDoesntMatchBaseName: 16
-  Failure: 1
-  InvalidApostrophe: 9
-  InvalidCharacter: 5
-  InvalidSpace: 12
-  MixedLanguages: 6
-  MultipleApostrophes: 10
-  NoName: 2
-  Profane: 7
-  Reserved: 8
-  RussianConsecutiveSilentCharacters: 14
-  RussianSilentCharacterAtBeginningOrEnd: 15
-  SpacesDisallowed: 17
-  Success: 0
-  ThreeConsecutive: 11
-  TooLong: 4
-  TooShort: 3
+  values:
+    ConsecutiveSpaces: 13
+    DeclensionDoesntMatchBaseName: 16
+    Failure: 1
+    InvalidApostrophe: 9
+    InvalidCharacter: 5
+    InvalidSpace: 12
+    MixedLanguages: 6
+    MultipleApostrophes: 10
+    NoName: 2
+    Profane: 7
+    Reserved: 8
+    RussianConsecutiveSilentCharacters: 14
+    RussianSilentCharacterAtBeginningOrEnd: 15
+    SpacesDisallowed: 17
+    Success: 0
+    ThreeConsecutive: 11
+    TooLong: 4
+    TooShort: 3
 VasPurchaseProgress:
-  ApplyingLicense: 3
-  Complete: 7
-  Invalid: 0
-  PaymentPending: 2
-  PrePurchase: 1
-  ProcessingFactionChange: 6
-  Ready: 5
-  WaitingOnQueue: 4
+  values:
+    ApplyingLicense: 3
+    Complete: 7
+    Invalid: 0
+    PaymentPending: 2
+    PrePurchase: 1
+    ProcessingFactionChange: 6
+    Ready: 5
+    WaitingOnQueue: 4
 VasServiceType:
-  AppearanceChange: 2
-  CharacterClone: 10
-  CharacterTransfer: 4
-  FactionChange: 1
-  FactionTransfer: 5
-  NameChange: 0
-  RaceChange: 3
+  values:
+    AppearanceChange: 2
+    CharacterClone: 10
+    CharacterTransfer: 4
+    FactionChange: 1
+    FactionTransfer: 5
+    NameChange: 0
+    RaceChange: 3
 VasTransactionPurchaseResult:
-  BeginDbErrors: 20010
-  BeginProxyErrors: 17
-  DbAccountDoesNotOwnCharacter: 20017
-  DbAllianceNotEligible: 20027
-  DbAlreadyRenameFlagged: 20055
-  DbAuthenticatorInsufficient: 20073
-  DbBatchProcessingDisabled: 20028
-  DbBatchStateInvalid: 20067
-  DbBnetAccountNotProvided: 20077
-  DbBoostProcessingDisabled: 20095
-  DbBpayDeliveryPending: 20078
-  DbCagedPetInInventory: 20084
-  DbCannotMoveArenaCaptn: 20064
-  DbCannotMoveGuildmaster: 20012
-  DbCharacterDoesNotExist: 20019
-  DbCharacterWithoutGuild: 20070
-  DbCharLocked: 20026
-  DbCharNotLocked: 20025
-  DbCouldNotObtainCharLock: 20041
-  DbCustomizeAlreadyRequested: 20057
-  DbDeletedGuild: 20071
-  DbDuplicateCharacterName: 20015
-  DbDuplicateSupportRequest: 20063
-  DbEventNotActive: 20068
-  DbEventRealmClosed: 20038
-  DbFactionChangeTooSoon: 20061
-  DbGmSenorityInsufficient: 20072
-  DbGuildLevelInsufficient: 20074
-  DbGuildRankInsufficient: 20069
-  DbHasAuctions: 20033
-  DbHasBpayToken: 20079
-  DbHasCraftingOrders: 20092
-  DbHasHeirloomItem: 20080
-  DbHasMail: 20016
-  DbHasNewPlayerExperienceRestriction: 20091
-  DbHasUnclaimedCacheRewards: 20089
-  DbHouseOwnerRestriction: 20096
-  DbIneligibleMapID: 20076
-  DbIneligibleTargetRealm: 20022
-  DbInvalidName: 20094
-  DbInventoryCorrupt: 20040
-  DbLastCustomizeTooSoon: 20058
-  DbLastRenameTooRecent: 20052
-  DbLastRequestTooSoon: 20054
-  DbLastSaveTooDistant: 20083
-  DbLastSaveTooRecent: 20034
-  DbLockAlreadyRequested: 20044
-  DbLockNotAcknowledged: 20043
-  DbMaxCharactersOnServer: 20013
-  DbMoveInProgress: 20018
-  DbMultipleTransferCn: 20056
-  DbNameChangeSkipped: 20093
-  DbNameNotAvailable: 20051
-  DbNeedsEraChoice: 20090
-  DbNeedsLevelSquish: 20088
-  DbNewLeaderInvalid: 20086
-  DbNewNameTooLong: 20024
-  DbNoCopiesAvailable: 20020
-  DbNoCsiFound: 20065
-  DbNoMixedAlliance: 20014
-  DbNoneBatchQueueID: 20029
-  DbNoneLockID: 20042
-  DbNoneRealmForEvent: 20037
-  DbNoneSupportActionID: 20046
-  DbNoneSupportQueueID: 20045
-  DbNoneTemplateForEvent: 20039
-  DbNotMovebackable: 20048
-  DbNotRollbackable: 20047
-  DbOnBoostCooldown: 20085
-  DbPendingItemAudit: 20066
-  DbPvEPvPTransferNotAllowed: 20087
-  DbRaceClassComboIneligible: 20062
-  DbRealmNotEligible: 20011
-  DbRegionalDbNotFound: 20075
-  DbRenameAlreadyRequested: 20049
-  DbReservationDoesNotMatch: 20053
-  DbReservationExpired: 20050
-  DbResultAccountRestricted: 20082
-  DbResultSourceAccountBanned: 20081
-  DbTooMuchMoneyForLevel: 20032
-  DbTransferDateTooSoon: 20023
-  DbTransferNotCancellable: 20031
-  DbTransferNotFinalized: 20030
-  DbTransferNotLockable: 20035
-  DbTransferNotUnlockable: 20036
-  DbUnableToCustomize: 20060
-  DbUnderMinLevelReq: 20021
-  DbWaitingForPayment: 20059
-  DisallowedDestinationAccount: 9
-  DisallowedSourceAccount: 8
-  EndDbErrors: 20097
-  EndProxyErrors: 56
-  EndServerErrors: 16
-  InvalidBpayDeliverableID: 14
-  InvalidBpayProductID: 13
-  InvalidBpayProductType: 15
-  InvalidDestinationAccount: 6
-  InvalidDestinationRealm: 5
-  InvalidDistribution: 12
-  InvalidSourceAccount: 7
-  LowerBoxLevel: 11
-  None: 0
-  NoneCharacter: 2
-  NoneProduct: 3
-  OnlyOneVasAtATime: 4
-  ProxyAccountDataTooBig: 55
-  ProxyBadDbType: 35
-  ProxyBadObjType: 18
-  ProxyBadRequestContained: 33
-  ProxyBindFailed: 51
-  ProxyCannotDeleteArenaCaptain: 31
-  ProxyCannotDeleteGuildLeader: 30
-  ProxyCannotInsertNull: 45
-  ProxyCannotUndeleteTrialBoostCharacter: 46
-  ProxyCharacterHasWoWToken: 53
-  ProxyCharacterLevelTooHigh: 38
-  ProxyCharacterTransferred: 39
-  ProxyCharacterTransferredNoBoostInProgress: 40
-  ProxyDataInvalid: 22
-  ProxyDbError: 21
-  ProxyDeleteNotSupported: 28
-  ProxyExternalUpdateDetected: 37
-  ProxyGenericError: 44
-  ProxyInsertRequestContainedNoData: 49
-  ProxyInvalidKey: 50
-  ProxyIsReadonly: 34
-  ProxyLockedForToken: 42
-  ProxyLockedForTransfer: 26
-  ProxyLockedForUpgrade: 41
-  ProxyLockedForVas: 43
-  ProxyLocksFailed: 24
-  ProxyLostProxyConnection: 23
-  ProxyMissingResultsPtr: 25
-  ProxyMoneyLimitExceeded: 32
-  ProxyNoReturnValue: 27
-  ProxyObjDropped: 29
-  ProxyObjNotInDb: 19
-  ProxyOperationAlreadyInProgress: 36
-  ProxyPredicateFailed: 47
-  ProxyTooBusyBackOff: 54
-  ProxyTooManyRows: 52
-  ProxyUniqueKey: 20
-  ProxyWeeklyRewardNotFound: 48
-  UnknownError: 10
-  VasPurchaseDisabled: 1
+  values:
+    BeginDbErrors: 20010
+    BeginProxyErrors: 17
+    DbAccountDoesNotOwnCharacter: 20017
+    DbAllianceNotEligible: 20027
+    DbAlreadyRenameFlagged: 20055
+    DbAuthenticatorInsufficient: 20073
+    DbBatchProcessingDisabled: 20028
+    DbBatchStateInvalid: 20067
+    DbBnetAccountNotProvided: 20077
+    DbBoostProcessingDisabled: 20095
+    DbBpayDeliveryPending: 20078
+    DbCagedPetInInventory: 20084
+    DbCannotMoveArenaCaptn: 20064
+    DbCannotMoveGuildmaster: 20012
+    DbCharacterDoesNotExist: 20019
+    DbCharacterWithoutGuild: 20070
+    DbCharLocked: 20026
+    DbCharNotLocked: 20025
+    DbCouldNotObtainCharLock: 20041
+    DbCustomizeAlreadyRequested: 20057
+    DbDeletedGuild: 20071
+    DbDuplicateCharacterName: 20015
+    DbDuplicateSupportRequest: 20063
+    DbEventNotActive: 20068
+    DbEventRealmClosed: 20038
+    DbFactionChangeTooSoon: 20061
+    DbGmSenorityInsufficient: 20072
+    DbGuildLevelInsufficient: 20074
+    DbGuildRankInsufficient: 20069
+    DbHasAuctions: 20033
+    DbHasBpayToken: 20079
+    DbHasCraftingOrders: 20092
+    DbHasHeirloomItem: 20080
+    DbHasMail: 20016
+    DbHasNewPlayerExperienceRestriction: 20091
+    DbHasUnclaimedCacheRewards: 20089
+    DbHouseOwnerRestriction: 20096
+    DbIneligibleMapID: 20076
+    DbIneligibleTargetRealm: 20022
+    DbInvalidName: 20094
+    DbInventoryCorrupt: 20040
+    DbLastCustomizeTooSoon: 20058
+    DbLastRenameTooRecent: 20052
+    DbLastRequestTooSoon: 20054
+    DbLastSaveTooDistant: 20083
+    DbLastSaveTooRecent: 20034
+    DbLockAlreadyRequested: 20044
+    DbLockNotAcknowledged: 20043
+    DbMaxCharactersOnServer: 20013
+    DbMoveInProgress: 20018
+    DbMultipleTransferCn: 20056
+    DbNameChangeSkipped: 20093
+    DbNameNotAvailable: 20051
+    DbNeedsEraChoice: 20090
+    DbNeedsLevelSquish: 20088
+    DbNewLeaderInvalid: 20086
+    DbNewNameTooLong: 20024
+    DbNoCopiesAvailable: 20020
+    DbNoCsiFound: 20065
+    DbNoMixedAlliance: 20014
+    DbNoneBatchQueueID: 20029
+    DbNoneLockID: 20042
+    DbNoneRealmForEvent: 20037
+    DbNoneSupportActionID: 20046
+    DbNoneSupportQueueID: 20045
+    DbNoneTemplateForEvent: 20039
+    DbNotMovebackable: 20048
+    DbNotRollbackable: 20047
+    DbOnBoostCooldown: 20085
+    DbPendingItemAudit: 20066
+    DbPvEPvPTransferNotAllowed: 20087
+    DbRaceClassComboIneligible: 20062
+    DbRealmNotEligible: 20011
+    DbRegionalDbNotFound: 20075
+    DbRenameAlreadyRequested: 20049
+    DbReservationDoesNotMatch: 20053
+    DbReservationExpired: 20050
+    DbResultAccountRestricted: 20082
+    DbResultSourceAccountBanned: 20081
+    DbTooMuchMoneyForLevel: 20032
+    DbTransferDateTooSoon: 20023
+    DbTransferNotCancellable: 20031
+    DbTransferNotFinalized: 20030
+    DbTransferNotLockable: 20035
+    DbTransferNotUnlockable: 20036
+    DbUnableToCustomize: 20060
+    DbUnderMinLevelReq: 20021
+    DbWaitingForPayment: 20059
+    DisallowedDestinationAccount: 9
+    DisallowedSourceAccount: 8
+    EndDbErrors: 20097
+    EndProxyErrors: 56
+    EndServerErrors: 16
+    InvalidBpayDeliverableID: 14
+    InvalidBpayProductID: 13
+    InvalidBpayProductType: 15
+    InvalidDestinationAccount: 6
+    InvalidDestinationRealm: 5
+    InvalidDistribution: 12
+    InvalidSourceAccount: 7
+    LowerBoxLevel: 11
+    None: 0
+    NoneCharacter: 2
+    NoneProduct: 3
+    OnlyOneVasAtATime: 4
+    ProxyAccountDataTooBig: 55
+    ProxyBadDbType: 35
+    ProxyBadObjType: 18
+    ProxyBadRequestContained: 33
+    ProxyBindFailed: 51
+    ProxyCannotDeleteArenaCaptain: 31
+    ProxyCannotDeleteGuildLeader: 30
+    ProxyCannotInsertNull: 45
+    ProxyCannotUndeleteTrialBoostCharacter: 46
+    ProxyCharacterHasWoWToken: 53
+    ProxyCharacterLevelTooHigh: 38
+    ProxyCharacterTransferred: 39
+    ProxyCharacterTransferredNoBoostInProgress: 40
+    ProxyDataInvalid: 22
+    ProxyDbError: 21
+    ProxyDeleteNotSupported: 28
+    ProxyExternalUpdateDetected: 37
+    ProxyGenericError: 44
+    ProxyInsertRequestContainedNoData: 49
+    ProxyInvalidKey: 50
+    ProxyIsReadonly: 34
+    ProxyLockedForToken: 42
+    ProxyLockedForTransfer: 26
+    ProxyLockedForUpgrade: 41
+    ProxyLockedForVas: 43
+    ProxyLocksFailed: 24
+    ProxyLostProxyConnection: 23
+    ProxyMissingResultsPtr: 25
+    ProxyMoneyLimitExceeded: 32
+    ProxyNoReturnValue: 27
+    ProxyObjDropped: 29
+    ProxyObjNotInDb: 19
+    ProxyOperationAlreadyInProgress: 36
+    ProxyPredicateFailed: 47
+    ProxyTooBusyBackOff: 54
+    ProxyTooManyRows: 52
+    ProxyUniqueKey: 20
+    ProxyWeeklyRewardNotFound: 48
+    UnknownError: 10
+    VasPurchaseDisabled: 1
 ViewArenaSize:
-  Three: 1
-  Two: 0
+  values:
+    Three: 1
+    Two: 0
 ViewRaidSize:
-  Forty: 2
-  Ten: 0
-  TwentyFive: 1
+  values:
+    Forty: 2
+    Ten: 0
+    TwentyFive: 1
 VignetteObjectiveType:
-  Defeat: 1
-  DefeatShowRemainingHealth: 2
-  None: 0
+  values:
+    Defeat: 1
+    DefeatShowRemainingHealth: 2
+    None: 0
 VignetteType:
-  FyrakkFlight: 4
-  Normal: 0
-  PvPBounty: 1
-  Torghast: 2
-  Treasure: 3
+  values:
+    FyrakkFlight: 4
+    Normal: 0
+    PvPBounty: 1
+    Torghast: 2
+    Treasure: 3
 Vocalerrorsounds:
-  Abilitycooling: 50
-  Alreadyingroup: 20
-  Alreadyinguild: 21
-  Ammoonlyinbag: 28
-  Bagfull: 29
-  BoundNodrop: 4
-  Cantaffordbankslot: 22
-  CantattackNotarget: 38
-  CantattackNotstandingObsolete: 37
-  Cantattackrongdirection: 36
-  CantcastOutofrange: 46
-  Cantcreate: 18
-  Cantdrinkmore: 6
-  Canteatmore: 7
-  CanteatMoving: 24
-  Cantequip2Hequipped: 42
-  Cantequip2HNoskill: 43
-  Cantequip2HSkill: 41
-  Cantflyhere: 60
-  Cantinvite: 8
-  CantlearnLevel: 13
-  Cantloot: 17
-  CantlootDidntkill: 31
-  CantlootLocked: 33
-  CantlootNotstandingObsolete: 34
-  CantlootToofar: 35
-  CantlootWrongfacing: 32
-  Cantputbag: 26
-  Cantswap: 58
-  CanttaxiNomoney: 54
-  CanttradeSoulbound: 59
-  Cantuseitem: 51
-  Cantuselocked: 55
-  Cantusetoofar: 57
-  Chestinuse: 52
-  Declinegroup: 19
-  ExhaustedObsolete: 67
-  FoodcoolingObsolete: 53
-  Genericnotarget: 45
-  Guildpermissions: 62
-  Invaliditemtarget: 66
-  Invalidtarget: 11
-  Inventoryfull: 0
-  Inviteebusy: 9
-  Itemcooling: 5
-  Itemlocked: 61
-  Itemmaxcount: 30
-  Locked: 14
-  Mustequippitem: 49
-  Noenergy: 64
-  NoequipEver: 3
-  NoequipLevel: 2
-  Noequipslotavailable: 56
-  Noessence: 65
-  Nomana: 15
-  Norage: 63
-  Notabag: 25
-  Notenoughgold: 39
-  Notenoughmoney: 40
-  Notequippable: 44
-  Notwhiledead: 16
-  Outofammo: 1
-  Potioncooling: 47
-  Proficiencyneeded: 48
-  Spellcooling: 12
-  Targettoofar: 10
-  Toomanybankslots: 23
-  Wrongslot: 27
+  values:
+    Abilitycooling: 50
+    Alreadyingroup: 20
+    Alreadyinguild: 21
+    Ammoonlyinbag: 28
+    Bagfull: 29
+    BoundNodrop: 4
+    Cantaffordbankslot: 22
+    CantattackNotarget: 38
+    CantattackNotstandingObsolete: 37
+    Cantattackrongdirection: 36
+    CantcastOutofrange: 46
+    Cantcreate: 18
+    Cantdrinkmore: 6
+    Canteatmore: 7
+    CanteatMoving: 24
+    Cantequip2Hequipped: 42
+    Cantequip2HNoskill: 43
+    Cantequip2HSkill: 41
+    Cantflyhere: 60
+    Cantinvite: 8
+    CantlearnLevel: 13
+    Cantloot: 17
+    CantlootDidntkill: 31
+    CantlootLocked: 33
+    CantlootNotstandingObsolete: 34
+    CantlootToofar: 35
+    CantlootWrongfacing: 32
+    Cantputbag: 26
+    Cantswap: 58
+    CanttaxiNomoney: 54
+    CanttradeSoulbound: 59
+    Cantuseitem: 51
+    Cantuselocked: 55
+    Cantusetoofar: 57
+    Chestinuse: 52
+    Declinegroup: 19
+    ExhaustedObsolete: 67
+    FoodcoolingObsolete: 53
+    Genericnotarget: 45
+    Guildpermissions: 62
+    Invaliditemtarget: 66
+    Invalidtarget: 11
+    Inventoryfull: 0
+    Inviteebusy: 9
+    Itemcooling: 5
+    Itemlocked: 61
+    Itemmaxcount: 30
+    Locked: 14
+    Mustequippitem: 49
+    Noenergy: 64
+    NoequipEver: 3
+    NoequipLevel: 2
+    Noequipslotavailable: 56
+    Noessence: 65
+    Nomana: 15
+    Norage: 63
+    Notabag: 25
+    Notenoughgold: 39
+    Notenoughmoney: 40
+    Notequippable: 44
+    Notwhiledead: 16
+    Outofammo: 1
+    Potioncooling: 47
+    Proficiencyneeded: 48
+    Spellcooling: 12
+    Targettoofar: 10
+    Toomanybankslots: 23
+    Wrongslot: 27
 VoiceChatStatusCode:
-  AlreadyInChannel: 10
-  ChannelAlreadyExists: 9
-  ChannelNameTooLong: 8
-  ChannelNameTooShort: 7
-  ClientAlreadyLoggedIn: 6
-  ClientNotInitialized: 4
-  ClientNotLoggedIn: 5
-  Disabled: 18
-  Failure: 12
-  InvalidCommunityStream: 20
-  InvalidInputDevice: 23
-  InvalidOutputDevice: 24
-  LoginProhibited: 3
-  OperationPending: 1
-  PlayerSilenced: 21
-  PlayerVoiceChatParentalDisabled: 22
-  ProxyConnectionTimeOut: 15
-  ProxyConnectionUnableToConnect: 16
-  ProxyConnectionUnexpectedDisconnect: 17
-  ServiceLost: 13
-  Success: 0
-  TargetNotFound: 11
-  TooManyRequests: 2
-  UnableToLaunchProxy: 14
-  UnsupportedChatChannelType: 19
+  values:
+    AlreadyInChannel: 10
+    ChannelAlreadyExists: 9
+    ChannelNameTooLong: 8
+    ChannelNameTooShort: 7
+    ClientAlreadyLoggedIn: 6
+    ClientNotInitialized: 4
+    ClientNotLoggedIn: 5
+    Disabled: 18
+    Failure: 12
+    InvalidCommunityStream: 20
+    InvalidInputDevice: 23
+    InvalidOutputDevice: 24
+    LoginProhibited: 3
+    OperationPending: 1
+    PlayerSilenced: 21
+    PlayerVoiceChatParentalDisabled: 22
+    ProxyConnectionTimeOut: 15
+    ProxyConnectionUnableToConnect: 16
+    ProxyConnectionUnexpectedDisconnect: 17
+    ServiceLost: 13
+    Success: 0
+    TargetNotFound: 11
+    TooManyRequests: 2
+    UnableToLaunchProxy: 14
+    UnsupportedChatChannelType: 19
 VoiceTtsStatusCode:
-  DestinationQueueFull: 8
-  EngineAllocationFailed: 2
-  EnqueueNotNecessary: 9
-  InputTextEnqueued: 6
-  InternalError: 13
-  InvalidArgument: 12
-  InvalidEngineType: 1
-  ManagerNotFound: 11
-  MaxCharactersExceeded: 4
-  NotSupported: 3
-  SdkNotInitialized: 7
-  Success: 0
-  UtteranceBelowMinimumDuration: 5
-  UtteranceNotFound: 10
+  values:
+    DestinationQueueFull: 8
+    EngineAllocationFailed: 2
+    EnqueueNotNecessary: 9
+    InputTextEnqueued: 6
+    InternalError: 13
+    InvalidArgument: 12
+    InvalidEngineType: 1
+    ManagerNotFound: 11
+    MaxCharactersExceeded: 4
+    NotSupported: 3
+    SdkNotInitialized: 7
+    Success: 0
+    UtteranceBelowMinimumDuration: 5
+    UtteranceNotFound: 10
 WarbandSceneFlags:
-  AwardedAutomatically: 8
-  CannotBeSaved: 4
-  DoNotInclude: 1
-  HiddenUntilCollected: 2
-  IsDefault: 16
+  values:
+    AwardedAutomatically: 8
+    CannotBeSaved: 4
+    DoNotInclude: 1
+    HiddenUntilCollected: 2
+    IsDefault: 16
 WeaponSlot:
-  MainHand: 0
-  OffHand: 1
+  values:
+    MainHand: 0
+    OffHand: 1
 WeeklyRewardChestActivityType:
-  LFGDungeons: 1
-  Scenario: 0
-  World: 2
+  values:
+    LFGDungeons: 1
+    Scenario: 0
+    World: 2
 WeeklyRewardChestClaimRewardResult:
-  CountExceeded: 7
-  DbError: 5
-  InvalidSlot: 3
-  InvalidThreshold: 1
-  LockFailure: 6
-  PlayerNotFound: 2
-  Success: 0
-  TooManyItems: 4
+  values:
+    CountExceeded: 7
+    DbError: 5
+    InvalidSlot: 3
+    InvalidThreshold: 1
+    LockFailure: 6
+    PlayerNotFound: 2
+    Success: 0
+    TooManyItems: 4
 WeeklyRewardChestThresholdType:
-  Activities: 1
-  AlsoReceive: 4
-  Concession: 5
-  None: 0
-  Raid: 3
-  RankedPvP: 2
-  World: 6
+  values:
+    Activities: 1
+    AlsoReceive: 4
+    Concession: 5
+    None: 0
+    Raid: 3
+    RankedPvP: 2
+    World: 6
 WeeklyRewardProgressResult:
-  DbError: 3
-  NoPlayer: 4
-  NoSeason: 1
-  Success: 0
-  TimedOut: 2
+  values:
+    DbError: 3
+    NoPlayer: 4
+    NoSeason: 1
+    Success: 0
+    TimedOut: 2
 WidgetAnimationType:
-  Fade: 1
-  None: 0
+  values:
+    Fade: 1
+    None: 0
 WidgetCurrencyClass:
-  Currency: 0
-  Item: 1
+  values:
+    Currency: 0
+    Item: 1
 WidgetEnabledState:
-  Artifact: 5
-  Black: 6
-  BrightBlue: 7
-  Disabled: 0
-  Green: 4
-  Red: 2
-  White: 3
-  Yellow: 1
+  values:
+    Artifact: 5
+    Black: 6
+    BrightBlue: 7
+    Disabled: 0
+    Green: 4
+    Red: 2
+    White: 3
+    Yellow: 1
 WidgetGlowAnimType:
-  None: 0
-  Pulse: 1
+  values:
+    None: 0
+    Pulse: 1
 WidgetIconSizeType:
-  Large: 2
-  Medium: 1
-  Small: 0
-  Standard: 3
+  values:
+    Large: 2
+    Medium: 1
+    Small: 0
+    Standard: 3
 WidgetIconSourceType:
-  Item: 1
-  Spell: 0
+  values:
+    Item: 1
+    Spell: 0
 WidgetOpacityType:
-  Eighty: 2
-  Fifty: 5
-  Forty: 6
-  Ninety: 1
-  OneHundred: 0
-  Seventy: 3
-  Sixty: 4
-  Ten: 9
-  Thirty: 7
-  Twenty: 8
-  Zero: 10
+  values:
+    Eighty: 2
+    Fifty: 5
+    Forty: 6
+    Ninety: 1
+    OneHundred: 0
+    Seventy: 3
+    Sixty: 4
+    Ten: 9
+    Thirty: 7
+    Twenty: 8
+    Zero: 10
 WidgetShowGlowState:
-  HideGlow: 0
-  ShowGlow: 1
+  values:
+    HideGlow: 0
+    ShowGlow: 1
 WidgetShownState:
-  Hidden: 0
-  Shown: 1
+  values:
+    Hidden: 0
+    Shown: 1
 WidgetTextHorizontalAlignmentType:
-  Center: 1
-  Left: 0
-  Right: 2
+  values:
+    Center: 1
+    Left: 0
+    Right: 2
 WidgetUnitPowerBarFlashMomentType:
-  FlashWhenMax: 0
-  FlashWhenMin: 1
-  NeverFlash: 2
+  values:
+    FlashWhenMax: 0
+    FlashWhenMin: 1
+    NeverFlash: 2
 WorldCursorAnchorType:
-  Cursor: 2
-  Default: 1
-  Nameplate: 3
-  None: 0
+  values:
+    Cursor: 2
+    Default: 1
+    Nameplate: 3
+    None: 0
 WorldElapsedTimerTypes:
-  ChallengeMode: 1
-  None: 0
-  ProvingGround: 2
+  values:
+    ChallengeMode: 1
+    None: 0
+    ProvingGround: 2
 WorldTierDifficulty:
-  Heroic: 2
-  Mythic: 3
-  Normal: 1
+  values:
+    Heroic: 2
+    Mythic: 3
+    Normal: 1
 WoWClientCursorSize:
-  ExtraLarge: 3
-  Large: 2
-  Massive: 4
-  Medium: 1
-  Standard: 0
+  values:
+    ExtraLarge: 3
+    Large: 2
+    Massive: 4
+    Medium: 1
+    Standard: 0
 WoWEntitlementType:
-  Appearance: 4
-  AppearanceSet: 5
-  Battlepet: 2
-  GameTime: 6
-  Illusion: 8
-  Invalid: 9
-  Item: 0
-  Mount: 1
-  Title: 7
-  Toy: 3
+  values:
+    Appearance: 4
+    AppearanceSet: 5
+    Battlepet: 2
+    GameTime: 6
+    Illusion: 8
+    Invalid: 9
+    Item: 0
+    Mount: 1
+    Title: 7
+    Toy: 3
 WoWLabsAreaType:
-  PlunderstormDropDense: 2
-  PlunderstormDropMedium: 1
-  PlunderstormDropSparse: 0
+  values:
+    PlunderstormDropDense: 2
+    PlunderstormDropMedium: 1
+    PlunderstormDropSparse: 0
 ZoneControlActiveState:
-  Active: 1
-  Inactive: 0
+  values:
+    Active: 1
+    Inactive: 0
 ZoneControlDangerFlashType:
-  ShowOnBadStates: 1
-  ShowOnBoth: 2
-  ShowOnGoodStates: 0
-  ShowOnNeither: 3
+  values:
+    ShowOnBadStates: 1
+    ShowOnBoth: 2
+    ShowOnGoodStates: 0
+    ShowOnNeither: 3
 ZoneControlFillType:
-  DoubleFillClockwise: 2
-  DoubleFillCounterClockwise: 3
-  SingleFillClockwise: 0
-  SingleFillCounterClockwise: 1
+  values:
+    DoubleFillClockwise: 2
+    DoubleFillCounterClockwise: 3
+    SingleFillClockwise: 0
+    SingleFillCounterClockwise: 1
 ZoneControlLeadingEdgeType:
-  NoLeadingEdge: 0
-  UseLeadingEdge: 1
+  values:
+    NoLeadingEdge: 0
+    UseLeadingEdge: 1
 ZoneControlMode:
-  BothStatesAreGood: 0
-  NeitherStateIsGood: 3
-  State1IsGood: 1
-  State2IsGood: 2
+  values:
+    BothStatesAreGood: 0
+    NeitherStateIsGood: 3
+    State1IsGood: 1
+    State2IsGood: 2
 ZoneControlState:
-  State1: 0
-  State2: 1
+  values:
+    State1: 0
+    State2: 1

--- a/data/products/wow_classic_ptr/enums.yaml
+++ b/data/products/wow_classic_ptr/enums.yaml
@@ -1,7222 +1,8017 @@
 AbbreviationDataError:
-  InvalidBreakpoint: 1
-  InvalidFractionDivisor: 4
-  InvalidSignificandDivisor: 2
-  NotMultipleOfTen: 8
+  values:
+    InvalidBreakpoint: 1
+    InvalidFractionDivisor: 4
+    InvalidSignificandDivisor: 2
+    NotMultipleOfTen: 8
 AccountCurrencyTransferResult:
-  CannotUseCurrency: 8
-  CharacterLoggedIn: 2
-  CurrencyTransferDisabled: 10
-  InsufficientCurrency: 3
-  InvalidCharacter: 1
-  InvalidCurrency: 5
-  MaxQuantity: 4
-  NoValidSourceCharacter: 6
-  ServerError: 7
-  Success: 0
-  TransactionInProgress: 9
+  values:
+    CannotUseCurrency: 8
+    CharacterLoggedIn: 2
+    CurrencyTransferDisabled: 10
+    InsufficientCurrency: 3
+    InvalidCharacter: 1
+    InvalidCurrency: 5
+    MaxQuantity: 4
+    NoValidSourceCharacter: 6
+    ServerError: 7
+    Success: 0
+    TransactionInProgress: 9
 AccountData:
-  Bindings: 2
-  Bindings2: 3
-  CharacterListOrder: 16
-  ChatSettings: 7
-  ClickBindings: 12
-  Config: 0
-  Config2: 1
-  CooldownManager: 17
-  CooldownManager2: 18
-  FlaggedIDs: 10
-  FlaggedIDs2: 11
-  FrontendChatSettings: 15
-  Macros: 4
-  Macros2: 5
-  Shop2PendingOrders: 19
-  TtsSettings: 8
-  TtsSettings2: 9
-  UIEditModeAccount: 13
-  UIEditModeChar: 14
-  UILayout: 6
+  values:
+    Bindings: 2
+    Bindings2: 3
+    CharacterListOrder: 16
+    ChatSettings: 7
+    ClickBindings: 12
+    Config: 0
+    Config2: 1
+    CooldownManager: 17
+    CooldownManager2: 18
+    FlaggedIDs: 10
+    FlaggedIDs2: 11
+    FrontendChatSettings: 15
+    Macros: 4
+    Macros2: 5
+    Shop2PendingOrders: 19
+    TtsSettings: 8
+    TtsSettings2: 9
+    UIEditModeAccount: 13
+    UIEditModeChar: 14
+    UILayout: 6
 AccountDataUpdateStatus:
-  Corrupt: 2
-  Failed: 1
-  Success: 0
-  Toobig: 3
+  values:
+    Corrupt: 2
+    Failed: 1
+    Success: 0
+    Toobig: 3
 AccountExportResult:
-  AlreadyInProgress: 11
-  Cancelled: 2
-  FailedToGenerateFile: 13
-  FailedToLockAccount: 12
-  FileInvalid: 8
-  FileWriteFailed: 9
-  NoAccountFound: 5
-  RequestedInvalidCharacter: 6
-  RpcError: 7
-  ShuttingDown: 3
-  Success: 0
-  TimedOut: 4
-  Unavailable: 10
-  UnknownError: 1
+  values:
+    AlreadyInProgress: 11
+    Cancelled: 2
+    FailedToGenerateFile: 13
+    FailedToLockAccount: 12
+    FileInvalid: 8
+    FileWriteFailed: 9
+    NoAccountFound: 5
+    RequestedInvalidCharacter: 6
+    RpcError: 7
+    ShuttingDown: 3
+    Success: 0
+    TimedOut: 4
+    Unavailable: 10
+    UnknownError: 1
 AccountSequenceCacheType:
-  HouseDecor: 2
-  Invalid: 0
-  Local: 1
+  values:
+    HouseDecor: 2
+    Invalid: 0
+    Local: 1
 AccountStateFlags:
-  AccountUpgradeComplete: 4
-  InPetCombat: 2
-  LoadFailed: 1
-  None: 0
-  TokenEligCheckComplete: 8
+  values:
+    AccountUpgradeComplete: 4
+    InPetCombat: 2
+    LoadFailed: 1
+    None: 0
+    TokenEligCheckComplete: 8
 AccountStateLoadedFlags:
-  AccountCurrenciesLoaded: '0x0000000000200000'
-  AccountFactionsLoaded: '0x0000000200000000'
-  AccountItemsLoaded: '0x0000000400000000'
-  AccountMappingLoaded: '0x0000008000000000'
-  AccountNotificationsLoaded: '0x0000000008000000'
-  AccountWowlabsLoaded: '0x0000000020000000'
-  AchievementsLoaded: '0x0000000000000001'
-  ArchivedPurchasesLoaded: '0x0000000000000200'
-  AuctionableTokensLoaded: '0x0000000000002000'
-  BanktabSettingsLoaded: '0x0000004000000000'
-  BattleNetAccountLoaded: '0x0000000000100000'
-  BitVectorsLoaded: '0x0000000100000000'
-  BpayAddLicenseObjectsLoaded: '0x0000000000000800'
-  BpayDistributionObjectsLoaded: '0x0000000000000100'
-  BpayProductitemObjectsLoaded: '0x0000000000020000'
-  CharacterItemsLoaded: '0x0000010000000000'
-  CharactersLoaded: '0x0000000000000040'
-  CombinedQuestLogLoaded: '0x0000000800000000'
-  ConsumableTokensLoaded: '0x0000000000004000'
-  CriteriaLoaded: '0x0000000000000002'
-  CurrencyCapsLoaded: '0x0000000000000010'
-  CurrencyTransferLogLoaded: '0x0000020000000000'
-  DataElementsLoaded: '0x0000001000000000'
-  DynamicCriteriaLoaded: '0x0000000001000000'
-  EventRecordsLoaded: '0x0000200000000000'
-  HousingDataLoaded: '0x0000080000000000'
-  ItemCollectionsLoaded: '0x0000000000001000'
-  LgVendorPurchaseLoaded: '0x0000040000000000'
-  LoadedNone: '0x0000000000000000'
-  MountsLoaded: '0x0000000000000004'
-  PerksHeldItemLoaded: '0x0000000040000000'
-  PerksPastRewardsLoaded: '0x0000000000008000'
-  PerksPendingPurchaseLoaded: '0x0000000010000000'
-  PerksPendingRewardsLoaded: '0x0000000080000000'
-  PetjournalInitialized: '0x0000000000000008'
-  PurchasesLoaded: '0x0000000000000080'
-  QuestCriteriaLoaded: '0x0000000000080000'
-  QuestLogLoaded: '0x0000000000000020'
-  RafActivityLoaded: '0x0000000002000000'
-  RafBalanceLoaded: '0x0000000000400000'
-  RafRewardsLoaded: '0x0000000000800000'
-  RevokedRafRewardsLoaded: '0x0000000004000000'
-  SettingsLoaded: '0x0000000000000400'
-  TransmogOutfitsLoaded: '0x0000400000000000'
-  TrialBoostHistoryLoaded: '0x0000000000040000'
-  VasTransactionsLoaded: '0x0000000000010000'
-  WarbandScenesLoaded: '0x0000100000000000'
-  WarbandsLoaded: '0x0000002000000000'
+  values:
+    AccountCurrenciesLoaded: '0x0000000000200000'
+    AccountFactionsLoaded: '0x0000000200000000'
+    AccountItemsLoaded: '0x0000000400000000'
+    AccountMappingLoaded: '0x0000008000000000'
+    AccountNotificationsLoaded: '0x0000000008000000'
+    AccountWowlabsLoaded: '0x0000000020000000'
+    AchievementsLoaded: '0x0000000000000001'
+    ArchivedPurchasesLoaded: '0x0000000000000200'
+    AuctionableTokensLoaded: '0x0000000000002000'
+    BanktabSettingsLoaded: '0x0000004000000000'
+    BattleNetAccountLoaded: '0x0000000000100000'
+    BitVectorsLoaded: '0x0000000100000000'
+    BpayAddLicenseObjectsLoaded: '0x0000000000000800'
+    BpayDistributionObjectsLoaded: '0x0000000000000100'
+    BpayProductitemObjectsLoaded: '0x0000000000020000'
+    CharacterItemsLoaded: '0x0000010000000000'
+    CharactersLoaded: '0x0000000000000040'
+    CombinedQuestLogLoaded: '0x0000000800000000'
+    ConsumableTokensLoaded: '0x0000000000004000'
+    CriteriaLoaded: '0x0000000000000002'
+    CurrencyCapsLoaded: '0x0000000000000010'
+    CurrencyTransferLogLoaded: '0x0000020000000000'
+    DataElementsLoaded: '0x0000001000000000'
+    DynamicCriteriaLoaded: '0x0000000001000000'
+    EventRecordsLoaded: '0x0000200000000000'
+    HousingDataLoaded: '0x0000080000000000'
+    ItemCollectionsLoaded: '0x0000000000001000'
+    LgVendorPurchaseLoaded: '0x0000040000000000'
+    LoadedNone: '0x0000000000000000'
+    MountsLoaded: '0x0000000000000004'
+    PerksHeldItemLoaded: '0x0000000040000000'
+    PerksPastRewardsLoaded: '0x0000000000008000'
+    PerksPendingPurchaseLoaded: '0x0000000010000000'
+    PerksPendingRewardsLoaded: '0x0000000080000000'
+    PetjournalInitialized: '0x0000000000000008'
+    PurchasesLoaded: '0x0000000000000080'
+    QuestCriteriaLoaded: '0x0000000000080000'
+    QuestLogLoaded: '0x0000000000000020'
+    RafActivityLoaded: '0x0000000002000000'
+    RafBalanceLoaded: '0x0000000000400000'
+    RafRewardsLoaded: '0x0000000000800000'
+    RevokedRafRewardsLoaded: '0x0000000004000000'
+    SettingsLoaded: '0x0000000000000400'
+    TransmogOutfitsLoaded: '0x0000400000000000'
+    TrialBoostHistoryLoaded: '0x0000000000040000'
+    VasTransactionsLoaded: '0x0000000000010000'
+    WarbandScenesLoaded: '0x0000100000000000'
+    WarbandsLoaded: '0x0000002000000000'
 AccountStoreCategoryType:
-  Creature: 1
-  Icon: 4
-  Mount: 3
-  TransmogSet: 2
+  values:
+    Creature: 1
+    Icon: 4
+    Mount: 3
+    TransmogSet: 2
 AccountStoreFrontFlag:
-  Enabled: 1
-  PurchaseEnabled: 2
-  RefundEnabled: 4
+  values:
+    Enabled: 1
+    PurchaseEnabled: 2
+    RefundEnabled: 4
 AccountStoreItemFlag:
-  DisplayAsNew: 4
-  DisplayDefaultArmor: 1
-  DisplayOnly: 8
-  NotInGameReward: 2
+  values:
+    DisplayAsNew: 4
+    DisplayDefaultArmor: 1
+    DisplayOnly: 8
+    NotInGameReward: 2
 AccountStoreItemMode:
-  Hidden: 2
-  Locked: 3
-  Normal: 1
+  values:
+    Hidden: 2
+    Locked: 3
+    Normal: 1
 AccountStoreItemRewardType:
-  Illusion: 7
-  Misc: 10
-  Mount: 2
-  Pet: 3
-  Tender: 9
-  Toy: 5
-  Transmog: 1
-  TransmogSet: 8
-  WarbandScene: 11
+  values:
+    Illusion: 7
+    Misc: 10
+    Mount: 2
+    Pet: 3
+    Tender: 9
+    Toy: 5
+    Transmog: 1
+    TransmogSet: 8
+    WarbandScene: 11
 AccountStoreItemStatus:
-  Owned: 3
-  Refundable: 2
-  Unowned: 1
+  values:
+    Owned: 3
+    Refundable: 2
+    Unowned: 1
 AccountStoreSettlementAction:
-  Give: 1
-  NotSet: 0
-  Remove: 2
+  values:
+    Give: 1
+    NotSet: 0
+    Remove: 2
 AccountStoreState:
-  Available: 0
-  Unavailable: 2
-  Unknown: 1
+  values:
+    Available: 0
+    Unavailable: 2
+    Unknown: 1
 AccountStoreTransactionResult:
-  Incomplete: 1
-  InsufficientFunds: 4
-  InvalidCurrencyType: 8
-  ItemAlreadyOwned: 6
-  ItemNotOwned: 7
-  ItemUnknown: 5
-  NotSupported: 10
-  OwnedButRefundTimeExpired: 9
-  ProxyError: 12
-  Success: 0
-  TransactionInProgress: 3
-  Unavailable: 11
-  UnknownError: 2
+  values:
+    Incomplete: 1
+    InsufficientFunds: 4
+    InvalidCurrencyType: 8
+    ItemAlreadyOwned: 6
+    ItemNotOwned: 7
+    ItemUnknown: 5
+    NotSupported: 10
+    OwnedButRefundTimeExpired: 9
+    ProxyError: 12
+    Success: 0
+    TransactionInProgress: 3
+    Unavailable: 11
+    UnknownError: 2
 AccountStoreTransactionType:
-  DebugRemoveItem: 4
-  DebugResetHistory: 3
-  Purchase: 1
-  Refund: 2
-  Undefined: 0
+  values:
+    DebugRemoveItem: 4
+    DebugResetHistory: 3
+    Purchase: 1
+    Refund: 2
+    Undefined: 0
 AccountTransType:
-  AccountCurrencies: 26
-  AccountNotifications: 38
-  AccountStore: 54
-  Achievements: 4
-  AddLicense: 16
-  ArchivedPurchases: 9
-  AuctionableToken: 18
-  BankTab: 48
-  BattlenetAccount: 25
-  Battlepet: 3
-  BitVectors: 50
-  CharacterDataMerge: 53
-  CharacterItems: 57
-  Characters: 7
-  CombinedQuestLog: 51
-  ConsumableToken: 19
-  CreateOrderInfo: 32
-  Criteria: 5
-  CriteriaNotif: 13
-  CurrencyCaps: 11
-  CurrencyTransferLog: 58
-  Distribution: 2
-  Distributions: 10
-  DynamicCriteria: 30
-  EventRecords: 63
-  Factions: 49
-  FixedLicense: 15
-  GetOrderStatusByPurchaseID: 46
-  HouseInitiativeFavor: 66
-  HousingItem: 64
-  ItemCollections: 17
-  Items: 47
-  LgVendorPurchase: 59
-  LoadWowlabs: 44
-  Mapping: 56
-  Mounts: 6
-  OutstandingRpc: 43
-  PerkItemHold: 39
-  PerkPastRewards: 41
-  PerkPendingRewards: 40
-  PerkTransaction: 42
-  PlayerDataElements: 52
-  Productitem: 21
-  Profile: 61
-  ProxyCreateAccountHonor: 34
-  ProxyForwarder: 0
-  ProxyGenerateBpayID: 37
-  ProxyGmSetHonor: 36
-  ProxyHonorInitialConversion: 33
-  ProxyValidateAccountHonor: 35
-  Purchase: 1
-  Purchases: 8
-  QuestCriteria: 24
-  QuestLog: 12
-  RafActivity: 31
-  RafFriendMonth: 28
-  RafRecruiterAcceptances: 27
-  RafReward: 29
-  SaveWarbandGroups: 60
-  Settings: 14
-  TransmogOutfitCollection: 65
-  TrialBoostHistories: 23
-  TrialBoostHistory: 22
-  UpgradeAccount: 45
-  VasTransaction: 20
-  WarbandGroups: 55
-  WarbandSceneCollection: 62
+  values:
+    AccountCurrencies: 26
+    AccountNotifications: 38
+    AccountStore: 54
+    Achievements: 4
+    AddLicense: 16
+    ArchivedPurchases: 9
+    AuctionableToken: 18
+    BankTab: 48
+    BattlenetAccount: 25
+    Battlepet: 3
+    BitVectors: 50
+    CharacterDataMerge: 53
+    CharacterItems: 57
+    Characters: 7
+    CombinedQuestLog: 51
+    ConsumableToken: 19
+    CreateOrderInfo: 32
+    Criteria: 5
+    CriteriaNotif: 13
+    CurrencyCaps: 11
+    CurrencyTransferLog: 58
+    Distribution: 2
+    Distributions: 10
+    DynamicCriteria: 30
+    EventRecords: 63
+    Factions: 49
+    FixedLicense: 15
+    GetOrderStatusByPurchaseID: 46
+    HouseInitiativeFavor: 66
+    HousingItem: 64
+    ItemCollections: 17
+    Items: 47
+    LgVendorPurchase: 59
+    LoadWowlabs: 44
+    Mapping: 56
+    Mounts: 6
+    OutstandingRpc: 43
+    PerkItemHold: 39
+    PerkPastRewards: 41
+    PerkPendingRewards: 40
+    PerkTransaction: 42
+    PlayerDataElements: 52
+    Productitem: 21
+    Profile: 61
+    ProxyCreateAccountHonor: 34
+    ProxyForwarder: 0
+    ProxyGenerateBpayID: 37
+    ProxyGmSetHonor: 36
+    ProxyHonorInitialConversion: 33
+    ProxyValidateAccountHonor: 35
+    Purchase: 1
+    Purchases: 8
+    QuestCriteria: 24
+    QuestLog: 12
+    RafActivity: 31
+    RafFriendMonth: 28
+    RafRecruiterAcceptances: 27
+    RafReward: 29
+    SaveWarbandGroups: 60
+    Settings: 14
+    TransmogOutfitCollection: 65
+    TrialBoostHistories: 23
+    TrialBoostHistory: 22
+    UpgradeAccount: 45
+    VasTransaction: 20
+    WarbandGroups: 55
+    WarbandSceneCollection: 62
 ActionBarOrientation:
-  Horizontal: 0
-  Vertical: 1
+  values:
+    Horizontal: 0
+    Vertical: 1
 ActionBarVisibleSetting:
-  Always: 0
-  Hidden: 3
-  InCombat: 1
-  OutOfCombat: 2
+  values:
+    Always: 0
+    Hidden: 3
+    InCombat: 1
+    OutOfCombat: 2
 AddOnEnableState:
-  All: 2
-  None: 0
-  Some: 1
+  values:
+    All: 2
+    None: 0
+    Some: 1
 AddOnPerformanceMessageType:
-  OverallAddOnErrorDialog: 2
-  SpecificAddOnChatWarning: 0
-  SpecificAddOnErrorDialog: 1
+  values:
+    OverallAddOnErrorDialog: 2
+    SpecificAddOnChatWarning: 0
+    SpecificAddOnErrorDialog: 1
 AddOnProfilerMetric:
-  CountTimeOver1000Ms: 11
-  CountTimeOver100Ms: 9
-  CountTimeOver10Ms: 7
-  CountTimeOver1Ms: 5
-  CountTimeOver500Ms: 10
-  CountTimeOver50Ms: 8
-  CountTimeOver5Ms: 6
-  EncounterAverageTime: 2
-  LastTime: 3
-  PeakTime: 4
-  RecentAverageTime: 1
-  SessionAverageTime: 0
+  values:
+    CountTimeOver1000Ms: 11
+    CountTimeOver100Ms: 9
+    CountTimeOver10Ms: 7
+    CountTimeOver1Ms: 5
+    CountTimeOver500Ms: 10
+    CountTimeOver50Ms: 8
+    CountTimeOver5Ms: 6
+    EncounterAverageTime: 2
+    LastTime: 3
+    PeakTime: 4
+    RecentAverageTime: 1
+    SessionAverageTime: 0
 AddOnRestrictionState:
-  Activating: 1
-  Active: 2
-  Inactive: 0
+  values:
+    Activating: 1
+    Active: 2
+    Inactive: 0
 AddOnRestrictionType:
-  ChallengeMode: 2
-  Chat: 5
-  Combat: 0
-  Encounter: 1
-  Map: 4
-  PvPMatch: 3
+  values:
+    ChallengeMode: 2
+    Chat: 5
+    Combat: 0
+    Encounter: 1
+    Map: 4
+    PvPMatch: 3
 AddOnSecurityStatus:
-  Banned: 2
-  Insecure: 1
-  NotAvailable: 3
-  Secure: 0
+  values:
+    Banned: 2
+    Insecure: 1
+    NotAvailable: 3
+    Secure: 0
 ArrowCalloutDirection:
-  Down: 1
-  Left: 2
-  Right: 3
-  Up: 0
+  values:
+    Down: 1
+    Left: 2
+    Right: 3
+    Up: 0
 ArrowCalloutType:
-  Generic: 1
-  None: 0
-  Tutorial: 3
-  WidgetContainerNoBorder: 4
-  WorldLootObject: 2
+  values:
+    Generic: 1
+    None: 0
+    Tutorial: 3
+    WidgetContainerNoBorder: 4
+    WorldLootObject: 2
 AssistActionType:
-  CapturedBuff: 6
-  GraveMarker: 2
-  LoungingPlayer: 1
-  None: 0
-  PlacedVo: 3
-  PlayerGuardian: 4
-  PlayerSlayer: 5
+  values:
+    CapturedBuff: 6
+    GraveMarker: 2
+    LoungingPlayer: 1
+    None: 0
+    PlacedVo: 3
+    PlayerGuardian: 4
+    PlayerSlayer: 5
 AuctionHouseCommoditySortOrder:
-  Quantity: 1
-  UnitPrice: 0
+  values:
+    Quantity: 1
+    UnitPrice: 0
 AuctionHouseError:
-  BidIncrement: 2
-  BidOwn: 3
-  BoundItem: 16
-  ConjuredItem: 17
-  DatabaseError: 10
-  DoubleBid: 23
-  EquippedBag: 20
-  FavoritesMaxed: 24
-  HasRestriction: 6
-  HigherBid: 1
-  IsBag: 19
-  IsBusy: 7
-  ItemBoundToAccountUntilEquip: 26
-  ItemHasQuote: 9
-  ItemNotAvailable: 25
-  ItemNotFound: 4
-  LimitedDurationItem: 18
-  LootItem: 22
-  MinBid: 11
-  NotEnoughItems: 12
-  NotEnoughMoney: 0
-  QuestItem: 15
-  RepairItem: 13
-  RestrictedAccountTrial: 5
-  Unavailable: 8
-  UsedCharges: 14
-  WrappedItem: 21
+  values:
+    BidIncrement: 2
+    BidOwn: 3
+    BoundItem: 16
+    ConjuredItem: 17
+    DatabaseError: 10
+    DoubleBid: 23
+    EquippedBag: 20
+    FavoritesMaxed: 24
+    HasRestriction: 6
+    HigherBid: 1
+    IsBag: 19
+    IsBusy: 7
+    ItemBoundToAccountUntilEquip: 26
+    ItemHasQuote: 9
+    ItemNotAvailable: 25
+    ItemNotFound: 4
+    LimitedDurationItem: 18
+    LootItem: 22
+    MinBid: 11
+    NotEnoughItems: 12
+    NotEnoughMoney: 0
+    QuestItem: 15
+    RepairItem: 13
+    RestrictedAccountTrial: 5
+    Unavailable: 8
+    UsedCharges: 14
+    WrappedItem: 21
 AuctionHouseFilter:
-  ArtifactQuality: 12
-  CommonQuality: 7
-  CurrentExpansionOnly: 3
-  EpicQuality: 10
-  ExactMatch: 5
-  LegendaryCraftedItemOnly: 13
-  LegendaryQuality: 11
-  None: 0
-  PoorQuality: 6
-  RareQuality: 9
-  UncollectedOnly: 1
-  UncommonQuality: 8
-  UpgradesOnly: 4
-  UsableOnly: 2
+  values:
+    ArtifactQuality: 12
+    CommonQuality: 7
+    CurrentExpansionOnly: 3
+    EpicQuality: 10
+    ExactMatch: 5
+    LegendaryCraftedItemOnly: 13
+    LegendaryQuality: 11
+    None: 0
+    PoorQuality: 6
+    RareQuality: 9
+    UncollectedOnly: 1
+    UncommonQuality: 8
+    UpgradesOnly: 4
+    UsableOnly: 2
 AuctionHouseFilterCategory:
-  Equipment: 1
-  Rarity: 2
-  Uncategorized: 0
+  values:
+    Equipment: 1
+    Rarity: 2
+    Uncategorized: 0
 AuctionHouseItemSortOrder:
-  Bid: 0
-  Buyout: 1
+  values:
+    Bid: 0
+    Buyout: 1
 AuctionHouseNotification:
-  AuctionExpired: 5
-  AuctionOutbid: 3
-  AuctionRemoved: 1
-  AuctionSold: 4
-  AuctionWon: 2
-  BidPlaced: 0
+  values:
+    AuctionExpired: 5
+    AuctionOutbid: 3
+    AuctionRemoved: 1
+    AuctionSold: 4
+    AuctionWon: 2
+    BidPlaced: 0
 AuctionHouseSortOrder:
-  Bid: 3
-  Buyout: 4
-  Level: 2
-  Name: 1
-  Price: 0
-  TimeRemaining: 5
+  values:
+    Bid: 3
+    Buyout: 4
+    Level: 2
+    Name: 1
+    Price: 0
+    TimeRemaining: 5
 AuctionHouseTimeLeftBand:
-  Long: 2
-  Medium: 1
-  Short: 0
-  VeryLong: 3
+  values:
+    Long: 2
+    Medium: 1
+    Short: 0
+    VeryLong: 3
 AuctionStatus:
-  Active: 0
-  Sold: 1
+  values:
+    Active: 0
+    Sold: 1
 AuraFrameIconDirection:
-  Down: 0
-  Left: 0
-  Right: 1
-  Up: 1
+  values:
+    Down: 0
+    Left: 0
+    Right: 1
+    Up: 1
 AuraFrameIconWrap:
-  Down: 0
-  Left: 0
-  Right: 1
-  Up: 1
+  values:
+    Down: 0
+    Left: 0
+    Right: 1
+    Up: 1
 AuraFrameOrientation:
-  Horizontal: 0
-  Vertical: 1
+  values:
+    Horizontal: 0
+    Vertical: 1
 AuraFrameVisibleSetting:
-  Always: 0
-  Hidden: 2
-  InCombat: 1
+  values:
+    Always: 0
+    Hidden: 2
+    InCombat: 1
 AutoCompleteEntryFlag:
-  AccountCharacter: 128
-  Bnet: 8
-  Friend: 4
-  InAOI: 64
-  InGroup: 1
-  InGuild: 2
-  InteractedWith: 16
-  Online: 32
-  RecentPlayer: 256
+  values:
+    AccountCharacter: 128
+    Bnet: 8
+    Friend: 4
+    InAOI: 64
+    InGroup: 1
+    InGuild: 2
+    InteractedWith: 16
+    Online: 32
+    RecentPlayer: 256
 AutoCompletePriority:
-  AccountCharacter: 5
-  AccountCharacterSameRealm: 6
-  Friend: 4
-  Guild: 3
-  InGroup: 2
-  Interacted: 1
-  Other: 0
+  values:
+    AccountCharacter: 5
+    AccountCharacterSameRealm: 6
+    Friend: 4
+    Guild: 3
+    InGroup: 2
+    Interacted: 1
+    Other: 0
 AvgItemLevelCategories:
-  Base: 0
-  EquippedBase: 1
-  EquippedEffective: 2
-  EquippedEffectiveWeighted: 5
-  PvP: 3
-  PvPWeighted: 4
+  values:
+    Base: 0
+    EquippedBase: 1
+    EquippedEffective: 2
+    EquippedEffectiveWeighted: 5
+    PvP: 3
+    PvPWeighted: 4
 AzeriteEssenceSlot:
-  MainSlot: 0
-  PassiveOneSlot: 1
-  PassiveThreeSlot: 3
-  PassiveTwoSlot: 2
+  values:
+    MainSlot: 0
+    PassiveOneSlot: 1
+    PassiveThreeSlot: 3
+    PassiveTwoSlot: 2
 AzeritePowerLevel:
-  Base: 0
-  Downgraded: 2
-  Upgraded: 1
+  values:
+    Base: 0
+    Downgraded: 2
+    Upgraded: 1
 BagFlag:
-  AllowBagsInNonBagSlots: 1024
-  AllowBuyback: 65536
-  AllowPartialStack: 16384
-  AllowSoulboundItemInAccountBank: 134217728
-  AlreadyBound: 4
-  AlreadyOwner: 2
-  AsymmetricSwap: 1048576
-  BagIsEmpty: 16
-  DontFindStack: 1
-  HasRefund: 33554432
-  IgnoreBankcheck: 512
-  IgnoreBoundItemCheck: 64
-  IgnoreExisting: 8192
-  IgnorePetBankcheck: 131072
-  IgnoreReagentBags: 8388608
-  IgnoreSoulbound: 4194304
-  LookInAccountBankOnly: 16777216
-  LookInBankOnly: 32768
-  LookInInventory: 32
-  PreferNeutralPriorityBags: 524288
-  PreferPriorityBags: 262144
-  PreferQuivers: 2048
-  PreferReagentBags: 2097152
-  RecurseQuivers: 256
-  SkipValidCountCheck: 67108864
-  StackOnly: 128
-  Swap: 8
-  SwapBags: 4096
+  values:
+    AllowBagsInNonBagSlots: 1024
+    AllowBuyback: 65536
+    AllowPartialStack: 16384
+    AllowSoulboundItemInAccountBank: 134217728
+    AlreadyBound: 4
+    AlreadyOwner: 2
+    AsymmetricSwap: 1048576
+    BagIsEmpty: 16
+    DontFindStack: 1
+    HasRefund: 33554432
+    IgnoreBankcheck: 512
+    IgnoreBoundItemCheck: 64
+    IgnoreExisting: 8192
+    IgnorePetBankcheck: 131072
+    IgnoreReagentBags: 8388608
+    IgnoreSoulbound: 4194304
+    LookInAccountBankOnly: 16777216
+    LookInBankOnly: 32768
+    LookInInventory: 32
+    PreferNeutralPriorityBags: 524288
+    PreferPriorityBags: 262144
+    PreferQuivers: 2048
+    PreferReagentBags: 2097152
+    RecurseQuivers: 256
+    SkipValidCountCheck: 67108864
+    StackOnly: 128
+    Swap: 8
+    SwapBags: 4096
 BagIndex:
-  Accountbanktab: -5
-  AccountBankTab_1: 13
-  AccountBankTab_2: 14
-  AccountBankTab_3: 15
-  AccountBankTab_4: 16
-  AccountBankTab_5: 17
-  Backpack: 0
-  Bag_1: 1
-  Bag_2: 2
-  Bag_3: 3
-  Bag_4: 4
-  Bank: -1
-  Bankbag: -4
-  BankBag_1: 6
-  BankBag_2: 7
-  BankBag_3: 8
-  BankBag_4: 9
-  BankBag_5: 10
-  BankBag_6: 11
-  BankBag_7: 12
-  Keyring: -2
-  ReagentBag: 5
-  Reagentbank: -3
+  values:
+    Accountbanktab: -5
+    AccountBankTab_1: 13
+    AccountBankTab_2: 14
+    AccountBankTab_3: 15
+    AccountBankTab_4: 16
+    AccountBankTab_5: 17
+    Backpack: 0
+    Bag_1: 1
+    Bag_2: 2
+    Bag_3: 3
+    Bag_4: 4
+    Bank: -1
+    Bankbag: -4
+    BankBag_1: 6
+    BankBag_2: 7
+    BankBag_3: 8
+    BankBag_4: 9
+    BankBag_5: 10
+    BankBag_6: 11
+    BankBag_7: 12
+    Keyring: -2
+    ReagentBag: 5
+    Reagentbank: -3
 BagsDirection:
-  Down: 1
-  Left: 0
-  Right: 1
-  Up: 0
+  values:
+    Down: 1
+    Left: 0
+    Right: 1
+    Up: 0
 BagSlotFlags:
-  ClassConsumables: 4
-  ClassEquipment: 2
-  ClassJunk: 16
-  ClassProfessionGoods: 8
-  ClassQuestItems: 32
-  ClassReagents: 128
-  DisableAutoSort: 1
-  ExcludeJunkSell: 64
-  ExpansionCurrent: 256
-  ExpansionLegacy: 512
+  values:
+    ClassConsumables: 4
+    ClassEquipment: 2
+    ClassJunk: 16
+    ClassProfessionGoods: 8
+    ClassQuestItems: 32
+    ClassReagents: 128
+    DisableAutoSort: 1
+    ExcludeJunkSell: 64
+    ExpansionCurrent: 256
+    ExpansionLegacy: 512
 BagsOrientation:
-  Horizontal: 0
-  Vertical: 1
+  values:
+    Horizontal: 0
+    Vertical: 1
 BalanceType:
-  Eclipse: 0
-  None: -1
+  values:
+    Eclipse: 0
+    None: -1
 BankLockedReason:
-  BankConversionFailed: 3
-  BankDisabled: 2
-  NoAccountInventoryLock: 1
-  None: 0
+  values:
+    BankConversionFailed: 3
+    BankDisabled: 2
+    NoAccountInventoryLock: 1
+    None: 0
 BankType:
-  Account: 2
-  Character: 0
-  Guild: 1
+  values:
+    Account: 2
+    Character: 0
+    Guild: 1
 Base64Variant:
-  Standard: 0
-  StandardUrlSafe: 1
+  values:
+    Standard: 0
+    StandardUrlSafe: 1
 BattlepayBannerType:
-  Discount: 1
-  Featured: 2
-  New: 3
-  None: 0
+  values:
+    Discount: 1
+    Featured: 2
+    New: 3
+    None: 0
 BattlepayDisplayFlags:
-  CardAlwaysShowsTexture: 4
-  CardDoesNotShowModel: 2
-  Deprecated1: 32
-  Deprecated2: 64
-  Expansion: 1
-  HiddenPrice: 8
-  HideWhenOwned: 256
-  RafReward: 512
-  ShowFancyToast: 1024
-  UseHorizontalLayoutForFullCard: 16
-  UseIconBorderWithOverrideTexture: 2048
-  UseSquareIconBorder: 128
+  values:
+    CardAlwaysShowsTexture: 4
+    CardDoesNotShowModel: 2
+    Deprecated1: 32
+    Deprecated2: 64
+    Expansion: 1
+    HiddenPrice: 8
+    HideWhenOwned: 256
+    RafReward: 512
+    ShowFancyToast: 1024
+    UseHorizontalLayoutForFullCard: 16
+    UseIconBorderWithOverrideTexture: 2048
+    UseSquareIconBorder: 128
 BattlepayGroupDisplayType:
-  ActiveTimeOnly: 2
-  Everyone: 0
-  TrialAndVeteranOnly: 1
+  values:
+    ActiveTimeOnly: 2
+    Everyone: 0
+    TrialAndVeteranOnly: 1
 BattlepayLicenseSynthesisFlags:
-  ForceToGameAccount: 1
+  values:
+    ForceToGameAccount: 1
 BattlepayProductChoiceType:
-  ChoiceNone: 0
-  ChoiceOne: 1
-  SpecAndFaction: 2
-  VasCharacter: 3
-  VasCharacterAndName: 4
+  values:
+    ChoiceNone: 0
+    ChoiceOne: 1
+    SpecAndFaction: 2
+    VasCharacter: 3
+    VasCharacterAndName: 4
 BattlepayProductDecorator:
-  Boost: 0
-  Expansion: 1
-  VasService: 3
-  WoWToken: 2
+  values:
+    Boost: 0
+    Expansion: 1
+    VasService: 3
+    WoWToken: 2
 BattlepayProductGroupFlags:
-  DisableOwnedProducts: 4
-  EnabledForTrial: 2
-  EnabledForVeteran: 8
-  HideOwnedProducts: 1
-  None: 0
-  TrialAndVeteranOnly: 16
+  values:
+    DisableOwnedProducts: 4
+    EnabledForTrial: 2
+    EnabledForVeteran: 8
+    HideOwnedProducts: 1
+    None: 0
+    TrialAndVeteranOnly: 16
 BattlepayShopEntryBannerType:
-  Discount: 1
-  Featured: 0
-  New: 2
+  values:
+    Discount: 1
+    Featured: 0
+    New: 2
 BattlepayShopEntryFlags:
-  None: 0
+  values:
+    None: 0
 BattlePetAction:
-  Ability: 1
-  None: 0
-  Skip: 4
-  SwitchPet: 2
-  Trap: 3
+  values:
+    Ability: 1
+    None: 0
+    Skip: 4
+    SwitchPet: 2
+    Trap: 3
 BattlePetBreedQuality:
-  Common: 1
-  Epic: 4
-  Legendary: 5
-  Poor: 0
-  Rare: 3
-  Uncommon: 2
+  values:
+    Common: 1
+    Epic: 4
+    Legendary: 5
+    Poor: 0
+    Rare: 3
+    Uncommon: 2
 BattlePetOwner:
-  Ally: 1
-  Enemy: 2
-  Weather: 0
+  values:
+    Ally: 1
+    Enemy: 2
+    Weather: 0
 BattlePetSources:
-  Achievement: 5
-  Discovery: 10
-  Drop: 0
-  PetStore: 9
-  Profession: 3
-  Promotion: 7
-  Quest: 1
-  Tcg: 8
-  TradingPost: 11
-  Vendor: 2
-  WildPet: 4
-  WorldEvent: 6
+  values:
+    Achievement: 5
+    Discovery: 10
+    Drop: 0
+    PetStore: 9
+    Profession: 3
+    Promotion: 7
+    Quest: 1
+    Tcg: 8
+    TradingPost: 11
+    Vendor: 2
+    WildPet: 4
+    WorldEvent: 6
 BindingContext:
-  HousingEditor: 1
-  HousingEditorBasicAndExpertDecorMode: 7
-  HousingEditorBasicDecorMode: 2
-  HousingEditorCleanupMode: 5
-  HousingEditorCustomizeMode: 4
-  HousingEditorExpertDecorMode: 3
-  HousingEditorExteriorCustomizationMode: 8
-  HousingEditorLayoutMode: 6
-  None: 0
-  ReservedFutureFeatureBinding01: 9
+  values:
+    HousingEditor: 1
+    HousingEditorBasicAndExpertDecorMode: 7
+    HousingEditorBasicDecorMode: 2
+    HousingEditorCleanupMode: 5
+    HousingEditorCustomizeMode: 4
+    HousingEditorExpertDecorMode: 3
+    HousingEditorExteriorCustomizationMode: 8
+    HousingEditorLayoutMode: 6
+    None: 0
+    ReservedFutureFeatureBinding01: 9
 BindingSet:
-  Account: 1
-  Character: 2
-  Current: 3
-  Default: 0
+  values:
+    Account: 1
+    Character: 2
+    Current: 3
+    Default: 0
 BnetAccountFlag:
-  AccountQuestBitFixUp: 64
-  AchievementsToBi: 128
-  BattlePetTrainer: 1
-  CanBuyAhGameTimeTokens: 32768
-  CataLegendaryMountChecked: 262144
-  CataLegendaryMountObtained: 524288
-  DarkRealmLightCopy: 2048
-  Employee: 16
-  EmployeeFlagIsManual: 32
-  GdprErased: 1024
-  InvalidTransmogsFixUp: 256
-  InvalidTransmogsFixUp2: 512
-  IsLegacy: 131072
-  LockedForExport: 16384
-  MopQuestLogFlagsFixUp: 1048576
-  None: 0
-  PetAchievementFixUp: 65536
-  QuestLogFlagsFixUp: 4096
-  RafVeteranNotified: 2
-  TwitterHasTempSecret: 8
-  TwitterLinked: 4
-  WasSecured: 8192
+  values:
+    AccountQuestBitFixUp: 64
+    AchievementsToBi: 128
+    BattlePetTrainer: 1
+    CanBuyAhGameTimeTokens: 32768
+    CataLegendaryMountChecked: 262144
+    CataLegendaryMountObtained: 524288
+    DarkRealmLightCopy: 2048
+    Employee: 16
+    EmployeeFlagIsManual: 32
+    GdprErased: 1024
+    InvalidTransmogsFixUp: 256
+    InvalidTransmogsFixUp2: 512
+    IsLegacy: 131072
+    LockedForExport: 16384
+    MopQuestLogFlagsFixUp: 1048576
+    None: 0
+    PetAchievementFixUp: 65536
+    QuestLogFlagsFixUp: 4096
+    RafVeteranNotified: 2
+    TwitterHasTempSecret: 8
+    TwitterLinked: 4
+    WasSecured: 8192
 BonusStatIndex:
-  Agility: 3
-  AgilityOrIntellect: 73
-  AgilityOrStrength: 72
-  AgilityOrStrengthOrIntellect: 71
-  ArcaneResistance: 56
-  ArmorPenetrationRating: 44
-  AttackPower: 38
-  BlockRating: 15
-  BlockValue: 48
-  CombatRatingAvoidance: 63
-  CombatRatingLifesteal: 62
-  CombatRatingSpeed: 61
-  CombatRatingSturdiness: 64
-  CombatRatingUnused_0: 58
-  CombatRatingUnused_10: 68
-  CombatRatingUnused_11: 69
-  CombatRatingUnused_12: 70
-  CombatRatingUnused_2: 59
-  CombatRatingUnused_27: 66
-  CombatRatingUnused_3: 60
-  CombatRatingUnused_7: 65
-  CombatRatingUnused_9: 67
-  CritMeleeRating: 19
-  CritRangedRating: 20
-  CritRating: 32
-  CritSpellRating: 21
-  CritTakenMeleeRatingObsolete: 25
-  CritTakenRangedRatingObsolete: 26
-  CritTakenRatingObsolete: 34
-  CritTakenSpellRatingObsolete: 27
-  DefenseSkillRating: 12
-  DodgeRating: 13
-  Endurance: 2
-  Energy: 8
-  ExpertiseRating: 37
-  ExtraArmor: 50
-  FireResistance: 51
-  Focus: 10
-  FrostResistance: 52
-  HasteMeleeRatingObsolete: 28
-  HasteRangedRatingObsolete: 29
-  HasteRating: 36
-  HasteSpellRatingObsolete: 30
-  Health: 1
-  HealthRegen: 46
-  HitMeleeRating: 16
-  HitRangedRating: 17
-  HitRating: 31
-  HitSpellRating: 18
-  HitTakenMeleeRatingObsolete: 22
-  HitTakenRangedRatingObsolete: 23
-  HitTakenRatingObsolete: 33
-  HitTakenSpellRatingObsolete: 24
-  HolyResistance: 53
-  Intellect: 5
-  Mana: 0
-  ManaRegeneration: 43
-  MasteryRating: 49
-  NatureResistance: 55
-  ParryRating: 14
-  ProfessionCraftingSpeed: 80
-  ProfessionDeftness: 78
-  ProfessionFinesse: 77
-  ProfessionIngenuity: 82
-  ProfessionInspiration: 75
-  ProfessionMulticraft: 81
-  ProfessionPerception: 79
-  ProfessionResourcefulness: 76
-  PvPPower: 57
-  Rage: 9
-  RangedAttackPower: 39
-  ResilienceRating: 35
-  ShadowResistance: 54
-  SpellDamageDone: 42
-  SpellHealingDone: 41
-  SpellPenetration: 47
-  SpellPower: 45
-  Spirit: 6
-  Stamina: 7
-  Strength: 4
-  StrengthOrIntellect: 74
-  Versatility: 40
-  WeaponSkillRating: 11
+  values:
+    Agility: 3
+    AgilityOrIntellect: 73
+    AgilityOrStrength: 72
+    AgilityOrStrengthOrIntellect: 71
+    ArcaneResistance: 56
+    ArmorPenetrationRating: 44
+    AttackPower: 38
+    BlockRating: 15
+    BlockValue: 48
+    CombatRatingAvoidance: 63
+    CombatRatingLifesteal: 62
+    CombatRatingSpeed: 61
+    CombatRatingSturdiness: 64
+    CombatRatingUnused_0: 58
+    CombatRatingUnused_10: 68
+    CombatRatingUnused_11: 69
+    CombatRatingUnused_12: 70
+    CombatRatingUnused_2: 59
+    CombatRatingUnused_27: 66
+    CombatRatingUnused_3: 60
+    CombatRatingUnused_7: 65
+    CombatRatingUnused_9: 67
+    CritMeleeRating: 19
+    CritRangedRating: 20
+    CritRating: 32
+    CritSpellRating: 21
+    CritTakenMeleeRatingObsolete: 25
+    CritTakenRangedRatingObsolete: 26
+    CritTakenRatingObsolete: 34
+    CritTakenSpellRatingObsolete: 27
+    DefenseSkillRating: 12
+    DodgeRating: 13
+    Endurance: 2
+    Energy: 8
+    ExpertiseRating: 37
+    ExtraArmor: 50
+    FireResistance: 51
+    Focus: 10
+    FrostResistance: 52
+    HasteMeleeRatingObsolete: 28
+    HasteRangedRatingObsolete: 29
+    HasteRating: 36
+    HasteSpellRatingObsolete: 30
+    Health: 1
+    HealthRegen: 46
+    HitMeleeRating: 16
+    HitRangedRating: 17
+    HitRating: 31
+    HitSpellRating: 18
+    HitTakenMeleeRatingObsolete: 22
+    HitTakenRangedRatingObsolete: 23
+    HitTakenRatingObsolete: 33
+    HitTakenSpellRatingObsolete: 24
+    HolyResistance: 53
+    Intellect: 5
+    Mana: 0
+    ManaRegeneration: 43
+    MasteryRating: 49
+    NatureResistance: 55
+    ParryRating: 14
+    ProfessionCraftingSpeed: 80
+    ProfessionDeftness: 78
+    ProfessionFinesse: 77
+    ProfessionIngenuity: 82
+    ProfessionInspiration: 75
+    ProfessionMulticraft: 81
+    ProfessionPerception: 79
+    ProfessionResourcefulness: 76
+    PvPPower: 57
+    Rage: 9
+    RangedAttackPower: 39
+    ResilienceRating: 35
+    ShadowResistance: 54
+    SpellDamageDone: 42
+    SpellHealingDone: 41
+    SpellPenetration: 47
+    SpellPower: 45
+    Spirit: 6
+    Stamina: 7
+    Strength: 4
+    StrengthOrIntellect: 74
+    Versatility: 40
+    WeaponSkillRating: 11
 BrawlType:
-  Arena: 2
-  Battleground: 1
-  LFG: 3
-  None: 0
-  SoloRbg: 5
-  SoloShuffle: 4
+  values:
+    Arena: 2
+    Battleground: 1
+    LFG: 3
+    None: 0
+    SoloRbg: 5
+    SoloShuffle: 4
 BulkPurchaseResult:
-  ResultFailed: 3
-  ResultInProgress: 1
-  ResultInsufficientFunds: 6
-  ResultOk: 0
-  ResultPartialSuccess: 2
-  ResultPurchaseTimeout: 7
-  ResultSystemDisabled: 5
-  ResultTooManyProducts: 4
+  values:
+    ResultFailed: 3
+    ResultInProgress: 1
+    ResultInsufficientFunds: 6
+    ResultOk: 0
+    ResultPartialSuccess: 2
+    ResultPurchaseTimeout: 7
+    ResultSystemDisabled: 5
+    ResultTooManyProducts: 4
 BulkPurchaseStatus:
-  Done: 3
-  Failed: 4
-  FetchEntitlements: 2
-  PlacingOrders: 0
-  PurchasesPending: 1
+  values:
+    Done: 3
+    Failed: 4
+    FetchEntitlements: 2
+    PlacingOrders: 0
+    PurchasesPending: 1
 BulkRefundResult:
-  ResultFailed: 1
-  ResultInvalidRequest: 2
-  ResultOk: 0
-  ResultRefundWindowExpired: 3
-  ResultSystemDisabled: 4
-  ResultTimeout: 5
+  values:
+    ResultFailed: 1
+    ResultInvalidRequest: 2
+    ResultOk: 0
+    ResultRefundWindowExpired: 3
+    ResultSystemDisabled: 4
+    ResultTimeout: 5
 CachedRewardType:
-  Currency: 2
-  Item: 1
-  None: 0
-  Quest: 3
+  values:
+    Currency: 2
+    Item: 1
+    None: 0
+    Quest: 3
 CalendarCommandType:
-  Complain: 10
-  Create: 0
-  GetCalendar: 7
-  GetEvent: 8
-  Invite: 1
-  ModeratorStatus: 6
-  Notes: 11
-  RemoveEvent: 4
-  RemoveInvite: 3
-  Rsvp: 2
-  Status: 5
-  UpdateEvent: 9
+  values:
+    Complain: 10
+    Create: 0
+    GetCalendar: 7
+    GetEvent: 8
+    Invite: 1
+    ModeratorStatus: 6
+    Notes: 11
+    RemoveEvent: 4
+    RemoveInvite: 3
+    Rsvp: 2
+    Status: 5
+    UpdateEvent: 9
 CalendarErrorType:
-  ArenaEventsExceeded: 27
-  CalendarDisabled: 25
-  CommunityEventsExceeded: 1
-  ComplaintAdded: 50
-  ComplaintDisabled: 31
-  ComplaintGm: 34
-  ComplaintLimit: 35
-  ComplaintNotFound: 36
-  ComplaintSameGuild: 33
-  ComplaintSelf: 32
-  CreatorNotFound: 46
-  DataAlreadySet: 24
-  DeleteCreatorFailed: 23
-  EventInvalid: 6
-  EventLocked: 22
-  EventPassed: 21
-  EventsExceeded: 2
-  EventThrottled: 47
-  EventWrongServer: 37
-  Ignored: 14
-  Internal: 49
-  InvalidClub: 45
-  InvalidDate: 17
-  InvalidDescription: 44
-  InvalidMaxSize: 16
-  InvalidNotes: 42
-  InvalidSignup: 39
-  InvalidTime: 18
-  InvalidTitle: 43
-  InvitesExceeded: 15
-  InviteThrottled: 48
-  ModeratorRestricted: 41
-  NameNotFound: 12
-  NeedsTitle: 20
-  NoCommunityInvites: 38
-  NoInvite: 30
-  NoInvites: 19
-  NoModerator: 40
-  NoPermission: 5
-  NotInCommunity: 10
-  NotInGuild: 9
-  NotInvited: 7
-  OtherInvitesExceeded: 4
-  RestrictedAccount: 26
-  RestrictedLevel: 28
-  SelfInvitesExceeded: 3
-  Squelched: 29
-  Success: 0
-  TargetAlreadyInvited: 11
-  UnknownError: 8
-  WrongFaction: 13
+  values:
+    ArenaEventsExceeded: 27
+    CalendarDisabled: 25
+    CommunityEventsExceeded: 1
+    ComplaintAdded: 50
+    ComplaintDisabled: 31
+    ComplaintGm: 34
+    ComplaintLimit: 35
+    ComplaintNotFound: 36
+    ComplaintSameGuild: 33
+    ComplaintSelf: 32
+    CreatorNotFound: 46
+    DataAlreadySet: 24
+    DeleteCreatorFailed: 23
+    EventInvalid: 6
+    EventLocked: 22
+    EventPassed: 21
+    EventsExceeded: 2
+    EventThrottled: 47
+    EventWrongServer: 37
+    Ignored: 14
+    Internal: 49
+    InvalidClub: 45
+    InvalidDate: 17
+    InvalidDescription: 44
+    InvalidMaxSize: 16
+    InvalidNotes: 42
+    InvalidSignup: 39
+    InvalidTime: 18
+    InvalidTitle: 43
+    InvitesExceeded: 15
+    InviteThrottled: 48
+    ModeratorRestricted: 41
+    NameNotFound: 12
+    NeedsTitle: 20
+    NoCommunityInvites: 38
+    NoInvite: 30
+    NoInvites: 19
+    NoModerator: 40
+    NoPermission: 5
+    NotInCommunity: 10
+    NotInGuild: 9
+    NotInvited: 7
+    OtherInvitesExceeded: 4
+    RestrictedAccount: 26
+    RestrictedLevel: 28
+    SelfInvitesExceeded: 3
+    Squelched: 29
+    Success: 0
+    TargetAlreadyInvited: 11
+    UnknownError: 8
+    WrongFaction: 13
 CalendarEventBits:
-  ArenaDeprecated: 256
-  AutoApprove: 32
-  CantComplain: 3788
-  CommunityAnnouncement: 64
-  CommunitySignup: 1024
-  CommunityWide: 3136
-  GuildDeprecated: 2
-  GuildSignup: 2048
-  Holiday: 8
-  Locked: 16
-  Player: 1
-  PlayerCreated: 3395
-  RaidLockout: 128
-  RaidReset: 512
-  System: 4
+  values:
+    ArenaDeprecated: 256
+    AutoApprove: 32
+    CantComplain: 3788
+    CommunityAnnouncement: 64
+    CommunitySignup: 1024
+    CommunityWide: 3136
+    GuildDeprecated: 2
+    GuildSignup: 2048
+    Holiday: 8
+    Locked: 16
+    Player: 1
+    PlayerCreated: 3395
+    RaidLockout: 128
+    RaidReset: 512
+    System: 4
 CalendarEventRepeatOptions:
-  Biweekly: 2
-  Monthly: 3
-  Never: 0
-  Weekly: 1
+  values:
+    Biweekly: 2
+    Monthly: 3
+    Never: 0
+    Weekly: 1
 CalendarEventType:
-  Dungeon: 1
-  HeroicDeprecated: 5
-  Meeting: 3
-  Other: 4
-  PvP: 2
-  Raid: 0
+  values:
+    Dungeon: 1
+    HeroicDeprecated: 5
+    Meeting: 3
+    Other: 4
+    PvP: 2
+    Raid: 0
 CalendarFilterFlags:
-  Battleground: 4
-  Darkmoon: 2
-  RaidLockout: 8
-  RaidReset: 16
-  WeeklyHoliday: 1
+  values:
+    Battleground: 4
+    Darkmoon: 2
+    RaidLockout: 8
+    RaidReset: 16
+    WeeklyHoliday: 1
 CalendarGetEventType:
-  Add: 1
-  Copy: 2
-  Get: 0
+  values:
+    Add: 1
+    Copy: 2
+    Get: 0
 CalendarHolidayFilterType:
-  Battleground: 2
-  Darkmoon: 1
-  Weekly: 0
+  values:
+    Battleground: 2
+    Darkmoon: 1
+    Weekly: 0
 CalendarInviteBits:
-  Creator: 4
-  Moderator: 2
-  None: 0
-  PendingInvite: 1
-  Signup: 8
+  values:
+    Creator: 4
+    Moderator: 2
+    None: 0
+    PendingInvite: 1
+    Signup: 8
 CalendarInviteSortType:
-  Class: 2
-  Level: 1
-  Name: 0
-  Notes: 5
-  Party: 4
-  Status: 3
+  values:
+    Class: 2
+    Level: 1
+    Name: 0
+    Notes: 5
+    Party: 4
+    Status: 3
 CalendarInviteType:
-  Normal: 0
-  Signup: 1
+  values:
+    Normal: 0
+    Signup: 1
 CalendarModeratorStatus:
-  Creator: 2
-  Moderator: 1
-  None: 0
+  values:
+    Creator: 2
+    Moderator: 1
+    None: 0
 CalendarStatus:
-  Available: 1
-  Confirmed: 3
-  Declined: 2
-  Invited: 0
-  NotSignedup: 7
-  Out: 4
-  Signedup: 6
-  Standby: 5
-  Tentative: 8
+  values:
+    Available: 1
+    Confirmed: 3
+    Declined: 2
+    Invited: 0
+    NotSignedup: 7
+    Out: 4
+    Signedup: 6
+    Standby: 5
+    Tentative: 8
 CalendarTexturesType:
-  Dungeons: 0
-  Raid: 1
+  values:
+    Dungeons: 0
+    Raid: 1
 CalendarType:
-  Community: 1
-  Holiday: 4
-  HolidayBattleground: 7
-  HolidayDarkmoon: 6
-  HolidayWeekly: 5
-  Player: 0
-  RaidLockout: 2
-  RaidReset: 3
+  values:
+    Community: 1
+    Holiday: 4
+    HolidayBattleground: 7
+    HolidayDarkmoon: 6
+    HolidayWeekly: 5
+    Player: 0
+    RaidLockout: 2
+    RaidReset: 3
 CalendarWebActionType:
-  Accept: 0
-  Decline: 1
-  Remove: 2
-  ReportSpam: 3
-  Signup: 4
-  Tentative: 5
-  TentativeSignup: 6
+  values:
+    Accept: 0
+    Decline: 1
+    Remove: 2
+    ReportSpam: 3
+    Signup: 4
+    Tentative: 5
+    TentativeSignup: 6
 CameraModeAspectRatio:
-  Cinemascope_2_Dot_4_X_1: 3
-  Default: 0
-  HighDefinition_16_X_9: 2
-  LegacyLetterbox: 1
+  values:
+    Cinemascope_2_Dot_4_X_1: 3
+    Default: 0
+    HighDefinition_16_X_9: 2
+    LegacyLetterbox: 1
 CanRedeemTokenForBalanceResult:
-  FailureCap: 1
-  Ok: 0
+  values:
+    FailureCap: 1
+    Ok: 0
 CaptureBarWidgetFillDirectionType:
-  LeftToRight: 1
-  RightToLeft: 0
+  values:
+    LeftToRight: 1
+    RightToLeft: 0
 Causeofdeath:
-  Creature: 3
-  Drowning: 5
-  Falling: 4
-  Fatigue: 6
-  Fire: 9
-  Lava: 8
-  None: 0
-  PlayerDuel: 2
-  PlayerPvP: 1
-  Slime: 7
+  values:
+    Creature: 3
+    Drowning: 5
+    Falling: 4
+    Fatigue: 6
+    Fire: 9
+    Lava: 8
+    None: 0
+    PlayerDuel: 2
+    PlayerPvP: 1
+    Slime: 7
 CauseofdeathFlags:
-  CreatureNameNeeded: 2
-  NoneNeeded: 0
-  PlayerNameNeeded: 1
-  ZoneNameNeeded: 4
+  values:
+    CreatureNameNeeded: 2
+    NoneNeeded: 0
+    PlayerNameNeeded: 1
+    ZoneNameNeeded: 4
 ChallengeModeHistoryFlags:
-  ConfirmedLeaver: 1
-  None: 0
+  values:
+    ConfirmedLeaver: 1
+    None: 0
 ChallengeModeHistoryResult:
-  Leaver: 1
-  Successful: 0
+  values:
+    Leaver: 1
+    Successful: 0
 ChallengeModeHistoryStatus:
-  Leaver: 1
-  Normal: 0
+  values:
+    Leaver: 1
+    Normal: 0
 ChannelPlayerFlags:
-  ChannelPlayerHidden: 8
-  ChannelPlayerModerator: 2
-  ChannelPlayerNone: 0
-  ChannelPlayerOwner: 1
-  ChannelPlayerTextAllow: 4
+  values:
+    ChannelPlayerHidden: 8
+    ChannelPlayerModerator: 2
+    ChannelPlayerNone: 0
+    ChannelPlayerOwner: 1
+    ChannelPlayerTextAllow: 4
 CharacterServiceInfoFlag:
-  AllowMaxLevelBoost: 2
-  RestrictToRecommendedSpecs: 1
+  values:
+    AllowMaxLevelBoost: 2
+    RestrictToRecommendedSpecs: 1
 CharCustomizationType:
-  CustomOptionFacewear: 7
-  CustomOptionHorn: 6
-  CustomOptionTattoo: 5
-  CustomOptionTattooColor: 8
-  Face: 1
-  FacialHair: 4
-  Hair: 2
-  HairColor: 3
-  Skin: 0
+  values:
+    CustomOptionFacewear: 7
+    CustomOptionHorn: 6
+    CustomOptionTattoo: 5
+    CustomOptionTattooColor: 8
+    Face: 1
+    FacialHair: 4
+    Hair: 2
+    HairColor: 3
+    Skin: 0
 ChatChannelRuleset:
-  ChromieTimeBuringCrusade: 4
-  ChromieTimeCataclysm: 3
-  ChromieTimeLegion: 8
-  ChromieTimeMists: 6
-  ChromieTimeWoD: 7
-  ChromieTimeWrath: 5
-  Disabled: 2
-  Mentor: 1
-  None: 0
+  values:
+    ChromieTimeBuringCrusade: 4
+    ChromieTimeCataclysm: 3
+    ChromieTimeLegion: 8
+    ChromieTimeMists: 6
+    ChromieTimeWoD: 7
+    ChromieTimeWrath: 5
+    Disabled: 2
+    Mentor: 1
+    None: 0
 ChatChannelType:
-  Communities: 4
-  Custom: 1
-  None: 0
-  PrivateParty: 2
-  PublicParty: 3
+  values:
+    Communities: 4
+    Custom: 1
+    None: 0
+    PrivateParty: 2
+    PublicParty: 3
 ChatToxityFilterOptOut:
-  ExcludeFilterAll: 4294967295
-  ExcludeFilterFriend: 1
-  ExcludeFilterGuild: 2
-  FilterAll: 0
+  values:
+    ExcludeFilterAll: 4294967295
+    ExcludeFilterFriend: 1
+    ExcludeFilterGuild: 2
+    FilterAll: 0
 ChatWhisperTargetStatus:
-  CanWhisper: 0
-  CanWhisperGuild: 1
-  Offline: 2
-  WrongFaction: 3
+  values:
+    CanWhisper: 0
+    CanWhisperGuild: 1
+    Offline: 2
+    WrongFaction: 3
 ChrCustomizationCategoryFlag:
-  Subcategory: 2
-  UndressModel: 1
+  values:
+    Subcategory: 2
+    UndressModel: 1
 ChrCustomizationOptionType:
-  Checkbox: 1
-  Dropdown: 0
-  Slider: 2
+  values:
+    Checkbox: 1
+    Dropdown: 0
+    Slider: 2
 ChrModelFeatureFlags:
-  Deprecated0: 8
-  Forms: 2
-  HunterPets: 32
-  Identity: 4
-  Mounts: 16
-  None: 0
-  Players: 64
-  Summons: 1
+  values:
+    Deprecated0: 8
+    Forms: 2
+    HunterPets: 32
+    Identity: 4
+    Mounts: 16
+    None: 0
+    Players: 64
+    Summons: 1
 ChrRacesAllianceType:
-  Alliance: 0
-  Horde: 1
-  NeutralOrNpc: 2
+  values:
+    Alliance: 0
+    Horde: 1
+    NeutralOrNpc: 2
 CinematicType:
-  GameCinematicSequence: 3
-  GameClientScene: 2
-  GameMovie: 1
-  GlueMovie: 0
+  values:
+    GameCinematicSequence: 3
+    GameClientScene: 2
+    GameMovie: 1
+    GlueMovie: 0
 ClientPlatformType:
-  Macintosh: 1
-  Windows: 0
+  values:
+    Macintosh: 1
+    Windows: 0
 ClientSceneType:
-  DefaultSceneType: 0
-  MinigameSceneType: 1
+  values:
+    DefaultSceneType: 0
+    MinigameSceneType: 1
 ClientSettingsConfigFlag:
-  ClientSettingsConfigBeta: 64
-  ClientSettingsConfigBetaRetail: 128
-  ClientSettingsConfigDebug: 1
-  ClientSettingsConfigGm: 8
-  ClientSettingsConfigInternal: 2
-  ClientSettingsConfigPerf: 4
-  ClientSettingsConfigRetail: 256
-  ClientSettingsConfigTest: 16
-  ClientSettingsConfigTestRetail: 32
+  values:
+    ClientSettingsConfigBeta: 64
+    ClientSettingsConfigBetaRetail: 128
+    ClientSettingsConfigDebug: 1
+    ClientSettingsConfigGm: 8
+    ClientSettingsConfigInternal: 2
+    ClientSettingsConfigPerf: 4
+    ClientSettingsConfigRetail: 256
+    ClientSettingsConfigTest: 16
+    ClientSettingsConfigTestRetail: 32
 ClubActionType:
-  ErrorClubActionAcceptInvitation: 13
-  ErrorClubActionAddBan: 22
-  ErrorClubActionCreate: 1
-  ErrorClubActionCreateMessage: 24
-  ErrorClubActionCreateStream: 15
-  ErrorClubActionCreateTicket: 5
-  ErrorClubActionDeclineInvitation: 14
-  ErrorClubActionDestroy: 3
-  ErrorClubActionDestroyMessage: 26
-  ErrorClubActionDestroyStream: 17
-  ErrorClubActionDestroyTicket: 6
-  ErrorClubActionEdit: 2
-  ErrorClubActionEditMember: 19
-  ErrorClubActionEditMemberNote: 20
-  ErrorClubActionEditMessage: 25
-  ErrorClubActionEditStream: 16
-  ErrorClubActionGetBans: 10
-  ErrorClubActionGetInvitations: 11
-  ErrorClubActionGetTicket: 8
-  ErrorClubActionGetTickets: 9
-  ErrorClubActionInviteMember: 18
-  ErrorClubActionKickMember: 21
-  ErrorClubActionLeave: 4
-  ErrorClubActionRedeemTicket: 7
-  ErrorClubActionRemoveBan: 23
-  ErrorClubActionRevokeInvitation: 12
-  ErrorClubActionSubscribe: 0
+  values:
+    ErrorClubActionAcceptInvitation: 13
+    ErrorClubActionAddBan: 22
+    ErrorClubActionCreate: 1
+    ErrorClubActionCreateMessage: 24
+    ErrorClubActionCreateStream: 15
+    ErrorClubActionCreateTicket: 5
+    ErrorClubActionDeclineInvitation: 14
+    ErrorClubActionDestroy: 3
+    ErrorClubActionDestroyMessage: 26
+    ErrorClubActionDestroyStream: 17
+    ErrorClubActionDestroyTicket: 6
+    ErrorClubActionEdit: 2
+    ErrorClubActionEditMember: 19
+    ErrorClubActionEditMemberNote: 20
+    ErrorClubActionEditMessage: 25
+    ErrorClubActionEditStream: 16
+    ErrorClubActionGetBans: 10
+    ErrorClubActionGetInvitations: 11
+    ErrorClubActionGetTicket: 8
+    ErrorClubActionGetTickets: 9
+    ErrorClubActionInviteMember: 18
+    ErrorClubActionKickMember: 21
+    ErrorClubActionLeave: 4
+    ErrorClubActionRedeemTicket: 7
+    ErrorClubActionRemoveBan: 23
+    ErrorClubActionRevokeInvitation: 12
+    ErrorClubActionSubscribe: 0
 ClubErrorType:
-  ErrorClubAlreadyMember: 19
-  ErrorClubBanAlreadyExists: 35
-  ErrorClubBanCountAtMax: 36
-  ErrorClubDoesntAllowCrossFaction: 40
-  ErrorClubEditHasCrossFactionMembers: 41
-  ErrorClubFull: 16
-  ErrorClubInsufficientPrivileges: 24
-  ErrorClubInvalidRoleID: 23
-  ErrorClubInvitationAlreadyExists: 22
-  ErrorClubMemberHasRequiredRole: 31
-  ErrorClubNoClub: 17
-  ErrorClubNoSuchInvitation: 21
-  ErrorClubNoSuchMember: 20
-  ErrorClubNotMember: 18
-  ErrorClubReceivedInvitationCountAtMax: 33
-  ErrorClubSentInvitationCountAtMax: 32
-  ErrorClubStreamCountAtMax: 30
-  ErrorClubStreamCountAtMin: 29
-  ErrorClubStreamInvalidName: 28
-  ErrorClubStreamNoStream: 27
-  ErrorClubTargetIsBanned: 34
-  ErrorClubTicketCountAtMax: 37
-  ErrorClubTicketHasConsumedAllowedRedeemCount: 39
-  ErrorClubTicketNoSuchTicket: 38
-  ErrorClubTooManyClubsJoined: 25
-  ErrorClubVoiceFull: 26
-  ErrorCommunitiesBadTarget: 4
-  ErrorCommunitiesChatMute: 15
-  ErrorCommunitiesGuild: 8
-  ErrorCommunitiesIgnored: 7
-  ErrorCommunitiesMissingShortName: 11
-  ErrorCommunitiesNeutralFaction: 2
-  ErrorCommunitiesNone: 0
-  ErrorCommunitiesProfanity: 12
-  ErrorCommunitiesRestricted: 6
-  ErrorCommunitiesTrial: 13
-  ErrorCommunitiesUnknown: 1
-  ErrorCommunitiesUnknownRealm: 3
-  ErrorCommunitiesUnknownTicket: 10
-  ErrorCommunitiesVeteranTrial: 14
-  ErrorCommunitiesWrongFaction: 5
-  ErrorCommunitiesWrongRegion: 9
+  values:
+    ErrorClubAlreadyMember: 19
+    ErrorClubBanAlreadyExists: 35
+    ErrorClubBanCountAtMax: 36
+    ErrorClubDoesntAllowCrossFaction: 40
+    ErrorClubEditHasCrossFactionMembers: 41
+    ErrorClubFull: 16
+    ErrorClubInsufficientPrivileges: 24
+    ErrorClubInvalidRoleID: 23
+    ErrorClubInvitationAlreadyExists: 22
+    ErrorClubMemberHasRequiredRole: 31
+    ErrorClubNoClub: 17
+    ErrorClubNoSuchInvitation: 21
+    ErrorClubNoSuchMember: 20
+    ErrorClubNotMember: 18
+    ErrorClubReceivedInvitationCountAtMax: 33
+    ErrorClubSentInvitationCountAtMax: 32
+    ErrorClubStreamCountAtMax: 30
+    ErrorClubStreamCountAtMin: 29
+    ErrorClubStreamInvalidName: 28
+    ErrorClubStreamNoStream: 27
+    ErrorClubTargetIsBanned: 34
+    ErrorClubTicketCountAtMax: 37
+    ErrorClubTicketHasConsumedAllowedRedeemCount: 39
+    ErrorClubTicketNoSuchTicket: 38
+    ErrorClubTooManyClubsJoined: 25
+    ErrorClubVoiceFull: 26
+    ErrorCommunitiesBadTarget: 4
+    ErrorCommunitiesChatMute: 15
+    ErrorCommunitiesGuild: 8
+    ErrorCommunitiesIgnored: 7
+    ErrorCommunitiesMissingShortName: 11
+    ErrorCommunitiesNeutralFaction: 2
+    ErrorCommunitiesNone: 0
+    ErrorCommunitiesProfanity: 12
+    ErrorCommunitiesRestricted: 6
+    ErrorCommunitiesTrial: 13
+    ErrorCommunitiesUnknown: 1
+    ErrorCommunitiesUnknownRealm: 3
+    ErrorCommunitiesUnknownTicket: 10
+    ErrorCommunitiesVeteranTrial: 14
+    ErrorCommunitiesWrongFaction: 5
+    ErrorCommunitiesWrongRegion: 9
 ClubFieldType:
-  ClubBroadcast: 3
-  ClubDescription: 2
-  ClubName: 0
-  ClubShortName: 1
-  ClubStreamName: 4
-  ClubStreamSubject: 5
-  NumTypes: 6
+  values:
+    ClubBroadcast: 3
+    ClubDescription: 2
+    ClubName: 0
+    ClubShortName: 1
+    ClubStreamName: 4
+    ClubStreamSubject: 5
+    NumTypes: 6
 ClubFinderApplicationUpdateType:
-  AcceptInvite: 1
-  Cancel: 3
-  DeclineInvite: 2
-  None: 0
+  values:
+    AcceptInvite: 1
+    Cancel: 3
+    DeclineInvite: 2
+    None: 0
 ClubFinderClubPostingStatusFlags:
-  Banned: 5
-  FakePost: 6
-  ForceDescriptionChange: 2
-  ForceNameChange: 3
-  NeedsCacheUpdate: 1
-  None: 0
-  PendingDelete: 7
-  PostDelisted: 8
-  UnderReview: 4
+  values:
+    Banned: 5
+    FakePost: 6
+    ForceDescriptionChange: 2
+    ForceNameChange: 3
+    NeedsCacheUpdate: 1
+    None: 0
+    PendingDelete: 7
+    PostDelisted: 8
+    UnderReview: 4
 ClubFinderDisableReason:
-  Muted: 0
-  Silenced: 1
-  VeteranTrial: 2
+  values:
+    Muted: 0
+    Silenced: 1
+    VeteranTrial: 2
 ClubFinderPostingReportType:
-  ApplicantsName: 3
-  ClubName: 1
-  JoinNote: 4
-  PostersName: 0
-  PostingDescription: 2
+  values:
+    ApplicantsName: 3
+    ClubName: 1
+    JoinNote: 4
+    PostersName: 0
+    PostingDescription: 2
 ClubFinderRequestType:
-  All: 3
-  Community: 2
-  Guild: 1
-  None: 0
+  values:
+    All: 3
+    Community: 2
+    Guild: 1
+    None: 0
 ClubFinderSettingFlags:
-  AutoAccept: 14
-  Damage: 11
-  Dungeons: 1
-  EnableListing: 12
-  FactionAlliance: 16
-  FactionHorde: 15
-  FactionNeutral: 17
-  Healer: 10
-  LanguageReserved1: 21
-  LanguageReserved2: 22
-  LanguageReserved3: 23
-  LanguageReserved4: 24
-  LanguageReserved5: 25
-  Large: 8
-  MaxLevelOnly: 13
-  Medium: 7
-  None: 0
-  PvP: 3
-  Raids: 2
-  RP: 4
-  Small: 6
-  Social: 5
-  SortMemberCount: 19
-  SortNewest: 20
-  SortRelevance: 18
-  Tank: 9
+  values:
+    AutoAccept: 14
+    Damage: 11
+    Dungeons: 1
+    EnableListing: 12
+    FactionAlliance: 16
+    FactionHorde: 15
+    FactionNeutral: 17
+    Healer: 10
+    LanguageReserved1: 21
+    LanguageReserved2: 22
+    LanguageReserved3: 23
+    LanguageReserved4: 24
+    LanguageReserved5: 25
+    Large: 8
+    MaxLevelOnly: 13
+    Medium: 7
+    None: 0
+    PvP: 3
+    Raids: 2
+    RP: 4
+    Small: 6
+    Social: 5
+    SortMemberCount: 19
+    SortNewest: 20
+    SortRelevance: 18
+    Tank: 9
 ClubInvitationCandidateStatus:
-  AlreadyMember: 2
-  Available: 0
-  InvitePending: 1
+  values:
+    AlreadyMember: 2
+    Available: 0
+    InvitePending: 1
 ClubMemberPresence:
-  Away: 4
-  Busy: 5
-  Offline: 3
-  Online: 1
-  OnlineMobile: 2
-  Unknown: 0
+  values:
+    Away: 4
+    Busy: 5
+    Offline: 3
+    Online: 1
+    OnlineMobile: 2
+    Unknown: 0
 ClubRemovedReason:
-  Banned: 1
-  ClubDestroyed: 3
-  None: 0
-  Removed: 2
+  values:
+    Banned: 1
+    ClubDestroyed: 3
+    None: 0
+    Removed: 2
 ClubRestrictionReason:
-  None: 0
-  Unavailable: 1
+  values:
+    None: 0
+    Unavailable: 1
 ClubRoleIdentifier:
-  Leader: 2
-  Member: 4
-  Moderator: 3
-  Owner: 1
+  values:
+    Leader: 2
+    Member: 4
+    Moderator: 3
+    Owner: 1
 ClubStreamNotificationFilter:
-  All: 2
-  Mention: 1
-  None: 0
+  values:
+    All: 2
+    Mention: 1
+    None: 0
 ClubStreamType:
-  General: 0
-  Guild: 1
-  Officer: 2
-  Other: 3
+  values:
+    General: 0
+    Guild: 1
+    Officer: 2
+    Other: 3
 ClubType:
-  BattleNet: 0
-  Character: 1
-  Guild: 2
-  Other: 3
+  values:
+    BattleNet: 0
+    Character: 1
+    Guild: 2
+    Other: 3
 ColorOverride:
-  ItemQualityAccount: 7
-  ItemQualityArtifact: 6
-  ItemQualityCommon: 1
-  ItemQualityEpic: 4
-  ItemQualityLegendary: 5
-  ItemQualityPoor: 0
-  ItemQualityRare: 3
-  ItemQualityUncommon: 2
+  values:
+    ItemQualityAccount: 7
+    ItemQualityArtifact: 6
+    ItemQualityCommon: 1
+    ItemQualityEpic: 4
+    ItemQualityLegendary: 5
+    ItemQualityPoor: 0
+    ItemQualityRare: 3
+    ItemQualityUncommon: 2
 CombatAudioAlertCastState:
-  Off: 0
-  OnCastEnd: 2
-  OnCastStart: 1
+  values:
+    Off: 0
+    OnCastEnd: 2
+    OnCastStart: 1
 CombatAudioAlertCategory:
-  General: 0
-  PartyHealth: 7
-  PlayerCast: 3
-  PlayerDebuffs: 8
-  PlayerHealth: 1
-  PlayerResource1: 5
-  PlayerResource2: 6
-  TargetCast: 4
-  TargetHealth: 2
+  values:
+    General: 0
+    PartyHealth: 7
+    PlayerCast: 3
+    PlayerDebuffs: 8
+    PlayerHealth: 1
+    PlayerResource1: 5
+    PlayerResource2: 6
+    TargetCast: 4
+    TargetHealth: 2
 CombatAudioAlertDebuffSelfAlertValues:
-  DispelType: 1
-  Off: 0
+  values:
+    DispelType: 1
+    Off: 0
 CombatAudioAlertPartyPercentValues:
-  Off: 0
-  Under100Percent: 1
-  Under10Percent: 10
-  Under20Percent: 9
-  Under30Percent: 8
-  Under40Percent: 7
-  Under50Percent: 6
-  Under60Percent: 5
-  Under70Percent: 4
-  Under80Percent: 3
-  Under90Percent: 2
+  values:
+    Off: 0
+    Under100Percent: 1
+    Under10Percent: 10
+    Under20Percent: 9
+    Under30Percent: 8
+    Under40Percent: 7
+    Under50Percent: 6
+    Under60Percent: 5
+    Under70Percent: 4
+    Under80Percent: 3
+    Under90Percent: 2
 CombatAudioAlertPercentValues:
-  Every10Percent: 1
-  Every20Percent: 2
-  Every30Percent: 3
-  Every40Percent: 4
-  Every50Percent: 5
-  Off: 0
+  values:
+    Every10Percent: 1
+    Every20Percent: 2
+    Every30Percent: 3
+    Every40Percent: 4
+    Every50Percent: 5
+    Off: 0
 CombatAudioAlertPlayerCastFormatValues:
-  Cast: 3
-  Casting: 2
-  CastingSpellname: 0
-  CastSpellname: 1
-  Spellname: 4
+  values:
+    Cast: 3
+    Casting: 2
+    CastingSpellname: 0
+    CastSpellname: 1
+    Spellname: 4
 CombatAudioAlertPlayerDebuffFormatValues:
-  Full: 0
-  NoSpellname: 1
+  values:
+    Full: 0
+    NoSpellname: 1
 CombatAudioAlertPlayerHealthFormatValues:
-  HealthFull: 0
-  HealthNoPercent: 1
-  HealthNoPercentDiv10: 2
-  NoHealthFull: 3
-  NoHealthNoPercent: 4
-  NoHealthNoPercentDiv10: 5
+  values:
+    HealthFull: 0
+    HealthNoPercent: 1
+    HealthNoPercentDiv10: 2
+    NoHealthFull: 3
+    NoHealthNoPercent: 4
+    NoHealthNoPercentDiv10: 5
 CombatAudioAlertPlayerResourceFormatValues:
-  NoResourceFull: 3
-  NoResourceNoPercent: 4
-  NoResourceNoPercentDiv10: 5
-  ResourceFull: 0
-  ResourceNoPercent: 1
-  ResourceNoPercentDiv10: 2
+  values:
+    NoResourceFull: 3
+    NoResourceNoPercent: 4
+    NoResourceNoPercentDiv10: 5
+    ResourceFull: 0
+    ResourceNoPercent: 1
+    ResourceNoPercentDiv10: 2
 CombatAudioAlertSayIfTargetedType:
-  Aggro: 1
-  None: 0
-  Targeted: 2
-  TargetedBy: 3
+  values:
+    Aggro: 1
+    None: 0
+    Targeted: 2
+    TargetedBy: 3
 CombatAudioAlertSpecSetting:
-  Resource1Format: 1
-  Resource1Percent: 0
-  Resource1Voice: 2
-  Resource1Volume: 3
-  Resource2Format: 5
-  Resource2Percent: 4
-  Resource2Voice: 6
-  Resource2Volume: 7
-  SayIfTargeted: 8
+  values:
+    Resource1Format: 1
+    Resource1Percent: 0
+    Resource1Voice: 2
+    Resource1Volume: 3
+    Resource2Format: 5
+    Resource2Percent: 4
+    Resource2Voice: 6
+    Resource2Volume: 7
+    SayIfTargeted: 8
 CombatAudioAlertTargetCastFormatValues:
-  Cast: 5
-  Casting: 4
-  CastingSpellname: 2
-  CastSpellname: 3
-  Spellname: 6
-  TargetCastingSpellname: 0
-  TargetCastSpellname: 1
+  values:
+    Cast: 5
+    Casting: 4
+    CastingSpellname: 2
+    CastSpellname: 3
+    Spellname: 6
+    TargetCastingSpellname: 0
+    TargetCastSpellname: 1
 CombatAudioAlertTargetDeathBehavior:
-  Default: 0
-  SayTargetDead: 1
+  values:
+    Default: 0
+    SayTargetDead: 1
 CombatAudioAlertTargetHealthFormatValues:
-  HealthFull: 3
-  HealthNoPercent: 4
-  HealthNoPercentDiv10: 5
-  NoHealthFull: 0
-  NoHealthNoPercent: 1
-  NoHealthNoPercentDiv10: 2
-  TargetFull: 6
-  TargetNoPercent: 7
-  TargetNoPercentDiv10: 8
+  values:
+    HealthFull: 3
+    HealthNoPercent: 4
+    HealthNoPercentDiv10: 5
+    NoHealthFull: 0
+    NoHealthNoPercent: 1
+    NoHealthNoPercentDiv10: 2
+    TargetFull: 6
+    TargetNoPercent: 7
+    TargetNoPercentDiv10: 8
 CombatAudioAlertThrottle:
-  PlayerCast: 3
-  PlayerHealth: 1
-  PlayerHealthSamePercent: 7
-  PlayerResource1: 5
-  PlayerResource1SamePercent: 9
-  PlayerResource2: 6
-  PlayerResource2SamePercent: 10
-  Sample: 0
-  TargetCast: 4
-  TargetHealth: 2
-  TargetHealthSamePercent: 8
+  values:
+    PlayerCast: 3
+    PlayerHealth: 1
+    PlayerHealthSamePercent: 7
+    PlayerResource1: 5
+    PlayerResource1SamePercent: 9
+    PlayerResource2: 6
+    PlayerResource2SamePercent: 10
+    Sample: 0
+    TargetCast: 4
+    TargetHealth: 2
+    TargetHealthSamePercent: 8
 CombatAudioAlertType:
-  Cast: 1
-  Health: 0
+  values:
+    Cast: 1
+    Health: 0
 CombatAudioAlertUnit:
-  Player: 0
-  Target: 1
+  values:
+    Player: 0
+    Target: 1
 CombatLogMessageOrder:
-  Newest: 0
-  Oldest: 1
+  values:
+    Newest: 0
+    Oldest: 1
 CombatLogObject:
-  AffiliationMine: 1
-  AffiliationOutsider: 8
-  AffiliationParty: 2
-  AffiliationRaid: 4
-  ControlNpc: 512
-  ControlPlayer: 256
-  Empty: 0
-  Focus: 131072
-  Mainassist: 524288
-  Maintank: 262144
-  None: 2147483648
-  ReactionFriendly: 16
-  ReactionHostile: 64
-  ReactionNeutral: 32
-  Target: 65536
-  TypeGuardian: 8192
-  TypeNpc: 2048
-  TypeObject: 16384
-  TypePet: 4096
-  TypePlayer: 1024
+  values:
+    AffiliationMine: 1
+    AffiliationOutsider: 8
+    AffiliationParty: 2
+    AffiliationRaid: 4
+    ControlNpc: 512
+    ControlPlayer: 256
+    Empty: 0
+    Focus: 131072
+    Mainassist: 524288
+    Maintank: 262144
+    None: 2147483648
+    ReactionFriendly: 16
+    ReactionHostile: 64
+    ReactionNeutral: 32
+    Target: 65536
+    TypeGuardian: 8192
+    TypeNpc: 2048
+    TypeObject: 16384
+    TypePet: 4096
+    TypePlayer: 1024
 CombatLogObjectTarget:
-  RaidNone: 2147483648
-  Raidtarget1: 1
-  Raidtarget2: 2
-  Raidtarget3: 4
-  Raidtarget4: 8
-  Raidtarget5: 16
-  Raidtarget6: 32
-  Raidtarget7: 64
-  Raidtarget8: 128
+  values:
+    RaidNone: 2147483648
+    Raidtarget1: 1
+    Raidtarget2: 2
+    Raidtarget3: 4
+    Raidtarget4: 8
+    Raidtarget5: 16
+    Raidtarget6: 32
+    Raidtarget7: 64
+    Raidtarget8: 128
 CombinedQuestLogStatus:
-  Available: 0
-  Complete: 1
-  CompleteDaily: 2
-  CompleteGameReset: 6
-  CompleteMonthly: 4
-  CompleteWeekly: 3
-  CompleteYearly: 5
-  Reset: 7
+  values:
+    Available: 0
+    Complete: 1
+    CompleteDaily: 2
+    CompleteGameReset: 6
+    CompleteMonthly: 4
+    CompleteWeekly: 3
+    CompleteYearly: 5
+    Reset: 7
 CombinedQuestStatus:
-  Completed: 1
-  Invalid: 0
-  NotCompleted: 2
+  values:
+    Completed: 1
+    Invalid: 0
+    NotCompleted: 2
 CommunicationMode:
-  OpenMic: 1
-  PushToTalk: 0
+  values:
+    OpenMic: 1
+    PushToTalk: 0
 CompanionConfigSlotTypes:
-  Combat: 2
-  Role: 0
-  Utility: 1
+  values:
+    Combat: 2
+    Role: 0
+    Utility: 1
 CompressionLevel:
-  Default: 0
-  OptimizeForSize: 2
-  OptimizeForSpeed: 1
+  values:
+    Default: 0
+    OptimizeForSize: 2
+    OptimizeForSpeed: 1
 CompressionMethod:
-  Deflate: 0
-  Gzip: 2
-  Zlib: 1
+  values:
+    Deflate: 0
+    Gzip: 2
+    Zlib: 1
 ConfirmationPromptUIType:
-  BonusRoll: 1
-  SimpleWarning: 2
-  SimpleWarningAlert: 4
-  StaticText: 0
-  StaticTextAlert: 3
+  values:
+    BonusRoll: 1
+    SimpleWarning: 2
+    SimpleWarningAlert: 4
+    StaticText: 0
+    StaticTextAlert: 3
 ConsoleCategory:
-  Combat: 3
-  Console: 2
-  Debug: 0
-  Default: 5
-  Game: 4
-  Gm: 8
-  Graphics: 1
-  Net: 6
-  None: 10
-  Reveal: 9
-  Sound: 7
+  values:
+    Combat: 3
+    Console: 2
+    Debug: 0
+    Default: 5
+    Game: 4
+    Gm: 8
+    Graphics: 1
+    Net: 6
+    None: 10
+    Reveal: 9
+    Sound: 7
 ConsoleColorType:
-  AdminColor: 6
-  BackgroundColor: 8
-  ClickbufferColor: 9
-  DefaultColor: 0
-  DefaultGreen: 11
-  EchoColor: 2
-  ErrorColor: 3
-  GlobalColor: 5
-  HighlightColor: 7
-  InputColor: 1
-  PrivateColor: 10
-  WarningColor: 4
+  values:
+    AdminColor: 6
+    BackgroundColor: 8
+    ClickbufferColor: 9
+    DefaultColor: 0
+    DefaultGreen: 11
+    EchoColor: 2
+    ErrorColor: 3
+    GlobalColor: 5
+    HighlightColor: 7
+    InputColor: 1
+    PrivateColor: 10
+    WarningColor: 4
 ConsoleCommandType:
-  Command: 1
-  Cvar: 0
-  Macro: 2
-  Script: 3
+  values:
+    Command: 1
+    Cvar: 0
+    Macro: 2
+    Script: 3
 ContentTrackingError:
-  AlreadyTracked: 2
-  MaxTracked: 1
-  Untrackable: 0
+  values:
+    AlreadyTracked: 2
+    MaxTracked: 1
+    Untrackable: 0
 ContentTrackingResult:
-  DataPending: 1
-  Failure: 2
-  Success: 0
+  values:
+    DataPending: 1
+    Failure: 2
+    Success: 0
 ContentTrackingStopType:
-  Collected: 1
-  Invalidated: 0
-  Manual: 2
+  values:
+    Collected: 1
+    Invalidated: 0
+    Manual: 2
 ContentTrackingTargetType:
-  Achievement: 2
-  JournalEncounter: 0
-  Profession: 3
-  Quest: 4
-  Vendor: 1
+  values:
+    Achievement: 2
+    JournalEncounter: 0
+    Profession: 3
+    Quest: 4
+    Vendor: 1
 ContentTrackingType:
-  Achievement: 2
-  Appearance: 0
-  Decor: 3
-  Mount: 1
+  values:
+    Achievement: 2
+    Appearance: 0
+    Decor: 3
+    Mount: 1
 ContributionAppearanceFlags:
-  TooltipUseTimeRemaining: 0
+  values:
+    TooltipUseTimeRemaining: 0
 ContributionResult:
-  FailedConditionCheck: 5
-  IncorrectState: 2
-  InternalError: 7
-  InvalidID: 3
-  MustBeNearNpc: 1
-  QuestDataMissing: 4
-  Success: 0
-  UnableToCompleteTurnIn: 6
+  values:
+    FailedConditionCheck: 5
+    IncorrectState: 2
+    InternalError: 7
+    InvalidID: 3
+    MustBeNearNpc: 1
+    QuestDataMissing: 4
+    Success: 0
+    UnableToCompleteTurnIn: 6
 ContributionState:
-  Active: 2
-  Building: 1
-  Destroyed: 4
-  None: 0
-  UnderAttack: 3
+  values:
+    Active: 2
+    Building: 1
+    Destroyed: 4
+    None: 0
+    UnderAttack: 3
 CooldownSetLinkedSpellFlags:
-  UseAsTooltip: 1
+  values:
+    UseAsTooltip: 1
 CooldownSetSpellFlags:
-  HideAura: 1
-  HideByDefault: 2
+  values:
+    HideAura: 1
+    HideByDefault: 2
 CooldownViewerAddAlertStatus:
-  DuplicateAlert: 3
-  InvalidAlertType: 1
-  InvalidEventType: 2
-  Success: 0
+  values:
+    DuplicateAlert: 3
+    InvalidAlertType: 1
+    InvalidEventType: 2
+    Success: 0
 CooldownViewerAlertEventType:
-  Available: 1
-  ChargeGained: 4
-  OnAuraApplied: 5
-  OnAuraRemoved: 6
-  OnCooldown: 3
-  PandemicTime: 2
+  values:
+    Available: 1
+    ChargeGained: 4
+    OnAuraApplied: 5
+    OnAuraRemoved: 6
+    OnCooldown: 3
+    PandemicTime: 2
 CooldownViewerAlertType:
-  Sound: 1
-  Visual: 2
+  values:
+    Sound: 1
+    Visual: 2
 CooldownViewerBarContent:
-  IconAndName: 0
-  IconOnly: 1
-  NameOnly: 2
+  values:
+    IconAndName: 0
+    IconOnly: 1
+    NameOnly: 2
 CooldownViewerCategory:
-  Essential: 0
-  TrackedBar: 3
-  TrackedBuff: 2
-  Utility: 1
+  values:
+    Essential: 0
+    TrackedBar: 3
+    TrackedBuff: 2
+    Utility: 1
 CooldownViewerIconDirection:
-  Left: 0
-  Right: 1
+  values:
+    Left: 0
+    Right: 1
 CooldownViewerOrientation:
-  Horizontal: 0
-  Vertical: 1
+  values:
+    Horizontal: 0
+    Vertical: 1
 CooldownViewerVisibleSetting:
-  Always: 0
-  Hidden: 2
-  InCombat: 1
+  values:
+    Always: 0
+    Hidden: 2
+    InCombat: 1
 CornerstonePurchaseMode:
-  Basic: 0
-  Import: 1
-  Move: 2
+  values:
+    Basic: 0
+    Import: 1
+    Move: 2
 CovenantSkill:
-  Kyrian: 2730
-  Necrolord: 2733
-  NightFae: 2732
-  Venthyr: 2731
+  values:
+    Kyrian: 2730
+    Necrolord: 2733
+    NightFae: 2732
+    Venthyr: 2731
 CovenantType:
-  Kyrian: 1
-  Necrolord: 4
-  NightFae: 3
-  None: 0
-  Venthyr: 2
+  values:
+    Kyrian: 1
+    Necrolord: 4
+    NightFae: 3
+    None: 0
+    Venthyr: 2
 CraftingOrderDuration:
-  Long: 2
-  Medium: 1
-  Short: 0
+  values:
+    Long: 2
+    Medium: 1
+    Short: 0
 CraftingOrderFlags:
-  HasAllReagents: 8
-  HasNoneReagents: 2
-  HasSomeReagents: 4
-  IsFulfillable: 16
-  IsRecraft: 1
-  None: 0
+  values:
+    HasAllReagents: 8
+    HasNoneReagents: 2
+    HasSomeReagents: 4
+    IsFulfillable: 16
+    IsRecraft: 1
+    None: 0
 CraftingOrderItemFlags:
-  HasEnchantmentData: 2
-  None: 0
-  NpcProvided: 1
+  values:
+    HasEnchantmentData: 2
+    None: 0
+    NpcProvided: 1
 CraftingOrderItemType:
-  CraftedResult: 2
-  Currency: 5
-  Deprecated: 4
-  Item: 0
-  Recraft: 1
-  RemoveReagent: 3
+  values:
+    CraftedResult: 2
+    Currency: 5
+    Deprecated: 4
+    Item: 0
+    Recraft: 1
+    RemoveReagent: 3
 CraftingOrderReagentSource:
-  Any: 0
-  Crafter: 2
-  Customer: 1
-  None: 3
+  values:
+    Any: 0
+    Crafter: 2
+    Customer: 1
+    None: 3
 CraftingOrderResult:
-  Aborted: 1
-  AlreadyClaimed: 2
-  AlreadyCrafted: 3
-  CannotBeOrdered: 4
-  CannotCancel: 5
-  CannotClaim: 6
-  CannotClaimOwnOrder: 7
-  CannotCraft: 8
-  CannotCreate: 9
-  CannotFulfill: 10
-  CannotRecraft: 11
-  CannotReject: 12
-  CannotRelease: 13
-  CrafterIsIgnored: 14
-  DatabaseError: 15
-  Expired: 16
-  InvalidDuration: 18
-  InvalidMinQuality: 19
-  InvalidNotes: 20
-  InvalidReagent: 21
-  InvalidRealm: 22
-  InvalidRecipe: 23
-  InvalidRecraftItem: 24
-  InvalidSort: 25
-  InvalidTarget: 26
-  InvalidType: 27
-  Locked: 17
-  MaxOrdersReached: 28
-  MissingCraftingTable: 29
-  MissingCurrency: 30
-  MissingItem: 31
-  MissingNpc: 32
-  MissingOrder: 33
-  MissingRecraftItem: 34
-  NoAccountItems: 35
-  NotClaimed: 36
-  NotCrafted: 37
-  NotInGuild: 38
-  NotYetImplemented: 39
-  Ok: 0
-  OutOfPublicOrderCapacity: 40
-  ServerIsNotAvailable: 41
-  TargetCannotCraft: 43
-  TargetLocked: 44
-  ThrottleViolation: 42
-  Timeout: 45
-  TooManyCurrencies: 46
-  TooManyItems: 47
-  WrongVersion: 48
+  values:
+    Aborted: 1
+    AlreadyClaimed: 2
+    AlreadyCrafted: 3
+    CannotBeOrdered: 4
+    CannotCancel: 5
+    CannotClaim: 6
+    CannotClaimOwnOrder: 7
+    CannotCraft: 8
+    CannotCreate: 9
+    CannotFulfill: 10
+    CannotRecraft: 11
+    CannotReject: 12
+    CannotRelease: 13
+    CrafterIsIgnored: 14
+    DatabaseError: 15
+    Expired: 16
+    InvalidDuration: 18
+    InvalidMinQuality: 19
+    InvalidNotes: 20
+    InvalidReagent: 21
+    InvalidRealm: 22
+    InvalidRecipe: 23
+    InvalidRecraftItem: 24
+    InvalidSort: 25
+    InvalidTarget: 26
+    InvalidType: 27
+    Locked: 17
+    MaxOrdersReached: 28
+    MissingCraftingTable: 29
+    MissingCurrency: 30
+    MissingItem: 31
+    MissingNpc: 32
+    MissingOrder: 33
+    MissingRecraftItem: 34
+    NoAccountItems: 35
+    NotClaimed: 36
+    NotCrafted: 37
+    NotInGuild: 38
+    NotYetImplemented: 39
+    Ok: 0
+    OutOfPublicOrderCapacity: 40
+    ServerIsNotAvailable: 41
+    TargetCannotCraft: 43
+    TargetLocked: 44
+    ThrottleViolation: 42
+    Timeout: 45
+    TooManyCurrencies: 46
+    TooManyItems: 47
+    WrongVersion: 48
 CraftingOrderSortType:
-  AveTip: 1
-  ItemName: 0
-  MaxTip: 2
-  Quantity: 3
-  Reagents: 4
-  Status: 7
-  TimeRemaining: 6
-  Tip: 5
+  values:
+    AveTip: 1
+    ItemName: 0
+    MaxTip: 2
+    Quantity: 3
+    Reagents: 4
+    Status: 7
+    TimeRemaining: 6
+    Tip: 5
 CraftingOrderState:
-  Canceled: 13
-  Canceling: 12
-  Claimed: 4
-  Claiming: 3
-  Crafting: 8
-  Created: 2
-  Creating: 1
-  Expired: 15
-  Expiring: 14
-  Fulfilled: 11
-  Fulfilling: 10
-  None: 0
-  Recrafting: 9
-  Rejected: 6
-  Rejecting: 5
-  Releasing: 7
+  values:
+    Canceled: 13
+    Canceling: 12
+    Claimed: 4
+    Claiming: 3
+    Crafting: 8
+    Created: 2
+    Creating: 1
+    Expired: 15
+    Expiring: 14
+    Fulfilled: 11
+    Fulfilling: 10
+    None: 0
+    Recrafting: 9
+    Rejected: 6
+    Rejecting: 5
+    Releasing: 7
 CraftingOrderType:
-  Guild: 1
-  Npc: 3
-  Personal: 2
-  Public: 0
+  values:
+    Guild: 1
+    Npc: 3
+    Personal: 2
+    Public: 0
 CraftingReagentItemFlag:
-  TooltipShowsAsStatModifications: 1
+  values:
+    TooltipShowsAsStatModifications: 1
 CraftingReagentType:
-  Automatic: 3
-  Basic: 1
-  Finishing: 2
-  Modifying: 0
+  values:
+    Automatic: 3
+    Basic: 1
+    Finishing: 2
+    Modifying: 0
 CreateAllAccountData:
-  AccountCurrenciesDone: '0x0000000000200000'
-  AccountDynamicCriteriaDone: '0x0000000001000000'
-  AccountFactionsDone: '0x0000000200000000'
-  AccountItemsDone: '0x0000000400000000'
-  AccountMappingDone: '0x0000008000000000'
-  AccountNotificationsDone: '0x0000000008000000'
-  AccountStateHousingData: '0x0000080000000000'
-  AchievementsDone: '0x0000000000000001'
-  ArchivedPurchasesDone: '0x0000000000000200'
-  AuctionableTokensDone: '0x0000000000002000'
-  BanktabSettingsDone: '0x0000004000000000'
-  BattlepetsDone: '0x0000000000000008'
-  BitVectorsDone: '0x0000000100000000'
-  BpayAddLicenseObjectsDone: '0x0000000000000800'
-  BpayDistributionObjectsDone: '0x0000000000000100'
-  BpayProductitemObjectsDone: '0x0000000000020000'
-  CharacterItemsDone: '0x0000010000000000'
-  CharactersDone: '0x0000000000000040'
-  CombinedQuestLogEntriesDone: '0x0000000800000000'
-  ConsumableTokensDone: '0x0000000000004000'
-  CriteriaDone: '0x0000000000000002'
-  CurrencycapsDone: '0x0000000000000010'
-  CurrencyTransferLogDone: '0x0000020000000000'
-  DataElementsDone: '0x0000001000000000'
-  EventRecordsDone: '0x0000200000000000'
-  ItemCollectionItemsDone: '0x0000000000001000'
-  LgVendorPurchaseDone: '0x0000040000000000'
-  MountsDone: '0x0000000000000004'
-  None: '0x0000000000000000'
-  Object: '0x0000000000100000'
-  PerkHeldItemsDone: '0x0000000040000000'
-  PerkPastRewardsDone: '0x0000000000008000'
-  PerkPendingPurchasesDone: '0x0000000010000000'
-  PerkPendingRewardsDone: '0x0000000080000000'
-  PurchasesDone: '0x0000000000000080'
-  QuestCriteriaDone: '0x0000000000080000'
-  QuestLogDone: '0x0000000000000020'
-  RafActivitiesDone: '0x0000000002000000'
-  RafBalanceDone: '0x0000000000400000'
-  RafRewardsDone: '0x0000000000800000'
-  RevokedRafRewardsDone: '0x0000000004000000'
-  SettingsDone: '0x0000000000000400'
-  TransmogOutfitsLoadedDone: '0x0000400000000000'
-  TrialBoostHistoryDone: '0x0000000000040000'
-  VasTransactionsDone: '0x0000000000010000'
-  WarbandGroupsDone: '0x0000002000000000'
-  WarbandScenesLoadedDone: '0x0000100000000000'
-  WowlabsDataDone: '0x0000000020000000'
+  values:
+    AccountCurrenciesDone: '0x0000000000200000'
+    AccountDynamicCriteriaDone: '0x0000000001000000'
+    AccountFactionsDone: '0x0000000200000000'
+    AccountItemsDone: '0x0000000400000000'
+    AccountMappingDone: '0x0000008000000000'
+    AccountNotificationsDone: '0x0000000008000000'
+    AccountStateHousingData: '0x0000080000000000'
+    AchievementsDone: '0x0000000000000001'
+    ArchivedPurchasesDone: '0x0000000000000200'
+    AuctionableTokensDone: '0x0000000000002000'
+    BanktabSettingsDone: '0x0000004000000000'
+    BattlepetsDone: '0x0000000000000008'
+    BitVectorsDone: '0x0000000100000000'
+    BpayAddLicenseObjectsDone: '0x0000000000000800'
+    BpayDistributionObjectsDone: '0x0000000000000100'
+    BpayProductitemObjectsDone: '0x0000000000020000'
+    CharacterItemsDone: '0x0000010000000000'
+    CharactersDone: '0x0000000000000040'
+    CombinedQuestLogEntriesDone: '0x0000000800000000'
+    ConsumableTokensDone: '0x0000000000004000'
+    CriteriaDone: '0x0000000000000002'
+    CurrencycapsDone: '0x0000000000000010'
+    CurrencyTransferLogDone: '0x0000020000000000'
+    DataElementsDone: '0x0000001000000000'
+    EventRecordsDone: '0x0000200000000000'
+    ItemCollectionItemsDone: '0x0000000000001000'
+    LgVendorPurchaseDone: '0x0000040000000000'
+    MountsDone: '0x0000000000000004'
+    None: '0x0000000000000000'
+    Object: '0x0000000000100000'
+    PerkHeldItemsDone: '0x0000000040000000'
+    PerkPastRewardsDone: '0x0000000000008000'
+    PerkPendingPurchasesDone: '0x0000000010000000'
+    PerkPendingRewardsDone: '0x0000000080000000'
+    PurchasesDone: '0x0000000000000080'
+    QuestCriteriaDone: '0x0000000000080000'
+    QuestLogDone: '0x0000000000000020'
+    RafActivitiesDone: '0x0000000002000000'
+    RafBalanceDone: '0x0000000000400000'
+    RafRewardsDone: '0x0000000000800000'
+    RevokedRafRewardsDone: '0x0000000004000000'
+    SettingsDone: '0x0000000000000400'
+    TransmogOutfitsLoadedDone: '0x0000400000000000'
+    TrialBoostHistoryDone: '0x0000000000040000'
+    VasTransactionsDone: '0x0000000000010000'
+    WarbandGroupsDone: '0x0000002000000000'
+    WarbandScenesLoadedDone: '0x0000100000000000'
+    WowlabsDataDone: '0x0000000020000000'
 CreateNeighborhoodErrorType:
-  None: 0
-  OversizedGuild: 3
-  Profanity: 1
-  UndersizedGuild: 2
+  values:
+    None: 0
+    OversizedGuild: 3
+    Profanity: 1
+    UndersizedGuild: 2
 CurioRarity:
-  Common: 1
-  Epic: 4
-  Rare: 3
-  Uncommon: 2
+  values:
+    Common: 1
+    Epic: 4
+    Rare: 3
+    Uncommon: 2
 CurrencyConversionResult:
-  Conversion: 1
-  NoConversion: 0
-  SkippedAccountCurrency: 2
+  values:
+    Conversion: 1
+    NoConversion: 0
+    SkippedAccountCurrency: 2
 CurrencyDestroyReason:
-  BonusRoll: 9
-  Capped: 6
-  Cheat: 0
-  DroppedToCorpse: 8
-  Garrison: 7
-  LegacyConversion: 10
-  QuestTurnin: 3
-  Spell: 1
-  Trade: 5
-  Vendor: 4
-  VersionUpdate: 2
+  values:
+    BonusRoll: 9
+    Capped: 6
+    Cheat: 0
+    DroppedToCorpse: 8
+    Garrison: 7
+    LegacyConversion: 10
+    QuestTurnin: 3
+    Spell: 1
+    Trade: 5
+    Vendor: 4
+    VersionUpdate: 2
 CurrencyFlags:
-  Currency_100_Scaler: 8
-  CurrencyAccountWide: 16777216
-  CurrencyAllowOverflowMailer: 33554432
-  CurrencyAppearsInLootWindow: 2
-  CurrencyComputedWeeklyMaximum: 4
-  CurrencyDeprecated: 131072
-  CurrencyDestroyExtraOnLoot: 2097152
-  CurrencyDoNotCompressChat: 8192
-  CurrencyDoNotLogAcquisitionToBi: 16384
-  CurrencyDoNotToast: 1048576
-  CurrencyDontCoalesceInLootWindow: 8388608
-  CurrencyDontShowTotalInTooltip: 4194304
-  CurrencyDynamicMaximum: 262144
-  CurrencyHasWarmodeBonus: 134217728
-  CurrencyHasWeeklyCatchup: 4096
-  CurrencyHideAsReward: 67108864
-  CurrencyIgnoreMaxQtyOnLoad: 32
-  CurrencyIsAllianceOnly: 268435456
-  CurrencyIsHordeOnly: 536870912
-  CurrencyLimitWarmodeBonusOncePerTooltip: 1073741824
-  CurrencyLogOnWorldChange: 64
-  CurrencyNoLowLevelDrop: 16
-  CurrencyNoRaidDrop: 32768
-  CurrencyNotPersistent: 65536
-  CurrencyResetTrackedQuantity: 256
-  CurrencySingleDropInLoot: 2048
-  CurrencySuppressChatMessageOnVersionChange: 1024
-  CurrencySuppressChatMessages: 524288
-  CurrencyTrackQuantity: 128
-  CurrencyTradable: 1
-  CurrencyUpdateVersionIgnoreMax: 512
-  CurrencyUsesLedgerBalance: 2147483648
+  values:
+    Currency_100_Scaler: 8
+    CurrencyAccountWide: 16777216
+    CurrencyAllowOverflowMailer: 33554432
+    CurrencyAppearsInLootWindow: 2
+    CurrencyComputedWeeklyMaximum: 4
+    CurrencyDeprecated: 131072
+    CurrencyDestroyExtraOnLoot: 2097152
+    CurrencyDoNotCompressChat: 8192
+    CurrencyDoNotLogAcquisitionToBi: 16384
+    CurrencyDoNotToast: 1048576
+    CurrencyDontCoalesceInLootWindow: 8388608
+    CurrencyDontShowTotalInTooltip: 4194304
+    CurrencyDynamicMaximum: 262144
+    CurrencyHasWarmodeBonus: 134217728
+    CurrencyHasWeeklyCatchup: 4096
+    CurrencyHideAsReward: 67108864
+    CurrencyIgnoreMaxQtyOnLoad: 32
+    CurrencyIsAllianceOnly: 268435456
+    CurrencyIsHordeOnly: 536870912
+    CurrencyLimitWarmodeBonusOncePerTooltip: 1073741824
+    CurrencyLogOnWorldChange: 64
+    CurrencyNoLowLevelDrop: 16
+    CurrencyNoRaidDrop: 32768
+    CurrencyNotPersistent: 65536
+    CurrencyResetTrackedQuantity: 256
+    CurrencySingleDropInLoot: 2048
+    CurrencySuppressChatMessageOnVersionChange: 1024
+    CurrencySuppressChatMessages: 524288
+    CurrencyTrackQuantity: 128
+    CurrencyTradable: 1
+    CurrencyUpdateVersionIgnoreMax: 512
+    CurrencyUsesLedgerBalance: 2147483648
 CurrencyFlagsB:
-  CurrencyBAllowReductionByResourcefulness: 1024
-  CurrencyBBattlenetVirtualCurrency: 8
-  CurrencyBDontDisplayIfZero: 32
-  CurrencyBForceMaxQuantityOnConversion: 256
-  CurrencyBNoBonusXP: 2048
-  CurrencyBNoNotificationMailOnOfflineProgress: 4
-  CurrencyBScaleMaxQuantityBySeasonWeeks: 64
-  CurrencyBScaleMaxQuantityByWeeksSinceStart: 128
-  CurrencyBShowQuestXPGainInTooltip: 2
-  CurrencyBUnearnableBeforeMaxQuantityStart: 512
-  CurrencyBUseTotalEarnedForEarned: 1
-  FutureCurrencyFlag: 16
+  values:
+    CurrencyBAllowReductionByResourcefulness: 1024
+    CurrencyBBattlenetVirtualCurrency: 8
+    CurrencyBDontDisplayIfZero: 32
+    CurrencyBForceMaxQuantityOnConversion: 256
+    CurrencyBNoBonusXP: 2048
+    CurrencyBNoNotificationMailOnOfflineProgress: 4
+    CurrencyBScaleMaxQuantityBySeasonWeeks: 64
+    CurrencyBScaleMaxQuantityByWeeksSinceStart: 128
+    CurrencyBShowQuestXPGainInTooltip: 2
+    CurrencyBUnearnableBeforeMaxQuantityStart: 512
+    CurrencyBUseTotalEarnedForEarned: 1
+    FutureCurrencyFlag: 16
 CurrencyGainFlags:
-  Autotracking: 8
-  BonusAward: 1
-  DroppedFromDeath: 2
-  FromAccountServer: 4
-  None: 0
+  values:
+    Autotracking: 8
+    BonusAward: 1
+    DroppedFromDeath: 2
+    FromAccountServer: 4
+    None: 0
 CurrencySource:
-  AccountCopy: 37
-  AccountServerConversion: 46
-  Arena: 17
-  ArenaPoints: 38
-  AuctionDeposit: 41
-  AzeriteRespec: 34
-  Barbershop: 42
-  BonusRoll: 33
-  ChallengeModeDungeon: 44
-  Cheat: 4
-  ConvertOldItem: 0
-  ConvertOldPvPCurrency: 1
-  ExceededMaxQty: 18
-  GarrisonBuilding: 23
-  GarrisonBuildingRefund: 26
-  GarrisonFollowerActivation: 25
-  GarrisonMissionReward: 27
-  GarrisonResourceOverTime: 28
-  GarrisonTalent: 30
-  GarrisonWorldQuestBonus: 31
-  GuildBankWithdrawal: 21
-  InitiativeReward: 45
-  ItemDeletion: 14
-  ItemRefund: 2
-  LFGReward: 11
-  Loot: 9
-  Pushloot: 22
-  PvPCompletionBonus: 19
-  PvPDrop: 24
-  PvPHonorQuestReward: 40
-  PvPHonorReward: 32
-  PvPKillCredit: 6
-  PvPMetaCredit: 7
-  PvPScriptedAward: 8
-  PvPTeamContribution: 39
-  QuestReward: 3
-  QuestRewardIgnoreCaps: 29
-  RandomBattleground: 16
-  RatedBattleground: 15
-  Script: 20
-  SimulateLoot: 43
-  Spell: 13
-  Trade: 12
-  UpdatingVersion: 10
-  Vendor: 5
-  WorldQuestReward: 35
-  WorldQuestRewardIgnoreCaps: 36
+  values:
+    AccountCopy: 37
+    AccountServerConversion: 46
+    Arena: 17
+    ArenaPoints: 38
+    AuctionDeposit: 41
+    AzeriteRespec: 34
+    Barbershop: 42
+    BonusRoll: 33
+    ChallengeModeDungeon: 44
+    Cheat: 4
+    ConvertOldItem: 0
+    ConvertOldPvPCurrency: 1
+    ExceededMaxQty: 18
+    GarrisonBuilding: 23
+    GarrisonBuildingRefund: 26
+    GarrisonFollowerActivation: 25
+    GarrisonMissionReward: 27
+    GarrisonResourceOverTime: 28
+    GarrisonTalent: 30
+    GarrisonWorldQuestBonus: 31
+    GuildBankWithdrawal: 21
+    InitiativeReward: 45
+    ItemDeletion: 14
+    ItemRefund: 2
+    LFGReward: 11
+    Loot: 9
+    Pushloot: 22
+    PvPCompletionBonus: 19
+    PvPDrop: 24
+    PvPHonorQuestReward: 40
+    PvPHonorReward: 32
+    PvPKillCredit: 6
+    PvPMetaCredit: 7
+    PvPScriptedAward: 8
+    PvPTeamContribution: 39
+    QuestReward: 3
+    QuestRewardIgnoreCaps: 29
+    RandomBattleground: 16
+    RatedBattleground: 15
+    Script: 20
+    SimulateLoot: 43
+    Spell: 13
+    Trade: 12
+    UpdatingVersion: 10
+    Vendor: 5
+    WorldQuestReward: 35
+    WorldQuestRewardIgnoreCaps: 36
 CurrencyTokenCategoryFlags:
-  FlagPlayerItemAssignment: 2
-  FlagSortLast: 1
-  Hidden: 4
-  StartsCollapsed: 16
-  Virtual: 8
+  values:
+    FlagPlayerItemAssignment: 2
+    FlagSortLast: 1
+    Hidden: 4
+    StartsCollapsed: 16
+    Virtual: 8
 CurrencyType:
-  Copper: 0
-  Gold: 2
-  Silver: 1
+  values:
+    Copper: 0
+    Gold: 2
+    Silver: 1
 Cursormode:
-  AttackCursor: 4
-  AttackErrorCursor: 50
-  BroomCursor: 42
-  BroomErrorCursor: 88
-  BuyCursor: 3
-  BuyErrorCursor: 49
-  CampaignQuestCursor: 23
-  CampaignQuestErrorCursor: 69
-  CampaignQuestTurninCursor: 24
-  CampaignQuestTurninErrorCursor: 70
-  CastCursor: 2
-  CastErrorCursor: 48
-  CustomCursor: 91
-  EnchantCursor: 39
-  EnchantErrorCursor: 85
-  GatherCursor: 13
-  GatherErrorCursor: 59
-  GrabbingHandCursor: 44
-  GrabbingHandErrorCursor: 90
-  HoldingHandCursor: 43
-  HoldingHandErrorCursor: 89
-  InnkeeperCursor: 22
-  InnkeeperErrorCursor: 68
-  InspectCursor: 7
-  InspectErrorCursor: 53
-  InteractCursor: 5
-  InteractErrorCursor: 51
-  ItemCursor: 19
-  ItemErrorCursor: 65
-  LockCursor: 14
-  LockErrorCursor: 60
-  LootAllCursor: 16
-  LootAllErrorCursor: 62
-  MailCursor: 15
-  MailErrorCursor: 61
-  MapPinCursor: 37
-  MapPinErrorCursor: 83
-  MineCursor: 11
-  MineErrorCursor: 57
-  NoCursor: 0
-  PaletteCursor: 41
-  PaletteErrorCursor: 87
-  PickupCursor: 8
-  PickupErrorCursor: 54
-  PingCursor: 38
-  PingErrorCursor: 84
-  PointCursor: 1
-  PointErrorCursor: 47
-  QuestCursor: 25
-  QuestErrorCursor: 71
-  QuestImportantCursor: 30
-  QuestImportantErrorCursor: 76
-  QuestImportantTurninCursor: 31
-  QuestImportantTurninErrorCursor: 77
-  QuestLegendaryCursor: 28
-  QuestLegendaryErrorCursor: 74
-  QuestLegendaryTurninCursor: 29
-  QuestLegendaryTurninErrorCursor: 75
-  QuestMetaCursor: 32
-  QuestMetaErrorCursor: 78
-  QuestMetaTurninCursor: 33
-  QuestMetaTurninErrorCursor: 79
-  QuestRecurringCursor: 34
-  QuestRecurringErrorCursor: 80
-  QuestRecurringTurninCursor: 35
-  QuestRecurringTurninErrorCursor: 81
-  QuestRepeatableCursor: 26
-  QuestRepeatableErrorCursor: 72
-  QuestTurninCursor: 27
-  QuestTurninErrorCursor: 73
-  RepairCursor: 17
-  RepairErrorCursor: 63
-  RepairnpcCursor: 18
-  RepairnpcErrorCursor: 64
-  SkinAllianceCursor: 21
-  SkinAllianceErrorCursor: 67
-  SkinCursor: 12
-  SkinErrorCursor: 58
-  SkinHordeCursor: 20
-  SkinHordeErrorCursor: 66
-  SpeakCursor: 6
-  SpeakErrorCursor: 52
-  StablemasterCursor: 40
-  StablemasterErrorCursor: 86
-  TaxiCursor: 9
-  TaxiErrorCursor: 55
-  TrainerCursor: 10
-  TrainerErrorCursor: 56
-  UIMoveCursor: 45
-  UIResizeCursor: 46
-  VehicleCursor: 36
-  VehicleErrorCursor: 82
+  values:
+    AttackCursor: 4
+    AttackErrorCursor: 50
+    BroomCursor: 42
+    BroomErrorCursor: 88
+    BuyCursor: 3
+    BuyErrorCursor: 49
+    CampaignQuestCursor: 23
+    CampaignQuestErrorCursor: 69
+    CampaignQuestTurninCursor: 24
+    CampaignQuestTurninErrorCursor: 70
+    CastCursor: 2
+    CastErrorCursor: 48
+    CustomCursor: 91
+    EnchantCursor: 39
+    EnchantErrorCursor: 85
+    GatherCursor: 13
+    GatherErrorCursor: 59
+    GrabbingHandCursor: 44
+    GrabbingHandErrorCursor: 90
+    HoldingHandCursor: 43
+    HoldingHandErrorCursor: 89
+    InnkeeperCursor: 22
+    InnkeeperErrorCursor: 68
+    InspectCursor: 7
+    InspectErrorCursor: 53
+    InteractCursor: 5
+    InteractErrorCursor: 51
+    ItemCursor: 19
+    ItemErrorCursor: 65
+    LockCursor: 14
+    LockErrorCursor: 60
+    LootAllCursor: 16
+    LootAllErrorCursor: 62
+    MailCursor: 15
+    MailErrorCursor: 61
+    MapPinCursor: 37
+    MapPinErrorCursor: 83
+    MineCursor: 11
+    MineErrorCursor: 57
+    NoCursor: 0
+    PaletteCursor: 41
+    PaletteErrorCursor: 87
+    PickupCursor: 8
+    PickupErrorCursor: 54
+    PingCursor: 38
+    PingErrorCursor: 84
+    PointCursor: 1
+    PointErrorCursor: 47
+    QuestCursor: 25
+    QuestErrorCursor: 71
+    QuestImportantCursor: 30
+    QuestImportantErrorCursor: 76
+    QuestImportantTurninCursor: 31
+    QuestImportantTurninErrorCursor: 77
+    QuestLegendaryCursor: 28
+    QuestLegendaryErrorCursor: 74
+    QuestLegendaryTurninCursor: 29
+    QuestLegendaryTurninErrorCursor: 75
+    QuestMetaCursor: 32
+    QuestMetaErrorCursor: 78
+    QuestMetaTurninCursor: 33
+    QuestMetaTurninErrorCursor: 79
+    QuestRecurringCursor: 34
+    QuestRecurringErrorCursor: 80
+    QuestRecurringTurninCursor: 35
+    QuestRecurringTurninErrorCursor: 81
+    QuestRepeatableCursor: 26
+    QuestRepeatableErrorCursor: 72
+    QuestTurninCursor: 27
+    QuestTurninErrorCursor: 73
+    RepairCursor: 17
+    RepairErrorCursor: 63
+    RepairnpcCursor: 18
+    RepairnpcErrorCursor: 64
+    SkinAllianceCursor: 21
+    SkinAllianceErrorCursor: 67
+    SkinCursor: 12
+    SkinErrorCursor: 58
+    SkinHordeCursor: 20
+    SkinHordeErrorCursor: 66
+    SpeakCursor: 6
+    SpeakErrorCursor: 52
+    StablemasterCursor: 40
+    StablemasterErrorCursor: 86
+    TaxiCursor: 9
+    TaxiErrorCursor: 55
+    TrainerCursor: 10
+    TrainerErrorCursor: 56
+    UIMoveCursor: 45
+    UIResizeCursor: 46
+    VehicleCursor: 36
+    VehicleErrorCursor: 82
 CursorStyle:
-  Crosshair: 1
-  Mouse: 0
+  values:
+    Crosshair: 1
+    Mouse: 0
 CustomBindingType:
-  VoicePushToTalk: 0
+  values:
+    VoicePushToTalk: 0
 Damageclass:
-  All: 127
-  AllMagical: 126
-  AllPhysical: 1
-  Arcane: 6
-  Fire: 2
-  FirstResist: 2
-  Frost: 4
-  Holy: 1
-  LastResist: 6
-  MaskArcane: 64
-  MaskChaos: 124
-  MaskChromatic: 62
-  MaskCosmic: 106
-  MaskDivine: 66
-  MaskElemental: 28
-  MaskFire: 4
-  MaskFirestorm: 12
-  MaskFlamestrike: 5
-  MaskFrost: 16
-  MaskFrostfire: 20
-  MaskFroststorm: 24
-  MaskFroststrike: 17
-  MaskHoly: 2
-  MaskHolyfire: 6
-  MaskHolyfrost: 18
-  MaskHolystorm: 10
-  MaskHolystrike: 3
-  MaskMagical: 126
-  MaskNature: 8
-  MaskNone: 0
-  MaskPhysical: 1
-  MaskShadow: 32
-  MaskShadowflame: 36
-  MaskShadowfrost: 48
-  MaskShadowstorm: 40
-  MaskShadowstrike: 33
-  MaskSpellfire: 68
-  MaskSpellfrost: 80
-  MaskSpellshadow: 96
-  MaskSpellstorm: 72
-  MaskSpellstrike: 65
-  MaskStormstrike: 9
-  MaskTwilight: 34
-  Nature: 3
-  Physical: 0
-  Shadow: 5
+  values:
+    All: 127
+    AllMagical: 126
+    AllPhysical: 1
+    Arcane: 6
+    Fire: 2
+    FirstResist: 2
+    Frost: 4
+    Holy: 1
+    LastResist: 6
+    MaskArcane: 64
+    MaskChaos: 124
+    MaskChromatic: 62
+    MaskCosmic: 106
+    MaskDivine: 66
+    MaskElemental: 28
+    MaskFire: 4
+    MaskFirestorm: 12
+    MaskFlamestrike: 5
+    MaskFrost: 16
+    MaskFrostfire: 20
+    MaskFroststorm: 24
+    MaskFroststrike: 17
+    MaskHoly: 2
+    MaskHolyfire: 6
+    MaskHolyfrost: 18
+    MaskHolystorm: 10
+    MaskHolystrike: 3
+    MaskMagical: 126
+    MaskNature: 8
+    MaskNone: 0
+    MaskPhysical: 1
+    MaskShadow: 32
+    MaskShadowflame: 36
+    MaskShadowfrost: 48
+    MaskShadowstorm: 40
+    MaskShadowstrike: 33
+    MaskSpellfire: 68
+    MaskSpellfrost: 80
+    MaskSpellshadow: 96
+    MaskSpellstorm: 72
+    MaskSpellstrike: 65
+    MaskStormstrike: 9
+    MaskTwilight: 34
+    Nature: 3
+    Physical: 0
+    Shadow: 5
 DamageclassType:
-  Magical: 1
-  Physical: 0
+  values:
+    Magical: 1
+    Physical: 0
 DamageMeterCombineSessionType:
-  Arena: 2
-  ArenaMultiRound: 3
-  ChallengeMode: 1
-  None: 0
+  values:
+    Arena: 2
+    ArenaMultiRound: 3
+    ChallengeMode: 1
+    None: 0
 DamageMeterNumbers:
-  Compact: 1
-  Complete: 2
-  Minimal: 0
+  values:
+    Compact: 1
+    Complete: 2
+    Minimal: 0
 DamageMeterOverrideType:
-  AllowFriendlyFire: 1
-  Ignore: 0
-  IgnoreForAbsorbSpell: 4
-  RedirectSourceToAuraCaster: 3
-  RedirectSourceToOwner: 2
+  values:
+    AllowFriendlyFire: 1
+    Ignore: 0
+    IgnoreForAbsorbSpell: 4
+    RedirectSourceToAuraCaster: 3
+    RedirectSourceToOwner: 2
 DamageMeterSessionType:
-  Current: 1
-  Expired: 2
-  Overall: 0
+  values:
+    Current: 1
+    Expired: 2
+    Overall: 0
 DamageMeterSourceDisplayType:
-  Ally: 1
-  Enemy: 2
-  None: 0
+  values:
+    Ally: 1
+    Enemy: 2
+    None: 0
 DamageMeterSpellDetailsDisplayType:
-  Deaths: 3
-  EnemyDamageTaken: 4
-  SpellAffected: 2
-  SpellCasted: 0
-  UnitSpecificSpellCasted: 1
+  values:
+    Deaths: 3
+    EnemyDamageTaken: 4
+    SpellAffected: 2
+    SpellCasted: 0
+    UnitSpecificSpellCasted: 1
 DamageMeterStorageType:
-  Absorbs: 2
-  AvoidableDamageTaken: 6
-  Damage: 0
-  DamageTaken: 5
-  Deaths: 7
-  Dispels: 4
-  EnemyDamageTaken: 8
-  HealingAndAbsorbs: 1
-  Interrupts: 3
+  values:
+    Absorbs: 2
+    AvoidableDamageTaken: 6
+    Damage: 0
+    DamageTaken: 5
+    Deaths: 7
+    Dispels: 4
+    EnemyDamageTaken: 8
+    HealingAndAbsorbs: 1
+    Interrupts: 3
 DamageMeterStyle:
-  Bordered: 2
-  Default: 0
-  FullBackground: 3
-  Thin: 1
+  values:
+    Bordered: 2
+    Default: 0
+    FullBackground: 3
+    Thin: 1
 DamageMeterType:
-  Absorbs: 4
-  AvoidableDamageTaken: 8
-  DamageDone: 0
-  DamageTaken: 7
-  Deaths: 9
-  Dispels: 6
-  Dps: 1
-  EnemyDamageTaken: 10
-  HealingDone: 2
-  Hps: 3
-  Interrupts: 5
+  values:
+    Absorbs: 4
+    AvoidableDamageTaken: 8
+    DamageDone: 0
+    DamageTaken: 7
+    Deaths: 9
+    Dispels: 6
+    Dps: 1
+    EnemyDamageTaken: 10
+    HealingDone: 2
+    Hps: 3
+    Interrupts: 5
 DamageMeterVisibility:
-  Always: 0
-  Hidden: 2
-  InCombat: 1
-  InGroup: 3
+  values:
+    Always: 0
+    Hidden: 2
+    InCombat: 1
+    InGroup: 3
 DeveloperLogAssertDomain:
-  Art: 1
-  Design: 2
-  Engineering: 4
-  LiveOperations: 64
-  Performance: 32
-  Sound: 8
-  Tools: 16
+  values:
+    Art: 1
+    Design: 2
+    Engineering: 4
+    LiveOperations: 64
+    Performance: 32
+    Sound: 8
+    Tools: 16
 DeveloperLogErrorDomain:
-  Assert: 0
-  AssertData: 1
-  Frame: 2
-  TestSuite: 3
+  values:
+    Assert: 0
+    AssertData: 1
+    Frame: 2
+    TestSuite: 3
 DeveloperLogTrafficType:
-  ClientToServer: 1
-  GameEvent: 2
-  LuaToClient: 3
-  ServerToClient: 0
+  values:
+    ClientToServer: 1
+    GameEvent: 2
+    LuaToClient: 3
+    ServerToClient: 0
 DisableAccountProfilesFlags:
-  DecorsCollections: 32
-  Document: 1
-  ItemsCollections: 16
-  MountsCollections: 4
-  None: 0
-  PetsCollections: 8
-  SharedCollections: 2
+  values:
+    DecorsCollections: 32
+    Document: 1
+    ItemsCollections: 16
+    MountsCollections: 4
+    None: 0
+    PetsCollections: 8
+    SharedCollections: 2
 DurationTextBindingProperty:
-  ElapsedDuration: 2
-  ElapsedPercent: 3
-  EndTime: 6
-  RemainingDuration: 0
-  RemainingPercent: 1
-  StartTime: 5
-  TotalDuration: 4
+  values:
+    ElapsedDuration: 2
+    ElapsedPercent: 3
+    EndTime: 6
+    RemainingDuration: 0
+    RemainingPercent: 1
+    StartTime: 5
+    TotalDuration: 4
 DurationTimeModifier:
-  BaseTime: 1
-  RealTime: 0
+  values:
+    BaseTime: 1
+    RealTime: 0
 EditModeAccountSetting:
-  DeprecatedShowDebuffFrame: 11
-  EnableAdvancedOptions: 23
-  EnableSnap: 22
-  GridSpacing: 1
-  SettingsExpanded: 2
-  ShowArchaeologyBar: 27
-  ShowArenaFrames: 17
-  ShowBossFrames: 16
-  ShowBuffsAndDebuffs: 10
-  ShowCastBar: 7
-  ShowCooldownViewer: 28
-  ShowDamageMeter: 31
-  ShowDurabilityFrame: 21
-  ShowEncounterBar: 8
-  ShowEncounterEvents: 30
-  ShowExternalDefensives: 32
-  ShowExtraAbilities: 9
-  ShowGrid: 0
-  ShowHudTooltip: 19
-  ShowLootFrame: 18
-  ShowPartyFrames: 12
-  ShowPersonalResourceDisplay: 29
-  ShowPetActionBar: 5
-  ShowPetFrame: 24
-  ShowPossessActionBar: 6
-  ShowRaidFrames: 13
-  ShowStanceBar: 4
-  ShowStatusTrackingBar2: 20
-  ShowTalkingHeadFrame: 14
-  ShowTargetAndFocus: 3
-  ShowTimerBars: 25
-  ShowTotemActionBar: 33
-  ShowVehicleLeaveButton: 15
-  ShowVehicleSeatIndicator: 26
+  values:
+    DeprecatedShowDebuffFrame: 11
+    EnableAdvancedOptions: 23
+    EnableSnap: 22
+    GridSpacing: 1
+    SettingsExpanded: 2
+    ShowArchaeologyBar: 27
+    ShowArenaFrames: 17
+    ShowBossFrames: 16
+    ShowBuffsAndDebuffs: 10
+    ShowCastBar: 7
+    ShowCooldownViewer: 28
+    ShowDamageMeter: 31
+    ShowDurabilityFrame: 21
+    ShowEncounterBar: 8
+    ShowEncounterEvents: 30
+    ShowExternalDefensives: 32
+    ShowExtraAbilities: 9
+    ShowGrid: 0
+    ShowHudTooltip: 19
+    ShowLootFrame: 18
+    ShowPartyFrames: 12
+    ShowPersonalResourceDisplay: 29
+    ShowPetActionBar: 5
+    ShowPetFrame: 24
+    ShowPossessActionBar: 6
+    ShowRaidFrames: 13
+    ShowStanceBar: 4
+    ShowStatusTrackingBar2: 20
+    ShowTalkingHeadFrame: 14
+    ShowTargetAndFocus: 3
+    ShowTimerBars: 25
+    ShowTotemActionBar: 33
+    ShowVehicleLeaveButton: 15
+    ShowVehicleSeatIndicator: 26
 EditModeActionBarSetting:
-  AlwaysShowButtons: 9
-  DeprecatedSnapToSide: 7
-  HideBarArt: 6
-  HideBarScrolling: 8
-  IconPadding: 4
-  IconSize: 3
-  NumIcons: 2
-  NumRows: 1
-  Orientation: 0
-  VisibleSetting: 5
+  values:
+    AlwaysShowButtons: 9
+    DeprecatedSnapToSide: 7
+    HideBarArt: 6
+    HideBarScrolling: 8
+    IconPadding: 4
+    IconSize: 3
+    NumIcons: 2
+    NumRows: 1
+    Orientation: 0
+    VisibleSetting: 5
 EditModeActionBarSystemIndices:
-  Bar2: 2
-  Bar3: 3
-  ExtraBar1: 6
-  ExtraBar2: 7
-  ExtraBar3: 8
-  MainBar: 1
-  PetActionBar: 12
-  PossessActionBar: 13
-  RightBar1: 4
-  RightBar2: 5
-  StanceBar: 11
+  values:
+    Bar2: 2
+    Bar3: 3
+    ExtraBar1: 6
+    ExtraBar2: 7
+    ExtraBar3: 8
+    MainBar: 1
+    PetActionBar: 12
+    PossessActionBar: 13
+    RightBar1: 4
+    RightBar2: 5
+    StanceBar: 11
 EditModeArchaeologyBarSetting:
-  Size: 0
+  values:
+    Size: 0
 EditModeAuraFrameSetting:
-  DeprecatedShowFull: 7
-  IconDirection: 2
-  IconLimitBuffFrame: 3
-  IconLimitDebuffFrame: 4
-  IconPadding: 6
-  IconSize: 5
-  IconWrap: 1
-  Opacity: 9
-  Orientation: 0
-  ShowDispelType: 10
-  VisibleSetting: 8
+  values:
+    DeprecatedShowFull: 7
+    IconDirection: 2
+    IconLimitBuffFrame: 3
+    IconLimitDebuffFrame: 4
+    IconPadding: 6
+    IconSize: 5
+    IconWrap: 1
+    Opacity: 9
+    Orientation: 0
+    ShowDispelType: 10
+    VisibleSetting: 8
 EditModeAuraFrameSystemIndices:
-  BuffFrame: 1
-  DebuffFrame: 2
-  ExternalDefensivesFrame: 3
+  values:
+    BuffFrame: 1
+    DebuffFrame: 2
+    ExternalDefensivesFrame: 3
 EditModeBagsSetting:
-  BagSlotPadding: 3
-  Direction: 1
-  Orientation: 0
-  Size: 2
+  values:
+    BagSlotPadding: 3
+    Direction: 1
+    Orientation: 0
+    Size: 2
 EditModeCastBarSetting:
-  BarSize: 0
-  LockToPlayerFrame: 1
-  ShowCastTime: 2
+  values:
+    BarSize: 0
+    LockToPlayerFrame: 1
+    ShowCastTime: 2
 EditModeChatFrameSetting:
-  HeightHundreds: 2
-  HeightTensAndOnes: 3
-  WidthHundreds: 0
-  WidthTensAndOnes: 1
+  values:
+    HeightHundreds: 2
+    HeightTensAndOnes: 3
+    WidthHundreds: 0
+    WidthTensAndOnes: 1
 EditModeCooldownViewerSetting:
-  BarContent: 7
-  BarWidthScale: 11
-  HideWhenInactive: 8
-  IconDirection: 2
-  IconLimit: 1
-  IconPadding: 4
-  IconSize: 3
-  Opacity: 5
-  Orientation: 0
-  ShowTimer: 9
-  ShowTooltips: 10
-  VisibleSetting: 6
+  values:
+    BarContent: 7
+    BarWidthScale: 11
+    HideWhenInactive: 8
+    IconDirection: 2
+    IconLimit: 1
+    IconPadding: 4
+    IconSize: 3
+    Opacity: 5
+    Orientation: 0
+    ShowTimer: 9
+    ShowTooltips: 10
+    VisibleSetting: 6
 EditModeCooldownViewerSystemIndices:
-  BuffBar: 4
-  BuffIcon: 3
-  Essential: 1
-  Utility: 2
+  values:
+    BuffBar: 4
+    BuffIcon: 3
+    Essential: 1
+    Utility: 2
 EditModeDamageMeterSetting:
-  BackgroundTransparency: 12
-  BarHeight: 10
-  FrameHeight: 4
-  FrameWidth: 3
-  Numbers: 2
-  ObsoleteReuse1: 7
-  Padding: 5
-  ShowClassColor: 9
-  ShowSpecIcon: 8
-  Style: 1
-  TextSize: 11
-  Transparency: 6
-  Visibility: 0
+  values:
+    BackgroundTransparency: 12
+    BarHeight: 10
+    FrameHeight: 4
+    FrameWidth: 3
+    Numbers: 2
+    ObsoleteReuse1: 7
+    Padding: 5
+    ShowClassColor: 9
+    ShowSpecIcon: 8
+    Style: 1
+    TextSize: 11
+    Transparency: 6
+    Visibility: 0
 EditModeDurabilityFrameSetting:
-  Size: 0
+  values:
+    Size: 0
 EditModeEncounterEventsSetting:
-  BackgroundTransparency: 5
-  BarWidth: 12
-  FlipHorizontally: 11
-  IconDirection: 1
-  IconSize: 3
-  Orientation: 0
-  OverallSize: 4
-  Padding: 13
-  ShowSpellName: 2
-  ShowTimer: 9
-  TooltipAnchor: 8
-  Transparency: 6
-  ViewType: 10
-  Visibility: 7
+  values:
+    BackgroundTransparency: 5
+    BarWidth: 12
+    FlipHorizontally: 11
+    IconDirection: 1
+    IconSize: 3
+    Orientation: 0
+    OverallSize: 4
+    Padding: 13
+    ShowSpellName: 2
+    ShowTimer: 9
+    TooltipAnchor: 8
+    Transparency: 6
+    ViewType: 10
+    Visibility: 7
 EditModeEncounterEventsSystemIndices:
-  CriticalWarnings: 2
-  MediumWarnings: 3
-  NormalWarnings: 4
-  Timeline: 1
+  values:
+    CriticalWarnings: 2
+    MediumWarnings: 3
+    NormalWarnings: 4
+    Timeline: 1
 EditModeLayoutType:
-  Account: 1
-  Character: 2
-  Override: 3
-  Preset: 0
+  values:
+    Account: 1
+    Character: 2
+    Override: 3
+    Preset: 0
 EditModeMicroMenuSetting:
-  EyeSize: 3
-  Order: 1
-  Orientation: 0
-  Size: 2
+  values:
+    EyeSize: 3
+    Order: 1
+    Orientation: 0
+    Size: 2
 EditModeMinimapSetting:
-  HeaderUnderneath: 0
-  RotateMinimap: 1
-  Size: 2
+  values:
+    HeaderUnderneath: 0
+    RotateMinimap: 1
+    Size: 2
 EditModeObjectiveTrackerSetting:
-  Height: 0
-  Opacity: 1
-  TextSize: 2
+  values:
+    Height: 0
+    Opacity: 1
+    TextSize: 2
 EditModePersonalResourceDisplaySetting:
-  BarWidth: 12
-  DeprecatedOnlyShowInCombat: 1
-  HealthBarHeight: 4
-  HideAltPower: 14
-  HideClassInfo: 3
-  HideClassInfoOnPlayerFrame: 10
-  HideHealth: 0
-  HidePower: 2
-  Opacity: 7
-  Padding: 6
-  PowerBarHeight: 5
-  ShowBarText: 13
-  ShowClassColor: 11
-  Size: 9
-  VisibleSetting: 8
+  values:
+    BarWidth: 12
+    DeprecatedOnlyShowInCombat: 1
+    HealthBarHeight: 4
+    HideAltPower: 14
+    HideClassInfo: 3
+    HideClassInfoOnPlayerFrame: 10
+    HideHealth: 0
+    HidePower: 2
+    Opacity: 7
+    Padding: 6
+    PowerBarHeight: 5
+    ShowBarText: 13
+    ShowClassColor: 11
+    Size: 9
+    VisibleSetting: 8
 EditModePresetLayouts:
-  Classic: 1
-  Modern: 0
+  values:
+    Classic: 1
+    Modern: 0
 EditModeSettingDisplayType:
-  Checkbox: 1
-  Dropdown: 0
-  Slider: 2
+  values:
+    Checkbox: 1
+    Dropdown: 0
+    Slider: 2
 EditModeStatusTrackingBarSetting:
-  Height: 0
-  Size: 3
-  TextSize: 2
-  Width: 1
+  values:
+    Height: 0
+    Size: 3
+    TextSize: 2
+    Width: 1
 EditModeStatusTrackingBarSystemIndices:
-  StatusTrackingBar1: 1
-  StatusTrackingBar2: 2
+  values:
+    StatusTrackingBar1: 1
+    StatusTrackingBar2: 2
 EditModeSystem:
-  ActionBar: 0
-  ArchaeologyBar: 19
-  AuraFrame: 6
-  Bags: 14
-  CastBar: 1
-  ChatFrame: 8
-  CooldownViewer: 20
-  DamageMeter: 23
-  DurabilityFrame: 16
-  EncounterBar: 4
-  EncounterEvents: 22
-  ExtraAbilities: 5
-  HudTooltip: 11
-  LootFrame: 10
-  MicroMenu: 13
-  Minimap: 2
-  ObjectiveTracker: 12
-  PersonalResourceDisplay: 21
-  StatusTrackingBar: 15
-  TalkingHeadFrame: 7
-  TimerBars: 17
-  TotemActionBar: 24
-  UnitFrame: 3
-  VehicleLeaveButton: 9
-  VehicleSeatIndicator: 18
+  values:
+    ActionBar: 0
+    ArchaeologyBar: 19
+    AuraFrame: 6
+    Bags: 14
+    CastBar: 1
+    ChatFrame: 8
+    CooldownViewer: 20
+    DamageMeter: 23
+    DurabilityFrame: 16
+    EncounterBar: 4
+    EncounterEvents: 22
+    ExtraAbilities: 5
+    HudTooltip: 11
+    LootFrame: 10
+    MicroMenu: 13
+    Minimap: 2
+    ObjectiveTracker: 12
+    PersonalResourceDisplay: 21
+    StatusTrackingBar: 15
+    TalkingHeadFrame: 7
+    TimerBars: 17
+    TotemActionBar: 24
+    UnitFrame: 3
+    VehicleLeaveButton: 9
+    VehicleSeatIndicator: 18
 EditModeTimerBarsSetting:
-  Size: 0
+  values:
+    Size: 0
 EditModeUnitFrameSetting:
-  AuraOrganizationType: 18
-  BigDefensiveIconSize: 21
-  BuffsOnTop: 2
-  CastBarOnSide: 7
-  CastBarUnderneath: 1
-  DisplayBorder: 12
-  FrameHeight: 11
-  FrameSize: 16
-  FrameWidth: 10
-  HidePortrait: 0
-  IconSize: 19
-  Opacity: 20
-  RaidGroupDisplayType: 13
-  RowSize: 15
-  ShowCastTime: 8
-  ShowPartyFrameBackground: 5
-  SortPlayersBy: 14
-  UseHorizontalGroups: 6
-  UseLargerFrame: 3
-  UseRaidStylePartyFrames: 4
-  ViewArenaSize: 17
-  ViewRaidSize: 9
+  values:
+    AuraOrganizationType: 18
+    BigDefensiveIconSize: 21
+    BuffsOnTop: 2
+    CastBarOnSide: 7
+    CastBarUnderneath: 1
+    DisplayBorder: 12
+    FrameHeight: 11
+    FrameSize: 16
+    FrameWidth: 10
+    HidePortrait: 0
+    IconSize: 19
+    Opacity: 20
+    RaidGroupDisplayType: 13
+    RowSize: 15
+    ShowCastTime: 8
+    ShowPartyFrameBackground: 5
+    SortPlayersBy: 14
+    UseHorizontalGroups: 6
+    UseLargerFrame: 3
+    UseRaidStylePartyFrames: 4
+    ViewArenaSize: 17
+    ViewRaidSize: 9
 EditModeUnitFrameSystemIndices:
-  Arena: 7
-  Boss: 6
-  Focus: 3
-  Party: 4
-  Pet: 8
-  Player: 1
-  Raid: 5
-  Target: 2
+  values:
+    Arena: 7
+    Boss: 6
+    Focus: 3
+    Party: 4
+    Pet: 8
+    Player: 1
+    Raid: 5
+    Target: 2
 EditModeVehicleSeatIndicatorSetting:
-  Size: 0
+  values:
+    Size: 0
 EncounterEventCastState:
-  Casting: 1
-  Expired: 3
-  NotCasting: 2
+  values:
+    Casting: 1
+    Expired: 3
+    NotCasting: 2
 EncounterEventColorTrigger:
-  TextWarning: 0
-  TimelineEvent: 1
-  TimelineEventHighlight: 2
+  values:
+    TextWarning: 0
+    TimelineEvent: 1
+    TimelineEventHighlight: 2
 EncounterEventIconmask:
-  BleedEffect: 4
-  CurseEffect: 32
-  DeadlyEffect: 1
-  DiseaseEffect: 16
-  DpsRole: 512
-  EnrageEffect: 2
-  HealerRole: 256
-  MagicEffect: 8
-  PoisonEffect: 64
-  TankRole: 128
+  values:
+    BleedEffect: 4
+    CurseEffect: 32
+    DeadlyEffect: 1
+    DiseaseEffect: 16
+    DpsRole: 512
+    EnrageEffect: 2
+    HealerRole: 256
+    MagicEffect: 8
+    PoisonEffect: 64
+    TankRole: 128
 EncounterEventSeverity:
-  High: 2
-  Low: 0
-  Medium: 1
+  values:
+    High: 2
+    Low: 0
+    Medium: 1
 EncounterEventsIconDirection:
-  Bottom: 1
-  Left: 0
-  Right: 1
-  Top: 0
+  values:
+    Bottom: 1
+    Left: 0
+    Right: 1
+    Top: 0
 EncounterEventsOrientation:
-  Horizontal: 0
-  Vertical: 1
+  values:
+    Horizontal: 0
+    Vertical: 1
 EncounterEventSoundTrigger:
-  OnTextWarningShown: 0
-  OnTimelineEventFinished: 1
-  OnTimelineEventHighlight: 2
+  values:
+    OnTextWarningShown: 0
+    OnTimelineEventFinished: 1
+    OnTimelineEventHighlight: 2
 EncounterEventsTooltipAnchor:
-  Cursor: 2
-  Default: 1
-  Hidden: 0
+  values:
+    Cursor: 2
+    Default: 1
+    Hidden: 0
 EncounterEventsViewType:
-  Bars: 1
-  Timeline: 0
+  values:
+    Bars: 1
+    Timeline: 0
 EncounterEventsVisibility:
-  Always: 0
-  DeprecatedHidden: 2
-  InEncounter: 1
+  values:
+    Always: 0
+    DeprecatedHidden: 2
+    InEncounter: 1
 EncounterTimelineEventSortDirection:
-  Ascending: 1
-  Descending: 0
+  values:
+    Ascending: 1
+    Descending: 0
 EncounterTimelineEventSource:
-  EditMode: 2
-  Encounter: 0
-  Script: 1
+  values:
+    EditMode: 2
+    Encounter: 0
+    Script: 1
 EncounterTimelineEventState:
-  Active: 0
-  Canceled: 3
-  Finished: 2
-  Paused: 1
+  values:
+    Active: 0
+    Canceled: 3
+    Finished: 2
+    Paused: 1
 EncounterTimelineIconSet:
-  DamageAlert: 3
-  Deadly: 4
-  Dispel: 5
-  Enrage: 6
-  HealerAlert: 2
-  TankAlert: 1
+  values:
+    DamageAlert: 3
+    Deadly: 4
+    Dispel: 5
+    Enrage: 6
+    HealerAlert: 2
+    TankAlert: 1
 EncounterTimelineTrack:
-  Indeterminate: 4
-  Long: 3
-  Medium: 2
-  Queued: 0
-  Short: 1
+  values:
+    Indeterminate: 4
+    Long: 3
+    Medium: 2
+    Queued: 0
+    Short: 1
 EncounterTimelineTrackType:
-  Hidden: 0
-  Linear: 2
-  Sorted: 1
+  values:
+    Hidden: 0
+    Linear: 2
+    Sorted: 1
 EncounterTimelineViewType:
-  Bars: 2
-  None: 0
-  Timeline: 1
+  values:
+    Bars: 2
+    None: 0
+    Timeline: 1
 EndOfMatchType:
-  None: 0
-  Plunderstorm: 1
+  values:
+    None: 0
+    Plunderstorm: 1
 EnvironmentalDamageFlags:
-  DmgIsPct: 2
-  OneTime: 1
+  values:
+    DmgIsPct: 2
+    OneTime: 1
 Environmentaldamagetype:
-  Drowning: 1
-  Falling: 2
-  Fatigue: 0
-  Fire: 5
-  Lava: 3
-  Slime: 4
+  values:
+    Drowning: 1
+    Falling: 2
+    Fatigue: 0
+    Fire: 5
+    Lava: 3
+    Slime: 4
 EventRealmQueues:
-  None: 0
-  PlunderstormDuo: 2
-  PlunderstormSolo: 1
-  PlunderstormTraining: 8
-  PlunderstormTrio: 4
+  values:
+    None: 0
+    PlunderstormDuo: 2
+    PlunderstormSolo: 1
+    PlunderstormTraining: 8
+    PlunderstormTrio: 4
 EventToastDisplayType:
-  CapstoneUnlocked: 12
-  ChallengeMode: 7
-  FlightpointDiscovered: 11
-  HouseUpgradeAvailable: 15
-  LargeTextWithIcon: 4
-  NormalBlockText: 1
-  NormalSingleLine: 0
-  NormalTextWithIcon: 3
-  NormalTextWithIconAndRarity: 5
-  NormalTitleAndSubTitle: 2
-  Scenario: 6
-  ScenarioClickExpand: 8
-  Scoreboard: 14
-  SingleLineWithIcon: 13
-  WeeklyRewardUnlock: 9
-  WeeklyRewardUpgrade: 10
+  values:
+    CapstoneUnlocked: 12
+    ChallengeMode: 7
+    FlightpointDiscovered: 11
+    HouseUpgradeAvailable: 15
+    LargeTextWithIcon: 4
+    NormalBlockText: 1
+    NormalSingleLine: 0
+    NormalTextWithIcon: 3
+    NormalTextWithIconAndRarity: 5
+    NormalTitleAndSubTitle: 2
+    Scenario: 6
+    ScenarioClickExpand: 8
+    Scoreboard: 14
+    SingleLineWithIcon: 13
+    WeeklyRewardUnlock: 9
+    WeeklyRewardUpgrade: 10
 EventToastEventType:
-  BattlePetLevelChanged: 8
-  BattlePetLevelUpAbility: 9
-  CriteriaUpdated: 19
-  FlightpointDiscovered: 25
-  HouseUpgradeAvailable: 26
-  LevelUp: 0
-  LevelUpDungeon: 2
-  LevelUpOther: 15
-  LevelUpPvP: 4
-  LevelUpRaid: 3
-  LevelUpSpell: 1
-  MythicPlusWeeklyRecord: 11
-  PetBattleCapture: 7
-  PetBattleFinalRound: 6
-  PetBattleNewAbility: 5
-  PlayerAuraAdded: 16
-  PlayerAuraRemoved: 17
-  PvPTierUpdate: 20
-  QuestBossEmote: 10
-  QuestTurnedIn: 12
-  Scenario: 14
-  SpellLearned: 21
-  SpellScript: 18
-  TreasureItem: 22
-  WeeklyRewardUnlock: 23
-  WeeklyRewardUpgrade: 24
-  WorldStateChange: 13
+  values:
+    BattlePetLevelChanged: 8
+    BattlePetLevelUpAbility: 9
+    CriteriaUpdated: 19
+    FlightpointDiscovered: 25
+    HouseUpgradeAvailable: 26
+    LevelUp: 0
+    LevelUpDungeon: 2
+    LevelUpOther: 15
+    LevelUpPvP: 4
+    LevelUpRaid: 3
+    LevelUpSpell: 1
+    MythicPlusWeeklyRecord: 11
+    PetBattleCapture: 7
+    PetBattleFinalRound: 6
+    PetBattleNewAbility: 5
+    PlayerAuraAdded: 16
+    PlayerAuraRemoved: 17
+    PvPTierUpdate: 20
+    QuestBossEmote: 10
+    QuestTurnedIn: 12
+    Scenario: 14
+    SpellLearned: 21
+    SpellScript: 18
+    TreasureItem: 22
+    WeeklyRewardUnlock: 23
+    WeeklyRewardUpgrade: 24
+    WorldStateChange: 13
 EventToastFlags:
-  DisableRightClickDismiss: 1
+  values:
+    DisableRightClickDismiss: 1
 ExcludedCensorSources:
-  All: 255
-  Friends: 1
-  Guild: 2
-  None: 0
-  Reserve1: 4
-  Reserve2: 8
-  Reserve3: 16
-  Reserve4: 32
-  Reserve5: 64
-  Reserve6: 128
+  values:
+    All: 255
+    Friends: 1
+    Guild: 2
+    None: 0
+    Reserve1: 4
+    Reserve2: 8
+    Reserve3: 16
+    Reserve4: 32
+    Reserve5: 64
+    Reserve6: 128
 ExpansionLandingPageType:
-  Midnight: 1
-  None: 0
+  values:
+    Midnight: 1
+    None: 0
 ExpansionLevel:
-  BattleForAzeroth: 7
-  BurningCrusade: 1
-  Cataclysm: 3
-  Draenor: 5
-  Dragonflight: 9
-  LastTitan: 12
-  Legion: 6
-  Midnight: 11
-  MistsOfPandaria: 4
-  None: 0
-  Northrend: 2
-  Shadowlands: 8
-  WarWithin: 10
+  values:
+    BattleForAzeroth: 7
+    BurningCrusade: 1
+    Cataclysm: 3
+    Draenor: 5
+    Dragonflight: 9
+    LastTitan: 12
+    Legion: 6
+    Midnight: 11
+    MistsOfPandaria: 4
+    None: 0
+    Northrend: 2
+    Shadowlands: 8
+    WarWithin: 10
 FlightPathFaction:
-  Alliance: 2
-  Horde: 1
-  Neutral: 0
+  values:
+    Alliance: 2
+    Horde: 1
+    Neutral: 0
 FlightPathState:
-  Current: 0
-  Reachable: 1
-  Unreachable: 2
+  values:
+    Current: 0
+    Reachable: 1
+    Unreachable: 2
 FollowerAbilityCastResult:
-  AlreadyAtMaxDurability: 13
-  CannotTargetLimitedUseFollower: 11
-  CannotTargetNonAutoMissionFollower: 14
-  Failure: 1
-  InvalidFollowerSpell: 4
-  InvalidFollowerType: 9
-  InvalidTarget: 3
-  MustBeUnique: 10
-  MustTargetFollower: 7
-  MustTargetLimitedUseFollower: 12
-  MustTargetTrait: 8
-  NoPendingCast: 2
-  RerollNotAllowed: 5
-  SingleMissionDuration: 6
-  Success: 0
+  values:
+    AlreadyAtMaxDurability: 13
+    CannotTargetLimitedUseFollower: 11
+    CannotTargetNonAutoMissionFollower: 14
+    Failure: 1
+    InvalidFollowerSpell: 4
+    InvalidFollowerType: 9
+    InvalidTarget: 3
+    MustBeUnique: 10
+    MustTargetFollower: 7
+    MustTargetLimitedUseFollower: 12
+    MustTargetTrait: 8
+    NoPendingCast: 2
+    RerollNotAllowed: 5
+    SingleMissionDuration: 6
+    Success: 0
 FontStringScaleAnimationMode:
-  FontSize: 0
-  Vertex: 1
+  values:
+    FontSize: 0
+    Vertex: 1
 FragmentID:
-  Actor: 15
-  CgObject: 2
-  ClientObservablesData: 6
-  DeferredMessages: 9
-  EntityPosition: 1
-  FHousingDecor: 20
-  FHousingDecorActor: 28
-  FHousingDecorProxy: 26
-  FHousingFixture: 34
-  FHousingHouseDecorSet: 24
-  FHousingHouseFixtureSet: 35
-  FHousingHouseRoomSet: 25
-  FHousingPlayerHouse: 23
-  FHousingPlotAreaTrigger: 29
-  FHousingRoom: 21
-  FHousingRoomComponentMesh: 22
-  FHousingStorageMirrorData: 33
-  FJamHousingCornerstone: 27
-  FLootObjectList: 12
-  FMeshObjectData: 19
-  FMirroredPositionData: 31
-  FNeighborhoodMirrorData: 30
-  FNeighborhoodStateData: 38
-  FPathingDoor: 41
-  FPathingDynamicLinks: 40
-  FPersistableJamServers: 10
-  FPhaseShiftData: 16
-  FPlayerHouseInfo: 32
-  FPlayerInitiativeInfo: 37
-  FPlayerJamServers: 11
-  FPlayerOwnershipLink: 13
-  FTransportLink: 5
-  FUnitAIGroupLink: 39
-  FUnitAreaTriggerLink: 14
-  FVendor: 17
-  HeartbeatData: 4
-  JamDispatcher: 3
-  MirroredObjectC: 18
-  MirrorState: 0
-  ReservedArchetypeSeparator: 255
-  TagActiveClientS: 216
-  TagActiveObjectC: 217
-  TagActivePlayer: 215
-  TagAIGroup: 212
-  TagAreaTrigger: 209
-  TagAzeriteEmpoweredItem: 202
-  TagAzeriteItem: 203
-  TagContainer: 201
-  TagConversation: 211
-  TagCorpse: 208
-  TagDynamicObject: 207
-  TagGameObject: 206
-  TagHouseExteriorPiece: 224
-  TagHouseExteriorRoot: 225
-  TagHousingDecorProxyGameObject: 226
-  TagHousingPoolObject: 223
-  TagHousingRoom: 220
-  TagHousingSubdivisionObject: 222
-  TagItem: 200
-  TagLootObject: 214
-  TagMeshObject: 221
-  TagPlayer: 205
-  TagScenario: 213
-  TagSceneObject: 210
-  TagUnit: 204
-  TagUnitVehicle: 219
-  TagVisibleObjectC: 218
-  TestFragment_1: 250
-  TestFragment_2: 251
-  TestFragment_3: 252
-  TestFragment_4: 253
-  TestFragment_5: 254
-  Timer: 36
-  TimerQueues: 7
-  TransferSuspensionData: 8
+  values:
+    Actor: 15
+    CgObject: 2
+    ClientObservablesData: 6
+    DeferredMessages: 9
+    EntityPosition: 1
+    FHousingDecor: 20
+    FHousingDecorActor: 28
+    FHousingDecorProxy: 26
+    FHousingFixture: 34
+    FHousingHouseDecorSet: 24
+    FHousingHouseFixtureSet: 35
+    FHousingHouseRoomSet: 25
+    FHousingPlayerHouse: 23
+    FHousingPlotAreaTrigger: 29
+    FHousingRoom: 21
+    FHousingRoomComponentMesh: 22
+    FHousingStorageMirrorData: 33
+    FJamHousingCornerstone: 27
+    FLootObjectList: 12
+    FMeshObjectData: 19
+    FMirroredPositionData: 31
+    FNeighborhoodMirrorData: 30
+    FNeighborhoodStateData: 38
+    FPathingDoor: 41
+    FPathingDynamicLinks: 40
+    FPersistableJamServers: 10
+    FPhaseShiftData: 16
+    FPlayerHouseInfo: 32
+    FPlayerInitiativeInfo: 37
+    FPlayerJamServers: 11
+    FPlayerOwnershipLink: 13
+    FTransportLink: 5
+    FUnitAIGroupLink: 39
+    FUnitAreaTriggerLink: 14
+    FVendor: 17
+    HeartbeatData: 4
+    JamDispatcher: 3
+    MirroredObjectC: 18
+    MirrorState: 0
+    ReservedArchetypeSeparator: 255
+    TagActiveClientS: 216
+    TagActiveObjectC: 217
+    TagActivePlayer: 215
+    TagAIGroup: 212
+    TagAreaTrigger: 209
+    TagAzeriteEmpoweredItem: 202
+    TagAzeriteItem: 203
+    TagContainer: 201
+    TagConversation: 211
+    TagCorpse: 208
+    TagDynamicObject: 207
+    TagGameObject: 206
+    TagHouseExteriorPiece: 224
+    TagHouseExteriorRoot: 225
+    TagHousingDecorProxyGameObject: 226
+    TagHousingPoolObject: 223
+    TagHousingRoom: 220
+    TagHousingSubdivisionObject: 222
+    TagItem: 200
+    TagLootObject: 214
+    TagMeshObject: 221
+    TagPlayer: 205
+    TagScenario: 213
+    TagSceneObject: 210
+    TagUnit: 204
+    TagUnitVehicle: 219
+    TagVisibleObjectC: 218
+    TestFragment_1: 250
+    TestFragment_2: 251
+    TestFragment_3: 252
+    TestFragment_4: 253
+    TestFragment_5: 254
+    Timer: 36
+    TimerQueues: 7
+    TransferSuspensionData: 8
 FrameTutorialAccount:
-  AccountWideReputation: 9
-  AssistedCombatRotationActionButton: 22
-  AssistedCombatRotationDragSpell: 21
-  BindToAccountUntilEquip: 11
-  CompletedQuestsFilter: 12
-  CompletedQuestsFilterSeen: 13
-  ConcentrationCurrency: 14
-  EditModeManager: 3
-  EnconterJournalTutorialsTabSeen: 33
-  EventSchedulerTabSeen: 20
-  HeirloomJournalLevel: 7
-  HousingCleanupMode: 40
-  HousingDecorCleanup: 23
-  HousingDecorClippingGrid: 25
-  HousingDecorCustomization: 26
-  HousingDecorLayout: 27
-  HousingDecorPlace: 24
-  HousingEndeavorsTabSeen: 48
-  HousingExpertMode: 39
-  HousingHouseFinderMap: 28
-  HousingHouseFinderVisitHouse: 29
-  HousingInvalidCollision: 37
-  HousingItemAcquisition: 30
-  HousingMarketTab: 34
-  HousingModesUnlocked: 38
-  HousingNewPip: 31
-  HousingTeleportButton: 35
-  HudRevampBagChanges: 1
-  LFGList: 6
-  LocalStoriesFilterSeen: 19
-  MapLegendOpened: 15
-  MountCollectionDragonriding: 5
-  NpcCraftingOrderCreateButton: 17
-  NpcCraftingOrders: 16
-  NpcCraftingOrderTabNew: 18
-  PerksProgramActivitiesIntro: 2
-  PerksProgramActivitiesOpen: 32
-  RPETalentStarterBuild: 36
-  RunesOfPower: 49
-  TimerunnersAdvantage: 8
-  TransferableCurrencies: 10
-  TransmogCustomSets: 43
-  TransmogCustomSetsMigration: 47
-  TransmogOutfits: 41
-  TransmogSets: 42
-  TransmogSetsTab: 4
-  TransmogSituations: 44
-  TransmogTrialOfStyle: 46
-  TransmogWeaponOptions: 45
+  values:
+    AccountWideReputation: 9
+    AssistedCombatRotationActionButton: 22
+    AssistedCombatRotationDragSpell: 21
+    BindToAccountUntilEquip: 11
+    CompletedQuestsFilter: 12
+    CompletedQuestsFilterSeen: 13
+    ConcentrationCurrency: 14
+    EditModeManager: 3
+    EnconterJournalTutorialsTabSeen: 33
+    EventSchedulerTabSeen: 20
+    HeirloomJournalLevel: 7
+    HousingCleanupMode: 40
+    HousingDecorCleanup: 23
+    HousingDecorClippingGrid: 25
+    HousingDecorCustomization: 26
+    HousingDecorLayout: 27
+    HousingDecorPlace: 24
+    HousingEndeavorsTabSeen: 48
+    HousingExpertMode: 39
+    HousingHouseFinderMap: 28
+    HousingHouseFinderVisitHouse: 29
+    HousingInvalidCollision: 37
+    HousingItemAcquisition: 30
+    HousingMarketTab: 34
+    HousingModesUnlocked: 38
+    HousingNewPip: 31
+    HousingTeleportButton: 35
+    HudRevampBagChanges: 1
+    LFGList: 6
+    LocalStoriesFilterSeen: 19
+    MapLegendOpened: 15
+    MountCollectionDragonriding: 5
+    NpcCraftingOrderCreateButton: 17
+    NpcCraftingOrders: 16
+    NpcCraftingOrderTabNew: 18
+    PerksProgramActivitiesIntro: 2
+    PerksProgramActivitiesOpen: 32
+    RPETalentStarterBuild: 36
+    RunesOfPower: 49
+    TimerunnersAdvantage: 8
+    TransferableCurrencies: 10
+    TransmogCustomSets: 43
+    TransmogCustomSetsMigration: 47
+    TransmogOutfits: 41
+    TransmogSets: 42
+    TransmogSetsTab: 4
+    TransmogSituations: 44
+    TransmogTrialOfStyle: 46
+    TransmogWeaponOptions: 45
 GameMode:
-  Plunderstorm: 2
-  Standard: 1
-  WoWHack: 3
+  values:
+    Plunderstorm: 2
+    Standard: 1
+    WoWHack: 3
 GamePadPowerLevel:
-  Critical: 0
-  High: 3
-  Low: 1
-  Medium: 2
-  Unknown: 5
-  Wired: 4
+  values:
+    Critical: 0
+    High: 3
+    Low: 1
+    Medium: 2
+    Unknown: 5
+    Wired: 4
 GameRule:
-  AchievementsPanelDisabled: 40
-  ActionbarIconIntroDisabled: 60
-  ActionButtonTypeOverlayStrategy: 165
-  ActionCombatTargetLockEnabled: 87
-  AfterDeathSpectatingUI: 49
-  AllPlayersAreFastMovers: 53
-  AlwaysAllowAlliedRaces: 59
-  AutoAttacksDisabled: 103
-  BagSpaceOverride: 172
-  BagsUIDisabled: 64
-  BlockWhileSheathedAllowed: 88
-  CharacterCreateUseFixedBackgroundModel: 55
-  CharacterlessLogin: 14
-  CharacterPanelDisabled: 37
-  CharNameReservationEnabled: 2
-  CharReservationsPerRealmReopenThreshold: 8
-  ChatLinkLevelToastsDisabled: 63
-  ClearMailOnRealmTransfer: 92
-  CollectionsPanelDisabled: 36
-  CommunitiesPanelDisabled: 41
-  CompactRaidFrameManagerDisabled: 81
-  CustomActionbarOverlayHeightOffset: 33
-  DeleteItemConfirmationDisabled: 62
-  DisableCampsites: 114
-  DisableHonorDecay: 23
-  DisablePct: 9
-  DisableQuickJoin: 162
-  DisableRaidGroups: 163
-  DisableRealmSelection: 113
-  DisableVas: 119
-  DoesNotCountTowardAccountCharacterMax: 142
-  EditModeDisabled: 82
-  EjDungeonsDisabled: 149
-  EjItemSetsDisabled: 151
-  EjJourneysDisabled: 156
-  EjRaidsDisabled: 150
-  EjSuggestedContentDisabled: 148
-  EncounterJournalDisabled: 42
-  EtaRealmLaunchTime: 5
-  ExperienceBarDisabled: 159
-  FastAreaTriggerTick: 52
-  FinderPanelDisabled: 43
-  ForceAlteredFormsOn: 56
-  ForcedChatLanguage: 34
-  ForcedMultiActionBarSetting: 133
-  ForcedPartyFrameScale: 32
-  FrontEndChat: 50
-  FullCharacterCreateDisabled: 84
-  GameMode: 13
-  GdapiCharacterProfileDisabled: 153
-  GroupFinderCapabilities: 98
-  GuildsDisabled: 46
-  HardcoreRuleset: 10
-  HelpPanelDisabled: 45
-  HideAllMultiActionBars: 135
-  HideFaction: 116
-  HideTransmogZeroCost: 161
-  HideUnavailableTransmogSlots: 160
-  HousingDashboardDisabled: 102
-  HousingEnabled: 154
-  IgnoreChrclassDisabledFlag: 54
-  IngameCalendarDisabled: 75
-  IngameFriendsListDisabled: 79
-  IngameMailNotificationDisabled: 74
-  IngameTrackingDisabled: 76
-  IngameWhoListDisabled: 77
-  InstanceDifficultyBannerDisabled: 83
-  LandingPageFactionID: 35
-  LootMethodStyle: 157
-  MacrosDisabled: 80
-  MailGameRule: 132
-  MapPlunderstormCircle: 48
-  MaxAccountCharReservationsPerContentset: 4
-  MaxCharactersPerContentSet: 139
-  MaxCharReservationsPerRealm: 3
-  MaximizeWorldMapDisabled: 67
-  MaxLootDropLevel: 25
-  MaxNameplateDistance: 28
-  MaxUnitNameDistance: 27
-  MerchantFilterDisabled: 101
-  MicrobarScale: 26
-  MinimapDisabled: 146
-  MinUndeleteLevelRequired: 140
-  NameplateCastBarDisabled: 107
-  NoDebuffLimit: 1
-  NonPlayerNameplateScale: 31
-  ObjectiveTrackerDisabled: 104
-  PerksProgramActivityTrackingDisabled: 66
-  PersonalResourceDisplayDisabled: 129
-  PetBattlesDisabled: 65
-  PlayerCastBarDisabled: 105
-  PlayerFrameDisabled: 131
-  PlayerNameplateAlternateHealthColor: 58
-  PlayerNameplateDifficultyIcon: 57
-  PlunderstormAreaSelection: 94
-  PremadeGroupFinderStyle: 93
-  PvPInitialRatingOverride: 190
-  QuestLogMicrobuttonDisabled: 47
-  QuestLogPanelDisabled: 71
-  QuestLogSuperTrackingDisabled: 72
-  RaceAlteredFormsDisabled: 78
-  RecommendLeastPopulatedRealm: 169
-  ReleaseSpiritGhostDisabled: 61
-  RepairArmorDisabled: 147
-  ReplaceAbsentGmSeconds: 11
-  ReplaceGmRankLastOnlineSeconds: 12
-  RestrictedAchievementCategoryID: 155
-  Runecarving: 17
-  SelfFoundAllowed: 22
-  SpellbookPanelDisabled: 38
-  StoreDisabled: 44
-  SummoningStones: 108
-  TalentRespecCostMax: 19
-  TalentRespecCostMin: 18
-  TalentRespecCostStep: 20
-  TalentsPanelDisabled: 39
-  TargetCastBarDisabled: 106
-  TargetFrameBuffsDisabled: 85
-  TargetFrameDisabled: 130
-  TimerunningAllowed: 137
-  TransmogEnabled: 109
-  TrivialGroupXPPercent: 7
-  TutorialFrameDisabled: 73
-  UnflaggedPlayersCanAttackPvPFlaggedPlayers: 173
-  UnitFramePvPContextualDisabled: 86
-  UniversalNameplateOcclusion: 51
-  UseGameTableVariation: 164
-  UserAddonsDisabled: 29
-  UserScriptsDisabled: 30
-  UseSimpleCharacterSelectList: 115
-  VanillaAccountMailInstant: 91
-  VanillaNpcKnockback: 16
-  VanillaRageGenerationModifier: 21
-  WorldMapDisabled: 145
-  WorldMapFrameStrata: 100
-  WorldMapHelpPlateDisabled: 70
-  WorldMapLegendDisabled: 99
-  WorldMapTrackingOptionsDisabled: 68
-  WorldMapTrackingPinDisabled: 69
+  values:
+    AchievementsPanelDisabled: 40
+    ActionbarIconIntroDisabled: 60
+    ActionButtonTypeOverlayStrategy: 165
+    ActionCombatTargetLockEnabled: 87
+    AfterDeathSpectatingUI: 49
+    AllPlayersAreFastMovers: 53
+    AlwaysAllowAlliedRaces: 59
+    AutoAttacksDisabled: 103
+    BagSpaceOverride: 172
+    BagsUIDisabled: 64
+    BlockWhileSheathedAllowed: 88
+    CharacterCreateUseFixedBackgroundModel: 55
+    CharacterlessLogin: 14
+    CharacterPanelDisabled: 37
+    CharNameReservationEnabled: 2
+    CharReservationsPerRealmReopenThreshold: 8
+    ChatLinkLevelToastsDisabled: 63
+    ClearMailOnRealmTransfer: 92
+    CollectionsPanelDisabled: 36
+    CommunitiesPanelDisabled: 41
+    CompactRaidFrameManagerDisabled: 81
+    CustomActionbarOverlayHeightOffset: 33
+    DeleteItemConfirmationDisabled: 62
+    DisableCampsites: 114
+    DisableHonorDecay: 23
+    DisablePct: 9
+    DisableQuickJoin: 162
+    DisableRaidGroups: 163
+    DisableRealmSelection: 113
+    DisableVas: 119
+    DoesNotCountTowardAccountCharacterMax: 142
+    EditModeDisabled: 82
+    EjDungeonsDisabled: 149
+    EjItemSetsDisabled: 151
+    EjJourneysDisabled: 156
+    EjRaidsDisabled: 150
+    EjSuggestedContentDisabled: 148
+    EncounterJournalDisabled: 42
+    EtaRealmLaunchTime: 5
+    ExperienceBarDisabled: 159
+    FastAreaTriggerTick: 52
+    FinderPanelDisabled: 43
+    ForceAlteredFormsOn: 56
+    ForcedChatLanguage: 34
+    ForcedMultiActionBarSetting: 133
+    ForcedPartyFrameScale: 32
+    FrontEndChat: 50
+    FullCharacterCreateDisabled: 84
+    GameMode: 13
+    GdapiCharacterProfileDisabled: 153
+    GroupFinderCapabilities: 98
+    GuildsDisabled: 46
+    HardcoreRuleset: 10
+    HelpPanelDisabled: 45
+    HideAllMultiActionBars: 135
+    HideFaction: 116
+    HideTransmogZeroCost: 161
+    HideUnavailableTransmogSlots: 160
+    HousingDashboardDisabled: 102
+    HousingEnabled: 154
+    IgnoreChrclassDisabledFlag: 54
+    IngameCalendarDisabled: 75
+    IngameFriendsListDisabled: 79
+    IngameMailNotificationDisabled: 74
+    IngameTrackingDisabled: 76
+    IngameWhoListDisabled: 77
+    InstanceDifficultyBannerDisabled: 83
+    LandingPageFactionID: 35
+    LootMethodStyle: 157
+    MacrosDisabled: 80
+    MailGameRule: 132
+    MapPlunderstormCircle: 48
+    MaxAccountCharReservationsPerContentset: 4
+    MaxCharactersPerContentSet: 139
+    MaxCharReservationsPerRealm: 3
+    MaximizeWorldMapDisabled: 67
+    MaxLootDropLevel: 25
+    MaxNameplateDistance: 28
+    MaxUnitNameDistance: 27
+    MerchantFilterDisabled: 101
+    MicrobarScale: 26
+    MinimapDisabled: 146
+    MinUndeleteLevelRequired: 140
+    NameplateCastBarDisabled: 107
+    NoDebuffLimit: 1
+    NonPlayerNameplateScale: 31
+    ObjectiveTrackerDisabled: 104
+    PerksProgramActivityTrackingDisabled: 66
+    PersonalResourceDisplayDisabled: 129
+    PetBattlesDisabled: 65
+    PlayerCastBarDisabled: 105
+    PlayerFrameDisabled: 131
+    PlayerNameplateAlternateHealthColor: 58
+    PlayerNameplateDifficultyIcon: 57
+    PlunderstormAreaSelection: 94
+    PremadeGroupFinderStyle: 93
+    PvPInitialRatingOverride: 190
+    QuestLogMicrobuttonDisabled: 47
+    QuestLogPanelDisabled: 71
+    QuestLogSuperTrackingDisabled: 72
+    RaceAlteredFormsDisabled: 78
+    RecommendLeastPopulatedRealm: 169
+    ReleaseSpiritGhostDisabled: 61
+    RepairArmorDisabled: 147
+    ReplaceAbsentGmSeconds: 11
+    ReplaceGmRankLastOnlineSeconds: 12
+    RestrictedAchievementCategoryID: 155
+    Runecarving: 17
+    SelfFoundAllowed: 22
+    SpellbookPanelDisabled: 38
+    StoreDisabled: 44
+    SummoningStones: 108
+    TalentRespecCostMax: 19
+    TalentRespecCostMin: 18
+    TalentRespecCostStep: 20
+    TalentsPanelDisabled: 39
+    TargetCastBarDisabled: 106
+    TargetFrameBuffsDisabled: 85
+    TargetFrameDisabled: 130
+    TimerunningAllowed: 137
+    TransmogEnabled: 109
+    TrivialGroupXPPercent: 7
+    TutorialFrameDisabled: 73
+    UnflaggedPlayersCanAttackPvPFlaggedPlayers: 173
+    UnitFramePvPContextualDisabled: 86
+    UniversalNameplateOcclusion: 51
+    UseGameTableVariation: 164
+    UserAddonsDisabled: 29
+    UserScriptsDisabled: 30
+    UseSimpleCharacterSelectList: 115
+    VanillaAccountMailInstant: 91
+    VanillaNpcKnockback: 16
+    VanillaRageGenerationModifier: 21
+    WorldMapDisabled: 145
+    WorldMapFrameStrata: 100
+    WorldMapHelpPlateDisabled: 70
+    WorldMapLegendDisabled: 99
+    WorldMapTrackingOptionsDisabled: 68
+    WorldMapTrackingPinDisabled: 69
 GameRuleFlags:
-  AllowClient: 1
-  None: 0
-  RequiresDefault: 2
+  values:
+    AllowClient: 1
+    None: 0
+    RequiresDefault: 2
 GameRuleType:
-  Bool: 2
-  Float: 1
-  Int: 0
+  values:
+    Bool: 2
+    Float: 1
+    Int: 0
 GarrAutoBoardIndex:
-  AllyCenterFront: 3
-  AllyLeftBack: 0
-  AllyLeftFront: 2
-  AllyRightBack: 1
-  AllyRightFront: 4
-  EnemyCenterLeftBack: 10
-  EnemyCenterLeftFront: 6
-  EnemyCenterRightBack: 11
-  EnemyCenterRightFront: 7
-  EnemyLeftBack: 9
-  EnemyLeftFront: 5
-  EnemyRightBack: 12
-  EnemyRightFront: 8
-  None: -1
+  values:
+    AllyCenterFront: 3
+    AllyLeftBack: 0
+    AllyLeftFront: 2
+    AllyRightBack: 1
+    AllyRightFront: 4
+    EnemyCenterLeftBack: 10
+    EnemyCenterLeftFront: 6
+    EnemyCenterRightBack: 11
+    EnemyCenterRightFront: 7
+    EnemyLeftBack: 9
+    EnemyLeftFront: 5
+    EnemyRightBack: 12
+    EnemyRightFront: 8
+    None: -1
 GarrAutoCombatantRole:
-  HealSupport: 4
-  Melee: 1
-  None: 0
-  RangedMagic: 3
-  RangedPhysical: 2
-  Tank: 5
+  values:
+    HealSupport: 4
+    Melee: 1
+    None: 0
+    RangedMagic: 3
+    RangedPhysical: 2
+    Tank: 5
 GarrAutoCombatSpellTutorialFlag:
-  All: 4
-  Column: 2
-  None: 0
-  Row: 3
-  Single: 1
+  values:
+    All: 4
+    Column: 2
+    None: 0
+    Row: 3
+    Single: 1
 GarrAutoCombatTutorial:
-  AttackAll: 256
-  AttackColumn: 64
-  AttackRow: 128
-  AttackSingle: 32
-  BeneficialEffect: 16
-  EnvironmentalEffect: 1024
-  HealCompanion: 4
-  LevelHeal: 8
-  PlaceCompanion: 2
-  SelectMission: 1
-  TroopTutorial: 512
+  values:
+    AttackAll: 256
+    AttackColumn: 64
+    AttackRow: 128
+    AttackSingle: 32
+    BeneficialEffect: 16
+    EnvironmentalEffect: 1024
+    HealCompanion: 4
+    LevelHeal: 8
+    PlaceCompanion: 2
+    SelectMission: 1
+    TroopTutorial: 512
 GarrAutoEventFlags:
-  AutoAttack: 1
-  Environment: 4
-  None: 0
-  Passive: 2
+  values:
+    AutoAttack: 1
+    Environment: 4
+    None: 0
+    Passive: 2
 GarrAutoMissionEventType:
-  ApplyAura: 7
-  Died: 9
-  Heal: 4
-  MeleeDamage: 0
-  PeriodicDamage: 5
-  PeriodicHeal: 6
-  RangeDamage: 1
-  RemoveAura: 8
-  SpellMeleeDamage: 2
-  SpellRangeDamage: 3
+  values:
+    ApplyAura: 7
+    Died: 9
+    Heal: 4
+    MeleeDamage: 0
+    PeriodicDamage: 5
+    PeriodicHeal: 6
+    RangeDamage: 1
+    RemoveAura: 8
+    SpellMeleeDamage: 2
+    SpellRangeDamage: 3
 GarrAutoPreviewTargetType:
-  Buff: 4
-  Damage: 1
-  Debuff: 8
-  Heal: 2
-  None: 0
+  values:
+    Buff: 4
+    Damage: 1
+    Debuff: 8
+    Heal: 2
+    None: 0
 GarrFollowerMissionCompleteState:
-  Alive: 0
-  KilledByMissionFailure: 1
-  OutOfDurability: 3
-  SavedByPreventDeath: 2
+  values:
+    Alive: 0
+    KilledByMissionFailure: 1
+    OutOfDurability: 3
+    SavedByPreventDeath: 2
 GarrFollowerQuality:
-  Common: 1
-  Epic: 4
-  Legendary: 5
-  None: 0
-  Rare: 3
-  Title: 6
-  Uncommon: 2
+  values:
+    Common: 1
+    Epic: 4
+    Legendary: 5
+    None: 0
+    Rare: 3
+    Title: 6
+    Uncommon: 2
 GarrisonFollowerType:
-  FollowerType_6_0_Boat: 2
-  FollowerType_6_0_GarrisonFollower: 1
-  FollowerType_7_0_GarrisonFollower: 4
-  FollowerType_8_0_GarrisonFollower: 22
-  FollowerType_9_0_GarrisonFollower: 123
+  values:
+    FollowerType_6_0_Boat: 2
+    FollowerType_6_0_GarrisonFollower: 1
+    FollowerType_7_0_GarrisonFollower: 4
+    FollowerType_8_0_GarrisonFollower: 22
+    FollowerType_9_0_GarrisonFollower: 123
 GarrisonTalentAvailability:
-  Available: 0
-  Unavailable: 1
-  UnavailableAlreadyHave: 7
-  UnavailableAnotherIsResearching: 2
-  UnavailableNotEnoughGold: 4
-  UnavailableNotEnoughResources: 3
-  UnavailablePlayerCondition: 6
-  UnavailableRequiresPrerequisiteTalent: 8
-  UnavailableTierUnavailable: 5
+  values:
+    Available: 0
+    Unavailable: 1
+    UnavailableAlreadyHave: 7
+    UnavailableAnotherIsResearching: 2
+    UnavailableNotEnoughGold: 4
+    UnavailableNotEnoughResources: 3
+    UnavailablePlayerCondition: 6
+    UnavailableRequiresPrerequisiteTalent: 8
+    UnavailableTierUnavailable: 5
 GarrisonType:
-  Type_6_0_Garrison: 2
-  Type_7_0_Garrison: 3
-  Type_8_0_Garrison: 9
-  Type_9_0_Garrison: 111
+  values:
+    Type_6_0_Garrison: 2
+    Type_7_0_Garrison: 3
+    Type_8_0_Garrison: 9
+    Type_9_0_Garrison: 111
 GarrTalentCostType:
-  Initial: 0
-  MakePermanent: 2
-  Respec: 1
-  TreeReset: 3
+  values:
+    Initial: 0
+    MakePermanent: 2
+    Respec: 1
+    TreeReset: 3
 GarrTalentFeatureSubtype:
-  Ardenweald: 3
-  Bastion: 1
-  Generic: 0
-  Maldraxxus: 4
-  Revendreth: 2
+  values:
+    Ardenweald: 3
+    Bastion: 1
+    Generic: 0
+    Maldraxxus: 4
+    Revendreth: 2
 GarrTalentFeatureType:
-  Adventures: 3
-  AnimaDiversion: 1
-  AnimaDiversionMap: 7
-  Cyphers: 8
-  Generic: 0
-  ReservoirUpgrades: 4
-  SanctumUnique: 5
-  SoulBinds: 6
-  TravelPortals: 2
+  values:
+    Adventures: 3
+    AnimaDiversion: 1
+    AnimaDiversionMap: 7
+    Cyphers: 8
+    Generic: 0
+    ReservoirUpgrades: 4
+    SanctumUnique: 5
+    SoulBinds: 6
+    TravelPortals: 2
 GarrTalentResearchCostSource:
-  Talent: 0
-  Tree: 1
+  values:
+    Talent: 0
+    Tree: 1
 GarrTalentSocketType:
-  Conduit: 2
-  None: 0
-  Spell: 1
+  values:
+    Conduit: 2
+    None: 0
+    Spell: 1
 GarrTalentTreeType:
-  Classic: 1
-  Tiers: 0
+  values:
+    Classic: 1
+    Tiers: 0
 GarrTalentType:
-  Major: 2
-  Minor: 1
-  Socket: 3
-  Standard: 0
+  values:
+    Major: 2
+    Minor: 1
+    Socket: 3
+    Standard: 0
 GarrTalentUI:
-  AnimaDiversionMap: 3
-  CovenantSanctum: 1
-  Generic: 0
-  SoulBinds: 2
+  values:
+    AnimaDiversionMap: 3
+    CovenantSanctum: 1
+    Generic: 0
+    SoulBinds: 2
 GossipNpcOption:
-  AccountBanker: 57
-  AdventureMap: 31
-  ArtifactRespec: 21
-  Auctioneer: 10
-  AzeriteRespec: 35
-  Banker: 6
-  BarbersChoice: 52
-  Battlemaster: 9
-  Binder: 5
-  BlackMarketAuctionHouse: 46
-  CemeterySelect: 22
-  CharacterBanker: 56
-  ChromieTimeNpc: 40
-  ContributionCollector: 33
-  CovenantPreviewNpc: 41
-  CovenantRenownNpc: 45
-  DisableXPGain: 16
-  EnableXPGain: 17
-  ForgeMaster: 55
-  GarrisonArchitect: 26
-  GarrisonMissionNpc: 27
-  GarrisonRecruitment: 30
-  GarrisonTalent: 32
-  GarrisonTradeskillNpc: 29
-  GlyphMaster: 24
-  GuildBanker: 14
-  GuildRename: 62
-  GuildTabardVendor: 8
-  HouseFinder: 65
-  HousingCreateGuildNeighborhood: 60
-  HousingGetNeighborhoodCharter: 61
-  HousingOpenCharterConfirmation: 63
-  IslandsMissionNpc: 36
-  ItemUpgrade: 64
-  LFGDungeon: 20
-  Mailbox: 18
-  MajorFactionRenown: 53
-  NewPlayerGuide: 43
-  None: 0
-  PerksProgramVendor: 47
-  PersonalTabardVendor: 54
-  PetitionVendor: 7
-  PetUntrainer: 13
-  ProfessionRespec: 58
-  ProfessionsCraftingOrder: 48
-  ProfessionsCustomerOrder: 50
-  ProfessionsOpen: 49
-  QueueScenario: 25
-  RenameNeighborhood: 59
-  RuneforgeLegendaryCrafting: 42
-  RuneforgeLegendaryUpgrade: 44
-  ShipmentCrafter: 28
-  Soulbind: 39
-  SpecializationMaster: 23
-  Spellclick: 15
-  SpiritHealer: 4
-  Stablemaster: 12
-  TalentMaster: 11
-  Taxinode: 2
-  TieredEntrance: 66
-  Trainer: 3
-  TraitSystem: 51
-  Transmogrify: 34
-  UIItemInteraction: 37
-  Vendor: 1
-  WorldMap: 38
-  WorldPvPQueue: 19
+  values:
+    AccountBanker: 57
+    AdventureMap: 31
+    ArtifactRespec: 21
+    Auctioneer: 10
+    AzeriteRespec: 35
+    Banker: 6
+    BarbersChoice: 52
+    Battlemaster: 9
+    Binder: 5
+    BlackMarketAuctionHouse: 46
+    CemeterySelect: 22
+    CharacterBanker: 56
+    ChromieTimeNpc: 40
+    ContributionCollector: 33
+    CovenantPreviewNpc: 41
+    CovenantRenownNpc: 45
+    DisableXPGain: 16
+    EnableXPGain: 17
+    ForgeMaster: 55
+    GarrisonArchitect: 26
+    GarrisonMissionNpc: 27
+    GarrisonRecruitment: 30
+    GarrisonTalent: 32
+    GarrisonTradeskillNpc: 29
+    GlyphMaster: 24
+    GuildBanker: 14
+    GuildRename: 62
+    GuildTabardVendor: 8
+    HouseFinder: 65
+    HousingCreateGuildNeighborhood: 60
+    HousingGetNeighborhoodCharter: 61
+    HousingOpenCharterConfirmation: 63
+    IslandsMissionNpc: 36
+    ItemUpgrade: 64
+    LFGDungeon: 20
+    Mailbox: 18
+    MajorFactionRenown: 53
+    NewPlayerGuide: 43
+    None: 0
+    PerksProgramVendor: 47
+    PersonalTabardVendor: 54
+    PetitionVendor: 7
+    PetUntrainer: 13
+    ProfessionRespec: 58
+    ProfessionsCraftingOrder: 48
+    ProfessionsCustomerOrder: 50
+    ProfessionsOpen: 49
+    QueueScenario: 25
+    RenameNeighborhood: 59
+    RuneforgeLegendaryCrafting: 42
+    RuneforgeLegendaryUpgrade: 44
+    ShipmentCrafter: 28
+    Soulbind: 39
+    SpecializationMaster: 23
+    Spellclick: 15
+    SpiritHealer: 4
+    Stablemaster: 12
+    TalentMaster: 11
+    Taxinode: 2
+    TieredEntrance: 66
+    Trainer: 3
+    TraitSystem: 51
+    Transmogrify: 34
+    UIItemInteraction: 37
+    Vendor: 1
+    WorldMap: 38
+    WorldPvPQueue: 19
 GossipNpcOptionDisplayFlags:
-  ForceInteractionOnSingleChoice: 1
+  values:
+    ForceInteractionOnSingleChoice: 1
 GossipOptionRecFlags:
-  HideOptionIDFromClient: 2
-  PlayMovieLabelPrepend: 4
-  QuestLabelPrepend: 1
+  values:
+    HideOptionIDFromClient: 2
+    PlayMovieLabelPrepend: 4
+    QuestLabelPrepend: 1
 GossipOptionStatus:
-  AlreadyComplete: 3
-  Available: 0
-  Locked: 2
-  Unavailable: 1
+  values:
+    AlreadyComplete: 3
+    Available: 0
+    Locked: 2
+    Unavailable: 1
 GraphicsValidationResult:
-  AmdGpuUnsupported: 36
-  AppleGpuUnsupported: 35
-  CompatMode: 41
-  CpuMem_2: 6
-  CpuMem_4: 7
-  CpuMem_8: 8
-  DualCore: 4
-  Dx11Unsupported: 30
-  Dx12Win7Unsupported: 31
-  GpuDriver: 40
-  Graphics: 3
-  Illegal: 1
-  IntelGpuUnsupported: 37
-  LegacyUnsupported: 29
-  MacOsUnsupported: 27
-  Needs_5_0: 9
-  Needs_6_0: 10
-  NeedsAmdGpu: 15
-  NeedsAppleGpu: 14
-  NeedsDx12: 12
-  NeedsDx12Vrs2: 13
-  NeedsIntelGpu: 16
-  NeedsMacOs_10_13: 19
-  NeedsMacOs_10_14: 20
-  NeedsMacOs_10_15: 21
-  NeedsMacOs_11_0: 22
-  NeedsMacOs_12_0: 23
-  NeedsMacOs_13_0: 24
-  NeedsNvidiaGpu: 17
-  NeedsQualcommGpu: 18
-  NeedsRt: 11
-  NeedsWindows_10: 25
-  NeedsWindows_11: 26
-  NvapiWineUnsupported: 34
-  NvidiaGpuUnsupported: 38
-  QuadCore: 5
-  QualcommGpuUnsupported: 39
-  RemoteDesktopUnsupported: 32
-  Supported: 0
-  Unknown: 42
-  Unsupported: 2
-  WindowsUnsupported: 28
-  WineUnsupported: 33
+  values:
+    AmdGpuUnsupported: 36
+    AppleGpuUnsupported: 35
+    CompatMode: 41
+    CpuMem_2: 6
+    CpuMem_4: 7
+    CpuMem_8: 8
+    DualCore: 4
+    Dx11Unsupported: 30
+    Dx12Win7Unsupported: 31
+    GpuDriver: 40
+    Graphics: 3
+    Illegal: 1
+    IntelGpuUnsupported: 37
+    LegacyUnsupported: 29
+    MacOsUnsupported: 27
+    Needs_5_0: 9
+    Needs_6_0: 10
+    NeedsAmdGpu: 15
+    NeedsAppleGpu: 14
+    NeedsDx12: 12
+    NeedsDx12Vrs2: 13
+    NeedsIntelGpu: 16
+    NeedsMacOs_10_13: 19
+    NeedsMacOs_10_14: 20
+    NeedsMacOs_10_15: 21
+    NeedsMacOs_11_0: 22
+    NeedsMacOs_12_0: 23
+    NeedsMacOs_13_0: 24
+    NeedsNvidiaGpu: 17
+    NeedsQualcommGpu: 18
+    NeedsRt: 11
+    NeedsWindows_10: 25
+    NeedsWindows_11: 26
+    NvapiWineUnsupported: 34
+    NvidiaGpuUnsupported: 38
+    QuadCore: 5
+    QualcommGpuUnsupported: 39
+    RemoteDesktopUnsupported: 32
+    Supported: 0
+    Unknown: 42
+    Unsupported: 2
+    WindowsUnsupported: 28
+    WineUnsupported: 33
 GuildErrorType:
-  AlreadyInGuild: 2
-  BadItem: 29
-  BankNotFound: 43
-  BankTabFull: 28
-  BankTabLocked: 35
-  Busy: 20
-  CantInviteSelf: 41
-  DeleteNoAppropriateLeader: 47
-  GuildBankNotAvailable: 45
-  GuildRepTooLow: 40
-  HasRestriction: 42
-  HousingEvictError: 51
-  Ignored: 19
-  InCooldown: 49
-  InvalidBankTab: 24
-  InvitedToGuild: 4
-  LockedForMove: 39
-  NameAlreadyExists: 7
-  NameInvalid: 6
-  NewLeaderWrongFaction: 44
-  NewLeaderWrongRealm: 46
-  NoPermisson: 8
-  NotEnoughMoney: 26
-  NotInGuild: 9
-  PlayerNotFound: 11
-  RankInUse: 18
-  RankRequiresAuthenticator: 34
-  RanksLocked: 17
-  RealmMismatch: 48
-  ReservationExpired: 50
-  Success: 0
-  TargetAlreadyInGuild: 3
-  TargetInvitedToGuild: 5
-  TargetLevelTooHigh: 22
-  TargetLevelTooLow: 21
-  TargetNotInGuild: 10
-  TargetTooHigh: 13
-  TargetTooLow: 14
-  TeamNotFound: 27
-  TeamsLocked: 30
-  Throttled: 52
-  TooFewRanks: 16
-  TooManyCreate: 33
-  TooManyMembers: 23
-  TooManyRanks: 15
-  TooMuchMoney: 31
-  TrialAccount: 36
-  UndeletableDueToLevel: 38
-  UnknownError: 1
-  VeteranAccount: 37
-  WithdrawLimit: 25
-  WrongBankTab: 32
-  WrongFaction: 12
+  values:
+    AlreadyInGuild: 2
+    BadItem: 29
+    BankNotFound: 43
+    BankTabFull: 28
+    BankTabLocked: 35
+    Busy: 20
+    CantInviteSelf: 41
+    DeleteNoAppropriateLeader: 47
+    GuildBankNotAvailable: 45
+    GuildRepTooLow: 40
+    HasRestriction: 42
+    HousingEvictError: 51
+    Ignored: 19
+    InCooldown: 49
+    InvalidBankTab: 24
+    InvitedToGuild: 4
+    LockedForMove: 39
+    NameAlreadyExists: 7
+    NameInvalid: 6
+    NewLeaderWrongFaction: 44
+    NewLeaderWrongRealm: 46
+    NoPermisson: 8
+    NotEnoughMoney: 26
+    NotInGuild: 9
+    PlayerNotFound: 11
+    RankInUse: 18
+    RankRequiresAuthenticator: 34
+    RanksLocked: 17
+    RealmMismatch: 48
+    ReservationExpired: 50
+    Success: 0
+    TargetAlreadyInGuild: 3
+    TargetInvitedToGuild: 5
+    TargetLevelTooHigh: 22
+    TargetLevelTooLow: 21
+    TargetNotInGuild: 10
+    TargetTooHigh: 13
+    TargetTooLow: 14
+    TeamNotFound: 27
+    TeamsLocked: 30
+    Throttled: 52
+    TooFewRanks: 16
+    TooManyCreate: 33
+    TooManyMembers: 23
+    TooManyRanks: 15
+    TooMuchMoney: 31
+    TrialAccount: 36
+    UndeletableDueToLevel: 38
+    UnknownError: 1
+    VeteranAccount: 37
+    WithdrawLimit: 25
+    WrongBankTab: 32
+    WrongFaction: 12
 HolidayCalendarFlags:
-  Alliance: 1
-  Horde: 2
+  values:
+    Alliance: 1
+    Horde: 2
 HolidayFlags:
-  BeginEventOnlyOnStageChange: 64
-  DontDisplayBanner: 8
-  DontDisplayEnd: 4
-  DontShowInCalendar: 2
-  DurationUseMinutes: 32
-  IsRegionwide: 1
-  NotAvailableClientSide: 16
+  values:
+    BeginEventOnlyOnStageChange: 64
+    DontDisplayBanner: 8
+    DontDisplayEnd: 4
+    DontShowInCalendar: 2
+    DurationUseMinutes: 32
+    IsRegionwide: 1
+    NotAvailableClientSide: 16
 HouseEditingContext:
-  Decor: 1
-  Fixture: 3
-  None: 0
-  Room: 2
+  values:
+    Decor: 1
+    Fixture: 3
+    None: 0
+    Room: 2
 HouseEditorMode:
-  BasicDecor: 1
-  Cleanup: 5
-  Customize: 4
-  ExpertDecor: 2
-  ExteriorCustomization: 6
-  Layout: 3
-  None: 0
+  values:
+    BasicDecor: 1
+    Cleanup: 5
+    Customize: 4
+    ExpertDecor: 2
+    ExteriorCustomization: 6
+    Layout: 3
+    None: 0
 HouseExteriorWMODataFlags:
-  AllowedInAllianceNeighborhoods: 4
-  AllowedInHordeNeighborhoods: 2
-  HiddenUnlessOwned: 8
-  None: 0
-  UnlockedByDefault: 1
+  values:
+    AllowedInAllianceNeighborhoods: 4
+    AllowedInHordeNeighborhoods: 2
+    HiddenUnlessOwned: 8
+    None: 0
+    UnlockedByDefault: 1
 HouseFinderSuggestionReason:
-  BNetFriends: 8
-  CharterInvite: 2
-  Guild: 4
-  HomeOwner: 64
-  None: 0
-  Owner: 1
-  PartySync: 16
-  Random: 32
+  values:
+    BNetFriends: 8
+    CharterInvite: 2
+    Guild: 4
+    HomeOwner: 64
+    None: 0
+    Owner: 1
+    PartySync: 16
+    Random: 32
 HouseLevelRewardType:
-  Object: 1
-  Value: 0
+  values:
+    Object: 1
+    Value: 0
 HouseLevelRewardValueType:
-  ExteriorDecor: 0
-  Fixtures: 3
-  InteriorDecor: 1
-  Rooms: 2
+  values:
+    ExteriorDecor: 0
+    Fixtures: 3
+    InteriorDecor: 1
+    Rooms: 2
 HouseOwnerError:
-  Faction: 1
-  GenericPermission: 3
-  Guild: 2
-  None: 0
+  values:
+    Faction: 1
+    GenericPermission: 3
+    Guild: 2
+    None: 0
 HouseSettingFlags:
-  HouseAccessAnyone: 1
-  HouseAccessFriends: 8
-  HouseAccessGuild: 4
-  HouseAccessNeighbors: 2
-  HouseAccessParty: 16
-  None: 0
-  PlotAccessAnyone: 32
-  PlotAccessFriends: 256
-  PlotAccessGuild: 128
-  PlotAccessNeighbors: 64
-  PlotAccessParty: 512
+  values:
+    HouseAccessAnyone: 1
+    HouseAccessFriends: 8
+    HouseAccessGuild: 4
+    HouseAccessNeighbors: 2
+    HouseAccessParty: 16
+    None: 0
+    PlotAccessAnyone: 32
+    PlotAccessFriends: 256
+    PlotAccessGuild: 128
+    PlotAccessNeighbors: 64
+    PlotAccessParty: 512
 HouseVisitType:
-  Friend: 1
-  Guild: 2
-  Party: 3
-  Unknown: 0
+  values:
+    Friend: 1
+    Guild: 2
+    Party: 3
+    Unknown: 0
 HousingBasicModeTargetType:
-  Decor: 1
-  House: 2
-  None: 0
+  values:
+    Decor: 1
+    House: 2
+    None: 0
 HousingCatalogEntryModelScenePresets:
-  DecorCeiling: 1338
-  DecorDefault: 1317
-  DecorFlat: 1318
-  DecorHorizontalSurface: 1452
-  DecorHuge: 1337
-  DecorLarge: 1336
-  DecorMedium: 1335
-  DecorSmall: 1334
-  DecorTiny: 1333
-  DecorWall: 1339
+  values:
+    DecorCeiling: 1338
+    DecorDefault: 1317
+    DecorFlat: 1318
+    DecorHorizontalSurface: 1452
+    DecorHuge: 1337
+    DecorLarge: 1336
+    DecorMedium: 1335
+    DecorSmall: 1334
+    DecorTiny: 1333
+    DecorWall: 1339
 HousingCatalogEntrySize:
-  Huge: 69
-  Large: 68
-  Medium: 67
-  None: 0
-  Small: 66
-  Tiny: 65
+  values:
+    Huge: 69
+    Large: 68
+    Medium: 67
+    None: 0
+    Small: 66
+    Tiny: 65
 HousingCatalogEntryType:
-  Decor: 1
-  Invalid: 0
-  Room: 2
+  values:
+    Decor: 1
+    Invalid: 0
+    Room: 2
 HousingCatalogSortType:
-  Alphabetical: 1
-  DateAdded: 0
+  values:
+    Alphabetical: 1
+    DateAdded: 0
 HousingCleanupModeTargetType:
-  Decor: 1
-  HouseExterior: 2
-  None: 0
+  values:
+    Decor: 1
+    HouseExterior: 2
+    None: 0
 HousingCustomizeModeTargetType:
-  Decor: 1
-  ExteriorHouse: 3
-  None: 0
-  RoomComponent: 2
+  values:
+    Decor: 1
+    ExteriorHouse: 3
+    None: 0
+    RoomComponent: 2
 HousingDecorActionFlags:
-  Add: 1
-  ClickTarget: 16
-  DragMove: 4
-  HoverTarget: 32
-  IncludeTargetChildren: 512
-  MaintainLastTarget: 256
-  None: 0
-  PrecisionMove: 8
-  PreviewDecor: 2048
-  Remove: 2
-  TargetHouseExterior: 128
-  TargetRoomComponents: 64
-  UsePlacedDecorList: 1024
+  values:
+    Add: 1
+    ClickTarget: 16
+    DragMove: 4
+    HoverTarget: 32
+    IncludeTargetChildren: 512
+    MaintainLastTarget: 256
+    None: 0
+    PrecisionMove: 8
+    PreviewDecor: 2048
+    Remove: 2
+    TargetHouseExterior: 128
+    TargetRoomComponents: 64
+    UsePlacedDecorList: 1024
 HousingDecorModelType:
-  M2: 1
-  None: 0
-  WMO: 2
+  values:
+    M2: 1
+    None: 0
+    WMO: 2
 HousingDecorPlacementRestriction:
-  ChildOutsideBounds: 8
-  InvalidCollision: 32
-  InvalidLightOverlap: 64
-  InvalidTarget: 16
-  OutsidePlotBounds: 4
-  OutsideRoomBounds: 2
-  TooFarAway: 1
+  values:
+    ChildOutsideBounds: 8
+    InvalidCollision: 32
+    InvalidLightOverlap: 64
+    InvalidTarget: 16
+    OutsidePlotBounds: 4
+    OutsideRoomBounds: 2
+    TooFarAway: 1
 HousingDecorTheme:
-  BloodElf: 5
-  Folk: 1
-  Generic: 3
-  NightElf: 4
-  None: 0
-  Rugged: 2
+  values:
+    BloodElf: 5
+    Folk: 1
+    Generic: 3
+    NightElf: 4
+    None: 0
+    Rugged: 2
 HousingDecorType:
-  Ceiling: 3
-  Floor: 1
-  Flooring: 4
-  None: 0
-  Wall: 2
+  values:
+    Ceiling: 3
+    Floor: 1
+    Flooring: 4
+    None: 0
+    Wall: 2
 HousingExpertModeTargetType:
-  Decor: 1
-  House: 2
-  None: 0
+  values:
+    Decor: 1
+    House: 2
+    None: 0
 HousingExpertSubmodeRestriction:
-  NoHouseExteriorScale: 2
-  None: 0
-  NotInExpertMode: 1
-  NoWMOScale: 3
+  values:
+    NoHouseExteriorScale: 2
+    None: 0
+    NotInExpertMode: 1
+    NoWMOScale: 3
 HousingFavorUpdateSource:
-  DecorCollection: 1
-  DeferredRewards: 2
-  InitiativeChest: 6
-  InitiativeTask: 5
-  NewHouseDecorFavor: 4
-  Quest: 7
-  RetroactiveDecor: 3
-  Unknown: 0
+  values:
+    DecorCollection: 1
+    DeferredRewards: 2
+    InitiativeChest: 6
+    InitiativeTask: 5
+    NewHouseDecorFavor: 4
+    Quest: 7
+    RetroactiveDecor: 3
+    Unknown: 0
 HousingFavorUpdateType:
-  Add: 0
-  InitiativeAdd: 1
-  Set: 2
+  values:
+    Add: 0
+    InitiativeAdd: 1
+    Set: 2
 HousingFixtureDecorAction:
-  Detach: 1
-  Store: 0
+  values:
+    Detach: 1
+    Store: 0
 HousingFixtureFlags:
-  IsDefaultFixture: 1
-  None: 0
-  UnlockedByDefault: 2
+  values:
+    IsDefaultFixture: 1
+    None: 0
+    UnlockedByDefault: 2
 HousingFixtureSize:
-  Any: 1
-  Large: 4
-  Medium: 3
-  None: 0
-  Small: 2
+  values:
+    Any: 1
+    Large: 4
+    Medium: 3
+    None: 0
+    Small: 2
 HousingFixtureType:
-  Base: 9
-  Chimney: 16
-  Door: 11
-  None: 0
-  Roof: 10
-  RoofDetail: 13
-  RoofWindow: 14
-  Tower: 15
-  Window: 12
+  values:
+    Base: 9
+    Chimney: 16
+    Door: 11
+    None: 0
+    Roof: 10
+    RoofDetail: 13
+    RoofWindow: 14
+    Tower: 15
+    Window: 12
 HousingIncrementType:
-  Back: 8
-  Down: 32
-  Forward: 4
-  Left: 1
-  Right: 2
-  RotateLeft: 64
-  RotateRight: 128
-  ScaleDown: 512
-  ScaleUp: 256
-  Up: 16
+  values:
+    Back: 8
+    Down: 32
+    Forward: 4
+    Left: 1
+    Right: 2
+    RotateLeft: 64
+    RotateRight: 128
+    ScaleDown: 512
+    ScaleUp: 256
+    Up: 16
 HousingItemToastType:
-  Customization: 2
-  Decor: 3
-  Fixture: 1
-  HouseType: 4
-  Room: 0
+  values:
+    Customization: 2
+    Decor: 3
+    Fixture: 1
+    HouseType: 4
+    Room: 0
 HousingLayoutCameraDirection:
-  Down: 2
-  Left: 4
-  None: 0
-  Right: 8
-  Up: 1
+  values:
+    Down: 2
+    Left: 4
+    None: 0
+    Right: 8
+    Up: 1
 HousingLayoutPinType:
-  Door: 0
-  Room: 1
+  values:
+    Door: 0
+    Room: 1
 HousingLayoutRestriction:
-  IsBaseRoom: 4
-  LastRoom: 7
-  None: 0
-  NotHouseOwner: 3
-  NotInsideHouse: 2
-  RoomNotFound: 1
-  RoomNotLeaf: 5
-  SingleDoor: 9
-  StairwellConnection: 6
-  UnreachableRoom: 8
+  values:
+    IsBaseRoom: 4
+    LastRoom: 7
+    None: 0
+    NotHouseOwner: 3
+    NotInsideHouse: 2
+    RoomNotFound: 1
+    RoomNotLeaf: 5
+    SingleDoor: 9
+    StairwellConnection: 6
+    UnreachableRoom: 8
 HousingLayoutStairDirection:
-  Down: 1
-  Up: 0
+  values:
+    Down: 1
+    Up: 0
 HousingPlotOwnerType:
-  Friend: 2
-  None: 0
-  Self: 3
-  Stranger: 1
+  values:
+    Friend: 2
+    None: 0
+    Self: 3
+    Stranger: 1
 HousingPrecisionSubmode:
-  Rotate: 1
-  Scale: 2
-  Translate: 0
+  values:
+    Rotate: 1
+    Scale: 2
+    Translate: 0
 HousingResult:
-  ActionLockedByCombat: 1
-  BoundsFailureChildren: 2
-  BoundsFailurePlot: 3
-  BoundsFailureRoom: 4
-  BoundToStartingArea: 5
-  CannotAfford: 6
-  CharterComplete: 7
-  CollisionInvalid: 8
-  DbError: 9
-  DecorCannotBeRedeemed: 10
-  DecorItemNotDestroyable: 11
-  DecorNotFound: 12
-  DecorNotFoundInStorage: 13
-  DuplicateCharterSignature: 14
-  FilterRejected: 15
-  FixtureCantDeleteDoor: 16
-  FixtureHookEmpty: 17
-  FixtureHookOccupied: 18
-  FixtureHouseTypeMismatch: 19
-  FixtureNotFound: 20
-  FixtureSizeMismatch: 21
-  FixtureTypeMismatch: 22
-  GenericFailure: 23
-  GuildMoreAccountsNeeded: 24
-  GuildMoreActivePlayersNeeded: 25
-  GuildNotLoaded: 26
-  HookNotChildOfFixture: 35
-  HouseEditLockFailed: 27
-  HouseExteriorAlreadyThatSize: 28
-  HouseExteriorAlreadyThatType: 29
-  HouseExteriorRootNotFound: 30
-  HouseExteriorSizeNotAvailable: 34
-  HouseExteriorTypeNeighborhoodMismatch: 31
-  HouseExteriorTypeNotFound: 32
-  HouseExteriorTypeSizeMismatch: 33
-  HouseNotFound: 36
-  IncorrectFaction: 37
-  InvalidDecorItem: 38
-  InvalidDistance: 39
-  InvalidGuild: 40
-  InvalidHouse: 41
-  InvalidInstance: 42
-  InvalidInteraction: 43
-  InvalidLightOverlap: 44
-  InvalidMap: 45
-  InvalidNeighborhoodName: 46
-  InvalidRoomLayout: 47
-  LockedByOtherPlayer: 48
-  LockOperationFailed: 49
-  MaxDecorReached: 50
-  MaxPreviewDecorReached: 51
-  MissingCoreFixture: 52
-  MissingDye: 53
-  MissingExpansionAccess: 54
-  MissingFactionMap: 55
-  MissingPrivateNeighborhoodInvite: 56
-  MoreHouseSlotsNeeded: 57
-  MoreSignaturesNeeded: 58
-  NeighborhoodNotFound: 59
-  NoNeighborhoodOwnershipRequests: 60
-  NotInDecorEditMode: 61
-  NotInFixtureEditMode: 62
-  NotInLayoutEditMode: 63
-  NotInsideHouse: 64
-  NotOnOwnedPlot: 65
-  OperationAborted: 66
-  OwnerNotInGuild: 67
-  PermissionDenied: 68
-  PlacementTargetInvalid: 69
-  PlayerNotFound: 70
-  PlayerNotInInstance: 71
-  PlotNotFound: 72
-  PlotNotVacant: 73
-  PlotReservationCooldown: 74
-  PlotReserved: 75
-  RoomNotFound: 76
-  RoomUpdateFailed: 77
-  RpcFailure: 78
-  ServiceNotAvailable: 79
-  StaticDataNotFound: 80
-  Success: 0
-  TimeoutLimit: 81
-  TimerunningNotAllowed: 82
-  TokenRequired: 83
-  TooManyRequests: 84
-  TransactionFailure: 85
-  UncollectedExteriorFixture: 86
-  UncollectedHouseType: 87
-  UncollectedRoom: 88
-  UncollectedRoomMaterial: 89
-  UncollectedRoomTheme: 90
-  UnlockOperationFailed: 91
+  values:
+    ActionLockedByCombat: 1
+    BoundsFailureChildren: 2
+    BoundsFailurePlot: 3
+    BoundsFailureRoom: 4
+    BoundToStartingArea: 5
+    CannotAfford: 6
+    CharterComplete: 7
+    CollisionInvalid: 8
+    DbError: 9
+    DecorCannotBeRedeemed: 10
+    DecorItemNotDestroyable: 11
+    DecorNotFound: 12
+    DecorNotFoundInStorage: 13
+    DuplicateCharterSignature: 14
+    FilterRejected: 15
+    FixtureCantDeleteDoor: 16
+    FixtureHookEmpty: 17
+    FixtureHookOccupied: 18
+    FixtureHouseTypeMismatch: 19
+    FixtureNotFound: 20
+    FixtureSizeMismatch: 21
+    FixtureTypeMismatch: 22
+    GenericFailure: 23
+    GuildMoreAccountsNeeded: 24
+    GuildMoreActivePlayersNeeded: 25
+    GuildNotLoaded: 26
+    HookNotChildOfFixture: 35
+    HouseEditLockFailed: 27
+    HouseExteriorAlreadyThatSize: 28
+    HouseExteriorAlreadyThatType: 29
+    HouseExteriorRootNotFound: 30
+    HouseExteriorSizeNotAvailable: 34
+    HouseExteriorTypeNeighborhoodMismatch: 31
+    HouseExteriorTypeNotFound: 32
+    HouseExteriorTypeSizeMismatch: 33
+    HouseNotFound: 36
+    IncorrectFaction: 37
+    InvalidDecorItem: 38
+    InvalidDistance: 39
+    InvalidGuild: 40
+    InvalidHouse: 41
+    InvalidInstance: 42
+    InvalidInteraction: 43
+    InvalidLightOverlap: 44
+    InvalidMap: 45
+    InvalidNeighborhoodName: 46
+    InvalidRoomLayout: 47
+    LockedByOtherPlayer: 48
+    LockOperationFailed: 49
+    MaxDecorReached: 50
+    MaxPreviewDecorReached: 51
+    MissingCoreFixture: 52
+    MissingDye: 53
+    MissingExpansionAccess: 54
+    MissingFactionMap: 55
+    MissingPrivateNeighborhoodInvite: 56
+    MoreHouseSlotsNeeded: 57
+    MoreSignaturesNeeded: 58
+    NeighborhoodNotFound: 59
+    NoNeighborhoodOwnershipRequests: 60
+    NotInDecorEditMode: 61
+    NotInFixtureEditMode: 62
+    NotInLayoutEditMode: 63
+    NotInsideHouse: 64
+    NotOnOwnedPlot: 65
+    OperationAborted: 66
+    OwnerNotInGuild: 67
+    PermissionDenied: 68
+    PlacementTargetInvalid: 69
+    PlayerNotFound: 70
+    PlayerNotInInstance: 71
+    PlotNotFound: 72
+    PlotNotVacant: 73
+    PlotReservationCooldown: 74
+    PlotReserved: 75
+    RoomNotFound: 76
+    RoomUpdateFailed: 77
+    RpcFailure: 78
+    ServiceNotAvailable: 79
+    StaticDataNotFound: 80
+    Success: 0
+    TimeoutLimit: 81
+    TimerunningNotAllowed: 82
+    TokenRequired: 83
+    TooManyRequests: 84
+    TransactionFailure: 85
+    UncollectedExteriorFixture: 86
+    UncollectedHouseType: 87
+    UncollectedRoom: 88
+    UncollectedRoomMaterial: 89
+    UncollectedRoomTheme: 90
+    UnlockOperationFailed: 91
 HousingRoomComponentCeilingType:
-  Flat: 0
-  Vaulted: 1
+  values:
+    Flat: 0
+    Vaulted: 1
 HousingRoomComponentDoorType:
-  Doorway: 1
-  None: 0
-  Threshold: 2
+  values:
+    Doorway: 1
+    None: 0
+    Threshold: 2
 HousingRoomComponentFlags:
-  HiddenInLayoutMode: 1
-  None: 0
+  values:
+    HiddenInLayoutMode: 1
+    None: 0
 HousingRoomComponentFloorType:
-  Floor: 0
+  values:
+    Floor: 0
 HousingRoomComponentOptionFlags:
-  IsDefault: 1
-  None: 0
+  values:
+    IsDefault: 1
+    None: 0
 HousingRoomComponentOptionType:
-  Cosmetic: 0
-  Doorway: 2
-  DoorwayWall: 1
+  values:
+    Cosmetic: 0
+    Doorway: 2
+    DoorwayWall: 1
 HousingRoomComponentStairType:
-  MiddleToEnd: 4
-  MiddleToMiddle: 3
-  None: 0
-  StartToEnd: 1
-  StartToMiddle: 2
+  values:
+    MiddleToEnd: 4
+    MiddleToMiddle: 3
+    None: 0
+    StartToEnd: 1
+    StartToMiddle: 2
 HousingRoomComponentTextureFlags:
-  None: 0
-  UnlockedByDefault: 1
+  values:
+    None: 0
+    UnlockedByDefault: 1
 HousingRoomComponentType:
-  Ceiling: 3
-  Doorway: 7
-  DoorwayWall: 6
-  Floor: 2
-  None: 0
-  Pillar: 5
-  Stairs: 4
-  Wall: 1
+  values:
+    Ceiling: 3
+    Doorway: 7
+    DoorwayWall: 6
+    Floor: 2
+    None: 0
+    Pillar: 5
+    Stairs: 4
+    Wall: 1
 HousingRoomFlags:
-  BaseRoom: 1
-  HasCustomGeometry: 8
-  HasStairs: 2
-  None: 0
-  UnlockedByDefault: 4
+  values:
+    BaseRoom: 1
+    HasCustomGeometry: 8
+    HasStairs: 2
+    None: 0
+    UnlockedByDefault: 4
 HousingTeleportReason:
-  Booted: 3
-  Cheat: 1
-  ExitingHouse: 9
-  Friend: 6
-  GuildMember: 7
-  Homestone: 4
-  None: 0
-  PartyMember: 8
-  Portal: 10
-  Tutorial: 11
-  UnspecifiedSpellcast: 2
-  Visit: 5
+  values:
+    Booted: 3
+    Cheat: 1
+    ExitingHouse: 9
+    Friend: 6
+    GuildMember: 7
+    Homestone: 4
+    None: 0
+    PartyMember: 8
+    Portal: 10
+    Tutorial: 11
+    UnspecifiedSpellcast: 2
+    Visit: 5
 HousingThemeFlags:
-  None: 0
-  ShowInStyleSelector: 2
-  UnlockedByDefault: 1
+  values:
+    None: 0
+    ShowInStyleSelector: 2
+    UnlockedByDefault: 1
 HousingThrottleType:
-  Decoration: 1
-  General: 0
+  values:
+    Decoration: 1
+    General: 0
 IconAndTextShiftTextType:
-  None: 0
-  ShiftText: 1
+  values:
+    None: 0
+    ShiftText: 1
 IconAndTextWidgetState:
-  Hidden: 0
-  Shown: 1
-  ShownWithDynamicIconFlashing: 2
-  ShownWithDynamicIconNotFlashing: 3
+  values:
+    Hidden: 0
+    Shown: 1
+    ShownWithDynamicIconFlashing: 2
+    ShownWithDynamicIconNotFlashing: 3
 IconState:
-  Hidden: 0
-  ShowState1: 1
-  ShowState2: 2
+  values:
+    Hidden: 0
+    ShowState1: 1
+    ShowState2: 2
 ImageSharingResult:
-  AccountDataRequestFailure: 6
-  EncryptionFailure: 11
-  EncryptionSecretNotSet: 14
-  FailedToCreateHeader: 10
-  Failure: 0
-  GetAccountDataRequestFailure: 7
-  InvalidOAuthExpiration: 12
-  InvalidRefreshExpiration: 13
-  MissingFieldApiError: 5
-  NotConfigured: 2
-  PlatformApiError: 4
-  RefreshTokenExpired: 9
-  RetrievedExisting: 3
-  SetAccountDataRequestFailure: 8
-  Success: 1
+  values:
+    AccountDataRequestFailure: 6
+    EncryptionFailure: 11
+    EncryptionSecretNotSet: 14
+    FailedToCreateHeader: 10
+    Failure: 0
+    GetAccountDataRequestFailure: 7
+    InvalidOAuthExpiration: 12
+    InvalidRefreshExpiration: 13
+    MissingFieldApiError: 5
+    NotConfigured: 2
+    PlatformApiError: 4
+    RefreshTokenExpired: 9
+    RetrievedExisting: 3
+    SetAccountDataRequestFailure: 8
+    Success: 1
 InitiativeMilestoneFlags:
-  FinalMilestone: 1
+  values:
+    FinalMilestone: 1
 InitiativeRewardFlags:
-  PermanentWorldState: 1
+  values:
+    PermanentWorldState: 1
 InputContext:
-  GamePad: 3
-  Keyboard: 1
-  Mouse: 2
-  None: 0
+  values:
+    GamePad: 3
+    Keyboard: 1
+    Mouse: 2
+    None: 0
 InvalidPlotScreenshotReason:
-  Facing: 2
-  NoActivePlayer: 4
-  None: 0
-  NoNeighborhoodFound: 3
-  OutOfBounds: 1
+  values:
+    Facing: 2
+    NoActivePlayer: 4
+    None: 0
+    NoNeighborhoodFound: 3
+    OutOfBounds: 1
 InventoryType:
-  Index2HweaponType: 17
-  IndexAmmoType: 24
-  IndexBagType: 18
-  IndexBodyType: 4
-  IndexChestType: 5
-  IndexCloakType: 16
-  IndexEquipablespellDefensiveType: 33
-  IndexEquipablespellOffensiveType: 31
-  IndexEquipablespellUtilityType: 32
-  IndexEquipablespellWeaponType: 34
-  IndexFeetType: 8
-  IndexFingerType: 11
-  IndexHandType: 10
-  IndexHeadType: 1
-  IndexHoldableType: 23
-  IndexLegsType: 7
-  IndexNeckType: 2
-  IndexNonEquipType: 0
-  IndexProfessionGearType: 30
-  IndexProfessionToolType: 29
-  IndexQuiverType: 27
-  IndexRangedrightType: 26
-  IndexRangedType: 15
-  IndexRelicType: 28
-  IndexRobeType: 20
-  IndexShieldType: 14
-  IndexShoulderType: 3
-  IndexTabardType: 19
-  IndexThrownType: 25
-  IndexTrinketType: 12
-  IndexWaistType: 6
-  IndexWeaponmainhandType: 21
-  IndexWeaponoffhandType: 22
-  IndexWeaponType: 13
-  IndexWristType: 9
+  values:
+    Index2HweaponType: 17
+    IndexAmmoType: 24
+    IndexBagType: 18
+    IndexBodyType: 4
+    IndexChestType: 5
+    IndexCloakType: 16
+    IndexEquipablespellDefensiveType: 33
+    IndexEquipablespellOffensiveType: 31
+    IndexEquipablespellUtilityType: 32
+    IndexEquipablespellWeaponType: 34
+    IndexFeetType: 8
+    IndexFingerType: 11
+    IndexHandType: 10
+    IndexHeadType: 1
+    IndexHoldableType: 23
+    IndexLegsType: 7
+    IndexNeckType: 2
+    IndexNonEquipType: 0
+    IndexProfessionGearType: 30
+    IndexProfessionToolType: 29
+    IndexQuiverType: 27
+    IndexRangedrightType: 26
+    IndexRangedType: 15
+    IndexRelicType: 28
+    IndexRobeType: 20
+    IndexShieldType: 14
+    IndexShoulderType: 3
+    IndexTabardType: 19
+    IndexThrownType: 25
+    IndexTrinketType: 12
+    IndexWaistType: 6
+    IndexWeaponmainhandType: 21
+    IndexWeaponoffhandType: 22
+    IndexWeaponType: 13
+    IndexWristType: 9
 ItemArmorSubclass:
-  Cloth: 1
-  Cosmetic: 5
-  Generic: 0
-  Idol: 8
-  Leather: 2
-  Libram: 7
-  Mail: 3
-  Plate: 4
-  Relic: 11
-  Shield: 6
-  Sigil: 10
-  Totem: 9
+  values:
+    Cloth: 1
+    Cosmetic: 5
+    Generic: 0
+    Idol: 8
+    Leather: 2
+    Libram: 7
+    Mail: 3
+    Plate: 4
+    Relic: 11
+    Shield: 6
+    Sigil: 10
+    Totem: 9
 ItemBind:
-  Multi: 6
-  None: 0
-  OnAcquire: 1
-  OnEquip: 2
-  OnUse: 3
-  Quest: 4
-  QuestMulti: 5
-  ToBnetAccount: 8
-  ToBnetAccountUntilEquipped: 9
-  ToWoWAccount: 7
+  values:
+    Multi: 6
+    None: 0
+    OnAcquire: 1
+    OnEquip: 2
+    OnUse: 3
+    Quest: 4
+    QuestMulti: 5
+    ToBnetAccount: 8
+    ToBnetAccountUntilEquipped: 9
+    ToWoWAccount: 7
 ItemClass:
-  Armor: 4
-  Battlepet: 17
-  Consumable: 0
-  Container: 1
-  CurrencyTokenObsolete: 10
-  Gem: 3
-  Glyph: 16
-  Housing: 20
-  ItemEnhancement: 8
-  Key: 13
-  Miscellaneous: 15
-  PermanentObsolete: 14
-  Profession: 19
-  Projectile: 6
-  Questitem: 12
-  Quiver: 11
-  Reagent: 5
-  Recipe: 9
-  Tradegoods: 7
-  Weapon: 2
-  WoWToken: 18
+  values:
+    Armor: 4
+    Battlepet: 17
+    Consumable: 0
+    Container: 1
+    CurrencyTokenObsolete: 10
+    Gem: 3
+    Glyph: 16
+    Housing: 20
+    ItemEnhancement: 8
+    Key: 13
+    Miscellaneous: 15
+    PermanentObsolete: 14
+    Profession: 19
+    Projectile: 6
+    Questitem: 12
+    Quiver: 11
+    Reagent: 5
+    Recipe: 9
+    Tradegoods: 7
+    Weapon: 2
+    WoWToken: 18
 Itemclassfilterflags:
-  Armor: 16
-  Battlepet: 131072
-  Consumable: 1
-  Container: 2
-  CurrencyTokenObsolete: 1024
-  Gem: 8
-  Glyph: 65536
-  ItemEnhancement: 256
-  Key: 8192
-  Miscellaneous: 32768
-  PermanentObsolete: 16384
-  Projectile: 64
-  Questitemclassfilterflags: 4096
-  Quiver: 2048
-  Reagent: 32
-  Recipe: 512
-  Tradegoods: 128
-  Weapon: 4
+  values:
+    Armor: 16
+    Battlepet: 131072
+    Consumable: 1
+    Container: 2
+    CurrencyTokenObsolete: 1024
+    Gem: 8
+    Glyph: 65536
+    ItemEnhancement: 256
+    Key: 8192
+    Miscellaneous: 32768
+    PermanentObsolete: 16384
+    Projectile: 64
+    Questitemclassfilterflags: 4096
+    Quiver: 2048
+    Reagent: 32
+    Recipe: 512
+    Tradegoods: 128
+    Weapon: 4
 ItemCollectionType:
-  ExteriorFixture: 9
-  Heirloom: 2
-  HouseType: 13
-  None: 0
-  Room: 8
-  RoomMaterial: 11
-  RoomTheme: 10
-  RuneforgeLegendaryAbility: 5
-  Toy: 1
-  Transmog: 3
-  TransmogIllusion: 6
-  TransmogOutfit: 12
-  TransmogSetFavorite: 4
-  WarbandScene: 7
+  values:
+    ExteriorFixture: 9
+    Heirloom: 2
+    HouseType: 13
+    None: 0
+    Room: 8
+    RoomMaterial: 11
+    RoomTheme: 10
+    RuneforgeLegendaryAbility: 5
+    Toy: 1
+    Transmog: 3
+    TransmogIllusion: 6
+    TransmogOutfit: 12
+    TransmogSetFavorite: 4
+    WarbandScene: 7
 ItemCommodityStatus:
-  Commodity: 2
-  Item: 1
-  Unknown: 0
+  values:
+    Commodity: 2
+    Item: 1
+    Unknown: 0
 ItemConsumableSubclass:
-  Bandage: 7
-  CombatCurio: 11
-  Elixir: 2
-  Flasksphials: 3
-  Fooddrink: 5
-  Generic: 0
-  Itemenhancement: 6
-  Other: 8
-  Potion: 1
-  Relic: 12
-  Scroll: 4
-  UtilityCurio: 10
-  VantusRune: 9
+  values:
+    Bandage: 7
+    CombatCurio: 11
+    Elixir: 2
+    Flasksphials: 3
+    Fooddrink: 5
+    Generic: 0
+    Itemenhancement: 6
+    Other: 8
+    Potion: 1
+    Relic: 12
+    Scroll: 4
+    UtilityCurio: 10
+    VantusRune: 9
 ItemCreationContext:
-  BlackMarket: 15
-  ChallengeMode_1: 16
-  ChallengeMode_2: 33
-  ChallengeMode_3: 34
-  ChallengeMode_4: 87
-  ChallengeModeJackpot: 35
-  CharacterBoost_1: 61
-  CharacterBoost_2: 62
-  CharacterBoost_3: 86
-  CorpseRecovery: 80
-  Delves_1: 104
-  Delves_2: 106
-  Delves_3: 107
-  DelvesBonus_1: 129
-  DelvesBonus_10: 138
-  DelvesBonus_2: 130
-  DelvesBonus_3: 131
-  DelvesBonus_4: 132
-  DelvesBonus_5: 133
-  DelvesBonus_6: 134
-  DelvesBonus_7: 135
-  DelvesBonus_8: 136
-  DelvesBonus_9: 137
-  DelvesBounty_1: 117
-  DelvesBounty_2: 118
-  DelvesBounty_3: 119
-  DelvesBounty_4: 120
-  DelvesBounty_5: 121
-  DelvesBounty_6: 122
-  DelvesBounty_7: 123
-  DelvesBounty_8: 124
-  DelvesJackpot: 108
-  DelvesKey_1: 109
-  DelvesKey_2: 110
-  DelvesKey_3: 111
-  DelvesKey_4: 112
-  DelvesKey_5: 113
-  DelvesKey_6: 114
-  DelvesKey_7: 115
-  DelvesKey_8: 116
-  DelvesLevelUp_1: 125
-  DelvesLevelUp_2: 126
-  DelvesLevelUp_3: 127
-  DelvesLevelUp_4: 128
-  DungeonBonus_1: 139
-  DungeonBonus_10: 148
-  DungeonBonus_2: 140
-  DungeonBonus_3: 141
-  DungeonBonus_4: 142
-  DungeonBonus_5: 143
-  DungeonBonus_6: 144
-  DungeonBonus_7: 145
-  DungeonBonus_8: 146
-  DungeonBonus_9: 147
-  DungeonHardMode_1: 159
-  DungeonHardMode_2: 160
-  DungeonHardMode_3: 161
-  DungeonHeroic: 2
-  DungeonHeroicJackpot: 102
-  DungeonLevelUp_1: 17
-  DungeonLevelUp_2: 18
-  DungeonLevelUp_3: 19
-  DungeonLevelUp_4: 20
-  DungeonMythic: 23
-  DungeonMythicJackpot: 103
-  DungeonNormal: 1
-  DungeonNormalJackpot: 101
-  Endeavors: 185
-  ForceNone: 21
-  LegendaryCrafting_1: 63
-  LegendaryCrafting_2: 64
-  LegendaryCrafting_3: 65
-  LegendaryCrafting_4: 66
-  LegendaryCrafting_5: 67
-  LegendaryCrafting_6: 68
-  LegendaryCrafting_7: 69
-  LegendaryCrafting_8: 70
-  LegendaryCrafting_9: 71
-  LegendaryForge: 59
-  MissionReward_1: 31
-  MissionReward_2: 32
-  NewCharacter: 75
-  None: 0
-  PvPBrawl_1: 77
-  PvPBrawl_2: 78
-  PvPHonorReward: 24
-  PvPRanked_1: 8
-  PvPRanked_2: 38
-  PvPRanked_3: 39
-  PvPRanked_4: 40
-  PvPRanked_5: 44
-  PvPRanked_6: 45
-  PvPRanked_7: 46
-  PvPRanked_8: 52
-  PvPRanked_9: 88
-  PvPRankedJackpot: 56
-  PvPUnranked_1: 7
-  PvPUnranked_2: 41
-  PvPUnranked_3: 47
-  PvPUnranked_4: 48
-  PvPUnranked_5: 49
-  PvPUnranked_6: 50
-  PvPUnranked_7: 51
-  QuestBonusLoot: 60
-  QuestReward: 11
-  RaidBonus_1: 149
-  RaidBonus_10: 158
-  RaidBonus_2: 150
-  RaidBonus_3: 151
-  RaidBonus_4: 152
-  RaidBonus_5: 153
-  RaidBonus_6: 154
-  RaidBonus_7: 155
-  RaidBonus_8: 156
-  RaidBonus_9: 157
-  RaidFinder: 4
-  RaidFinderExtended: 83
-  RaidFinderExtended_2: 90
-  RaidFinderExtended_3: 94
-  RaidHeroic: 5
-  RaidHeroicExtended: 84
-  RaidHeroicExtended_2: 91
-  RaidHeroicExtended_3: 95
-  RaidMythic: 6
-  RaidMythicExtended: 85
-  RaidMythicExtended_2: 92
-  RaidMythicExtended_3: 96
-  RaidNormal: 3
-  RaidNormalExtended: 82
-  RaidNormalExtended_2: 89
-  RaidNormalExtended_3: 93
-  Relinquished: 58
-  ScenarioHeroic: 10
-  ScenarioNormal: 9
-  Store: 12
-  TemplateCharacter_1: 97
-  TemplateCharacter_2: 98
-  TemplateCharacter_3: 99
-  TemplateCharacter_4: 100
-  Timerunning: 105
-  TimewalkerLevelUp: 22
-  TimewalkerMaxLevel: 186
-  Torghast: 79
-  TournamentRealm_1: 57
-  TournamentRealm_2: 162
-  TournamentRealm_3: 163
-  TournamentRealm_4: 164
-  TradeSkill: 13
-  Vendor: 14
-  Warbound_1: 165
-  Warbound_10: 174
-  Warbound_11: 175
-  Warbound_12: 176
-  Warbound_13: 177
-  Warbound_14: 178
-  Warbound_15: 179
-  Warbound_16: 180
-  Warbound_17: 181
-  Warbound_18: 182
-  Warbound_19: 183
-  Warbound_2: 166
-  Warbound_20: 184
-  Warbound_3: 167
-  Warbound_4: 168
-  Warbound_5: 169
-  Warbound_6: 170
-  Warbound_7: 171
-  Warbound_8: 172
-  Warbound_9: 173
-  WarMode: 76
-  WeeklyRewardsAdditional: 72
-  WeeklyRewardsConcession: 73
-  WorldBoss: 81
-  WorldQuest_1: 25
-  WorldQuest_10: 43
-  WorldQuest_11: 53
-  WorldQuest_12: 54
-  WorldQuest_13: 55
-  WorldQuest_2: 26
-  WorldQuest_3: 27
-  WorldQuest_4: 28
-  WorldQuest_5: 29
-  WorldQuest_6: 30
-  WorldQuest_7: 36
-  WorldQuest_8: 37
-  WorldQuest_9: 42
-  WorldQuestJackpot: 74
+  values:
+    BlackMarket: 15
+    ChallengeMode_1: 16
+    ChallengeMode_2: 33
+    ChallengeMode_3: 34
+    ChallengeMode_4: 87
+    ChallengeModeJackpot: 35
+    CharacterBoost_1: 61
+    CharacterBoost_2: 62
+    CharacterBoost_3: 86
+    CorpseRecovery: 80
+    Delves_1: 104
+    Delves_2: 106
+    Delves_3: 107
+    DelvesBonus_1: 129
+    DelvesBonus_10: 138
+    DelvesBonus_2: 130
+    DelvesBonus_3: 131
+    DelvesBonus_4: 132
+    DelvesBonus_5: 133
+    DelvesBonus_6: 134
+    DelvesBonus_7: 135
+    DelvesBonus_8: 136
+    DelvesBonus_9: 137
+    DelvesBounty_1: 117
+    DelvesBounty_2: 118
+    DelvesBounty_3: 119
+    DelvesBounty_4: 120
+    DelvesBounty_5: 121
+    DelvesBounty_6: 122
+    DelvesBounty_7: 123
+    DelvesBounty_8: 124
+    DelvesJackpot: 108
+    DelvesKey_1: 109
+    DelvesKey_2: 110
+    DelvesKey_3: 111
+    DelvesKey_4: 112
+    DelvesKey_5: 113
+    DelvesKey_6: 114
+    DelvesKey_7: 115
+    DelvesKey_8: 116
+    DelvesLevelUp_1: 125
+    DelvesLevelUp_2: 126
+    DelvesLevelUp_3: 127
+    DelvesLevelUp_4: 128
+    DungeonBonus_1: 139
+    DungeonBonus_10: 148
+    DungeonBonus_2: 140
+    DungeonBonus_3: 141
+    DungeonBonus_4: 142
+    DungeonBonus_5: 143
+    DungeonBonus_6: 144
+    DungeonBonus_7: 145
+    DungeonBonus_8: 146
+    DungeonBonus_9: 147
+    DungeonHardMode_1: 159
+    DungeonHardMode_2: 160
+    DungeonHardMode_3: 161
+    DungeonHeroic: 2
+    DungeonHeroicJackpot: 102
+    DungeonLevelUp_1: 17
+    DungeonLevelUp_2: 18
+    DungeonLevelUp_3: 19
+    DungeonLevelUp_4: 20
+    DungeonMythic: 23
+    DungeonMythicJackpot: 103
+    DungeonNormal: 1
+    DungeonNormalJackpot: 101
+    Endeavors: 185
+    ForceNone: 21
+    LegendaryCrafting_1: 63
+    LegendaryCrafting_2: 64
+    LegendaryCrafting_3: 65
+    LegendaryCrafting_4: 66
+    LegendaryCrafting_5: 67
+    LegendaryCrafting_6: 68
+    LegendaryCrafting_7: 69
+    LegendaryCrafting_8: 70
+    LegendaryCrafting_9: 71
+    LegendaryForge: 59
+    MissionReward_1: 31
+    MissionReward_2: 32
+    NewCharacter: 75
+    None: 0
+    PvPBrawl_1: 77
+    PvPBrawl_2: 78
+    PvPHonorReward: 24
+    PvPRanked_1: 8
+    PvPRanked_2: 38
+    PvPRanked_3: 39
+    PvPRanked_4: 40
+    PvPRanked_5: 44
+    PvPRanked_6: 45
+    PvPRanked_7: 46
+    PvPRanked_8: 52
+    PvPRanked_9: 88
+    PvPRankedJackpot: 56
+    PvPUnranked_1: 7
+    PvPUnranked_2: 41
+    PvPUnranked_3: 47
+    PvPUnranked_4: 48
+    PvPUnranked_5: 49
+    PvPUnranked_6: 50
+    PvPUnranked_7: 51
+    QuestBonusLoot: 60
+    QuestReward: 11
+    RaidBonus_1: 149
+    RaidBonus_10: 158
+    RaidBonus_2: 150
+    RaidBonus_3: 151
+    RaidBonus_4: 152
+    RaidBonus_5: 153
+    RaidBonus_6: 154
+    RaidBonus_7: 155
+    RaidBonus_8: 156
+    RaidBonus_9: 157
+    RaidFinder: 4
+    RaidFinderExtended: 83
+    RaidFinderExtended_2: 90
+    RaidFinderExtended_3: 94
+    RaidHeroic: 5
+    RaidHeroicExtended: 84
+    RaidHeroicExtended_2: 91
+    RaidHeroicExtended_3: 95
+    RaidMythic: 6
+    RaidMythicExtended: 85
+    RaidMythicExtended_2: 92
+    RaidMythicExtended_3: 96
+    RaidNormal: 3
+    RaidNormalExtended: 82
+    RaidNormalExtended_2: 89
+    RaidNormalExtended_3: 93
+    Relinquished: 58
+    ScenarioHeroic: 10
+    ScenarioNormal: 9
+    Store: 12
+    TemplateCharacter_1: 97
+    TemplateCharacter_2: 98
+    TemplateCharacter_3: 99
+    TemplateCharacter_4: 100
+    Timerunning: 105
+    TimewalkerLevelUp: 22
+    TimewalkerMaxLevel: 186
+    Torghast: 79
+    TournamentRealm_1: 57
+    TournamentRealm_2: 162
+    TournamentRealm_3: 163
+    TournamentRealm_4: 164
+    TradeSkill: 13
+    Vendor: 14
+    Warbound_1: 165
+    Warbound_10: 174
+    Warbound_11: 175
+    Warbound_12: 176
+    Warbound_13: 177
+    Warbound_14: 178
+    Warbound_15: 179
+    Warbound_16: 180
+    Warbound_17: 181
+    Warbound_18: 182
+    Warbound_19: 183
+    Warbound_2: 166
+    Warbound_20: 184
+    Warbound_3: 167
+    Warbound_4: 168
+    Warbound_5: 169
+    Warbound_6: 170
+    Warbound_7: 171
+    Warbound_8: 172
+    Warbound_9: 173
+    WarMode: 76
+    WeeklyRewardsAdditional: 72
+    WeeklyRewardsConcession: 73
+    WorldBoss: 81
+    WorldQuest_1: 25
+    WorldQuest_10: 43
+    WorldQuest_11: 53
+    WorldQuest_12: 54
+    WorldQuest_13: 55
+    WorldQuest_2: 26
+    WorldQuest_3: 27
+    WorldQuest_4: 28
+    WorldQuest_5: 29
+    WorldQuest_6: 30
+    WorldQuest_7: 36
+    WorldQuest_8: 37
+    WorldQuest_9: 42
+    WorldQuestJackpot: 74
 ItemDisplayTextDisplayStyle:
-  ItemNameAndInfoText: 1
-  ItemNameOnlyCentered: 2
-  PlayerChoiceReward: 3
-  WorldQuestReward: 0
+  values:
+    ItemNameAndInfoText: 1
+    ItemNameOnlyCentered: 2
+    PlayerChoiceReward: 3
+    WorldQuestReward: 0
 ItemDisplayTooltipEnabledType:
-  Disabled: 1
-  Enabled: 0
+  values:
+    Disabled: 1
+    Enabled: 0
 ItemGemColor:
-  Arcane: 1024
-  Blood: 128
-  Blue: 8
-  Cogwheel: 32
-  Cypher: 8388608
-  DominationBlood: 1048576
-  DominationFrost: 2097152
-  DominationUnholy: 4194304
-  Fel: 512
-  Fiber: 1073741824
-  Fire: 4096
-  Fragrance: 67108864
-  Frost: 2048
-  Holy: 65536
-  Hydraulic: 16
-  Iron: 64
-  Life: 16384
-  Meta: 1
-  Primordial: 33554432
-  PunchcardBlue: 524288
-  PunchcardRed: 131072
-  PunchcardYellow: 262144
-  Red: 2
-  Shadow: 256
-  SingingSea: 268435456
-  SingingThunder: 134217728
-  SingingWind: 536870912
-  Tinker: 16777216
-  Water: 8192
-  Wind: 32768
-  Yellow: 4
+  values:
+    Arcane: 1024
+    Blood: 128
+    Blue: 8
+    Cogwheel: 32
+    Cypher: 8388608
+    DominationBlood: 1048576
+    DominationFrost: 2097152
+    DominationUnholy: 4194304
+    Fel: 512
+    Fiber: 1073741824
+    Fire: 4096
+    Fragrance: 67108864
+    Frost: 2048
+    Holy: 65536
+    Hydraulic: 16
+    Iron: 64
+    Life: 16384
+    Meta: 1
+    Primordial: 33554432
+    PunchcardBlue: 524288
+    PunchcardRed: 131072
+    PunchcardYellow: 262144
+    Red: 2
+    Shadow: 256
+    SingingSea: 268435456
+    SingingThunder: 134217728
+    SingingWind: 536870912
+    Tinker: 16777216
+    Water: 8192
+    Wind: 32768
+    Yellow: 4
 ItemGemSubclass:
-  Blue: 1
-  Green: 4
-  Meta: 6
-  Orange: 5
-  Prismatic: 8
-  Purple: 3
-  Red: 0
-  Simple: 7
-  Yellow: 2
+  values:
+    Blue: 1
+    Green: 4
+    Meta: 6
+    Orange: 5
+    Prismatic: 8
+    Purple: 3
+    Red: 0
+    Simple: 7
+    Yellow: 2
 ItemHousingSubclass:
-  Decor: 0
-  Dye: 1
-  ExteriorCustomization: 4
-  Room: 2
-  RoomCustomization: 3
-  ServiceItem: 5
+  values:
+    Decor: 0
+    Dye: 1
+    ExteriorCustomization: 4
+    Room: 2
+    RoomCustomization: 3
+    ServiceItem: 5
 ItemMiscellaneousSubclass:
-  CompanionPet: 2
-  Holiday: 3
-  Junk: 0
-  Mount: 5
-  MountEquipment: 6
-  Other: 4
-  Reagent: 1
+  values:
+    CompanionPet: 2
+    Holiday: 3
+    Junk: 0
+    Mount: 5
+    MountEquipment: 6
+    Other: 4
+    Reagent: 1
 ItemModification:
-  ArtifactAppearanceID: 8
-  ArtifactTier: 24
-  BattlePetBreed: 4
-  BattlePetCreaturedisplayid: 6
-  BattlePetLevel: 5
-  BattlePetSpecies: 3
-  ChangeModifiedCraftingStat_1: 29
-  ChangeModifiedCraftingStat_2: 30
-  ContentTuningID: 28
-  CraftingDataID: 40
-  CraftingQualityID: 38
-  CraftingReagentSlot_0: 43
-  CraftingReagentSlot_1: 44
-  CraftingReagentSlot_10: 53
-  CraftingReagentSlot_11: 54
-  CraftingReagentSlot_12: 55
-  CraftingReagentSlot_13: 56
-  CraftingReagentSlot_14: 57
-  CraftingReagentSlot_2: 45
-  CraftingReagentSlot_3: 46
-  CraftingReagentSlot_4: 47
-  CraftingReagentSlot_5: 48
-  CraftingReagentSlot_6: 49
-  CraftingReagentSlot_7: 50
-  CraftingReagentSlot_8: 51
-  CraftingReagentSlot_9: 52
-  CraftingSkillLineAbilityID: 39
-  CraftingSkillReagents: 41
-  CraftingSkillWatermark: 42
-  CurrencyWalletID: 61
-  CurrencyWalletQuantity: 62
-  CurrencyWalletVersion: 63
-  DbidHigh: 59
-  DbidLow: 60
-  IncrementLevel: 2
-  KeystoneAffix0: 19
-  KeystoneAffix01: 20
-  KeystoneAffix02: 21
-  KeystoneAffix03: 22
-  KeystoneMapChallengeModeID: 17
-  KeystonePowerLevel: 18
-  LegionArtifactKnowledgeObsolete: 23
-  PvPRating: 26
-  RedirectedBaseStats: 64
-  Reforge: 58
-  SoulbindConduitRank: 37
-  TimewalkerLevel: 9
-  TransmogrifyItemModifiedAppearanceIDSpec_0: 1
-  TransmogrifyItemModifiedAppearanceIDSpec_1: 11
-  TransmogrifyItemModifiedAppearanceIDSpec_2: 13
-  TransmogrifyItemModifiedAppearanceIDSpec_3: 15
-  TransmogrifyItemModifiedAppearanceIDSpec_4: 25
-  TransmogrifyItemModifiedAppearanceIDSpecAll: 0
-  TransmogrifyOverrideEnchantVisualIDSpec_0: 10
-  TransmogrifyOverrideEnchantVisualIDSpec_1: 12
-  TransmogrifyOverrideEnchantVisualIDSpec_2: 14
-  TransmogrifyOverrideEnchantVisualIDSpec_3: 16
-  TransmogrifyOverrideEnchantVisualIDSpec_4: 27
-  TransmogrifyOverrideEnchantVisualIDSpecAll: 7
-  TransmogrifySecondaryItemModifiedAppearanceIDSpec_0: 32
-  TransmogrifySecondaryItemModifiedAppearanceIDSpec_1: 33
-  TransmogrifySecondaryItemModifiedAppearanceIDSpec_2: 34
-  TransmogrifySecondaryItemModifiedAppearanceIDSpec_3: 35
-  TransmogrifySecondaryItemModifiedAppearanceIDSpec_4: 36
-  TransmogrifySecondaryItemModifiedAppearanceIDSpecAll: 31
+  values:
+    ArtifactAppearanceID: 8
+    ArtifactTier: 24
+    BattlePetBreed: 4
+    BattlePetCreaturedisplayid: 6
+    BattlePetLevel: 5
+    BattlePetSpecies: 3
+    ChangeModifiedCraftingStat_1: 29
+    ChangeModifiedCraftingStat_2: 30
+    ContentTuningID: 28
+    CraftingDataID: 40
+    CraftingQualityID: 38
+    CraftingReagentSlot_0: 43
+    CraftingReagentSlot_1: 44
+    CraftingReagentSlot_10: 53
+    CraftingReagentSlot_11: 54
+    CraftingReagentSlot_12: 55
+    CraftingReagentSlot_13: 56
+    CraftingReagentSlot_14: 57
+    CraftingReagentSlot_2: 45
+    CraftingReagentSlot_3: 46
+    CraftingReagentSlot_4: 47
+    CraftingReagentSlot_5: 48
+    CraftingReagentSlot_6: 49
+    CraftingReagentSlot_7: 50
+    CraftingReagentSlot_8: 51
+    CraftingReagentSlot_9: 52
+    CraftingSkillLineAbilityID: 39
+    CraftingSkillReagents: 41
+    CraftingSkillWatermark: 42
+    CurrencyWalletID: 61
+    CurrencyWalletQuantity: 62
+    CurrencyWalletVersion: 63
+    DbidHigh: 59
+    DbidLow: 60
+    IncrementLevel: 2
+    KeystoneAffix0: 19
+    KeystoneAffix01: 20
+    KeystoneAffix02: 21
+    KeystoneAffix03: 22
+    KeystoneMapChallengeModeID: 17
+    KeystonePowerLevel: 18
+    LegionArtifactKnowledgeObsolete: 23
+    PvPRating: 26
+    RedirectedBaseStats: 64
+    Reforge: 58
+    SoulbindConduitRank: 37
+    TimewalkerLevel: 9
+    TransmogrifyItemModifiedAppearanceIDSpec_0: 1
+    TransmogrifyItemModifiedAppearanceIDSpec_1: 11
+    TransmogrifyItemModifiedAppearanceIDSpec_2: 13
+    TransmogrifyItemModifiedAppearanceIDSpec_3: 15
+    TransmogrifyItemModifiedAppearanceIDSpec_4: 25
+    TransmogrifyItemModifiedAppearanceIDSpecAll: 0
+    TransmogrifyOverrideEnchantVisualIDSpec_0: 10
+    TransmogrifyOverrideEnchantVisualIDSpec_1: 12
+    TransmogrifyOverrideEnchantVisualIDSpec_2: 14
+    TransmogrifyOverrideEnchantVisualIDSpec_3: 16
+    TransmogrifyOverrideEnchantVisualIDSpec_4: 27
+    TransmogrifyOverrideEnchantVisualIDSpecAll: 7
+    TransmogrifySecondaryItemModifiedAppearanceIDSpec_0: 32
+    TransmogrifySecondaryItemModifiedAppearanceIDSpec_1: 33
+    TransmogrifySecondaryItemModifiedAppearanceIDSpec_2: 34
+    TransmogrifySecondaryItemModifiedAppearanceIDSpec_3: 35
+    TransmogrifySecondaryItemModifiedAppearanceIDSpec_4: 36
+    TransmogrifySecondaryItemModifiedAppearanceIDSpecAll: 31
 ItemProfessionSubclass:
-  Alchemy: 2
-  Archaeology: 13
-  Blacksmithing: 0
-  Cooking: 4
-  Enchanting: 8
-  Engineering: 7
-  Fishing: 9
-  Herbalism: 3
-  Inscription: 12
-  Jewelcrafting: 11
-  Leatherworking: 1
-  Mining: 5
-  Skinning: 10
-  Tailoring: 6
+  values:
+    Alchemy: 2
+    Archaeology: 13
+    Blacksmithing: 0
+    Cooking: 4
+    Enchanting: 8
+    Engineering: 7
+    Fishing: 9
+    Herbalism: 3
+    Inscription: 12
+    Jewelcrafting: 11
+    Leatherworking: 1
+    Mining: 5
+    Skinning: 10
+    Tailoring: 6
 ItemQuality:
-  Artifact: 6
-  Epic: 4
-  Good: 2
-  Heirloom: 7
-  Legendary: 5
-  Poor: 0
-  Rare: 3
-  Standard: 1
-  WoWToken: 8
+  values:
+    Artifact: 6
+    Epic: 4
+    Good: 2
+    Heirloom: 7
+    Legendary: 5
+    Poor: 0
+    Rare: 3
+    Standard: 1
+    WoWToken: 8
 ItemReagentSubclass:
-  ContextToken: 2
-  Keystone: 1
-  Reagent: 0
+  values:
+    ContextToken: 2
+    Keystone: 1
+    Reagent: 0
 ItemRecipeSubclass:
-  Alchemy: 6
-  Blacksmithing: 4
-  Book: 0
-  Cooking: 5
-  Enchanting: 8
-  Engineering: 3
-  FirstAid: 7
-  Fishing: 9
-  Inscription: 11
-  Jewelcrafting: 10
-  Leatherworking: 1
-  Tailoring: 2
+  values:
+    Alchemy: 6
+    Blacksmithing: 4
+    Book: 0
+    Cooking: 5
+    Enchanting: 8
+    Engineering: 3
+    FirstAid: 7
+    Fishing: 9
+    Inscription: 11
+    Jewelcrafting: 10
+    Leatherworking: 1
+    Tailoring: 2
 ItemRecraftFlags:
-  Invalid: 1
+  values:
+    Invalid: 1
 Itemsetflags:
-  Legacy: 1
-  RequiresPvPTalentsActive: 4
-  UseItemHistorySetSlots: 2
+  values:
+    Legacy: 1
+    RequiresPvPTalentsActive: 4
+    UseItemHistorySetSlots: 2
 ItemSlotFilterType:
-  Chest: 4
-  Cloak: 3
-  Feet: 9
-  Finger: 12
-  Hand: 6
-  Head: 0
-  Legs: 8
-  MainHand: 10
-  Neck: 1
-  NoFilter: 15
-  OffHand: 11
-  Other: 14
-  Shoulder: 2
-  Trinket: 13
-  Waist: 7
-  Wrist: 5
+  values:
+    Chest: 4
+    Cloak: 3
+    Feet: 9
+    Finger: 12
+    Hand: 6
+    Head: 0
+    Legs: 8
+    MainHand: 10
+    Neck: 1
+    NoFilter: 15
+    OffHand: 11
+    Other: 14
+    Shoulder: 2
+    Trinket: 13
+    Waist: 7
+    Wrist: 5
 ItemSocketInfoUIType:
-  Default: 0
+  values:
+    Default: 0
 ItemSocketType:
-  Arcane: 12
-  Blood: 9
-  Blue: 4
-  Cogwheel: 6
-  Cypher: 23
-  Domination: 22
-  Fel: 11
-  Fiber: 30
-  Fire: 14
-  Fragrance: 26
-  Frost: 13
-  Holy: 18
-  Hydraulic: 5
-  Iron: 8
-  Life: 16
-  Meta: 1
-  None: 0
-  Primordial: 25
-  Prismatic: 7
-  PunchcardBlue: 21
-  PunchcardRed: 19
-  PunchcardYellow: 20
-  Red: 2
-  Shadow: 10
-  SingingSea: 28
-  SingingThunder: 27
-  SingingWind: 29
-  Tinker: 24
-  Water: 15
-  Wind: 17
-  Yellow: 3
+  values:
+    Arcane: 12
+    Blood: 9
+    Blue: 4
+    Cogwheel: 6
+    Cypher: 23
+    Domination: 22
+    Fel: 11
+    Fiber: 30
+    Fire: 14
+    Fragrance: 26
+    Frost: 13
+    Holy: 18
+    Hydraulic: 5
+    Iron: 8
+    Life: 16
+    Meta: 1
+    None: 0
+    Primordial: 25
+    Prismatic: 7
+    PunchcardBlue: 21
+    PunchcardRed: 19
+    PunchcardYellow: 20
+    Red: 2
+    Shadow: 10
+    SingingSea: 28
+    SingingThunder: 27
+    SingingWind: 29
+    Tinker: 24
+    Water: 15
+    Wind: 17
+    Yellow: 3
 ItemSoundType:
-  Close: 3
-  Drop: 1
-  Pickup: 0
-  Use: 2
+  values:
+    Close: 3
+    Drop: 1
+    Pickup: 0
+    Use: 2
 ItemSubclassDisplay:
-  HideSubclassInAuction: 2
-  HideSubclassInTooltips: 1
-  ShowItemCount: 4
+  values:
+    HideSubclassInAuction: 2
+    HideSubclassInTooltips: 1
+    ShowItemCount: 4
 ItemSubclassFlag:
-  ArmorsubclassLfgscalingarmor: 1024
-  ItemsubclassQuivernotrequired: 64
-  ItemsubclassUsesInvtype: 512
-  WeaponsubclassCanparry: 1
-  WeaponsubclassDeprecatedReuseMe: 256
-  WeaponsubclassIsrifle: 8
-  WeaponsubclassIsthrown: 16
-  WeaponsubclassIsunarmed: 4
-  WeaponsubclassRanged: 128
-  WeaponsubclassRighthandRanged: 32
-  WeaponsubclassSetfingerseq: 2
+  values:
+    ArmorsubclassLfgscalingarmor: 1024
+    ItemsubclassQuivernotrequired: 64
+    ItemsubclassUsesInvtype: 512
+    WeaponsubclassCanparry: 1
+    WeaponsubclassDeprecatedReuseMe: 256
+    WeaponsubclassIsrifle: 8
+    WeaponsubclassIsthrown: 16
+    WeaponsubclassIsunarmed: 4
+    WeaponsubclassRanged: 128
+    WeaponsubclassRighthandRanged: 32
+    WeaponsubclassSetfingerseq: 2
 ItemTryOnReason:
-  DataPending: 3
-  NotEquippable: 2
-  Success: 0
-  WrongRace: 1
+  values:
+    DataPending: 3
+    NotEquippable: 2
+    Success: 0
+    WrongRace: 1
 ItemWeaponSubclass:
-  Axe1H: 0
-  Axe2H: 1
-  Bearclaw: 11
-  Bows: 2
-  Catclaw: 12
-  Crossbow: 18
-  Dagger: 15
-  Fishingpole: 20
-  Generic: 14
-  Guns: 3
-  Mace1H: 4
-  Mace2H: 5
-  Obsolete3: 17
-  Polearm: 6
-  Staff: 10
-  Sword1H: 7
-  Sword2H: 8
-  Thrown: 16
-  Unarmed: 13
-  Wand: 19
-  Warglaive: 9
+  values:
+    Axe1H: 0
+    Axe2H: 1
+    Bearclaw: 11
+    Bows: 2
+    Catclaw: 12
+    Crossbow: 18
+    Dagger: 15
+    Fishingpole: 20
+    Generic: 14
+    Guns: 3
+    Mace1H: 4
+    Mace2H: 5
+    Obsolete3: 17
+    Polearm: 6
+    Staff: 10
+    Sword1H: 7
+    Sword2H: 8
+    Thrown: 16
+    Unarmed: 13
+    Wand: 19
+    Warglaive: 9
 JailersTowerType:
-  AdamantVaults: 11
-  ArkobanHall: 7
-  BossRush: 14
-  Coldheart: 4
-  ForgottenCatacombs: 12
-  FractureChambers: 2
-  Mortregar: 5
-  Ossuary: 13
-  SkoldusHalls: 1
-  Soulforges: 3
-  TormentChamberAnduin: 10
-  TormentChamberJaina: 8
-  TormentChamberThrall: 9
-  TwistingCorridors: 0
-  UpperReaches: 6
+  values:
+    AdamantVaults: 11
+    ArkobanHall: 7
+    BossRush: 14
+    Coldheart: 4
+    ForgottenCatacombs: 12
+    FractureChambers: 2
+    Mortregar: 5
+    Ossuary: 13
+    SkoldusHalls: 1
+    Soulforges: 3
+    TormentChamberAnduin: 10
+    TormentChamberJaina: 8
+    TormentChamberThrall: 9
+    TwistingCorridors: 0
+    UpperReaches: 6
 JournalEncounterFlags:
-  AllianceOnly: 4
-  DoNotDisplayEncounter: 64
-  HordeOnly: 8
-  InternalOnly: 32
-  LimitDifficulties: 2
-  NoMap: 16
-  Obsolete: 1
+  values:
+    AllianceOnly: 4
+    DoNotDisplayEncounter: 64
+    HordeOnly: 8
+    InternalOnly: 32
+    LimitDifficulties: 2
+    NoMap: 16
+    Obsolete: 1
 JournalEncounterIconFlags:
-  Bleed: 8192
-  Curse: 256
-  Deadly: 16
-  Disease: 1024
-  Dps: 2
-  Enrage: 2048
-  Healer: 4
-  Heroic: 8
-  Important: 32
-  Interruptible: 64
-  Magic: 128
-  Mythic: 4096
-  Poison: 512
-  Tank: 1
+  values:
+    Bleed: 8192
+    Curse: 256
+    Deadly: 16
+    Disease: 1024
+    Dps: 2
+    Enrage: 2048
+    Healer: 4
+    Heroic: 8
+    Important: 32
+    Interruptible: 64
+    Magic: 128
+    Mythic: 4096
+    Poison: 512
+    Tank: 1
 JournalEncounterItemFlags:
-  DisplayAsExtremelyRare: 16
-  DisplayAsPerPlayerLoot: 4
-  DisplayAsVeryRare: 8
-  LimitDifficulties: 2
-  Obsolete: 1
+  values:
+    DisplayAsExtremelyRare: 16
+    DisplayAsPerPlayerLoot: 4
+    DisplayAsVeryRare: 8
+    LimitDifficulties: 2
+    Obsolete: 1
 JournalEncounterLocFlags:
-  Primary: 1
+  values:
+    Primary: 1
 JournalEncounterSectionFlags:
-  LimitDifficulties: 2
-  StartExpanded: 1
+  values:
+    LimitDifficulties: 2
+    StartExpanded: 1
 JournalEncounterSecTypes:
-  Ability: 2
-  Creature: 1
-  Generic: 0
-  Overview: 3
+  values:
+    Ability: 2
+    Creature: 1
+    Generic: 0
+    Overview: 3
 JournalInstanceFlags:
-  DoNotDisplayInstance: 4
-  HideUserSelectableDifficulty: 2
-  Timewalker: 1
+  values:
+    DoNotDisplayInstance: 4
+    HideUserSelectableDifficulty: 2
+    Timewalker: 1
 JournalLinkTypes:
-  Encounter: 1
-  Instance: 0
-  Section: 2
-  Tier: 3
+  values:
+    Encounter: 1
+    Instance: 0
+    Section: 2
+    Tier: 3
 LanguageFlag:
-  HiddenFromPlayer: 2
-  HideLanguageNameInChat: 4
-  IsExotic: 1
+  values:
+    HiddenFromPlayer: 2
+    HideLanguageNameInChat: 4
+    IsExotic: 1
 LeavePartyConfirmReason:
-  QuestSync: 0
-  RestrictedChallengeMode: 1
+  values:
+    QuestSync: 0
+    RestrictedChallengeMode: 1
 LFGEntryGeneralPlaystyle:
-  Expert: 4
-  FunRelaxed: 2
-  FunSerious: 3
-  Learning: 1
-  None: 0
+  values:
+    Expert: 4
+    FunRelaxed: 2
+    FunSerious: 3
+    Learning: 1
+    None: 0
 LFGEntryPlaystyle:
-  Casual: 2
-  Hardcore: 3
-  None: 0
-  Standard: 1
+  values:
+    Casual: 2
+    Hardcore: 3
+    None: 0
+    Standard: 1
 LFGListDisplayType:
-  ClassEnumerate: 2
-  Comment: 5
-  HideAll: 3
-  PlayerCount: 4
-  RoleCount: 0
-  RoleEnumerate: 1
+  values:
+    ClassEnumerate: 2
+    Comment: 5
+    HideAll: 3
+    PlayerCount: 4
+    RoleCount: 0
+    RoleEnumerate: 1
 LFGListFilter:
-  CurrentExpansion: 32
-  CurrentSeason: 64
-  NotCurrentSeason: 128
-  NotRecommended: 2
-  PvE: 4
-  PvP: 8
-  Recommended: 1
-  Timerunning: 16
+  values:
+    CurrentExpansion: 32
+    CurrentSeason: 64
+    NotCurrentSeason: 128
+    NotRecommended: 2
+    PvE: 4
+    PvP: 8
+    Recommended: 1
+    Timerunning: 16
 LFGRole:
-  Damage: 2
-  Healer: 1
-  Tank: 0
+  values:
+    Damage: 2
+    Healer: 1
+    Tank: 0
 LFGSlotInvalidReason:
-  AreaNotExplored: 9
-  CannotRunAnyChildDungeon: 14
-  ChromieTime: 16
-  EngagedInPvP: 12
-  ExpansionTooLow: 1
-  GearTooHigh: 5
-  GearTooLow: 4
-  LevelTargetTooHigh: 8
-  LevelTargetTooLow: 7
-  LevelTooHigh: 3
-  LevelTooLow: 2
-  None: 0
-  NoSpec: 13
-  NoValidRoles: 11
-  Npe: 17
-  PlayerConditionFailed: 19
-  RaidLocked: 6
-  Restricted: 15
-  Timerunning: 18
-  WrongFaction: 10
+  values:
+    AreaNotExplored: 9
+    CannotRunAnyChildDungeon: 14
+    ChromieTime: 16
+    EngagedInPvP: 12
+    ExpansionTooLow: 1
+    GearTooHigh: 5
+    GearTooLow: 4
+    LevelTargetTooHigh: 8
+    LevelTargetTooLow: 7
+    LevelTooHigh: 3
+    LevelTooLow: 2
+    None: 0
+    NoSpec: 13
+    NoValidRoles: 11
+    Npe: 17
+    PlayerConditionFailed: 19
+    RaidLocked: 6
+    Restricted: 15
+    Timerunning: 18
+    WrongFaction: 10
 LgVendorPurchaseSettlementState:
-  NotSettled: 1
-  Settled: 0
+  values:
+    NotSettled: 1
+    Settled: 0
 LgVendorPurchaseSqlResults:
-  AlreadyOwned: 102
-  Failed: 0
-  InsufficientFunds: 101
-  InsufficientSpent: 103
-  InvalidState: 107
-  NoRecord: 106
-  NotOwned: 104
-  RefundExpired: 105
-  Success: 100
+  values:
+    AlreadyOwned: 102
+    Failed: 0
+    InsufficientFunds: 101
+    InsufficientSpent: 103
+    InvalidState: 107
+    NoRecord: 106
+    NotOwned: 104
+    RefundExpired: 105
+    Success: 100
 LgVendorPurchaseState:
-  NotOwned: 0
-  Owned: 1
+  values:
+    NotOwned: 0
+    Owned: 1
 LightRadiusIndicatorType:
-  Always: 0
-  Never: 2
-  Overlap: 1
+  values:
+    Always: 0
+    Never: 2
+    Overlap: 1
 LimitedInputType:
-  MouseDown: 1
-  MouseMove: 0
-  MouseUp: 2
-  MouseWheel: 3
+  values:
+    MouseDown: 1
+    MouseMove: 0
+    MouseUp: 2
+    MouseWheel: 3
 LinkedCurrencyFlags:
-  AddIgnoresMax: 8
-  IgnoreAdd: 1
-  IgnoreSubtract: 2
-  SuppressChatLog: 4
+  values:
+    AddIgnoresMax: 8
+    IgnoreAdd: 1
+    IgnoreSubtract: 2
+    SuppressChatLog: 4
 LogicLogicop:
-  And: 1
-  None: 0
-  Or: 2
-  Xor: 3
+  values:
+    And: 1
+    None: 0
+    Or: 2
+    Xor: 3
 LogicMathop:
-  Div: 4
-  Minus: 2
-  Mod: 5
-  None: 0
-  Plus: 1
-  Times: 3
+  values:
+    Div: 4
+    Minus: 2
+    Mod: 5
+    None: 0
+    Plus: 1
+    Times: 3
 LogicRelop:
-  Equal: 1
-  Gt: 5
-  Gteq: 6
-  Lt: 3
-  Lteq: 4
-  None: 0
-  Notequal: 2
+  values:
+    Equal: 1
+    Gt: 5
+    Gteq: 6
+    Lt: 3
+    Lteq: 4
+    None: 0
+    Notequal: 2
 LogPriority:
-  Debug: 30
-  Error: 2
-  Fatal: 1
-  Normal: 10
-  Spam: 40
-  Warning: 3
+  values:
+    Debug: 30
+    Error: 2
+    Fatal: 1
+    Normal: 10
+    Spam: 40
+    Warning: 3
 LootMethod:
-  Freeforall: 0
-  Group: 3
-  Masterlooter: 2
-  Needbeforegreed: 4
-  Personal: 5
-  Roundrobin: 1
+  values:
+    Freeforall: 0
+    Group: 3
+    Masterlooter: 2
+    Needbeforegreed: 4
+    Personal: 5
+    Roundrobin: 1
 LootMethodStyles:
-  Mainline: 0
-  Vanilla: 1
+  values:
+    Mainline: 0
+    Vanilla: 1
 LootSlotType:
-  Currency: 3
-  Item: 1
-  Money: 2
-  None: 0
+  values:
+    Currency: 3
+    Item: 1
+    Money: 2
+    None: 0
 LuaCurveType:
-  Cosine: 2
-  Cubic: 3
-  Linear: 0
-  Step: 1
+  values:
+    Cosine: 2
+    Cubic: 3
+    Linear: 0
+    Step: 1
 ManipulatorEventType:
-  Complete: 2
-  Delete: 3
-  Move: 1
-  Start: 0
+  values:
+    Complete: 2
+    Delete: 3
+    Move: 1
+    Start: 0
 MapCanvasPosition:
-  BottomLeft: 1
-  BottomRight: 2
-  None: 0
-  TopLeft: 3
-  TopRight: 4
+  values:
+    BottomLeft: 1
+    BottomRight: 2
+    None: 0
+    TopLeft: 3
+    TopRight: 4
 MapIconUIWidgetSetType:
-  AdventureMapDetails: 2
-  BehindIcon: 1
-  Tooltip: 0
+  values:
+    AdventureMapDetails: 2
+    BehindIcon: 1
+    Tooltip: 0
 MapobjEventTypes:
-  PlayAnim: 0
-  SetAnimSpeed: 1
+  values:
+    PlayAnim: 0
+    SetAnimSpeed: 1
 MapPinAnimationType:
-  None: 0
-  Pulse: 1
+  values:
+    None: 0
+    Pulse: 1
 MatchDetailType:
-  Kills: 1
-  Placement: 0
-  PlunderAcquired: 2
+  values:
+    Kills: 1
+    Placement: 0
+    PlunderAcquired: 2
 MicroMenuOrder:
-  Default: 0
-  Reverse: 1
+  values:
+    Default: 0
+    Reverse: 1
 MicroMenuOrientation:
-  Horizontal: 0
-  Vertical: 1
+  values:
+    Horizontal: 0
+    Vertical: 1
 MinimapTrackingFilter:
-  AccountBanker: 4194304
-  AccountCompletedQuests: 2097152
-  Auctioneer: 1
-  Banker: 2
-  Battlemaster: 4
-  Digsites: 131072
-  Focus: 32768
-  Innkeeper: 32
-  Mailbox: 64
-  POI: 8192
-  QuestPOIs: 65536
-  Repair: 512
-  Stablemaster: 2048
-  Target: 16384
-  TaxiNode: 8
-  TrainerClass: 262144
-  TrainerProfession: 128
-  Transmogrifier: 4096
-  TrivialQuests: 1024
-  Unfiltered: 0
-  VenderFood: 16
-  VendorAmmo: 524288
-  VendorPoison: 1048576
-  VendorReagent: 256
+  values:
+    AccountBanker: 4194304
+    AccountCompletedQuests: 2097152
+    Auctioneer: 1
+    Banker: 2
+    Battlemaster: 4
+    Digsites: 131072
+    Focus: 32768
+    Innkeeper: 32
+    Mailbox: 64
+    POI: 8192
+    QuestPOIs: 65536
+    Repair: 512
+    Stablemaster: 2048
+    Target: 16384
+    TaxiNode: 8
+    TrainerClass: 262144
+    TrainerProfession: 128
+    Transmogrifier: 4096
+    TrivialQuests: 1024
+    Unfiltered: 0
+    VenderFood: 16
+    VendorAmmo: 524288
+    VendorPoison: 1048576
+    VendorReagent: 256
 ModelBlendOperation:
-  Anim: 1
-  None: 0
+  values:
+    Anim: 1
+    None: 0
 ModelLightType:
-  Directional: 0
-  Point: 1
+  values:
+    Directional: 0
+    Point: 1
 ModelSceneSetting:
-  AlignLightToOrbitDelta: 1
+  values:
+    AlignLightToOrbitDelta: 1
 ModelSceneType:
-  ArtifactRelicTalentEffect: 9
-  ArtifactTier2: 5
-  ArtifactTier2ForgingScene: 6
-  ArtifactTier2SlamEffect: 7
-  AzeriteItemLevelUpToast: 13
-  AzeritePowers: 14
-  AzeriteRewardGlow: 15
-  CommentatorVictoryFanfare: 8
-  EncounterJournal: 3
-  MountJournal: 0
-  PartyPose: 12
-  PetJournalCard: 1
-  PetJournalLoadout: 4
-  PvPWarModeFire: 11
-  PvPWarModeOrb: 10
-  ShopCard: 2
+  values:
+    ArtifactRelicTalentEffect: 9
+    ArtifactTier2: 5
+    ArtifactTier2ForgingScene: 6
+    ArtifactTier2SlamEffect: 7
+    AzeriteItemLevelUpToast: 13
+    AzeritePowers: 14
+    AzeriteRewardGlow: 15
+    CommentatorVictoryFanfare: 8
+    EncounterJournal: 3
+    MountJournal: 0
+    PartyPose: 12
+    PetJournalCard: 1
+    PetJournalLoadout: 4
+    PvPWarModeFire: 11
+    PvPWarModeOrb: 10
+    ShopCard: 2
 ModelSoundOverrideType:
-  Mute: 2
-  UseOverride: 1
-  UseParent: 0
+  values:
+    Mute: 2
+    UseOverride: 1
+    UseParent: 0
 ModelSoundTagType:
-  Looping: 2
-  Oneshot: 1
+  values:
+    Looping: 2
+    Oneshot: 1
 MountType:
-  Aquatic: 2
-  Dragonriding: 3
-  Flying: 1
-  Ground: 0
-  RideAlong: 4
+  values:
+    Aquatic: 2
+    Dragonriding: 3
+    Flying: 1
+    Ground: 0
+    RideAlong: 4
 MountTypeFlag:
-  IsAquaticMount: 2
-  IsDragonRidingMount: 4
-  IsFlyingMount: 1
-  IsRideAlongMount: 8
+  values:
+    IsAquaticMount: 2
+    IsDragonRidingMount: 4
+    IsFlyingMount: 1
+    IsRideAlongMount: 8
 NamePlateCastBarDisplay:
-  HighlightImportantCasts: 4
-  HighlightWhenCastTarget: 5
-  None: 0
-  SpellIcon: 2
-  SpellName: 1
-  SpellTarget: 3
+  values:
+    HighlightImportantCasts: 4
+    HighlightWhenCastTarget: 5
+    None: 0
+    SpellIcon: 2
+    SpellName: 1
+    SpellTarget: 3
 NamePlateEnemyNpcAuraDisplay:
-  Buffs: 1
-  CrowdControl: 3
-  Debuffs: 2
-  None: 0
+  values:
+    Buffs: 1
+    CrowdControl: 3
+    Debuffs: 2
+    None: 0
 NamePlateEnemyPlayerAuraDisplay:
-  Buffs: 1
-  Debuffs: 2
-  LossOfControl: 3
-  None: 0
+  values:
+    Buffs: 1
+    Debuffs: 2
+    LossOfControl: 3
+    None: 0
 NamePlateFriendlyPlayerAuraDisplay:
-  Buffs: 1
-  Debuffs: 2
-  LossOfControl: 3
-  None: 0
+  values:
+    Buffs: 1
+    Debuffs: 2
+    LossOfControl: 3
+    None: 0
 NamePlateInfoDisplay:
-  CurrentHealthPercent: 1
-  CurrentHealthValue: 2
-  None: 0
-  RarityIcon: 3
+  values:
+    CurrentHealthPercent: 1
+    CurrentHealthValue: 2
+    None: 0
+    RarityIcon: 3
 NamePlateSimplifiedType:
-  FriendlyNpc: 4
-  FriendlyPlayer: 3
-  Minion: 1
-  MinusMob: 2
-  None: 0
+  values:
+    FriendlyNpc: 4
+    FriendlyPlayer: 3
+    Minion: 1
+    MinusMob: 2
+    None: 0
 NamePlateSize:
-  ExtraLarge: 4
-  Huge: 5
-  Large: 3
-  Medium: 2
-  Small: 1
+  values:
+    ExtraLarge: 4
+    Huge: 5
+    Large: 3
+    Medium: 2
+    Small: 1
 NamePlateStackType:
-  Enemy: 1
-  Friendly: 2
-  None: 0
+  values:
+    Enemy: 1
+    Friendly: 2
+    None: 0
 NamePlateStyle:
-  Block: 2
-  CastFocus: 4
-  Classic: 6
-  HealthFocus: 3
-  Legacy: 5
-  Modern: 0
-  Thin: 1
+  values:
+    Block: 2
+    CastFocus: 4
+    Classic: 6
+    HealthFocus: 3
+    Legacy: 5
+    Modern: 0
+    Thin: 1
 NamePlateThreatDisplay:
-  Flash: 2
-  HealthBarColor: 3
-  None: 0
-  Progressive: 1
+  values:
+    Flash: 2
+    HealthBarColor: 3
+    None: 0
+    Progressive: 1
 NamePlateType:
-  Enemy: 1
-  Friendly: 0
+  values:
+    Enemy: 1
+    Friendly: 0
 NeighborhoodFlags:
-  None: 0
-  OpenToPublic: 2
-  PoolParent: 1
+  values:
+    None: 0
+    OpenToPublic: 2
+    PoolParent: 1
 NeighborhoodInitiativeChestResult:
-  NiNoHouseFound: 2
-  NiNoRewards: 3
-  NiServiceDisabled: 5
-  NiSuccess: 0
-  NiThrottled: 4
-  NiUnspecifiedFailure: 1
+  values:
+    NiNoHouseFound: 2
+    NiNoRewards: 3
+    NiServiceDisabled: 5
+    NiSuccess: 0
+    NiThrottled: 4
+    NiUnspecifiedFailure: 1
 NeighborhoodInitiativeFlags:
-  Disabled: 1
-  NoAbandon: 2
-  NoRepeat: 4
+  values:
+    Disabled: 1
+    NoAbandon: 2
+    NoRepeat: 4
 NeighborhoodInitiativeNeighborhoodTypes:
-  NiNeighborhoodTypePool: 1
-  NiNeighborhoodTypeSingleton: 0
+  values:
+    NiNeighborhoodTypePool: 1
+    NiNeighborhoodTypeSingleton: 0
 NeighborhoodInitiativesCompletionStates:
-  NiCompletionStateNotCompleted: 0
-  NiCompletionStatePlayerCompleted: 1
-  NiCompletionStateSystemAbandoned: 2
+  values:
+    NiCompletionStateNotCompleted: 0
+    NiCompletionStatePlayerCompleted: 1
+    NiCompletionStateSystemAbandoned: 2
 NeighborhoodInitiativeTaskType:
-  RepeatableFinite: 1
-  RepeatableInfinite: 2
-  Single: 0
+  values:
+    RepeatableFinite: 1
+    RepeatableInfinite: 2
+    Single: 0
 NeighborhoodInitiativeUpdateStatus:
-  Completed: 2
-  Failed: 3
-  MilestoneCompleted: 1
-  Started: 0
+  values:
+    Completed: 2
+    Failed: 3
+    MilestoneCompleted: 1
+    Started: 0
 NeighborhoodInviteResult:
-  AlreadyInNeighborhood: 11
-  DbError: 1
-  Faction: 5
-  GenericFailure: 3
-  InviteLimit: 7
-  NotEnoughPlots: 8
-  NotFound: 9
-  PendingInvitation: 6
-  Permission: 4
-  RpcFailure: 2
-  Success: 0
-  TooManyRequests: 10
+  values:
+    AlreadyInNeighborhood: 11
+    DbError: 1
+    Faction: 5
+    GenericFailure: 3
+    InviteLimit: 7
+    NotEnoughPlots: 8
+    NotFound: 9
+    PendingInvitation: 6
+    Permission: 4
+    RpcFailure: 2
+    Success: 0
+    TooManyRequests: 10
 NeighborhoodMapFlags:
-  AlliancePurchasable: 1
-  CanSystemGenerate: 4
-  HordePurchasable: 2
-  None: 0
+  values:
+    AlliancePurchasable: 1
+    CanSystemGenerate: 4
+    HordePurchasable: 2
+    None: 0
 NeighborhoodOwnerType:
-  Charter: 2
-  Guild: 1
-  None: 0
+  values:
+    Charter: 2
+    Guild: 1
+    None: 0
 NeighborhoodType:
-  Open: 0
-  Private: 1
-  Public: 2
+  values:
+    Open: 0
+    Private: 1
+    Public: 2
 NewCharGear:
-  Preview: 1
-  Start: 0
+  values:
+    Preview: 1
+    Start: 0
 NodeOpFailureReason:
-  AccountDataNoMatch: 25
-  DataError: 13
-  EntryNotFound: 19
-  HasMutuallyExclusiveEdge: 4
-  LevelTooLow: 22
-  MaxRank: 12
-  MissingAchievement: 8
-  MissingEdgeConnection: 1
-  MissingQuest: 9
-  MissingRequiredEdge: 3
-  NodeNeverPurchasable: 24
-  NodeNotFound: 18
-  None: 0
-  NotEnoughCurrency: 15
-  NotEnoughCurrencySpent: 6
-  NotEnoughGold: 16
-  NotEnoughGoldSpent: 7
-  NotEnoughRanksInEntry: 26
-  NotEnoughSourcedCurrency: 14
-  NotEnoughSourcedCurrencySpent: 5
-  RequiredForCondition: 20
-  RequiredForEdge: 2
-  SameSelection: 17
-  TreeFlaggedNoRefund: 23
-  WrongSelection: 11
-  WrongSpec: 10
-  WrongTreeID: 21
+  values:
+    AccountDataNoMatch: 25
+    DataError: 13
+    EntryNotFound: 19
+    HasMutuallyExclusiveEdge: 4
+    LevelTooLow: 22
+    MaxRank: 12
+    MissingAchievement: 8
+    MissingEdgeConnection: 1
+    MissingQuest: 9
+    MissingRequiredEdge: 3
+    NodeNeverPurchasable: 24
+    NodeNotFound: 18
+    None: 0
+    NotEnoughCurrency: 15
+    NotEnoughCurrencySpent: 6
+    NotEnoughGold: 16
+    NotEnoughGoldSpent: 7
+    NotEnoughRanksInEntry: 26
+    NotEnoughSourcedCurrency: 14
+    NotEnoughSourcedCurrencySpent: 5
+    RequiredForCondition: 20
+    RequiredForEdge: 2
+    SameSelection: 17
+    TreeFlaggedNoRefund: 23
+    WrongSelection: 11
+    WrongSpec: 10
+    WrongTreeID: 21
 NoRPEReason:
-  BNetToken: 8
-  FactionOrRaceChange: 7
-  HasRPE: 0
-  IneligibleMap: 3
-  LowLevel: 1
-  PlayerLocked: 9
-  RecentlyActive: 4
-  RecentlyBoosted: 5
-  Timerunner: 2
-  UpgradeInProgress: 6
+  values:
+    BNetToken: 8
+    FactionOrRaceChange: 7
+    HasRPE: 0
+    IneligibleMap: 3
+    LowLevel: 1
+    PlayerLocked: 9
+    RecentlyActive: 4
+    RecentlyBoosted: 5
+    Timerunner: 2
+    UpgradeInProgress: 6
 NpcCraftingOrderSetFlags:
-  AllowDuplicate: 2
-  AllowMultiple: 1
+  values:
+    AllowDuplicate: 2
+    AllowMultiple: 1
 NumericRuleFormatRounding:
-  Down: 2
-  Nearest: 0
-  Up: 1
+  values:
+    Down: 2
+    Nearest: 0
+    Up: 1
 PartyPlaylistEntry:
-  DuoGameMode: 1
-  SoloGameMode: 0
-  TrainingGameMode: 3
-  TrioGameMode: 2
+  values:
+    DuoGameMode: 1
+    SoloGameMode: 0
+    TrainingGameMode: 3
+    TrioGameMode: 2
 PartyPoseFlags:
-  HideLeaveInstanceButton: 1
+  values:
+    HideLeaveInstanceButton: 1
 PartyRequestJoinRelation:
-  Club: 3
-  Friend: 1
-  Guild: 2
-  None: 0
-  RecentAllies: 4
+  values:
+    Club: 3
+    Friend: 1
+    Guild: 2
+    None: 0
+    RecentAllies: 4
 PerksVendorCategoryType:
-  Achievement: 23
-  Activity: 21
-  GmAdjustment: 22
-  Illusion: 7
-  Mount: 2
-  Pet: 3
-  RefundUnused: 24
-  Stipend: 20
-  Toy: 5
-  Transmog: 1
-  Transmogset: 8
-  WarbandScene: 9
+  values:
+    Achievement: 23
+    Activity: 21
+    GmAdjustment: 22
+    Illusion: 7
+    Mount: 2
+    Pet: 3
+    RefundUnused: 24
+    Stipend: 20
+    Toy: 5
+    Transmog: 1
+    Transmogset: 8
+    WarbandScene: 9
 PermanentChatChannelType:
-  Communities: 2
-  Custom: 3
-  None: 0
-  Zone: 1
+  values:
+    Communities: 2
+    Custom: 3
+    None: 0
+    Zone: 1
 PersonalResourceDisplayVisibleSetting:
-  Always: 0
-  Hidden: 2
-  InCombat: 1
+  values:
+    Always: 0
+    Hidden: 2
+    InCombat: 1
 PetActionbuttonType:
-  Max: 18
-  Mode: 6
-  None: 0
-  Orders: 7
-  Slot1: 8
-  Slot10: 17
-  Slot1Obsolete: 2
-  Slot2: 9
-  Slot2Obsolete: 3
-  Slot3: 10
-  Slot3Obsolete: 4
-  Slot4: 11
-  Slot4Obsolete: 5
-  Slot5: 12
-  Slot6: 13
-  Slot7: 14
-  Slot8: 15
-  Slot9: 16
-  Spell: 1
-  VehicleAction: 19
+  values:
+    Max: 18
+    Mode: 6
+    None: 0
+    Orders: 7
+    Slot1: 8
+    Slot10: 17
+    Slot1Obsolete: 2
+    Slot2: 9
+    Slot2Obsolete: 3
+    Slot3: 10
+    Slot3Obsolete: 4
+    Slot4: 11
+    Slot4Obsolete: 5
+    Slot5: 12
+    Slot6: 13
+    Slot7: 14
+    Slot8: 15
+    Slot9: 16
+    Spell: 1
+    VehicleAction: 19
 PetActionFeedback:
-  Dead: 1
-  FriendlyTarget: 3
-  InvalidTarget: 2
-  NoPath: 4
-  Success: 0
+  values:
+    Dead: 1
+    FriendlyTarget: 3
+    InvalidTarget: 2
+    NoPath: 4
+    Success: 0
 PetBattleQueueStatus:
-  AlreadyQueued: 3
-  InBattle: 20
-  JoinFailed: 4
-  JoinFailedJournalLock: 6
-  JoinFailedNeutral: 7
-  JoinFailedSlots: 5
-  LostConnection: 16
-  MatchAccepted: 8
-  MatchDeclined: 9
-  Matchmaking: 15
-  MatchOpponentDeclined: 10
-  NoBattlingHere: 21
-  None: 0
-  ProposalTimedOut: 11
-  Queued: 1
-  QueuedUpdate: 2
-  Removed: 12
-  RequeuedAfterInternalError: 13
-  RequeuedAfterOpponentRemoved: 14
-  Shutdown: 17
-  Suspended: 18
-  Unsuspended: 19
+  values:
+    AlreadyQueued: 3
+    InBattle: 20
+    JoinFailed: 4
+    JoinFailedJournalLock: 6
+    JoinFailedNeutral: 7
+    JoinFailedSlots: 5
+    LostConnection: 16
+    MatchAccepted: 8
+    MatchDeclined: 9
+    Matchmaking: 15
+    MatchOpponentDeclined: 10
+    NoBattlingHere: 21
+    None: 0
+    ProposalTimedOut: 11
+    Queued: 1
+    QueuedUpdate: 2
+    Removed: 12
+    RequeuedAfterInternalError: 13
+    RequeuedAfterOpponentRemoved: 14
+    Shutdown: 17
+    Suspended: 18
+    Unsuspended: 19
 PetbattleSlot:
-  Slot_0: 0
-  Slot_1: 1
-  Slot_2: 2
+  values:
+    Slot_0: 0
+    Slot_1: 1
+    Slot_2: 2
 PetbattleState:
-  Created: 0
-  CreatedFailed: 4
-  FinalRound: 5
-  Finished: 6
-  RoundInProgress: 2
-  WaitingForFrontPets: 3
-  WaitingPreBattle: 1
+  values:
+    Created: 0
+    CreatedFailed: 4
+    FinalRound: 5
+    Finished: 6
+    RoundInProgress: 2
+    WaitingForFrontPets: 3
+    WaitingPreBattle: 1
 PetJournalError:
-  InvalidFaction: 3
-  JournalIsLocked: 2
-  NoFavoritesToSummon: 4
-  None: 0
-  NoValidRandomSummon: 5
-  PetIsDead: 1
+  values:
+    InvalidFaction: 3
+    JournalIsLocked: 2
+    NoFavoritesToSummon: 4
+    None: 0
+    NoValidRandomSummon: 5
+    PetIsDead: 1
 PetMode:
-  Aggressive: 2
-  Assist: 3
-  Defensive: 1
-  Passive: 0
+  values:
+    Aggressive: 2
+    Assist: 3
+    Defensive: 1
+    Passive: 0
 PetOrders:
-  Attack: 2
-  Dismiss: 3
-  Follow: 1
-  MoveTo: 4
-  Wait: 0
+  values:
+    Attack: 2
+    Dismiss: 3
+    Follow: 1
+    MoveTo: 4
+    Wait: 0
 PetOverride:
-  AICombatControl: 1
-  AICombatPassive: 2
-  None: 0
-  OwnerMounted: 4
+  values:
+    AICombatControl: 1
+    AICombatPassive: 2
+    None: 0
+    OwnerMounted: 4
 Pettameresult:
-  Anothersummonactive: 5
-  Cantcontrolexotic: 12
-  Creaturealreadyowned: 3
-  Dead: 10
-  EliteToohighlevel: 14
-  Internalerror: 8
-  Invalidcreature: 1
-  Invalidslot: 13
-  Nopetavailable: 7
-  Notdead: 11
-  Nottameable: 4
-  Numresults: 15
-  Ok: 0
-  Toohighlevel: 9
-  Toomany: 2
-  Unitscanttame: 6
+  values:
+    Anothersummonactive: 5
+    Cantcontrolexotic: 12
+    Creaturealreadyowned: 3
+    Dead: 10
+    EliteToohighlevel: 14
+    Internalerror: 8
+    Invalidcreature: 1
+    Invalidslot: 13
+    Nopetavailable: 7
+    Notdead: 11
+    Nottameable: 4
+    Numresults: 15
+    Ok: 0
+    Toohighlevel: 9
+    Toomany: 2
+    Unitscanttame: 6
 PhaseReason:
-  ChromieTime: 3
-  Phasing: 0
-  Sharding: 1
-  TimerunningHwt: 4
-  WarMode: 2
+  values:
+    ChromieTime: 3
+    Phasing: 0
+    Sharding: 1
+    TimerunningHwt: 4
+    WarMode: 2
 PhotoSharingStatus:
-  AADCRestricted: 6
-  Configured: 2
-  Disabled: 0
-  Error: 7
-  Expired: 3
-  FailedToClear: 8
-  NotConfigured: 1
-  ParentalControl: 4
-  TrialOrVeteran: 5
+  values:
+    AADCRestricted: 6
+    Configured: 2
+    Disabled: 0
+    Error: 7
+    Expired: 3
+    FailedToClear: 8
+    NotConfigured: 1
+    ParentalControl: 4
+    TrialOrVeteran: 5
 PhotoSharingUploadStatus:
-  CreatePageApiCallFailed: 13
-  CreatePageBadRequest: 14
-  CreatePageForbidden: 16
-  CreatePageGenericFailure: 19
-  CreatePageNoBoardIDFound: 20
-  CreatePageNotFound: 17
-  CreatePageTooManyRequests: 18
-  CreatePageUnauthorized: 15
-  CreatePostApiCallFailed: 21
-  CreatePostBadRequest: 22
-  CreatePostForbidden: 24
-  CreatePostGenericFailure: 27
-  CreatePostNoIDFound: 28
-  CreatePostNotFound: 25
-  CreatePostThrottled: 29
-  CreatePostTooManyRequests: 26
-  CreatePostUnauthorized: 23
-  Disabled: 0
-  Failed: 1
-  ListPagesApiCallFailed: 4
-  ListPagesBadRequest: 5
-  ListPagesEmptyBoardID: 11
-  ListPagesForbidden: 7
-  ListPagesGenericFailure: 10
-  ListPagesInvalidBookmark: 12
-  ListPagesNotFound: 8
-  ListPagesTooManyRequests: 9
-  ListPagesUnauthorized: 6
-  Locked: 3
-  Success: 2
+  values:
+    CreatePageApiCallFailed: 13
+    CreatePageBadRequest: 14
+    CreatePageForbidden: 16
+    CreatePageGenericFailure: 19
+    CreatePageNoBoardIDFound: 20
+    CreatePageNotFound: 17
+    CreatePageTooManyRequests: 18
+    CreatePageUnauthorized: 15
+    CreatePostApiCallFailed: 21
+    CreatePostBadRequest: 22
+    CreatePostForbidden: 24
+    CreatePostGenericFailure: 27
+    CreatePostNoIDFound: 28
+    CreatePostNotFound: 25
+    CreatePostThrottled: 29
+    CreatePostTooManyRequests: 26
+    CreatePostUnauthorized: 23
+    Disabled: 0
+    Failed: 1
+    ListPagesApiCallFailed: 4
+    ListPagesBadRequest: 5
+    ListPagesEmptyBoardID: 11
+    ListPagesForbidden: 7
+    ListPagesGenericFailure: 10
+    ListPagesInvalidBookmark: 12
+    ListPagesNotFound: 8
+    ListPagesTooManyRequests: 9
+    ListPagesUnauthorized: 6
+    Locked: 3
+    Success: 2
 PingSubjectType:
-  AlertNotThreat: 5
-  AlertThreat: 4
-  Assist: 2
-  Attack: 0
-  OnMyWay: 3
-  Warning: 1
+  values:
+    AlertNotThreat: 5
+    AlertThreat: 4
+    Assist: 2
+    Attack: 0
+    OnMyWay: 3
+    Warning: 1
 PingTextureType:
-  Center: 0
-  Expand: 1
-  Rotation: 2
+  values:
+    Center: 0
+    Expand: 1
+    Rotation: 2
 PingTypeFlags:
-  DefaultPing: 1
+  values:
+    DefaultPing: 1
 PlayerClubRequestStatus:
-  Approved: 4
-  AutoApproved: 2
-  Canceled: 7
-  Declined: 3
-  Joined: 5
-  JoinedAnother: 6
-  None: 0
-  Pending: 1
+  values:
+    Approved: 4
+    AutoApproved: 2
+    Canceled: 7
+    Declined: 3
+    Joined: 5
+    JoinedAnother: 6
+    None: 0
+    Pending: 1
 PlayerCompanionInfoFlags:
-  IgnoreSeasonInScenarios: 1
+  values:
+    IgnoreSeasonInScenarios: 1
 PlayerCurrencyFlags:
-  Incremented: 1
-  Loading: 2
+  values:
+    Incremented: 1
+    Loading: 2
 PlayerCurrencyFlagsDbFlags:
-  IgnoreMaxQtyOnload: 1
-  InBackpack: 4
-  Reuse1: 2
-  Reuse2: 16
-  UnusedInUI: 8
+  values:
+    IgnoreMaxQtyOnload: 1
+    InBackpack: 4
+    Reuse1: 2
+    Reuse2: 16
+    UnusedInUI: 8
 PlayerDataElementType:
-  Float: 1
-  Int: 0
+  values:
+    Float: 1
+    Int: 0
 PlayerInteractionType:
-  AccountBanker: 68
-  AdventureJournal: 54
-  AdventureMap: 28
-  AlliedRaceDetailsGiver: 9
-  AnimaDiversion: 47
-  AreaSpiritHealer: 19
-  ArtifactForge: 38
-  Auctioneer: 21
-  AzeriteForge: 56
-  AzeriteRespec: 42
-  Banker: 8
-  BarbersChoice: 62
-  BattleMaster: 23
-  Binder: 20
-  BlackMarketAuctioneer: 27
-  CharacterBanker: 67
-  ChromieTime: 45
-  ContributionCollector: 41
-  CornerstoneInteraction: 70
-  CovenantPreview: 46
-  CovenantSanctum: 51
-  CreateGuildNeighborhood: 74
-  ForgeMaster: 66
-  GarrArchitect: 30
-  GarrMission: 32
-  GarrRecruitment: 34
-  GarrTalent: 35
-  GarrTradeskill: 31
-  Gossip: 3
-  GuildBanker: 10
-  GuildRename: 76
-  GuildTabardVendor: 14
-  HousingBulletinBoard: 72
-  HousingPedestal: 73
-  IslandQueue: 43
-  Item: 2
-  ItemInteraction: 44
-  ItemUpgrade: 53
-  JailersTowerBuffs: 63
-  LegendaryCrafting: 48
-  LFGDungeon: 25
-  MailInfo: 17
-  MajorFactionRenown: 64
-  Merchant: 5
-  NeighborhoodCharter: 75
-  NewPlayerGuide: 52
-  None: 0
-  ObliterumForge: 39
-  OpenHouseFinder: 78
-  OpenNeighborhoodCharterConfirmation: 77
-  PerksProgramVendor: 57
-  PersonalTabardVendor: 65
-  PetitionVendor: 13
-  PlayerChoice: 37
-  ProfessionRespec: 69
-  Professions: 59
-  ProfessionsCraftingOrder: 58
-  ProfessionsCustomerOrder: 60
-  QuestGiver: 4
-  Registrar: 11
-  RenameNeighborhood: 71
-  Renown: 55
-  ScrappingMachine: 40
-  ShipmentCrafter: 33
-  Soulbind: 50
-  SpecializationMaster: 16
-  SpiritHealer: 18
-  StableMaster: 22
-  TalentMaster: 15
-  TaxiNode: 6
-  TieredEntrance: 79
-  TradePartner: 1
-  Trainer: 7
-  TraitSystem: 61
-  Transmogrifier: 24
-  Trophy: 36
-  Vendor: 12
-  VoidStorageBanker: 26
-  WeeklyRewards: 49
-  WorldMap: 29
+  values:
+    AccountBanker: 68
+    AdventureJournal: 54
+    AdventureMap: 28
+    AlliedRaceDetailsGiver: 9
+    AnimaDiversion: 47
+    AreaSpiritHealer: 19
+    ArtifactForge: 38
+    Auctioneer: 21
+    AzeriteForge: 56
+    AzeriteRespec: 42
+    Banker: 8
+    BarbersChoice: 62
+    BattleMaster: 23
+    Binder: 20
+    BlackMarketAuctioneer: 27
+    CharacterBanker: 67
+    ChromieTime: 45
+    ContributionCollector: 41
+    CornerstoneInteraction: 70
+    CovenantPreview: 46
+    CovenantSanctum: 51
+    CreateGuildNeighborhood: 74
+    ForgeMaster: 66
+    GarrArchitect: 30
+    GarrMission: 32
+    GarrRecruitment: 34
+    GarrTalent: 35
+    GarrTradeskill: 31
+    Gossip: 3
+    GuildBanker: 10
+    GuildRename: 76
+    GuildTabardVendor: 14
+    HousingBulletinBoard: 72
+    HousingPedestal: 73
+    IslandQueue: 43
+    Item: 2
+    ItemInteraction: 44
+    ItemUpgrade: 53
+    JailersTowerBuffs: 63
+    LegendaryCrafting: 48
+    LFGDungeon: 25
+    MailInfo: 17
+    MajorFactionRenown: 64
+    Merchant: 5
+    NeighborhoodCharter: 75
+    NewPlayerGuide: 52
+    None: 0
+    ObliterumForge: 39
+    OpenHouseFinder: 78
+    OpenNeighborhoodCharterConfirmation: 77
+    PerksProgramVendor: 57
+    PersonalTabardVendor: 65
+    PetitionVendor: 13
+    PlayerChoice: 37
+    ProfessionRespec: 69
+    Professions: 59
+    ProfessionsCraftingOrder: 58
+    ProfessionsCustomerOrder: 60
+    QuestGiver: 4
+    Registrar: 11
+    RenameNeighborhood: 71
+    Renown: 55
+    ScrappingMachine: 40
+    ShipmentCrafter: 33
+    Soulbind: 50
+    SpecializationMaster: 16
+    SpiritHealer: 18
+    StableMaster: 22
+    TalentMaster: 15
+    TaxiNode: 6
+    TieredEntrance: 79
+    TradePartner: 1
+    Trainer: 7
+    TraitSystem: 61
+    Transmogrifier: 24
+    Trophy: 36
+    Vendor: 12
+    VoidStorageBanker: 26
+    WeeklyRewards: 49
+    WorldMap: 29
 PlayerMentorshipApplicationResult:
-  AlreadyMentor: 1
-  Ineligible: 2
-  Success: 0
+  values:
+    AlreadyMentor: 1
+    Ineligible: 2
+    Success: 0
 PlayerMentorshipStatus:
-  Mentor: 2
-  Newcomer: 1
-  None: 0
+  values:
+    Mentor: 2
+    Newcomer: 1
+    None: 0
 PlunderstormQueueState:
-  None: 0
-  Proposed: 2
-  Queued: 1
-  Suspended: 3
+  values:
+    None: 0
+    Proposed: 2
+    Queued: 1
+    Suspended: 3
 PowerType:
-  Alternate: 10
-  AlternateEncounter: 24
-  AlternateMount: 25
-  AlternateQuest: 23
-  ArcaneCharges: 16
-  Balance: 26
-  BurningEmbers: 14
-  Chi: 12
-  ComboPoints: 4
-  DemonicFury: 15
-  Energy: 3
-  Essence: 19
-  Focus: 2
-  Fury: 17
-  Happiness: 27
-  HolyPower: 9
-  Insanity: 13
-  LunarPower: 8
-  Maelstrom: 11
-  Mana: 0
-  Pain: 18
-  Rage: 1
-  RuneBlood: 20
-  RuneChromatic: 29
-  RuneFrost: 21
-  Runes: 5
-  RuneUnholy: 22
-  RunicPower: 6
-  ShadowOrbs: 28
-  SoulShards: 7
+  values:
+    Alternate: 10
+    AlternateEncounter: 24
+    AlternateMount: 25
+    AlternateQuest: 23
+    ArcaneCharges: 16
+    Balance: 26
+    BurningEmbers: 14
+    Chi: 12
+    ComboPoints: 4
+    DemonicFury: 15
+    Energy: 3
+    Essence: 19
+    Focus: 2
+    Fury: 17
+    Happiness: 27
+    HolyPower: 9
+    Insanity: 13
+    LunarPower: 8
+    Maelstrom: 11
+    Mana: 0
+    Pain: 18
+    Rage: 1
+    RuneBlood: 20
+    RuneChromatic: 29
+    RuneFrost: 21
+    Runes: 5
+    RuneUnholy: 22
+    RunicPower: 6
+    ShadowOrbs: 28
+    SoulShards: 7
 PowerTypeSign:
-  Negative: 1
-  None: -1
-  Positive: 0
+  values:
+    Negative: 1
+    None: -1
+    Positive: 0
 PowerTypeSlot:
-  Slot_0: 0
-  Slot_1: 1
-  Slot_2: 2
-  Slot_3: 3
-  Slot_4: 4
-  Slot_5: 5
-  Slot_6: 6
-  Slot_7: 7
-  Slot_8: 8
-  Slot_9: 9
+  values:
+    Slot_0: 0
+    Slot_1: 1
+    Slot_2: 2
+    Slot_3: 3
+    Slot_4: 4
+    Slot_5: 5
+    Slot_6: 6
+    Slot_7: 7
+    Slot_8: 8
+    Slot_9: 9
 PremadeGroupFinderStyle:
-  Disabled: 0
-  Mainline: 1
-  Vanilla: 2
+  values:
+    Disabled: 0
+    Mainline: 1
+    Vanilla: 2
 PreyHuntProgressState:
-  Cold: 0
-  Final: 3
-  Hot: 2
-  Warm: 1
+  values:
+    Cold: 0
+    Final: 3
+    Hot: 2
+    Warm: 1
 ProceduralSpawnInteractionMode:
-  Manipulate: 2
-  None: 0
-  Paint: 1
+  values:
+    Manipulate: 2
+    None: 0
+    Paint: 1
 ProceduralSpawnVolumeChunkFlags:
-  AllSubChunksSet: 1
-  None: 0
+  values:
+    AllSubChunksSet: 1
+    None: 0
 Profession:
-  Alchemy: 3
-  Archaeology: 14
-  Blacksmithing: 1
-  Cooking: 5
-  Enchanting: 9
-  Engineering: 8
-  FirstAid: 0
-  Fishing: 10
-  Herbalism: 4
-  Inscription: 13
-  Jewelcrafting: 12
-  Leatherworking: 2
-  Mining: 6
-  Skinning: 11
-  Tailoring: 7
+  values:
+    Alchemy: 3
+    Archaeology: 14
+    Blacksmithing: 1
+    Cooking: 5
+    Enchanting: 9
+    Engineering: 8
+    FirstAid: 0
+    Fishing: 10
+    Herbalism: 4
+    Inscription: 13
+    Jewelcrafting: 12
+    Leatherworking: 2
+    Mining: 6
+    Skinning: 11
+    Tailoring: 7
 ProfessionActionType:
-  Craft: 0
-  Gather: 1
+  values:
+    Craft: 0
+    Gather: 1
 ProfessionEffect:
-  AccumulateRanksByLabel: 25
-  ConcentrationRefund: 30
-  DecreaseDifficulty: 22
-  IncreaseDifficulty: 23
-  ModConcentration: 27
-  ModCraftCritSize: 20
-  ModCraftExtraQuantity: 18
-  ModCraftingSpeed: 14
-  ModCraftReductionQuantity: 21
-  ModDeftness: 12
-  ModFinesse: 11
-  ModGatherExtraQuantity: 19
-  ModIngenuity: 29
-  ModInspiration: 9
-  ModMulticraft: 15
-  ModPerception: 13
-  ModResourcefulness: 10
-  ModSkillGain: 24
-  ModUnused_1: 16
-  ModUnused_2: 17
-  Skill: 0
-  StatCraftingSpeed: 6
-  StatDeftness: 4
-  StatFinesse: 3
-  StatIngenuity: 26
-  StatInspiration: 1
-  StatMulticraft: 7
-  StatPerception: 5
-  StatResourcefulness: 2
-  Tokenizer: 28
-  UnlockReagentSlot: 8
+  values:
+    AccumulateRanksByLabel: 25
+    ConcentrationRefund: 30
+    DecreaseDifficulty: 22
+    IncreaseDifficulty: 23
+    ModConcentration: 27
+    ModCraftCritSize: 20
+    ModCraftExtraQuantity: 18
+    ModCraftingSpeed: 14
+    ModCraftReductionQuantity: 21
+    ModDeftness: 12
+    ModFinesse: 11
+    ModGatherExtraQuantity: 19
+    ModIngenuity: 29
+    ModInspiration: 9
+    ModMulticraft: 15
+    ModPerception: 13
+    ModResourcefulness: 10
+    ModSkillGain: 24
+    ModUnused_1: 16
+    ModUnused_2: 17
+    Skill: 0
+    StatCraftingSpeed: 6
+    StatDeftness: 4
+    StatFinesse: 3
+    StatIngenuity: 26
+    StatInspiration: 1
+    StatMulticraft: 7
+    StatPerception: 5
+    StatResourcefulness: 2
+    Tokenizer: 28
+    UnlockReagentSlot: 8
 ProfessionRating:
-  CraftingSpeed: 5
-  Deftness: 3
-  Finesse: 2
-  Ingenuity: 7
-  Inspiration: 0
-  Multicraft: 6
-  Perception: 4
-  Resourcefulness: 1
-  Unused_2: 8
+  values:
+    CraftingSpeed: 5
+    Deftness: 3
+    Finesse: 2
+    Ingenuity: 7
+    Inspiration: 0
+    Multicraft: 6
+    Perception: 4
+    Resourcefulness: 1
+    Unused_2: 8
 ProfessionRatingType:
-  Craft: 0
-  Gather: 1
+  values:
+    Craft: 0
+    Gather: 1
 PurchaseEligibility:
-  ExpansionTooHigh: 4
-  ExpansionTooLow: 3
-  MissingRequiredDeliverable: 5
-  Ok: 0
-  Owned: 2
-  PartiallyOwned: 1
+  values:
+    ExpansionTooHigh: 4
+    ExpansionTooLow: 3
+    MissingRequiredDeliverable: 5
+    Ok: 0
+    Owned: 2
+    PartiallyOwned: 1
 PurchaseHouseDisabledReason:
-  CharterLockout: 7
-  GuildLockout: 6
-  MaxHouses: 8
-  NoExpansion: 4
-  NoGameTimeRemaining: 9
-  None: 0
-  NotInvited: 3
-  Reserved: 5
-  WrongFaction: 1
-  WrongGuild: 2
+  values:
+    CharterLockout: 7
+    GuildLockout: 6
+    MaxHouses: 8
+    NoExpansion: 4
+    NoGameTimeRemaining: 9
+    None: 0
+    NotInvited: 3
+    Reserved: 5
+    WrongFaction: 1
+    WrongGuild: 2
 PurchaseResult:
-  ErrorAuthorizingPayment: 37
-  ErrorBattlepayDisabled: 14
-  ErrorBattlepayTemporarilyUnavailable: 13
-  ErrorBattlepayTimeoutMopAndRisk: 11
-  ErrorBattlepayTimeoutValidatePurchase: 56
-  ErrorBattlepayTimeoutValidationHash: 62
-  ErrorBlockedByParentalControls: 33
-  ErrorBuyingProductNotAllowedInGlueScreen: 27
-  ErrorBuyingProductNotAllowedInWorld: 32
-  ErrorCharacterUpgradeOperationInProgress: 51
-  ErrorClientCheckoutCanceledOrFailed: 63
-  ErrorClientCheckoutTimeout: 60
-  ErrorClientDeclined: 4
-  ErrorClientDeclinedChallenge: 41
-  ErrorClientGone: 9
-  ErrorClientRestricted: 66
-  ErrorClientTimeout: 3
-  ErrorClientTimeoutChallenge: 40
-  ErrorCommerceServerDisabled: 48
-  ErrorCouldNotGetValidationHash: 64
-  ErrorCurrencyInvalidInRegion: 12
-  ErrorDistributionObjectAlreadyAssigned: 20
-  ErrorDistributionObjectExpansionBlocked: 45
-  ErrorDistributionObjectInvalidChoice: 35
-  ErrorDistributionObjectInvalidTarget: 42
-  ErrorDistributionObjectNotFound: 19
-  ErrorDistributionObjectTrialBlocked: 44
-  ErrorDistributionObjectWrongGameAccount: 65
-  ErrorFailedOldPurchaseFlow: 59
-  ErrorFailedToCreatePurchaseRecord: 5
-  ErrorFailedToGetPurchaseID: 6
-  ErrorFailedToSaveClientCheckoutStatus: 58
-  ErrorFailedToSaveMopAndRiskResponse: 8
-  ErrorFailedToSaveMopAndRiskStatus: 7
-  ErrorFailedToSavePlaceOrderStatus: 10
-  ErrorFailedToSaveRedeemTokenStatus: 67
-  ErrorFailedToSaveValidatePurchaseResponse: 55
-  ErrorFailedToSaveValidatePurchaseStatus: 54
-  ErrorFailedToSaveValidationHashStatus: 61
-  ErrorFailedToWriteVasLicenseID: 50
-  ErrorFailedToWriteVasPurchaseID: 49
-  ErrorFixedLicenseProductAlreadyExists: 43
-  ErrorInManualReview: 71
-  ErrorInvalidCreditCardExpiryDate: 36
-  ErrorInvalidDeviceID: 53
-  ErrorInvalidPlatform: 52
-  ErrorInvalidProduct: 16
-  ErrorInvalidPurchaseID: 68
-  ErrorInvalidRegionGroupMask: 17
-  ErrorMopAndRiskAmqpRpcFailed: 22
-  ErrorMopAndRiskNotEnoughBalance: 28
-  ErrorMopAndRiskNoValidPaymentMethods: 25
-  ErrorMopAndRiskRpcErrorFromBattlepay: 23
-  ErrorMopAndRiskUnexpectedResponseFromBattlepay: 24
-  ErrorNoStorePurchaseFlagIsSet: 34
-  ErrorOrderCanceledPriceChange: 26
-  ErrorOrderFailed: 2
-  ErrorOverSpendingLimit: 39
-  ErrorOwnsConsumableToken: 46
-  ErrorPaymentProviderDeniedPayment: 38
-  ErrorPlaceOrderNotEnoughBalance: 29
-  ErrorProductInvalidInRegion: 18
-  ErrorProductNotPurchasable: 57
-  ErrorProgrammerManualFail: 30
-  ErrorRiskDenied: 1
-  ErrorRiskResponseMissingScore: 21
-  ErrorServerRestarted: 15
-  ErrorThrottledByUserServer: 31
-  ErrorTokenRedemptionOrderFailed: 69
-  ErrorTooManyTokens: 47
-  ErrorVasTransactionCreateFailed: 70
-  Ok: 0
+  values:
+    ErrorAuthorizingPayment: 37
+    ErrorBattlepayDisabled: 14
+    ErrorBattlepayTemporarilyUnavailable: 13
+    ErrorBattlepayTimeoutMopAndRisk: 11
+    ErrorBattlepayTimeoutValidatePurchase: 56
+    ErrorBattlepayTimeoutValidationHash: 62
+    ErrorBlockedByParentalControls: 33
+    ErrorBuyingProductNotAllowedInGlueScreen: 27
+    ErrorBuyingProductNotAllowedInWorld: 32
+    ErrorCharacterUpgradeOperationInProgress: 51
+    ErrorClientCheckoutCanceledOrFailed: 63
+    ErrorClientCheckoutTimeout: 60
+    ErrorClientDeclined: 4
+    ErrorClientDeclinedChallenge: 41
+    ErrorClientGone: 9
+    ErrorClientRestricted: 66
+    ErrorClientTimeout: 3
+    ErrorClientTimeoutChallenge: 40
+    ErrorCommerceServerDisabled: 48
+    ErrorCouldNotGetValidationHash: 64
+    ErrorCurrencyInvalidInRegion: 12
+    ErrorDistributionObjectAlreadyAssigned: 20
+    ErrorDistributionObjectExpansionBlocked: 45
+    ErrorDistributionObjectInvalidChoice: 35
+    ErrorDistributionObjectInvalidTarget: 42
+    ErrorDistributionObjectNotFound: 19
+    ErrorDistributionObjectTrialBlocked: 44
+    ErrorDistributionObjectWrongGameAccount: 65
+    ErrorFailedOldPurchaseFlow: 59
+    ErrorFailedToCreatePurchaseRecord: 5
+    ErrorFailedToGetPurchaseID: 6
+    ErrorFailedToSaveClientCheckoutStatus: 58
+    ErrorFailedToSaveMopAndRiskResponse: 8
+    ErrorFailedToSaveMopAndRiskStatus: 7
+    ErrorFailedToSavePlaceOrderStatus: 10
+    ErrorFailedToSaveRedeemTokenStatus: 67
+    ErrorFailedToSaveValidatePurchaseResponse: 55
+    ErrorFailedToSaveValidatePurchaseStatus: 54
+    ErrorFailedToSaveValidationHashStatus: 61
+    ErrorFailedToWriteVasLicenseID: 50
+    ErrorFailedToWriteVasPurchaseID: 49
+    ErrorFixedLicenseProductAlreadyExists: 43
+    ErrorInManualReview: 71
+    ErrorInvalidCreditCardExpiryDate: 36
+    ErrorInvalidDeviceID: 53
+    ErrorInvalidPlatform: 52
+    ErrorInvalidProduct: 16
+    ErrorInvalidPurchaseID: 68
+    ErrorInvalidRegionGroupMask: 17
+    ErrorMopAndRiskAmqpRpcFailed: 22
+    ErrorMopAndRiskNotEnoughBalance: 28
+    ErrorMopAndRiskNoValidPaymentMethods: 25
+    ErrorMopAndRiskRpcErrorFromBattlepay: 23
+    ErrorMopAndRiskUnexpectedResponseFromBattlepay: 24
+    ErrorNoStorePurchaseFlagIsSet: 34
+    ErrorOrderCanceledPriceChange: 26
+    ErrorOrderFailed: 2
+    ErrorOverSpendingLimit: 39
+    ErrorOwnsConsumableToken: 46
+    ErrorPaymentProviderDeniedPayment: 38
+    ErrorPlaceOrderNotEnoughBalance: 29
+    ErrorProductInvalidInRegion: 18
+    ErrorProductNotPurchasable: 57
+    ErrorProgrammerManualFail: 30
+    ErrorRiskDenied: 1
+    ErrorRiskResponseMissingScore: 21
+    ErrorServerRestarted: 15
+    ErrorThrottledByUserServer: 31
+    ErrorTokenRedemptionOrderFailed: 69
+    ErrorTooManyTokens: 47
+    ErrorVasTransactionCreateFailed: 70
+    Ok: 0
 PvPFaction:
-  Alliance: 1
-  Horde: 0
+  values:
+    Alliance: 1
+    Horde: 0
 PvPMatchmakingType:
-  Arena: 1
-  Battleground: 0
+  values:
+    Arena: 1
+    Battleground: 0
 PvPMatchState:
-  Complete: 5
-  Engaged: 3
-  Inactive: 0
-  PostRound: 4
-  StartUp: 2
-  Waiting: 1
+  values:
+    Complete: 5
+    Engaged: 3
+    Inactive: 0
+    PostRound: 4
+    StartUp: 2
+    Waiting: 1
 PvPRanks:
-  Rank_1: 5
-  Rank_10: 14
-  Rank_11: 15
-  Rank_12: 16
-  Rank_13: 17
-  Rank_14: 18
-  Rank_2: 6
-  Rank_3: 7
-  Rank_4: 8
-  Rank_5: 9
-  Rank_6: 10
-  Rank_7: 11
-  Rank_8: 12
-  Rank_9: 13
-  RankDishonored: 4
-  RankExiled: 3
-  RankNone: 0
-  RankOutlaw: 2
-  RankPariah: 1
+  values:
+    Rank_1: 5
+    Rank_10: 14
+    Rank_11: 15
+    Rank_12: 16
+    Rank_13: 17
+    Rank_14: 18
+    Rank_2: 6
+    Rank_3: 7
+    Rank_4: 8
+    Rank_5: 9
+    Rank_6: 10
+    Rank_7: 11
+    Rank_8: 12
+    Rank_9: 13
+    RankDishonored: 4
+    RankExiled: 3
+    RankNone: 0
+    RankOutlaw: 2
+    RankPariah: 1
 PvPUnitClassification:
-  AssassinAlliance: 6
-  AssassinHorde: 5
-  CartRunnerAlliance: 4
-  CartRunnerHorde: 3
-  FlagCarrierAlliance: 1
-  FlagCarrierHorde: 0
-  FlagCarrierNeutral: 2
-  OrbCarrierBlue: 7
-  OrbCarrierGreen: 8
-  OrbCarrierOrange: 9
-  OrbCarrierPurple: 10
+  values:
+    AssassinAlliance: 6
+    AssassinHorde: 5
+    CartRunnerAlliance: 4
+    CartRunnerHorde: 3
+    FlagCarrierAlliance: 1
+    FlagCarrierHorde: 0
+    FlagCarrierNeutral: 2
+    OrbCarrierBlue: 7
+    OrbCarrierGreen: 8
+    OrbCarrierOrange: 9
+    OrbCarrierPurple: 10
 QuestClassification:
-  BonusObjective: 8
-  Calling: 3
-  Campaign: 2
-  Important: 0
-  Legendary: 1
-  Meta: 4
-  Normal: 7
-  Questline: 6
-  Recurring: 5
-  Threat: 9
-  WorldQuest: 10
+  values:
+    BonusObjective: 8
+    Calling: 3
+    Campaign: 2
+    Important: 0
+    Legendary: 1
+    Meta: 4
+    Normal: 7
+    Questline: 6
+    Recurring: 5
+    Threat: 9
+    WorldQuest: 10
 QuestCompleteSpellType:
-  Ability: 3
-  Aura: 4
-  Companion: 7
-  Follower: 1
-  LegacyBehavior: 0
-  PossibleReward: 11
-  QuestlineReward: 9
-  QuestlineUnlock: 8
-  QuestlineUnlockPart: 10
-  Spell: 5
-  Tradeskill: 2
-  Unlock: 6
+  values:
+    Ability: 3
+    Aura: 4
+    Companion: 7
+    Follower: 1
+    LegacyBehavior: 0
+    PossibleReward: 11
+    QuestlineReward: 9
+    QuestlineUnlock: 8
+    QuestlineUnlockPart: 10
+    Spell: 5
+    Tradeskill: 2
+    Unlock: 6
 QuestFrequency:
-  Daily: 1
-  Default: 0
-  ResetByScheduler: 3
-  Weekly: 2
+  values:
+    Daily: 1
+    Default: 0
+    ResetByScheduler: 3
+    Weekly: 2
 QuestLineFloorLocation:
-  Above: 0
-  Below: 1
-  Same: 2
+  values:
+    Above: 0
+    Below: 1
+    Same: 2
 QuestRepeatability:
-  Daily: 1
-  None: 0
-  Turnin: 3
-  Weekly: 2
-  World: 4
+  values:
+    Daily: 1
+    None: 0
+    Turnin: 3
+    Weekly: 2
+    World: 4
 QuestRewardContextFlags:
-  FirstCompletionBonus: 1
-  None: 0
-  RepeatCompletionBonus: 2
+  values:
+    FirstCompletionBonus: 1
+    None: 0
+    RepeatCompletionBonus: 2
 QuestSessionCommand:
-  None: 0
-  SessionActiveNoCommand: 3
-  Start: 1
-  Stop: 2
+  values:
+    None: 0
+    SessionActiveNoCommand: 3
+    Start: 1
+    Stop: 2
 QuestSessionResult:
-  AlreadyActive: 3
-  AlreadyJoined: 20
-  AlreadyMember: 17
-  AlreadyOwner: 19
-  Busy: 22
-  Disabled: 8
-  Empty: 25
-  InCombat: 32
-  InPetBattle: 29
-  InRaid: 5
-  InvalidOwner: 2
-  InvalidPublicParty: 30
-  Joined: 11
-  JoinRejected: 23
-  Left: 12
-  Logout: 24
-  MemberInCombat: 33
-  MemberTimeout: 16
-  NotActive: 4
-  NotInParty: 1
-  NotMember: 21
-  NotOwner: 18
-  Ok: 0
-  OwnerLeft: 13
-  OwnerRefused: 6
-  PartyDestroyed: 15
-  QuestNotCompleted: 26
-  ReadyCheckFailed: 14
-  Restricted: 28
-  RestrictedCrossFaction: 34
-  Resync: 27
-  Started: 9
-  Stopped: 10
-  Timeout: 7
-  Unknown: 31
+  values:
+    AlreadyActive: 3
+    AlreadyJoined: 20
+    AlreadyMember: 17
+    AlreadyOwner: 19
+    Busy: 22
+    Disabled: 8
+    Empty: 25
+    InCombat: 32
+    InPetBattle: 29
+    InRaid: 5
+    InvalidOwner: 2
+    InvalidPublicParty: 30
+    Joined: 11
+    JoinRejected: 23
+    Left: 12
+    Logout: 24
+    MemberInCombat: 33
+    MemberTimeout: 16
+    NotActive: 4
+    NotInParty: 1
+    NotMember: 21
+    NotOwner: 18
+    Ok: 0
+    OwnerLeft: 13
+    OwnerRefused: 6
+    PartyDestroyed: 15
+    QuestNotCompleted: 26
+    ReadyCheckFailed: 14
+    Restricted: 28
+    RestrictedCrossFaction: 34
+    Resync: 27
+    Started: 9
+    Stopped: 10
+    Timeout: 7
+    Unknown: 31
 QuestTag:
-  Account: 102
-  Delve: 288
-  Dungeon: 81
-  Group: 1
-  Heroic: 85
-  Legendary: 83
-  PvP: 41
-  Raid: 62
-  Raid10: 88
-  Raid25: 89
-  Scenario: 98
+  values:
+    Account: 102
+    Delve: 288
+    Dungeon: 81
+    Group: 1
+    Heroic: 85
+    Legendary: 83
+    PvP: 41
+    Raid: 62
+    Raid10: 88
+    Raid25: 89
+    Scenario: 98
 QuestTagType:
-  Bounty: 5
-  Capstone: 17
-  Contribution: 9
-  CovenantCalling: 15
-  DragonRiderRacing: 16
-  Dungeon: 6
-  FactionAssault: 12
-  Invasion: 7
-  InvasionWrapper: 11
-  Islands: 13
-  Normal: 2
-  PetBattle: 4
-  Prey: 19
-  Profession: 1
-  PvP: 3
-  Raid: 8
-  RatedReward: 10
-  Tag: 0
-  Threat: 14
-  WorldBoss: 18
+  values:
+    Bounty: 5
+    Capstone: 17
+    Contribution: 9
+    CovenantCalling: 15
+    DragonRiderRacing: 16
+    Dungeon: 6
+    FactionAssault: 12
+    Invasion: 7
+    InvasionWrapper: 11
+    Islands: 13
+    Normal: 2
+    PetBattle: 4
+    Prey: 19
+    Profession: 1
+    PvP: 3
+    Raid: 8
+    RatedReward: 10
+    Tag: 0
+    Threat: 14
+    WorldBoss: 18
 QuestTreasurePickerType:
-  Hidden: 1
-  Select: 2
-  Visible: 0
+  values:
+    Hidden: 1
+    Select: 2
+    Visible: 0
 RafLinkType:
-  Both: 3
-  Friend: 2
-  None: 0
-  Recruit: 1
+  values:
+    Both: 3
+    Friend: 2
+    None: 0
+    Recruit: 1
 RafRecruitActivityState:
-  Complete: 1
-  Incomplete: 0
-  RewardClaimed: 2
+  values:
+    Complete: 1
+    Incomplete: 0
+    RewardClaimed: 2
 RafRecruitSubStatus:
-  Active: 1
-  Inactive: 2
-  Trial: 0
+  values:
+    Active: 1
+    Inactive: 2
+    Trial: 0
 RafRewardType:
-  Appearance: 2
-  AppearanceSet: 5
-  GameTime: 4
-  Illusion: 6
-  Invalid: 7
-  Mount: 1
-  Pet: 0
-  Title: 3
+  values:
+    Appearance: 2
+    AppearanceSet: 5
+    GameTime: 4
+    Illusion: 6
+    Invalid: 7
+    Mount: 1
+    Pet: 0
+    Title: 3
 RaidAuraOrganizationType:
-  BuffsRightDebuffsLeft: 2
-  BuffsTopDebuffsBottom: 1
-  Legacy: 0
+  values:
+    BuffsRightDebuffsLeft: 2
+    BuffsTopDebuffsBottom: 1
+    Legacy: 0
 RaidDispelDisplayType:
-  Disabled: 0
-  DispellableByMe: 1
-  DisplayAll: 2
+  values:
+    Disabled: 0
+    DispellableByMe: 1
+    DisplayAll: 2
 RaidGroupDisplayType:
-  CombineGroupsHorizontal: 3
-  CombineGroupsVertical: 2
-  SeparateGroupsHorizontal: 1
-  SeparateGroupsVertical: 0
+  values:
+    CombineGroupsHorizontal: 3
+    CombineGroupsVertical: 2
+    SeparateGroupsHorizontal: 1
+    SeparateGroupsVertical: 0
 RcoCloseReason:
-  Cancel: 2
-  CrafterFulfill: 5
-  Expire: 1
-  Fulfill: 0
-  GmCancel: 4
-  Invalid: 6
-  Reject: 3
+  values:
+    Cancel: 2
+    CrafterFulfill: 5
+    Expire: 1
+    Fulfill: 0
+    GmCancel: 4
+    Invalid: 6
+    Reject: 3
 RecentAllyPinResult:
-  ServerError: 1
-  Success: 0
+  values:
+    ServerError: 1
+    Success: 0
 RecruitAFriendRewardsVersion:
-  InvalidVersion: 0
-  UnusedVersionOne: 1
-  VersionThree: 3
-  VersionTwo: 2
+  values:
+    InvalidVersion: 0
+    UnusedVersionOne: 1
+    VersionThree: 3
+    VersionTwo: 2
 ReforgeFailedReason:
-  None: 0
-  ReforgeAlreadyHasDstStat: 3
-  ReforgeInsufficientSrcStat: 2
-  ReforgeItemTooLowLevel: 4
-  ReforgeSrcStatNotFound: 1
+  values:
+    None: 0
+    ReforgeAlreadyHasDstStat: 3
+    ReforgeInsufficientSrcStat: 2
+    ReforgeItemTooLowLevel: 4
+    ReforgeSrcStatNotFound: 1
 RegisterAddonMessagePrefixResult:
-  DuplicatePrefix: 1
-  InvalidPrefix: 2
-  MaxPrefixes: 3
-  Success: 0
+  values:
+    DuplicatePrefix: 1
+    InvalidPrefix: 2
+    MaxPrefixes: 3
+    Success: 0
 RelativeContentDifficulty:
-  Difficult: 3
-  Easy: 1
-  Fair: 2
-  Impossible: 4
-  Trivial: 0
+  values:
+    Difficult: 3
+    Easy: 1
+    Fair: 2
+    Impossible: 4
+    Trivial: 0
 ReleaseType:
-  Classic: 2
-  Original: 1
+  values:
+    Classic: 2
+    Original: 1
 RenownRewardDisplayType:
-  Currency: 9
-  GarrFollower: 8
-  Item: 1
-  Mount: 3
-  None: 0
-  Spell: 2
-  Title: 7
-  Transmog: 4
-  TransmogIllusion: 6
-  TransmogSet: 5
+  values:
+    Currency: 9
+    GarrFollower: 8
+    Item: 1
+    Mount: 3
+    None: 0
+    Spell: 2
+    Title: 7
+    Transmog: 4
+    TransmogIllusion: 6
+    TransmogSet: 5
 RenownRewardsFlags:
-  AccountUnlock: 8
-  Capstone: 2
-  Hidden: 4
-  Milestone: 1
+  values:
+    AccountUnlock: 8
+    Capstone: 2
+    Hidden: 4
+    Milestone: 1
 ReportEvidenceType:
-  HouseLayoutJson: 2
-  HouseScreenshot: 1
-  Invalid: 0
+  values:
+    HouseLayoutJson: 2
+    HouseScreenshot: 1
+    Invalid: 0
 ReportMajorCategory:
-  Cheating: 2
-  GameplaySabotage: 1
-  InappropriateCommunication: 0
-  InappropriateDecor: 4
-  InappropriateName: 3
+  values:
+    Cheating: 2
+    GameplaySabotage: 1
+    InappropriateCommunication: 0
+    InappropriateDecor: 4
+    InappropriateName: 3
 ReportMinorCategory:
-  Advertisement: 256
-  Afk: 8
-  BlockingProgress: 32
-  Boosting: 2
-  Botting: 128
-  BTag: 512
-  CharacterName: 2048
-  ChildSexualExploitationAndAbuse: 262144
-  Description: 8192
-  Disruption: 65536
-  GroupName: 1024
-  GuildName: 4096
-  Hacking: 64
-  HarmfulToMinors: 32768
-  IntentionallyFeeding: 16
-  Name: 16384
-  NeighborhoodName: 524288
-  Spam: 4
-  TerroristAndViolentExtremistContent: 131072
-  TextChat: 1
+  values:
+    Advertisement: 256
+    Afk: 8
+    BlockingProgress: 32
+    Boosting: 2
+    Botting: 128
+    BTag: 512
+    CharacterName: 2048
+    ChildSexualExploitationAndAbuse: 262144
+    Description: 8192
+    Disruption: 65536
+    GroupName: 1024
+    GuildName: 4096
+    Hacking: 64
+    HarmfulToMinors: 32768
+    IntentionallyFeeding: 16
+    Name: 16384
+    NeighborhoodName: 524288
+    Spam: 4
+    TerroristAndViolentExtremistContent: 131072
+    TextChat: 1
 ReportSubComplaintTypes:
-  Advertising: 1
-  Inappropriate: 0
+  values:
+    Advertising: 1
+    Inappropriate: 0
 ReportThrottleType:
-  Expensive: 2
-  General: 1
-  Invalid: 0
+  values:
+    Expensive: 2
+    General: 1
+    Invalid: 0
 ReportType:
-  BattlePet: 10
-  Calendar: 11
-  Chat: 0
-  ClubFinderApplicant: 3
-  ClubFinderPosting: 2
-  ClubMember: 6
-  CraftingOrder: 16
-  Friend: 8
-  GroupFinderApplicant: 5
-  GroupFinderPosting: 4
-  GroupMember: 7
-  HousingDecor: 18
-  InWorld: 1
-  Mail: 12
-  Neighborhood: 19
-  NeighborhoodRoster: 20
-  Pet: 9
-  PvP: 13
-  PvPGroupMember: 15
-  PvPScoreboard: 14
-  RecentAlly: 17
+  values:
+    BattlePet: 10
+    Calendar: 11
+    Chat: 0
+    ClubFinderApplicant: 3
+    ClubFinderPosting: 2
+    ClubMember: 6
+    CraftingOrder: 16
+    Friend: 8
+    GroupFinderApplicant: 5
+    GroupFinderPosting: 4
+    GroupMember: 7
+    HousingDecor: 18
+    InWorld: 1
+    Mail: 12
+    Neighborhood: 19
+    NeighborhoodRoster: 20
+    Pet: 9
+    PvP: 13
+    PvPGroupMember: 15
+    PvPScoreboard: 14
+    RecentAlly: 17
 ReservationFlags:
-  Canceled: 2
-  None: 0
-  Plotless: 4
-  Relinquish: 1
+  values:
+    Canceled: 2
+    None: 0
+    Plotless: 4
+    Relinquish: 1
 ResidentType:
-  Manager: 1
-  Owner: 2
-  Resident: 0
+  values:
+    Manager: 1
+    Owner: 2
+    Resident: 0
 RestrictPingsTo:
-  Assist: 2
-  Lead: 1
-  None: 0
-  TankHealer: 3
+  values:
+    Assist: 2
+    Lead: 1
+    None: 0
+    TankHealer: 3
 RetroactiveDecorRewardFlags:
-  AllCriteriaRequired: 1
-  None: 0
+  values:
+    AllCriteriaRequired: 1
+    None: 0
 RolodexContextLevelType:
-  DelveTier: 3
-  Difficulty: 1
-  KeystoneLevel: 2
-  None: 0
+  values:
+    DelveTier: 3
+    Difficulty: 1
+    KeystoneLevel: 2
+    None: 0
 RolodexType:
-  CompleteArena: 16
-  CompleteBg: 17
-  CompleteDelve: 15
-  CompleteDungeon: 12
-  CreatureKill: 11
-  Duel: 18
-  GuildOrderFilledByOther: 9
-  GuildOrderFilledByYou: 10
-  KillLfrBoss: 14
-  KillRaidBoss: 13
-  None: 0
-  PartyMember: 1
-  PersonalOrderFilledByOther: 7
-  PersonalOrderFilledByYou: 8
-  PetBattle: 19
-  PublicOrderFilledByOther: 5
-  PublicOrderFilledByYou: 6
-  PvPKill: 20
-  RaidMember: 2
-  Trade: 3
-  Whisper: 4
+  values:
+    CompleteArena: 16
+    CompleteBg: 17
+    CompleteDelve: 15
+    CompleteDungeon: 12
+    CreatureKill: 11
+    Duel: 18
+    GuildOrderFilledByOther: 9
+    GuildOrderFilledByYou: 10
+    KillLfrBoss: 14
+    KillRaidBoss: 13
+    None: 0
+    PartyMember: 1
+    PersonalOrderFilledByOther: 7
+    PersonalOrderFilledByYou: 8
+    PetBattle: 19
+    PublicOrderFilledByOther: 5
+    PublicOrderFilledByYou: 6
+    PvPKill: 20
+    RaidMember: 2
+    Trade: 3
+    Whisper: 4
 RolodexTypeFlags:
-  HiddenFromHistory: 1
-  None: 0
+  values:
+    HiddenFromHistory: 1
+    None: 0
 RoomConnectionType:
-  All: 1
-  None: 0
+  values:
+    All: 1
+    None: 0
 ScalingArmorType:
-  Cloth: 0
-  Leather: 1
-  Mail: 2
-  Plate: 3
+  values:
+    Cloth: 0
+    Leather: 1
+    Mail: 2
+    Plate: 3
 ScreenLocationType:
-  Bottom: 4
-  Center: 0
-  Left: 1
-  LeftOutside: 7
-  LeftRight: 9
-  LeftRightOutside: 11
-  Right: 2
-  RightOutside: 8
-  Top: 3
-  TopBottom: 10
-  TopLeft: 5
-  TopRight: 6
+  values:
+    Bottom: 4
+    Center: 0
+    Left: 1
+    LeftOutside: 7
+    LeftRight: 9
+    LeftRightOutside: 11
+    Right: 2
+    RightOutside: 8
+    Top: 3
+    TopBottom: 10
+    TopLeft: 5
+    TopRight: 6
 ScreenshotSource:
-  Automatic: 0
-  Cheat: 2
-  PlayerReport: 1
+  values:
+    Automatic: 0
+    Cheat: 2
+    PlayerReport: 1
 ScriptedAnimationBehavior:
-  None: 0
-  SourceCollideWithTarget: 4
-  SourceRecoil: 3
-  TargetKnockBack: 2
-  TargetShake: 1
-  UIParentShake: 5
+  values:
+    None: 0
+    SourceCollideWithTarget: 4
+    SourceRecoil: 3
+    TargetKnockBack: 2
+    TargetShake: 1
+    UIParentShake: 5
 ScriptedAnimationFlags:
-  UseTargetAsSource: 1
+  values:
+    UseTargetAsSource: 1
 ScriptedAnimationTrajectory:
-  AtSource: 0
-  AtTarget: 1
-  CurveLeft: 3
-  CurveRandom: 5
-  CurveRight: 4
-  HalfwayBetween: 6
-  Straight: 2
+  values:
+    AtSource: 0
+    AtTarget: 1
+    CurveLeft: 3
+    CurveRandom: 5
+    CurveRight: 4
+    HalfwayBetween: 6
+    Straight: 2
 ScrubStringFlags:
-  AllowBarCodes: 2
-  None: 0
-  StripControlCodes: 4
-  TruncateNewLines: 1
+  values:
+    AllowBarCodes: 2
+    None: 0
+    StripControlCodes: 4
+    TruncateNewLines: 1
 SeasonID:
-  Fresh: 11
-  FreshHardcore: 12
-  Hardcore: 3
-  NoSeason: 0
-  SeasonOfDiscovery: 2
-  SeasonOfMastery: 1
+  values:
+    Fresh: 11
+    FreshHardcore: 12
+    Hardcore: 3
+    NoSeason: 0
+    SeasonOfDiscovery: 2
+    SeasonOfMastery: 1
 SecondsFormatterAbbreviation:
-  None: 0
-  OneLetter: 2
-  Truncate: 1
+  values:
+    None: 0
+    OneLetter: 2
+    Truncate: 1
 SecondsFormatterInterval:
-  Days: 3
-  Hours: 2
-  Minutes: 1
-  Seconds: 0
+  values:
+    Days: 3
+    Hours: 2
+    Minutes: 1
+    Seconds: 0
 SecondsFormatterIntervalWhitespace:
-  Preserve: 0
-  Strip: 1
-  StripIgnoreLocale: 2
+  values:
+    Preserve: 0
+    Strip: 1
+    StripIgnoreLocale: 2
 SecrecyLevel:
-  AlwaysSecret: 1
-  ContextuallySecret: 2
-  NeverSecret: 0
+  values:
+    AlwaysSecret: 1
+    ContextuallySecret: 2
+    NeverSecret: 0
 SecretAspect:
-  Alpha: 128
-  Attributes: 1
-  BarValue: 16384
-  ButtonState: 2097152
-  Cooldown: 32768
-  CooldownStyle: 524288
-  Cursor: 1024
-  Desaturation: 4096
-  FrameLevel: 256
-  Hierarchy: 1
-  ID: 2
-  MinimumWidth: 131072
-  ObjectDebug: 1
-  ObjectName: 1
-  ObjectSecrets: 1
-  ObjectSecurity: 1
-  ObjectType: 1
-  Padding: 262144
-  Rotation: 65536
-  Scale: 64
-  ScrollOffset: 4194304
-  ScrollRange: 512
-  SecureText: 16
-  Shown: 32
-  TexCoords: 8192
-  Text: 8
-  TooltipTexture: 1048576
-  Toplevel: 4
-  VertexColor: 2048
+  values:
+    Alpha: 128
+    Attributes: 1
+    BarValue: 16384
+    ButtonState: 2097152
+    Cooldown: 32768
+    CooldownStyle: 524288
+    Cursor: 1024
+    Desaturation: 4096
+    FrameLevel: 256
+    Hierarchy: 1
+    ID: 2
+    MinimumWidth: 131072
+    ObjectDebug: 1
+    ObjectName: 1
+    ObjectSecrets: 1
+    ObjectSecurity: 1
+    ObjectType: 1
+    Padding: 262144
+    Rotation: 65536
+    Scale: 64
+    ScrollOffset: 4194304
+    ScrollRange: 512
+    SecureText: 16
+    Shown: 32
+    TexCoords: 8192
+    Text: 8
+    TooltipTexture: 1048576
+    Toplevel: 4
+    VertexColor: 2048
 SelfResurrectOptionType:
-  Item: 1
-  Spell: 0
+  values:
+    Item: 1
+    Spell: 0
 SendAddonMessageResult:
-  AddOnMessageLockdown: 11
-  AddonMessageThrottle: 3
-  ChannelThrottle: 8
-  GeneralError: 9
-  InvalidChannel: 7
-  InvalidChatType: 4
-  InvalidMessage: 2
-  InvalidPrefix: 1
-  NotInGroup: 5
-  NotInGuild: 10
-  Success: 0
-  TargetOffline: 12
-  TargetRequired: 6
+  values:
+    AddOnMessageLockdown: 11
+    AddonMessageThrottle: 3
+    ChannelThrottle: 8
+    GeneralError: 9
+    InvalidChannel: 7
+    InvalidChatType: 4
+    InvalidMessage: 2
+    InvalidPrefix: 1
+    NotInGroup: 5
+    NotInGuild: 10
+    Success: 0
+    TargetOffline: 12
+    TargetRequired: 6
 SendReportResult:
-  GeneralError: 1
-  RequiresChatLine: 3
-  RequiresChatLineOrVoice: 4
-  RequiresScreenshot: 5
-  Success: 0
-  TooManyReports: 2
+  values:
+    GeneralError: 1
+    RequiresChatLine: 3
+    RequiresChatLineOrVoice: 4
+    RequiresScreenshot: 5
+    Success: 0
+    TooManyReports: 2
 SharedStringFlag:
-  InternalOnly: 1
+  values:
+    InternalOnly: 1
 ShutdownSessionReason:
-  AccountLoginCommand: 4
-  Error: 6
-  ForceLogoutCommand: 2
-  LuaScript: 5
-  RealmSelectCommand: 3
-  RestartSessionCommand: 1
-  SessionEnded: 0
+  values:
+    AccountLoginCommand: 4
+    Error: 6
+    ForceLogoutCommand: 2
+    LuaScript: 5
+    RealmSelectCommand: 3
+    RestartSessionCommand: 1
+    SessionEnded: 0
 Siflag:
-  Affectedbyaltitude: 16
-  Affectedbysanity: 2048
-  AutocreatedByBroadcastText: 4
-  CasterOwnsTargetSound: 128
-  Disablepositionallpf: 1
-  Dontplayindoors: 256
-  Dontplayunderwater: 1024
-  Dontstopondeath: 4096
-  Ignoresuppressors: 64
-  Ignorevopriority: 16384
-  Looping: 512
-  Noduplicates: 32
-  None: 0
-  Onlyplayindoors: 32768
-  Onlyplayunderwater: 65536
-  Playonlyforowner: 8192
-  Playsequential: 8
-  UseModCastSpeed: 2
+  values:
+    Affectedbyaltitude: 16
+    Affectedbysanity: 2048
+    AutocreatedByBroadcastText: 4
+    CasterOwnsTargetSound: 128
+    Disablepositionallpf: 1
+    Dontplayindoors: 256
+    Dontplayunderwater: 1024
+    Dontstopondeath: 4096
+    Ignoresuppressors: 64
+    Ignorevopriority: 16384
+    Looping: 512
+    Noduplicates: 32
+    None: 0
+    Onlyplayindoors: 32768
+    Onlyplayunderwater: 65536
+    Playonlyforowner: 8192
+    Playsequential: 8
+    UseModCastSpeed: 2
 SimpleOrderStatus:
-  Creating: 1
-  Failed: 4
-  InProgress: 2
-  Invalid: 0
-  Success: 3
+  values:
+    Creating: 1
+    Failed: 4
+    InProgress: 2
+    Invalid: 0
+    Success: 3
 SleevesGeoRange:
-  Default: 1
-  Flared: 2
-  None: 0
-  PandaCollar: 4
-  Puffy: 3
+  values:
+    Default: 1
+    Flared: 2
+    None: 0
+    PandaCollar: 4
+    Puffy: 3
 SlotRegion:
-  AccountBank: 5
-  CharacterBank: 4
-  Invalid: 0
-  PlayerBags: 2
-  PlayerEquip: 1
-  PlayerInv: 3
+  values:
+    AccountBank: 5
+    CharacterBank: 4
+    Invalid: 0
+    PlayerBags: 2
+    PlayerEquip: 1
+    PlayerInv: 3
 SlotRegionMask:
-  AccountBank: 64
-  CharacterBank: 16
-  Invalid: 1
-  PlayerBags: 4
-  PlayerEquip: 2
-  PlayerInv: 8
+  values:
+    AccountBank: 64
+    CharacterBank: 16
+    Invalid: 1
+    PlayerBags: 4
+    PlayerEquip: 2
+    PlayerInv: 8
 SocialWhoOrigin:
-  Chat: 2
-  Item: 3
-  Social: 1
-  Unknown: 0
+  values:
+    Chat: 2
+    Item: 3
+    Social: 1
+    Unknown: 0
 SoftTargetEnableFlags:
-  Any: 3
-  Gamepad: 1
-  Kbm: 2
-  None: 0
+  values:
+    Any: 3
+    Gamepad: 1
+    Kbm: 2
+    None: 0
 SortPlayersBy:
-  Alphabetical: 2
-  Group: 1
-  Role: 0
+  values:
+    Alphabetical: 2
+    Group: 1
+    Role: 0
 SoundBusFlag:
-  Disablepositionallpf: 1
+  values:
+    Disablepositionallpf: 1
 SpecializationSystem:
-  ChrSpecialization: 1
-  TalentTab: 0
+  values:
+    ChrSpecialization: 1
+    TalentTab: 0
 SpellAuraVisibilityType:
-  EnemyTarget: 2
-  RaidInCombat: 0
-  RaidOutOfCombat: 1
+  values:
+    EnemyTarget: 2
+    RaidInCombat: 0
+    RaidOutOfCombat: 1
 SpellBookItemType:
-  Flyout: 4
-  FutureSpell: 2
-  None: 0
-  PetAction: 3
-  Spell: 1
+  values:
+    Flyout: 4
+    FutureSpell: 2
+    None: 0
+    PetAction: 3
+    Spell: 1
 SpellBookSpellBank:
-  Pet: 1
-  Player: 0
+  values:
+    Pet: 1
+    Player: 0
 SpellDiminishCategory:
-  AoEKnockback: 3
-  Disarm: 7
-  Disorient: 5
-  Incapacitate: 4
-  Root: 0
-  Silence: 6
-  Stun: 2
-  Taunt: 1
+  values:
+    AoEKnockback: 3
+    Disarm: 7
+    Disorient: 5
+    Incapacitate: 4
+    Root: 0
+    Silence: 6
+    Stun: 2
+    Taunt: 1
 SpellDiminishRuleset:
-  None: 0
-  PvE: 1
-  PvP: 2
+  values:
+    None: 0
+    PvE: 1
+    PvP: 2
 SpellDisplayBorderColor:
-  Black: 1
-  Blue: 8
-  Green: 7
-  None: 0
-  Orange: 5
-  Purple: 6
-  Red: 3
-  White: 2
-  Yellow: 4
+  values:
+    Black: 1
+    Blue: 8
+    Green: 7
+    None: 0
+    Orange: 5
+    Purple: 6
+    Red: 3
+    White: 2
+    Yellow: 4
 SpellDisplayIconDisplayType:
-  Buff: 0
-  Circular: 2
-  Debuff: 1
-  NoBorder: 3
+  values:
+    Buff: 0
+    Circular: 2
+    Debuff: 1
+    NoBorder: 3
 SpellDisplayTextShownStateType:
-  Hidden: 1
-  Shown: 0
+  values:
+    Hidden: 1
+    Shown: 0
 SpellDisplayTint:
-  None: 0
-  Red: 1
+  values:
+    None: 0
+    Red: 1
 SplashScreenType:
-  SeasonRollOver: 1
-  WhatsNew: 0
+  values:
+    SeasonRollOver: 1
+    WhatsNew: 0
 StableResult:
-  AlreadyStabled: 5
-  AlreadySummoned: 6
-  BuySlotSuccess: 14
-  CantControlExotic: 11
-  CheckForLuaHack: 13
-  FavoriteToggle: 15
-  InsufficientFunds: 1
-  InternalError: 12
-  InvalidSlot: 3
-  MaxSlots: 0
-  NoPet: 4
-  NotFound: 7
-  NotStableMaster: 2
-  PetRenamed: 16
-  ReviveSuccess: 10
-  StableSuccess: 8
-  UnstableSuccess: 9
+  values:
+    AlreadyStabled: 5
+    AlreadySummoned: 6
+    BuySlotSuccess: 14
+    CantControlExotic: 11
+    CheckForLuaHack: 13
+    FavoriteToggle: 15
+    InsufficientFunds: 1
+    InternalError: 12
+    InvalidSlot: 3
+    MaxSlots: 0
+    NoPet: 4
+    NotFound: 7
+    NotStableMaster: 2
+    PetRenamed: 16
+    ReviveSuccess: 10
+    StableSuccess: 8
+    UnstableSuccess: 9
 StartTimerType:
-  ChallengeModeCountdown: 1
-  PlayerCountdown: 2
-  PlunderstormCountdown: 3
-  PvPBeginTimer: 0
+  values:
+    ChallengeModeCountdown: 1
+    PlayerCountdown: 2
+    PlunderstormCountdown: 3
+    PvPBeginTimer: 0
 StatusBarColorTintValue:
-  Black: 1
-  Blue: 8
-  Green: 7
-  None: 0
-  Orange: 5
-  Purple: 6
-  Red: 3
-  White: 2
-  Yellow: 4
+  values:
+    Black: 1
+    Blue: 8
+    Green: 7
+    None: 0
+    Orange: 5
+    Purple: 6
+    Red: 3
+    White: 2
+    Yellow: 4
 StatusBarFillStyle:
-  Center: 2
-  Reverse: 3
-  Standard: 0
-  StandardNoRangeFill: 1
+  values:
+    Center: 2
+    Reverse: 3
+    Standard: 0
+    StandardNoRangeFill: 1
 StatusBarInterpolation:
-  ExponentialEaseOut: 1
-  Immediate: 0
+  values:
+    ExponentialEaseOut: 1
+    Immediate: 0
 StatusBarOverrideBarTextShownType:
-  Always: 1
-  Never: 0
-  OnlyNotOnMouseover: 3
-  OnlyOnMouseover: 2
+  values:
+    Always: 1
+    Never: 0
+    OnlyNotOnMouseover: 3
+    OnlyOnMouseover: 2
 StatusBarTimerDirection:
-  ElapsedTime: 0
-  RemainingTime: 1
+  values:
+    ElapsedTime: 0
+    RemainingTime: 1
 StatusBarValueTextType:
-  Hidden: 0
-  Percentage: 1
-  Time: 3
-  TimeShowOneLevelOnly: 4
-  Value: 2
-  ValueOverMax: 5
-  ValueOverMaxNormalized: 6
+  values:
+    Hidden: 0
+    Percentage: 1
+    Time: 3
+    TimeShowOneLevelOnly: 4
+    Value: 2
+    ValueOverMax: 5
+    ValueOverMaxNormalized: 6
 StoreDeliveryType:
-  Battlepet: 2
-  Collection: 3
-  Item: 0
-  Mount: 1
+  values:
+    Battlepet: 2
+    Collection: 3
+    Item: 0
+    Mount: 1
 StoreError:
-  AlreadyOwned: 7
-  BattlepayDisabled: 4
-  ClientRestricted: 13
-  ConsumableTokenOwned: 10
-  InsufficientBalance: 5
-  InvalidPaymentMethod: 1
-  ItemUnavailable: 12
-  Other: 6
-  ParentalControlsNoPurchase: 8
-  PaymentFailed: 2
-  PurchaseDenied: 9
-  Success: 0
-  TooManyTokens: 11
-  WrongCurrency: 3
+  values:
+    AlreadyOwned: 7
+    BattlepayDisabled: 4
+    ClientRestricted: 13
+    ConsumableTokenOwned: 10
+    InsufficientBalance: 5
+    InvalidPaymentMethod: 1
+    ItemUnavailable: 12
+    Other: 6
+    ParentalControlsNoPurchase: 8
+    PaymentFailed: 2
+    PurchaseDenied: 9
+    Success: 0
+    TooManyTokens: 11
+    WrongCurrency: 3
 SubcontainerType:
-  AccountBankTabs: 36
-  Auction: 5
-  Bag: 0
-  Bankbag: 3
-  Bankgeneric: 2
-  BuybackSlots: 26
-  CachedReward: 27
-  CharacterBankTabs: 38
-  Childequipmentstorage: 23
-  CraftingOrder: 34
-  CraftingOrderReagents: 35
-  CreatedImmediately: 25
-  CurrencytokenOboslete: 15
-  CurrencyTransfer: 37
-  Equipablespells: 14
-  Equipped: 1
-  EquippedBags: 28
-  EquippedCooking: 31
-  EquippedFishing: 32
-  EquippedProfession1: 29
-  EquippedProfession2: 30
-  EquippedReagentbag: 33
-  GuildBank0: 7
-  GuildBank1: 8
-  GuildBank10: 20
-  GuildBank11: 21
-  GuildBank2: 9
-  GuildBank3: 10
-  GuildBank4: 11
-  GuildBank5: 12
-  GuildBank6: 16
-  GuildBank7: 17
-  GuildBank8: 18
-  GuildBank9: 19
-  GuildOverflow: 13
-  HousingDecorConversion: 39
-  Keyring: 6
-  Mail: 4
-  Quarantine: 24
-  ReagentbankObsolete: 22
+  values:
+    AccountBankTabs: 36
+    Auction: 5
+    Bag: 0
+    Bankbag: 3
+    Bankgeneric: 2
+    BuybackSlots: 26
+    CachedReward: 27
+    CharacterBankTabs: 38
+    Childequipmentstorage: 23
+    CraftingOrder: 34
+    CraftingOrderReagents: 35
+    CreatedImmediately: 25
+    CurrencytokenOboslete: 15
+    CurrencyTransfer: 37
+    Equipablespells: 14
+    Equipped: 1
+    EquippedBags: 28
+    EquippedCooking: 31
+    EquippedFishing: 32
+    EquippedProfession1: 29
+    EquippedProfession2: 30
+    EquippedReagentbag: 33
+    GuildBank0: 7
+    GuildBank1: 8
+    GuildBank10: 20
+    GuildBank11: 21
+    GuildBank2: 9
+    GuildBank3: 10
+    GuildBank4: 11
+    GuildBank5: 12
+    GuildBank6: 16
+    GuildBank7: 17
+    GuildBank8: 18
+    GuildBank9: 19
+    GuildOverflow: 13
+    HousingDecorConversion: 39
+    Keyring: 6
+    Mail: 4
+    Quarantine: 24
+    ReagentbankObsolete: 22
 SummonReason:
-  Scenario: 1
-  Spell: 0
+  values:
+    Scenario: 1
+    Spell: 0
 SummonStatus:
-  Accepted: 2
-  Declined: 3
-  None: 0
-  Pending: 1
+  values:
+    Accepted: 2
+    Declined: 3
+    None: 0
+    Pending: 1
 SurveyDeliveryFlags:
-  EncounterSucccessOnly: 1
-  None: 0
+  values:
+    EncounterSucccessOnly: 1
+    None: 0
 SurveyDeliveryMoment:
-  ChestLooted: 3
-  EncounterEnd: 5
-  Login: 0
-  MythicPlusCompleted: 4
-  ProfessionTable: 1
-  QuestTurnIn: 2
+  values:
+    ChestLooted: 3
+    EncounterEnd: 5
+    Login: 0
+    MythicPlusCompleted: 4
+    ProfessionTable: 1
+    QuestTurnIn: 2
 TableSecurityOption:
-  DisallowSecretKeys: 1
-  DisallowTaintedAccess: 0
-  SecretWrapContents: 2
+  values:
+    DisallowSecretKeys: 1
+    DisallowTaintedAccess: 0
+    SecretWrapContents: 2
 TieredEntranceType:
-  Delve: 1
-  Invalid: 0
-  Sites: 2
-  WorldTier: 3
+  values:
+    Delve: 1
+    Invalid: 0
+    Sites: 2
+    WorldTier: 3
 TimeEventFlag:
-  GlueScreenShortcut: 1
+  values:
+    GlueScreenShortcut: 1
 TitleIconVersion:
-  Large: 2
-  Medium: 1
-  Small: 0
+  values:
+    Large: 2
+    Medium: 1
+    Small: 0
 TooltipComparisonMethod:
-  Single: 0
-  WithBagMainHandItem: 2
-  WithBagOffHandItem: 3
-  WithBothHands: 1
+  values:
+    Single: 0
+    WithBagMainHandItem: 2
+    WithBagOffHandItem: 3
+    WithBothHands: 1
 TooltipDataItemBinding:
-  Account: 1
-  AccountUntilEquipped: 9
-  BindOnEquip: 7
-  BindOnPickup: 6
-  BindOnUse: 8
-  BindToAccount: 4
-  BindToAccountUntilEquipped: 10
-  BindToBnetAccount: 5
-  BnetAccount: 2
-  Quest: 0
-  Soulbound: 3
+  values:
+    Account: 1
+    AccountUntilEquipped: 9
+    BindOnEquip: 7
+    BindOnPickup: 6
+    BindOnUse: 8
+    BindToAccount: 4
+    BindToAccountUntilEquipped: 10
+    BindToBnetAccount: 5
+    BnetAccount: 2
+    Quest: 0
+    Soulbound: 3
 TooltipDataLineType:
-  AzeriteEssencePower: 5
-  AzeriteEssenceSlot: 4
-  AzeriteItemPowerDescription: 9
-  Blank: 1
-  CurrencyTotal: 14
-  DisabledLine: 42
-  EquipSlot: 21
-  ErrorLine: 41
-  FlavorText: 37
-  GemSocket: 3
-  GemSocketEnchantment: 30
-  ItemBinding: 20
-  ItemEnchantmentPermanent: 15
-  ItemLevel: 31
-  ItemName: 22
-  ItemQuality: 35
-  ItemSpellTriggerLearn: 38
-  ItemUpgradeLevel: 32
-  LearnableSpell: 6
-  LearnTransmogIllusion: 40
-  LearnTransmogSet: 39
-  NestedBlock: 19
-  None: 0
-  ProfessionCraftingQuality: 12
-  QuestObjective: 8
-  QuestPlayer: 18
-  QuestTitle: 17
-  RuneforgeLegendaryPowerDescription: 10
-  SellPrice: 11
-  Separator: 23
-  SpellDescription: 34
-  SpellName: 13
-  SpellPassive: 33
-  ToyDescription: 28
-  ToyDuration: 27
-  ToyEffect: 26
-  ToyName: 24
-  ToySource: 29
-  ToyText: 25
-  TradeTimeRemaining: 36
-  UnitName: 2
-  UnitOwner: 16
-  UnitThreat: 7
-  UsageRequirement: 43
+  values:
+    AzeriteEssencePower: 5
+    AzeriteEssenceSlot: 4
+    AzeriteItemPowerDescription: 9
+    Blank: 1
+    CurrencyTotal: 14
+    DisabledLine: 42
+    EquipSlot: 21
+    ErrorLine: 41
+    FlavorText: 37
+    GemSocket: 3
+    GemSocketEnchantment: 30
+    ItemBinding: 20
+    ItemEnchantmentPermanent: 15
+    ItemLevel: 31
+    ItemName: 22
+    ItemQuality: 35
+    ItemSpellTriggerLearn: 38
+    ItemUpgradeLevel: 32
+    LearnableSpell: 6
+    LearnTransmogIllusion: 40
+    LearnTransmogSet: 39
+    NestedBlock: 19
+    None: 0
+    ProfessionCraftingQuality: 12
+    QuestObjective: 8
+    QuestPlayer: 18
+    QuestTitle: 17
+    RuneforgeLegendaryPowerDescription: 10
+    SellPrice: 11
+    Separator: 23
+    SpellDescription: 34
+    SpellName: 13
+    SpellPassive: 33
+    ToyDescription: 28
+    ToyDuration: 27
+    ToyEffect: 26
+    ToyName: 24
+    ToySource: 29
+    ToyText: 25
+    TradeTimeRemaining: 36
+    UnitName: 2
+    UnitOwner: 16
+    UnitThreat: 7
+    UsageRequirement: 43
 TooltipDataType:
-  Achievement: 12
-  AzeriteEssence: 8
-  BattlePet: 6
-  CompanionPet: 9
-  Corpse: 3
-  CorruptionCleanser: 20
-  Currency: 5
-  Debug: 26
-  EnhancedConduit: 13
-  EquipmentSet: 14
-  Flyout: 22
-  InstanceLock: 15
-  Item: 0
-  Macro: 25
-  MinimapMouseover: 21
-  Mount: 10
-  Object: 4
-  Outfit: 27
-  PetAction: 11
-  PvPBrawl: 16
-  Quest: 23
-  QuestPartyProgress: 24
-  RecipeRankInfo: 17
-  Spell: 1
-  Totem: 18
-  Toy: 19
-  Unit: 2
-  UnitAura: 7
+  values:
+    Achievement: 12
+    AzeriteEssence: 8
+    BattlePet: 6
+    CompanionPet: 9
+    Corpse: 3
+    CorruptionCleanser: 20
+    Currency: 5
+    Debug: 26
+    EnhancedConduit: 13
+    EquipmentSet: 14
+    Flyout: 22
+    InstanceLock: 15
+    Item: 0
+    Macro: 25
+    MinimapMouseover: 21
+    Mount: 10
+    Object: 4
+    Outfit: 27
+    PetAction: 11
+    PvPBrawl: 16
+    Quest: 23
+    QuestPartyProgress: 24
+    RecipeRankInfo: 17
+    Spell: 1
+    Totem: 18
+    Toy: 19
+    Unit: 2
+    UnitAura: 7
 TooltipDataUsageRequirementType:
-  Achievement: 7
-  ArenaRating: 11
-  EarnCurrency: 12
-  EquippedItem: 9
-  Faction: 1
-  Guild: 6
-  Level: 5
-  NotAlreadyKnown: 14
-  NotInArena: 15
-  NotInRatedBg: 16
-  PvPMedal: 3
-  PvPRank: 8
-  RaceClass: 0
-  Reputation: 4
-  ShapeshiftForm: 10
-  Skill: 2
-  Specialization: 13
+  values:
+    Achievement: 7
+    ArenaRating: 11
+    EarnCurrency: 12
+    EquippedItem: 9
+    Faction: 1
+    Guild: 6
+    Level: 5
+    NotAlreadyKnown: 14
+    NotInArena: 15
+    NotInRatedBg: 16
+    PvPMedal: 3
+    PvPRank: 8
+    RaceClass: 0
+    Reputation: 4
+    ShapeshiftForm: 10
+    Skill: 2
+    Specialization: 13
 TooltipSide:
-  Bottom: 3
-  Left: 0
-  Right: 1
-  Top: 2
+  values:
+    Bottom: 3
+    Left: 0
+    Right: 1
+    Top: 2
 TooltipTextureAnchor:
-  All: 6
-  LeftBottom: 2
-  LeftCenter: 1
-  LeftTop: 0
-  RightBottom: 5
-  RightCenter: 4
-  RightTop: 3
+  values:
+    All: 6
+    LeftBottom: 2
+    LeftCenter: 1
+    LeftTop: 0
+    RightBottom: 5
+    RightCenter: 4
+    RightTop: 3
 TooltipTextureRelativeRegion:
-  LeftLine: 0
-  RightLine: 1
+  values:
+    LeftLine: 0
+    RightLine: 1
 TrackedSpellCategory:
-  Debuff: 3
-  Defensive: 2
-  None: 0
-  Offensive: 1
-  RacialAbility: 4
+  values:
+    Debuff: 3
+    Defensive: 2
+    None: 0
+    Offensive: 1
+    RacialAbility: 4
 TradeskillRelativeDifficulty:
-  Easy: 2
-  Medium: 1
-  Optimal: 0
-  Trivial: 3
+  values:
+    Easy: 2
+    Medium: 1
+    Optimal: 0
+    Trivial: 3
 TraitCombatConfigFlags:
-  ActiveForSpec: 1
-  SharedActionBars: 4
-  StarterBuild: 2
+  values:
+    ActiveForSpec: 1
+    SharedActionBars: 4
+    StarterBuild: 2
 TraitCondFlag:
-  IsAlwaysMet: 2
-  IsGate: 1
-  IsSufficient: 4
+  values:
+    IsAlwaysMet: 2
+    IsGate: 1
+    IsSufficient: 4
 TraitConditionType:
-  Available: 0
-  DisplayError: 4
-  Granted: 2
-  Increased: 3
-  RanksAllowed: 5
-  Visible: 1
+  values:
+    Available: 0
+    DisplayError: 4
+    Granted: 2
+    Increased: 3
+    RanksAllowed: 5
+    Visible: 1
 TraitConfigDbState:
-  Created: 1
-  Deleted: 3
-  Ready: 0
-  Removed: 2
+  values:
+    Created: 1
+    Deleted: 3
+    Ready: 0
+    Removed: 2
 TraitConfigType:
-  Combat: 1
-  Generic: 3
-  Invalid: 0
-  Profession: 2
+  values:
+    Combat: 1
+    Generic: 3
+    Invalid: 0
+    Profession: 2
 TraitCurrencyFlag:
-  ShowQuantityAsSpent: 1
-  TraitSourcedShowMax: 2
-  UseClassIcon: 4
-  UseSpecIcon: 8
+  values:
+    ShowQuantityAsSpent: 1
+    TraitSourcedShowMax: 2
+    UseClassIcon: 4
+    UseSpecIcon: 8
 TraitCurrencyType:
-  CurrencyTypesBased: 1
-  Gold: 0
-  TraitSourced: 2
-  TraitSourcedPlayerDataElement: 3
+  values:
+    CurrencyTypesBased: 1
+    Gold: 0
+    TraitSourced: 2
+    TraitSourcedPlayerDataElement: 3
 TraitDefinitionSubType:
-  DragonflightBlack: 4
-  DragonflightBlue: 1
-  DragonflightBronze: 3
-  DragonflightGreen: 2
-  DragonflightRed: 0
+  values:
+    DragonflightBlack: 4
+    DragonflightBlue: 1
+    DragonflightBronze: 3
+    DragonflightGreen: 2
+    DragonflightRed: 0
 TraitEdgeType:
-  DeprecatedRankConnection: 1
-  DeprecatedSelectionOption: 5
-  MutuallyExclusive: 4
-  RequiredForAvailability: 3
-  SufficientForAvailability: 2
-  VisualOnly: 0
+  values:
+    DeprecatedRankConnection: 1
+    DeprecatedSelectionOption: 5
+    MutuallyExclusive: 4
+    RequiredForAvailability: 3
+    SufficientForAvailability: 2
+    VisualOnly: 0
 TraitEdgeVisualStyle:
-  None: 0
-  Straight: 1
+  values:
+    None: 0
+    Straight: 1
 TraitNodeEntryType:
-  ArmorSet: 11
-  DeprecatedSelect: 4
-  DragAndDrop: 5
-  ProfPath: 7
-  ProfPathUnlock: 9
-  ProfPerk: 8
-  RedButton: 10
-  SpendCapstoneCircle: 13
-  SpendCapstoneSquare: 14
-  SpendCircle: 2
-  SpendDiamond: 6
-  SpendHex: 0
-  SpendInfinite: 12
-  SpendSmallCircle: 3
-  SpendSquare: 1
+  values:
+    ArmorSet: 11
+    DeprecatedSelect: 4
+    DragAndDrop: 5
+    ProfPath: 7
+    ProfPathUnlock: 9
+    ProfPerk: 8
+    RedButton: 10
+    SpendCapstoneCircle: 13
+    SpendCapstoneSquare: 14
+    SpendCircle: 2
+    SpendDiamond: 6
+    SpendHex: 0
+    SpendInfinite: 12
+    SpendSmallCircle: 3
+    SpendSquare: 1
 TraitNodeFlag:
-  ActiveAtFirstRank: 16
-  HideMaxRank: 64
-  HighestChosenRank: 128
-  NeverPurchasable: 2
-  ShowExpandedSelection: 32
-  ShowMultipleIcons: 1
-  ShowTierTrack: 256
-  TestGridPositioned: 8
-  TestPositionLocked: 4
+  values:
+    ActiveAtFirstRank: 16
+    HideMaxRank: 64
+    HighestChosenRank: 128
+    NeverPurchasable: 2
+    ShowExpandedSelection: 32
+    ShowMultipleIcons: 1
+    ShowTierTrack: 256
+    TestGridPositioned: 8
+    TestPositionLocked: 4
 TraitNodeGroupFlag:
-  AvailableByDefault: 1
+  values:
+    AvailableByDefault: 1
 TraitNodeType:
-  Selection: 2
-  Single: 0
-  SubTreeSelection: 3
-  Tiered: 1
+  values:
+    Selection: 2
+    Single: 0
+    SubTreeSelection: 3
+    Tiered: 1
 TraitPointsOperationType:
-  Multiply: 1
-  None: -1
-  Set: 0
+  values:
+    Multiply: 1
+    None: -1
+    Set: 0
 TraitSystemFlag:
-  AllowEditInChallengeMode: 8
-  AllowEditInCombat: 4
-  AllowMultipleLoadoutsPerTree: 1
-  ShowSpendConfirmation: 2
+  values:
+    AllowEditInChallengeMode: 8
+    AllowEditInCombat: 4
+    AllowMultipleLoadoutsPerTree: 1
+    ShowSpendConfirmation: 2
 TraitSystemVariationType:
-  None: 0
-  Spec: 1
+  values:
+    None: 0
+    Spec: 1
 TraitTreeFlag:
-  CannotRefund: 1
-  HideSingleRankNumbers: 2
+  values:
+    CannotRefund: 1
+    HideSingleRankNumbers: 2
 TransformManipulatorAxis:
-  X: 1
-  Y: 2
-  Z: 4
+  values:
+    X: 1
+    Y: 2
+    Z: 4
 TransformManipulatorControlState:
-  Default: 0
-  Dimmed: 2
-  ExternallyHighlighted: 3
-  Hidden: 1
-  Hovered: 4
-  Moving: 6
-  Selected: 5
+  values:
+    Default: 0
+    Dimmed: 2
+    ExternallyHighlighted: 3
+    Hidden: 1
+    Hovered: 4
+    Moving: 6
+    Selected: 5
 TransformManipulatorDirection:
-  Negative: 1
-  Positive: 0
+  values:
+    Negative: 1
+    Positive: 0
 TransformManipulatorEvent:
-  Cancel: 3
-  Change: 1
-  Complete: 2
-  Hover: 4
-  MouseDown: 5
-  MouseUp: 6
-  Start: 0
+  values:
+    Cancel: 3
+    Change: 1
+    Complete: 2
+    Hover: 4
+    MouseDown: 5
+    MouseUp: 6
+    Start: 0
 TransformManipulatorMode:
-  Rotate: 1
-  Scale: 2
-  Translate: 0
+  values:
+    Rotate: 1
+    Scale: 2
+    Translate: 0
 TransmogCameraVariation:
-  CloakBackpack: 1
-  None: 0
-  RightShoulder: 1
+  values:
+    CloakBackpack: 1
+    None: 0
+    RightShoulder: 1
 TransmogCollectionType:
-  Back: 3
-  Bow: 25
-  Chest: 4
-  Crossbow: 27
-  Dagger: 16
-  Feet: 11
-  Fist: 17
-  Gun: 26
-  Hands: 8
-  Head: 1
-  Holdable: 19
-  Legs: 10
-  None: 0
-  OneHAxe: 13
-  OneHMace: 15
-  OneHSword: 14
-  Paired: 29
-  Polearm: 24
-  Shield: 18
-  Shirt: 5
-  Shoulder: 2
-  Staff: 23
-  Tabard: 6
-  TwoHAxe: 20
-  TwoHMace: 22
-  TwoHSword: 21
-  Waist: 9
-  Wand: 12
-  Warglaives: 28
-  Wrist: 7
+  values:
+    Back: 3
+    Bow: 25
+    Chest: 4
+    Crossbow: 27
+    Dagger: 16
+    Feet: 11
+    Fist: 17
+    Gun: 26
+    Hands: 8
+    Head: 1
+    Holdable: 19
+    Legs: 10
+    None: 0
+    OneHAxe: 13
+    OneHMace: 15
+    OneHSword: 14
+    Paired: 29
+    Polearm: 24
+    Shield: 18
+    Shirt: 5
+    Shoulder: 2
+    Staff: 23
+    Tabard: 6
+    TwoHAxe: 20
+    TwoHMace: 22
+    TwoHSword: 21
+    Waist: 9
+    Wand: 12
+    Warglaives: 28
+    Wrist: 7
 TransmogIllusionFlags:
-  AllowedRangedShieldsHoldables: 4
-  HideUntilCollected: 1
-  PlayerConditionGrantsOnLogin: 2
+  values:
+    AllowedRangedShieldsHoldables: 4
+    HideUntilCollected: 1
+    PlayerConditionGrantsOnLogin: 2
 TransmogModification:
-  Main: 0
-  Secondary: 1
+  values:
+    Main: 0
+    Secondary: 1
 TransmogOutfitCostModifiersApplied:
-  AuraDiscountApplied: 8
-  DebugOnlyFreeDiscountApplied: 1
-  OutfitCostModifierApplied: 4
-  VoidRacialDiscountApplied: 2
+  values:
+    AuraDiscountApplied: 8
+    DebugOnlyFreeDiscountApplied: 1
+    OutfitCostModifierApplied: 4
+    VoidRacialDiscountApplied: 2
 TransmogOutfitDataFlags:
-  IsCachedLocally: 1
+  values:
+    IsCachedLocally: 1
 TransmogOutfitDisplayType:
-  Assigned: 1
-  Disabled: 4
-  Equipped: 2
-  Hidden: 3
-  Unassigned: 0
+  values:
+    Assigned: 1
+    Disabled: 4
+    Equipped: 2
+    Hidden: 3
+    Unassigned: 0
 TransmogOutfitEntryFlags:
-  AutomaticallyAwardedOnLogin: 1
-  IsDefaultEquipped: 32
-  OnlyAvailableDuringEvent: 4
-  SortedToTopOfList: 8
-  UseOverrideCostModifier: 16
-  UseOverrideName: 2
+  values:
+    AutomaticallyAwardedOnLogin: 1
+    IsDefaultEquipped: 32
+    OnlyAvailableDuringEvent: 4
+    SortedToTopOfList: 8
+    UseOverrideCostModifier: 16
+    UseOverrideName: 2
 TransmogOutfitEntrySource:
-  AutomaticallyAwarded: 1
-  PlayerPurchased: 2
-  StampedSource: 0
+  values:
+    AutomaticallyAwarded: 1
+    PlayerPurchased: 2
+    StampedSource: 0
 TransmogOutfitEquipAction:
-  Equip: 0
-  EquipAndLock: 1
-  Lock: 5
-  Remove: 2
-  RemoveAndLock: 3
-  Unlock: 4
+  values:
+    Equip: 0
+    EquipAndLock: 1
+    Lock: 5
+    Remove: 2
+    RemoveAndLock: 3
+    Unlock: 4
 TransmogOutfitSetType:
-  CustomSet: 2
-  Equipped: 0
-  Outfit: 1
+  values:
+    CustomSet: 2
+    Equipped: 0
+    Outfit: 1
 TransmogOutfitSlot:
-  Back: 3
-  Body: 6
-  Chest: 4
-  Feet: 11
-  Hand: 8
-  Head: 0
-  Legs: 10
-  ShoulderLeft: 2
-  ShoulderRight: 1
-  Tabard: 5
-  Waist: 9
-  WeaponMainHand: 12
-  WeaponOffHand: 13
-  WeaponRanged: 14
-  Wrist: 7
+  values:
+    Back: 3
+    Body: 6
+    Chest: 4
+    Feet: 11
+    Hand: 8
+    Head: 0
+    Legs: 10
+    ShoulderLeft: 2
+    ShoulderRight: 1
+    Tabard: 5
+    Waist: 9
+    WeaponMainHand: 12
+    WeaponOffHand: 13
+    WeaponRanged: 14
+    Wrist: 7
 TransmogOutfitSlotError:
-  CannotUseItem: 10
-  IncompatibleWithMainHand: 14
-  InvalidDestination: 5
-  InvalidItemType: 4
-  InvalidSlotForForm: 13
-  InvalidSlotForRace: 11
-  InvalidSource: 8
-  InvalidSourceQuality: 9
-  Legendary: 3
-  Mismatch: 6
-  NoIllusion: 12
-  NoItem: 1
-  NotSoulbound: 2
-  Ok: 0
-  SameItem: 7
+  values:
+    CannotUseItem: 10
+    IncompatibleWithMainHand: 14
+    InvalidDestination: 5
+    InvalidItemType: 4
+    InvalidSlotForForm: 13
+    InvalidSlotForRace: 11
+    InvalidSource: 8
+    InvalidSourceQuality: 9
+    Legendary: 3
+    Mismatch: 6
+    NoIllusion: 12
+    NoItem: 1
+    NotSoulbound: 2
+    Ok: 0
+    SameItem: 7
 TransmogOutfitSlotFlags:
-  CanHaveIllusions: 2
-  CannotBeHidden: 1
-  IsSecondarySlot: 4
+  values:
+    CanHaveIllusions: 2
+    CannotBeHidden: 1
+    IsSecondarySlot: 4
 TransmogOutfitSlotOption:
-  ArtifactSpecFour: 11
-  ArtifactSpecOne: 8
-  ArtifactSpecThree: 10
-  ArtifactSpecTwo: 9
-  DeprecatedReuseMe: 6
-  FuryTwoHandedWeapon: 7
-  None: 0
-  OffHand: 4
-  OneHandedWeapon: 1
-  RangedWeapon: 3
-  Shield: 5
-  TwoHandedWeapon: 2
+  values:
+    ArtifactSpecFour: 11
+    ArtifactSpecOne: 8
+    ArtifactSpecThree: 10
+    ArtifactSpecTwo: 9
+    DeprecatedReuseMe: 6
+    FuryTwoHandedWeapon: 7
+    None: 0
+    OffHand: 4
+    OneHandedWeapon: 1
+    RangedWeapon: 3
+    Shield: 5
+    TwoHandedWeapon: 2
 TransmogOutfitSlotOptionFlags:
-  DisablesOffhandSlot: 4
-  DynamicOptionName: 2
-  IllusionNotAllowed: 1
+  values:
+    DisablesOffhandSlot: 4
+    DynamicOptionName: 2
+    IllusionNotAllowed: 1
 TransmogOutfitSlotOptionSheatheCategory:
-  Back: 1
-  Default: 0
-  Hide: 3
-  Side: 2
+  values:
+    Back: 1
+    Default: 0
+    Hide: 3
+    Side: 2
 TransmogOutfitSlotPosition:
-  Bottom: 2
-  Left: 0
-  Right: 1
+  values:
+    Bottom: 2
+    Left: 0
+    Right: 1
 TransmogOutfitSlotSaveFlags:
-  AppearanceIsNotValid: 1
+  values:
+    AppearanceIsNotValid: 1
 TransmogOutfitSlotWarning:
-  InvalidEquippedDestinationItem: 1
-  NothingEquipped: 5
-  Ok: 0
-  PendingWeaponChanges: 3
-  WeaponDoesNotSupportIllusions: 4
-  WrongWeaponCategoryEquipped: 2
+  values:
+    InvalidEquippedDestinationItem: 1
+    NothingEquipped: 5
+    Ok: 0
+    PendingWeaponChanges: 3
+    WeaponDoesNotSupportIllusions: 4
+    WrongWeaponCategoryEquipped: 2
 TransmogOutfitTransactionFlags:
-  AddNewOutfitMask: 20
-  AddOutfitAndUpdateSlots: 28
-  CreateAndUpdateOutfitInfoMask: 6
-  CreateOutfitInfo: 4
-  FullOutfitUpdateMask: 27
-  UpdateMetadata: 1
-  UpdateOutfitInfo: 2
-  UpdateSituations: 16
-  UpdateSituationsMask: 18
-  UpdateSlots: 8
+  values:
+    AddNewOutfitMask: 20
+    AddOutfitAndUpdateSlots: 28
+    CreateAndUpdateOutfitInfoMask: 6
+    CreateOutfitInfo: 4
+    FullOutfitUpdateMask: 27
+    UpdateMetadata: 1
+    UpdateOutfitInfo: 2
+    UpdateSituations: 16
+    UpdateSituationsMask: 18
+    UpdateSlots: 8
 TransmogOutfitTransactionType:
-  CreateOutfitInfo: 2
-  UpdateMetadata: 0
-  UpdateOutfitInfo: 1
-  UpdateSituations: 4
-  UpdateSlots: 3
+  values:
+    CreateOutfitInfo: 2
+    UpdateMetadata: 0
+    UpdateOutfitInfo: 1
+    UpdateSituations: 4
+    UpdateSlots: 3
 TransmogPendingType:
-  Apply: 0
-  Revert: 1
-  ToggleOff: 3
-  ToggleOn: 2
+  values:
+    Apply: 0
+    Revert: 1
+    ToggleOff: 3
+    ToggleOn: 2
 TransmogSearchType:
-  BaseSets: 2
-  Items: 1
-  UsableSets: 3
+  values:
+    BaseSets: 2
+    Items: 1
+    UsableSets: 3
 TransmogSituation:
-  AllEquipmentSets: 17
-  AllLocations: 2
-  AllMovement: 12
-  AllRacialForms: 19
-  AllSpecs: 0
-  AllTime: 27
-  AllWeather: 22
-  EquipmentSets: 18
-  FormNative: 20
-  FormNonNative: 21
-  LocationArenas: 10
-  LocationBattlegrounds: 11
-  LocationCharacterSelect: 5
-  LocationDelves: 7
-  LocationDungeons: 8
-  LocationHouse: 4
-  LocationRaids: 9
-  LocationRested: 3
-  LocationWorld: 6
-  MovementFlyingMount: 16
-  MovementGroundMount: 15
-  MovementSwimming: 14
-  MovementUnmounted: 13
-  Spec: 1
-  TimeDay: 29
-  TimeEvening: 30
-  TimeMorning: 28
-  TimeNight: 31
-  WeatherClear: 23
-  WeatherRain: 24
-  WeatherSand: 26
-  WeatherSnow: 25
+  values:
+    AllEquipmentSets: 17
+    AllLocations: 2
+    AllMovement: 12
+    AllRacialForms: 19
+    AllSpecs: 0
+    AllTime: 27
+    AllWeather: 22
+    EquipmentSets: 18
+    FormNative: 20
+    FormNonNative: 21
+    LocationArenas: 10
+    LocationBattlegrounds: 11
+    LocationCharacterSelect: 5
+    LocationDelves: 7
+    LocationDungeons: 8
+    LocationHouse: 4
+    LocationRaids: 9
+    LocationRested: 3
+    LocationWorld: 6
+    MovementFlyingMount: 16
+    MovementGroundMount: 15
+    MovementSwimming: 14
+    MovementUnmounted: 13
+    Spec: 1
+    TimeDay: 29
+    TimeEvening: 30
+    TimeMorning: 28
+    TimeNight: 31
+    WeatherClear: 23
+    WeatherRain: 24
+    WeatherSand: 26
+    WeatherSnow: 25
 TransmogSituationFlags:
-  AllSituation: 4
-  DefaultsToOn: 8
-  DisabledSituation: 64
-  DynamicallyNamed: 16
-  IsPlayerFacing: 1
-  NoneSituation: 32
-  SpecUseTalentLoadout: 2
+  values:
+    AllSituation: 4
+    DefaultsToOn: 8
+    DisabledSituation: 64
+    DynamicallyNamed: 16
+    IsPlayerFacing: 1
+    NoneSituation: 32
+    SpecUseTalentLoadout: 2
 TransmogSituationGroupFlags:
-  DynamicallyCreatesGroups: 1
+  values:
+    DynamicallyCreatesGroups: 1
 TransmogSituationTrigger:
-  EquipmentSet: 6
-  EventOutfit: 8
-  Forms: 7
-  Location: 3
-  Manual: 1
-  Movement: 4
-  None: 0
-  Specialization: 5
-  TimeOfDay: 10
-  TransmogUpdate: 2
-  Weather: 9
+  values:
+    EquipmentSet: 6
+    EventOutfit: 8
+    Forms: 7
+    Location: 3
+    Manual: 1
+    Movement: 4
+    None: 0
+    Specialization: 5
+    TimeOfDay: 10
+    TransmogUpdate: 2
+    Weather: 9
 TransmogSituationTriggerFlags:
-  CanChangeLockedOutfit: 2
-  CanLockOutfit: 1
-  DisabledTrigger: 16
-  IsPlayerFacing: 4
-  SituationsAreExclusive: 8
+  values:
+    CanChangeLockedOutfit: 2
+    CanLockOutfit: 1
+    DisabledTrigger: 16
+    IsPlayerFacing: 4
+    SituationsAreExclusive: 8
 TransmogSituationTriggerType:
-  Automatic: 2
-  Manual: 1
-  None: 0
-  TransmogUpdate: 3
+  values:
+    Automatic: 2
+    Manual: 1
+    None: 0
+    TransmogUpdate: 3
 TransmogSlot:
-  Back: 2
-  Body: 4
-  Chest: 3
-  Feet: 10
-  Hand: 7
-  Head: 0
-  Legs: 9
-  Mainhand: 11
-  Offhand: 12
-  Ranged: 13
-  Shoulder: 1
-  Tabard: 5
-  Waist: 8
-  Wrist: 6
+  values:
+    Back: 2
+    Body: 4
+    Chest: 3
+    Feet: 10
+    Hand: 7
+    Head: 0
+    Legs: 9
+    Mainhand: 11
+    Offhand: 12
+    Ranged: 13
+    Shoulder: 1
+    Tabard: 5
+    Waist: 8
+    Wrist: 6
 TransmogSource:
-  Achievement: 7
-  CantCollect: 6
-  HiddenUntilCollected: 5
-  JournalEncounter: 1
-  None: 0
-  NotValidForTransmog: 9
-  Profession: 8
-  Quest: 2
-  TradingPost: 10
-  Vendor: 3
-  WorldDrop: 4
+  values:
+    Achievement: 7
+    CantCollect: 6
+    HiddenUntilCollected: 5
+    JournalEncounter: 1
+    None: 0
+    NotValidForTransmog: 9
+    Profession: 8
+    Quest: 2
+    TradingPost: 10
+    Vendor: 3
+    WorldDrop: 4
 TransmogTimeOfDayCategory:
-  Evening: 2
-  Midday: 1
-  Morning: 0
-  Night: 3
+  values:
+    Evening: 2
+    Midday: 1
+    Morning: 0
+    Night: 3
 TransmogType:
-  Appearance: 0
-  Illusion: 1
+  values:
+    Appearance: 0
+    Illusion: 1
 TransmogUseErrorType:
-  Ability: 3
-  Class: 7
-  Faction: 9
-  Holiday: 5
-  HotRecheckFailed: 6
-  ItemProficiency: 10
-  None: 0
-  PlayerCondition: 1
-  Race: 8
-  Reputation: 4
-  Skill: 2
+  values:
+    Ability: 3
+    Class: 7
+    Faction: 9
+    Holiday: 5
+    HotRecheckFailed: 6
+    ItemProficiency: 10
+    None: 0
+    PlayerCondition: 1
+    Race: 8
+    Reputation: 4
+    Skill: 2
 TtsBoolSetting:
-  AddCharacterNameToSpeech: 1
-  AlternateSystemVoice: 3
-  NarrateMyMessages: 4
-  PlayActivitySoundWhenNotFocused: 2
-  PlaySoundSeparatingChatLineBreaks: 0
+  values:
+    AddCharacterNameToSpeech: 1
+    AlternateSystemVoice: 3
+    NarrateMyMessages: 4
+    PlayActivitySoundWhenNotFocused: 2
+    PlaySoundSeparatingChatLineBreaks: 0
 TtsVoiceType:
-  Alternate: 1
-  Standard: 0
+  values:
+    Alternate: 1
+    Standard: 0
 TugOfWarMarkerArrowShownState:
-  Always: 1
-  FlashOnMove: 2
-  Never: 0
+  values:
+    Always: 1
+    FlashOnMove: 2
+    Never: 0
 TugOfWarStyleValue:
-  ArchaeologyBrown: 1
-  DefaultYellow: 0
+  values:
+    ArchaeologyBrown: 1
+    DefaultYellow: 0
 TurnStrafeStyle:
-  Custom: 2
-  Legacy: 1
-  Modern: 0
+  values:
+    Custom: 2
+    Legacy: 1
+    Modern: 0
 UIActionType:
-  DefaultAction: 0
-  Reserved1: 2
-  UpdateMapSystem: 1
+  values:
+    DefaultAction: 0
+    Reserved1: 2
+    UpdateMapSystem: 1
 UICovenantDisplayInfoFlags:
-  DisplayCovenantAsJourney: 1
-  UseJourneyRewardTrack: 2
-  UseJourneyUnlockToastText: 3
+  values:
+    DisplayCovenantAsJourney: 1
+    UseJourneyRewardTrack: 2
+    UseJourneyUnlockToastText: 3
 UICursorType:
-  ActionBar: 6
-  Ammo: 8
-  BattlePet: 16
-  ConduitCollectionItem: 19
-  Currency: 13
-  Default: 0
-  EquipmentSet: 12
-  Flyout: 14
-  GuildBank: 10
-  GuildBankMoney: 11
-  Item: 1
-  Macro: 7
-  Merchant: 5
-  Money: 2
-  Mount: 17
-  Outfit: 21
-  PerksProgramVendorItem: 20
-  Pet: 9
-  PetAction: 4
-  Spell: 3
-  Toy: 18
-  VoidItem: 15
+  values:
+    ActionBar: 6
+    Ammo: 8
+    BattlePet: 16
+    ConduitCollectionItem: 19
+    Currency: 13
+    Default: 0
+    EquipmentSet: 12
+    Flyout: 14
+    GuildBank: 10
+    GuildBankMoney: 11
+    Item: 1
+    Macro: 7
+    Merchant: 5
+    Money: 2
+    Mount: 17
+    Outfit: 21
+    PerksProgramVendorItem: 20
+    Pet: 9
+    PetAction: 4
+    Spell: 3
+    Toy: 18
+    VoidItem: 15
 UIItemInteractionFlags:
-  AddCurrency: 16
-  ClickShowsFlyout: 8
-  ConfirmationHasDelay: 2
-  ConversionMode: 4
-  DisplayWithInset: 1
-  UsesCharges: 32
+  values:
+    AddCurrency: 16
+    ClickShowsFlyout: 8
+    ConfirmationHasDelay: 2
+    ConversionMode: 4
+    DisplayWithInset: 1
+    UsesCharges: 32
 UIItemInteractionType:
-  CastSpell: 1
-  CleanseCorruption: 2
-  ItemConversion: 4
-  None: 0
-  RunecarverScrapping: 3
+  values:
+    CastSpell: 1
+    CleanseCorruption: 2
+    ItemConversion: 4
+    None: 0
+    RunecarverScrapping: 3
 UIMapFlag:
-  AlwaysAllowTaxiPathing: 131072
-  AlwaysAllowUserWaypoints: 65536
-  DoNotShowOnNavbar: 524288
-  DoNotTranslateBranches: 512
-  FallbackToParentMap: 16
-  FlightMapAutoZoom: 16384
-  FlightMapShowZoomOut: 8192
-  ForceAllOverlayExplored: 4096
-  ForceAllowMapLinks: 262144
-  ForceOnNavbar: 32768
-  GarrisonMap: 8
-  HideArchaeologyDigs: 256
-  HideIcons: 1024
-  HideVignettes: 2048
-  IgnoreInTranslationsToParent: 2097152
-  IsCityMap: 1048576
-  NoHighlight: 1
-  NoHighlightTexture: 32
-  NoWorldPositions: 128
-  ShowOverlays: 2
-  ShowTaskObjectives: 64
-  ShowTaxiNodes: 4
+  values:
+    AlwaysAllowTaxiPathing: 131072
+    AlwaysAllowUserWaypoints: 65536
+    DoNotShowOnNavbar: 524288
+    DoNotTranslateBranches: 512
+    FallbackToParentMap: 16
+    FlightMapAutoZoom: 16384
+    FlightMapShowZoomOut: 8192
+    ForceAllOverlayExplored: 4096
+    ForceAllowMapLinks: 262144
+    ForceOnNavbar: 32768
+    GarrisonMap: 8
+    HideArchaeologyDigs: 256
+    HideIcons: 1024
+    HideVignettes: 2048
+    IgnoreInTranslationsToParent: 2097152
+    IsCityMap: 1048576
+    NoHighlight: 1
+    NoHighlightTexture: 32
+    NoWorldPositions: 128
+    ShowOverlays: 2
+    ShowTaskObjectives: 64
+    ShowTaxiNodes: 4
 UIMapGroupFlag:
-  ShowIconsAcrossFloors: 1
+  values:
+    ShowIconsAcrossFloors: 1
 UIMapSystem:
-  Adventure: 2
-  Minimap: 3
-  Taxi: 1
-  World: 0
+  values:
+    Adventure: 2
+    Minimap: 3
+    Taxi: 1
+    World: 0
 UIMapType:
-  Continent: 2
-  Cosmic: 0
-  Dungeon: 4
-  Micro: 5
-  Orphan: 6
-  World: 1
-  Zone: 3
+  values:
+    Continent: 2
+    Cosmic: 0
+    Dungeon: 4
+    Micro: 5
+    Orphan: 6
+    World: 1
+    Zone: 3
 UIModelSceneActorFlag:
-  Deprecated1: 1
-  UseCenterForOriginX: 2
-  UseCenterForOriginY: 4
-  UseCenterForOriginZ: 8
+  values:
+    Deprecated1: 1
+    UseCenterForOriginX: 2
+    UseCenterForOriginY: 4
+    UseCenterForOriginZ: 8
 UIModelSceneContext:
-  None: -1
-  PerksProgram: 0
+  values:
+    None: -1
+    PerksProgram: 0
 UIModelSceneFlags:
-  Autodress: 4
-  HideWeapon: 2
-  NoCameraSpin: 8
-  SheatheWeapon: 1
+  values:
+    Autodress: 4
+    HideWeapon: 2
+    NoCameraSpin: 8
+    SheatheWeapon: 1
 UISystemType:
-  InGameNavigation: 0
+  values:
+    InGameNavigation: 0
 UITextureSliceMode:
-  Stretched: 0
-  Tiled: 1
+  values:
+    Stretched: 0
+    Tiled: 1
 UIWidgetBlendModeType:
-  Additive: 1
-  Opaque: 0
+  values:
+    Additive: 1
+    Opaque: 0
 UIWidgetButtonEnabledState:
-  Disabled: 0
-  Enabled: 1
+  values:
+    Disabled: 0
+    Enabled: 1
 UIWidgetButtonIconType:
-  Checkmark: 3
-  Exit: 0
-  RedX: 4
-  Speak: 1
-  Undo: 2
+  values:
+    Checkmark: 3
+    Exit: 0
+    RedX: 4
+    Speak: 1
+    Undo: 2
 UIWidgetFlag:
-  UniversalWidget: 1
+  values:
+    UniversalWidget: 1
 UIWidgetFontType:
-  Normal: 0
-  Outline: 2
-  Shadow: 1
+  values:
+    Normal: 0
+    Outline: 2
+    Shadow: 1
 UIWidgetHorizontalDirection:
-  LeftToRight: 0
-  RightToLeft: 1
+  values:
+    LeftToRight: 0
+    RightToLeft: 1
 UIWidgetLayoutDirection:
-  Default: 0
-  Horizontal: 2
-  HorizontalForceNewRow: 4
-  Overlap: 3
-  Vertical: 1
+  values:
+    Default: 0
+    Horizontal: 2
+    HorizontalForceNewRow: 4
+    Overlap: 3
+    Vertical: 1
 UIWidgetModelSceneLayer:
-  Back: 2
-  Front: 1
-  None: 0
+  values:
+    Back: 2
+    Front: 1
+    None: 0
 UIWidgetMotionType:
-  Instant: 0
-  Smooth: 1
+  values:
+    Instant: 0
+    Smooth: 1
 UIWidgetOverrideState:
-  Active: 1
-  Inactive: 0
+  values:
+    Active: 1
+    Inactive: 0
 UIWidgetRewardShownState:
-  Hidden: 0
-  ShownEarned: 1
-  ShownUnearned: 2
+  values:
+    Hidden: 0
+    ShownEarned: 1
+    ShownUnearned: 2
 UIWidgetScale:
-  Eighty: 2
-  Fifty: 5
-  Ninty: 1
-  OneHundred: 0
-  OneHundredEighty: 13
-  OneHundredFifty: 10
-  OneHundredForty: 9
-  OneHundredNinety: 14
-  OneHundredSeventy: 12
-  OneHundredSixty: 11
-  OneHundredTen: 6
-  OneHundredThirty: 8
-  OneHundredTwenty: 7
-  Seventy: 3
-  Sixty: 4
-  TwoHundred: 15
+  values:
+    Eighty: 2
+    Fifty: 5
+    Ninty: 1
+    OneHundred: 0
+    OneHundredEighty: 13
+    OneHundredFifty: 10
+    OneHundredForty: 9
+    OneHundredNinety: 14
+    OneHundredSeventy: 12
+    OneHundredSixty: 11
+    OneHundredTen: 6
+    OneHundredThirty: 8
+    OneHundredTwenty: 7
+    Seventy: 3
+    Sixty: 4
+    TwoHundred: 15
 UIWidgetSetLayoutDirection:
-  Horizontal: 1
-  Overlap: 2
-  Vertical: 0
+  values:
+    Horizontal: 1
+    Overlap: 2
+    Vertical: 0
 UIWidgetSpellButtonCooldownType:
-  HideCooldown: 0
-  ShowCooldown: 1
-  ShowCooldownAndDisableOnCooldown: 2
+  values:
+    HideCooldown: 0
+    ShowCooldown: 1
+    ShowCooldownAndDisableOnCooldown: 2
 UIWidgetTextFormatType:
-  LeadingZeroesWithSixDigits: 3
-  None: 0
-  TimeOneLevel: 1
-  TimeTwoLevel: 2
+  values:
+    LeadingZeroesWithSixDigits: 3
+    None: 0
+    TimeOneLevel: 1
+    TimeTwoLevel: 2
 UIWidgetTextSizeType:
-  Huge27Pt: 3
-  Large20Pt: 8
-  Large24Pt: 2
-  Medium16Pt: 1
-  Medium18Pt: 7
-  Small10Pt: 5
-  Small11Pt: 6
-  Small12Pt: 0
-  Standard14Pt: 4
+  values:
+    Huge27Pt: 3
+    Large20Pt: 8
+    Large24Pt: 2
+    Medium16Pt: 1
+    Medium18Pt: 7
+    Small10Pt: 5
+    Small11Pt: 6
+    Small12Pt: 0
+    Standard14Pt: 4
 UIWidgetTextureAndTextSizeType:
-  Huge: 3
-  Large: 2
-  Medium: 1
-  Medium2: 5
-  Small: 0
-  Standard: 4
+  values:
+    Huge: 3
+    Large: 2
+    Medium: 1
+    Medium2: 5
+    Small: 0
+    Standard: 4
 UIWidgetTooltipLocation:
-  Bottom: 8
-  BottomLeft: 1
-  BottomRight: 7
-  Default: 0
-  Left: 2
-  Right: 6
-  Top: 4
-  TopLeft: 3
-  TopRight: 5
+  values:
+    Bottom: 8
+    BottomLeft: 1
+    BottomRight: 7
+    Default: 0
+    Left: 2
+    Right: 6
+    Top: 4
+    TopLeft: 3
+    TopRight: 5
 UIWidgetUpdateAnimType:
-  Flash: 1
-  FlashAndAnimateNumber: 2
-  None: 0
+  values:
+    Flash: 1
+    FlashAndAnimateNumber: 2
+    None: 0
 UIWidgetVisualizationType:
-  BulletTextList: 10
-  ButtonHeader: 30
-  CaptureBar: 1
-  CaptureZone: 17
-  DiscreteProgressSteps: 19
-  DoubleIconAndText: 5
-  DoubleStateIconRow: 14
-  DoubleStatusBar: 3
-  FillUpFrames: 24
-  HorizontalCurrencies: 9
-  IconAndText: 0
-  IconTextAndBackground: 4
-  IconTextAndCurrencies: 7
-  ItemDisplay: 27
-  MapPinAnimation: 26
-  PreyHuntProgress: 31
-  ScenarioHeaderCurrenciesAndBackground: 11
-  ScenarioHeaderDelves: 29
-  ScenarioHeaderTimer: 20
-  Spacer: 22
-  SpellDisplay: 13
-  StackedResourceTracker: 6
-  StatusBar: 2
-  TextColumnRow: 21
-  TextureAndText: 12
-  TextureAndTextRow: 15
-  TextureWithAnimation: 18
-  TextWithState: 8
-  TextWithSubtext: 25
-  TugOfWar: 28
-  UnitPowerBar: 23
-  ZoneControl: 16
+  values:
+    BulletTextList: 10
+    ButtonHeader: 30
+    CaptureBar: 1
+    CaptureZone: 17
+    DiscreteProgressSteps: 19
+    DoubleIconAndText: 5
+    DoubleStateIconRow: 14
+    DoubleStatusBar: 3
+    FillUpFrames: 24
+    HorizontalCurrencies: 9
+    IconAndText: 0
+    IconTextAndBackground: 4
+    IconTextAndCurrencies: 7
+    ItemDisplay: 27
+    MapPinAnimation: 26
+    PreyHuntProgress: 31
+    ScenarioHeaderCurrenciesAndBackground: 11
+    ScenarioHeaderDelves: 29
+    ScenarioHeaderTimer: 20
+    Spacer: 22
+    SpellDisplay: 13
+    StackedResourceTracker: 6
+    StatusBar: 2
+    TextColumnRow: 21
+    TextureAndText: 12
+    TextureAndTextRow: 15
+    TextureWithAnimation: 18
+    TextWithState: 8
+    TextWithSubtext: 25
+    TugOfWar: 28
+    UnitPowerBar: 23
+    ZoneControl: 16
 UnitAuraSortDirection:
-  Normal: 0
-  Reverse: 1
+  values:
+    Normal: 0
+    Reverse: 1
 UnitAuraSortRule:
-  BigDefensive: 2
-  Default: 1
-  Expiration: 3
-  ExpirationOnly: 4
-  Name: 5
-  NameOnly: 6
-  Unsorted: 0
+  values:
+    BigDefensive: 2
+    Default: 1
+    Expiration: 3
+    ExpirationOnly: 4
+    Name: 5
+    NameOnly: 6
+    Unsorted: 0
 UnitDamageAbsorbClampMode:
-  MaximumHealth: 2
-  MissingHealth: 0
-  MissingHealthWithoutIncomingHeals: 1
+  values:
+    MaximumHealth: 2
+    MissingHealth: 0
+    MissingHealthWithoutIncomingHeals: 1
 UnitHealAbsorbClampMode:
-  CurrentHealth: 0
-  MaximumHealth: 1
+  values:
+    CurrentHealth: 0
+    MaximumHealth: 1
 UnitHealAbsorbMode:
-  ReducedByIncomingHeals: 0
-  Total: 1
+  values:
+    ReducedByIncomingHeals: 0
+    Total: 1
 UnitIncomingHealClampMode:
-  MaximumHealth: 1
-  MissingHealth: 0
+  values:
+    MaximumHealth: 1
+    MissingHealth: 0
 UnitMaximumHealthMode:
-  Default: 0
-  WithAbsorbs: 1
+  values:
+    Default: 0
+    WithAbsorbs: 1
 UnitMirrorPetFlags:
-  Dismissable: 2
-  ExtraPet: 16
-  RecentlyTamed: 4
-  Renameable: 1
-  Stampede: 8
+  values:
+    Dismissable: 2
+    ExtraPet: 16
+    RecentlyTamed: 4
+    Renameable: 1
+    Stampede: 8
 UnitSex:
-  Both: 3
-  Female: 1
-  Male: 0
-  Neutral: 4
-  None: 2
+  values:
+    Both: 3
+    Female: 1
+    Male: 0
+    Neutral: 4
+    None: 2
 UrlTextureResult:
-  Found: 1
-  NotAllowed: 4
-  NotFound: 2
-  Requested: 3
+  values:
+    Found: 1
+    NotAllowed: 4
+    NotFound: 2
+    Requested: 3
 ValidateNameResult:
-  ConsecutiveSpaces: 13
-  DeclensionDoesntMatchBaseName: 16
-  Failure: 1
-  InvalidApostrophe: 9
-  InvalidCharacter: 5
-  InvalidSpace: 12
-  MixedLanguages: 6
-  MultipleApostrophes: 10
-  NoName: 2
-  Profane: 7
-  Reserved: 8
-  RussianConsecutiveSilentCharacters: 14
-  RussianSilentCharacterAtBeginningOrEnd: 15
-  SpacesDisallowed: 17
-  Success: 0
-  ThreeConsecutive: 11
-  TooLong: 4
-  TooShort: 3
+  values:
+    ConsecutiveSpaces: 13
+    DeclensionDoesntMatchBaseName: 16
+    Failure: 1
+    InvalidApostrophe: 9
+    InvalidCharacter: 5
+    InvalidSpace: 12
+    MixedLanguages: 6
+    MultipleApostrophes: 10
+    NoName: 2
+    Profane: 7
+    Reserved: 8
+    RussianConsecutiveSilentCharacters: 14
+    RussianSilentCharacterAtBeginningOrEnd: 15
+    SpacesDisallowed: 17
+    Success: 0
+    ThreeConsecutive: 11
+    TooLong: 4
+    TooShort: 3
 VasPurchaseProgress:
-  ApplyingLicense: 3
-  Complete: 7
-  Invalid: 0
-  PaymentPending: 2
-  PrePurchase: 1
-  ProcessingFactionChange: 6
-  Ready: 5
-  WaitingOnQueue: 4
+  values:
+    ApplyingLicense: 3
+    Complete: 7
+    Invalid: 0
+    PaymentPending: 2
+    PrePurchase: 1
+    ProcessingFactionChange: 6
+    Ready: 5
+    WaitingOnQueue: 4
 VasServiceType:
-  AppearanceChange: 2
-  CharacterClone: 10
-  CharacterTransfer: 4
-  FactionChange: 1
-  FactionTransfer: 5
-  NameChange: 0
-  RaceChange: 3
+  values:
+    AppearanceChange: 2
+    CharacterClone: 10
+    CharacterTransfer: 4
+    FactionChange: 1
+    FactionTransfer: 5
+    NameChange: 0
+    RaceChange: 3
 VasTransactionPurchaseResult:
-  BeginDbErrors: 20010
-  BeginProxyErrors: 17
-  DbAccountDoesNotOwnCharacter: 20017
-  DbAllianceNotEligible: 20027
-  DbAlreadyRenameFlagged: 20055
-  DbAuthenticatorInsufficient: 20073
-  DbBatchProcessingDisabled: 20028
-  DbBatchStateInvalid: 20067
-  DbBnetAccountNotProvided: 20077
-  DbBoostProcessingDisabled: 20095
-  DbBpayDeliveryPending: 20078
-  DbCagedPetInInventory: 20084
-  DbCannotMoveArenaCaptn: 20064
-  DbCannotMoveGuildmaster: 20012
-  DbCharacterDoesNotExist: 20019
-  DbCharacterWithoutGuild: 20070
-  DbCharLocked: 20026
-  DbCharNotLocked: 20025
-  DbCouldNotObtainCharLock: 20041
-  DbCustomizeAlreadyRequested: 20057
-  DbDeletedGuild: 20071
-  DbDuplicateCharacterName: 20015
-  DbDuplicateSupportRequest: 20063
-  DbEventNotActive: 20068
-  DbEventRealmClosed: 20038
-  DbFactionChangeTooSoon: 20061
-  DbGmSenorityInsufficient: 20072
-  DbGuildLevelInsufficient: 20074
-  DbGuildRankInsufficient: 20069
-  DbHasAuctions: 20033
-  DbHasBpayToken: 20079
-  DbHasCraftingOrders: 20092
-  DbHasHeirloomItem: 20080
-  DbHasMail: 20016
-  DbHasNewPlayerExperienceRestriction: 20091
-  DbHasUnclaimedCacheRewards: 20089
-  DbHouseOwnerRestriction: 20096
-  DbIneligibleMapID: 20076
-  DbIneligibleTargetRealm: 20022
-  DbInvalidName: 20094
-  DbInventoryCorrupt: 20040
-  DbLastCustomizeTooSoon: 20058
-  DbLastRenameTooRecent: 20052
-  DbLastRequestTooSoon: 20054
-  DbLastSaveTooDistant: 20083
-  DbLastSaveTooRecent: 20034
-  DbLockAlreadyRequested: 20044
-  DbLockNotAcknowledged: 20043
-  DbMaxCharactersOnServer: 20013
-  DbMoveInProgress: 20018
-  DbMultipleTransferCn: 20056
-  DbNameChangeSkipped: 20093
-  DbNameNotAvailable: 20051
-  DbNeedsEraChoice: 20090
-  DbNeedsLevelSquish: 20088
-  DbNewLeaderInvalid: 20086
-  DbNewNameTooLong: 20024
-  DbNoCopiesAvailable: 20020
-  DbNoCsiFound: 20065
-  DbNoMixedAlliance: 20014
-  DbNoneBatchQueueID: 20029
-  DbNoneLockID: 20042
-  DbNoneRealmForEvent: 20037
-  DbNoneSupportActionID: 20046
-  DbNoneSupportQueueID: 20045
-  DbNoneTemplateForEvent: 20039
-  DbNotMovebackable: 20048
-  DbNotRollbackable: 20047
-  DbOnBoostCooldown: 20085
-  DbPendingItemAudit: 20066
-  DbPvEPvPTransferNotAllowed: 20087
-  DbRaceClassComboIneligible: 20062
-  DbRealmNotEligible: 20011
-  DbRegionalDbNotFound: 20075
-  DbRenameAlreadyRequested: 20049
-  DbReservationDoesNotMatch: 20053
-  DbReservationExpired: 20050
-  DbResultAccountRestricted: 20082
-  DbResultSourceAccountBanned: 20081
-  DbTooMuchMoneyForLevel: 20032
-  DbTransferDateTooSoon: 20023
-  DbTransferNotCancellable: 20031
-  DbTransferNotFinalized: 20030
-  DbTransferNotLockable: 20035
-  DbTransferNotUnlockable: 20036
-  DbUnableToCustomize: 20060
-  DbUnderMinLevelReq: 20021
-  DbWaitingForPayment: 20059
-  DisallowedDestinationAccount: 9
-  DisallowedSourceAccount: 8
-  EndDbErrors: 20097
-  EndProxyErrors: 56
-  EndServerErrors: 16
-  InvalidBpayDeliverableID: 14
-  InvalidBpayProductID: 13
-  InvalidBpayProductType: 15
-  InvalidDestinationAccount: 6
-  InvalidDestinationRealm: 5
-  InvalidDistribution: 12
-  InvalidSourceAccount: 7
-  LowerBoxLevel: 11
-  None: 0
-  NoneCharacter: 2
-  NoneProduct: 3
-  OnlyOneVasAtATime: 4
-  ProxyAccountDataTooBig: 55
-  ProxyBadDbType: 35
-  ProxyBadObjType: 18
-  ProxyBadRequestContained: 33
-  ProxyBindFailed: 51
-  ProxyCannotDeleteArenaCaptain: 31
-  ProxyCannotDeleteGuildLeader: 30
-  ProxyCannotInsertNull: 45
-  ProxyCannotUndeleteTrialBoostCharacter: 46
-  ProxyCharacterHasWoWToken: 53
-  ProxyCharacterLevelTooHigh: 38
-  ProxyCharacterTransferred: 39
-  ProxyCharacterTransferredNoBoostInProgress: 40
-  ProxyDataInvalid: 22
-  ProxyDbError: 21
-  ProxyDeleteNotSupported: 28
-  ProxyExternalUpdateDetected: 37
-  ProxyGenericError: 44
-  ProxyInsertRequestContainedNoData: 49
-  ProxyInvalidKey: 50
-  ProxyIsReadonly: 34
-  ProxyLockedForToken: 42
-  ProxyLockedForTransfer: 26
-  ProxyLockedForUpgrade: 41
-  ProxyLockedForVas: 43
-  ProxyLocksFailed: 24
-  ProxyLostProxyConnection: 23
-  ProxyMissingResultsPtr: 25
-  ProxyMoneyLimitExceeded: 32
-  ProxyNoReturnValue: 27
-  ProxyObjDropped: 29
-  ProxyObjNotInDb: 19
-  ProxyOperationAlreadyInProgress: 36
-  ProxyPredicateFailed: 47
-  ProxyTooBusyBackOff: 54
-  ProxyTooManyRows: 52
-  ProxyUniqueKey: 20
-  ProxyWeeklyRewardNotFound: 48
-  UnknownError: 10
-  VasPurchaseDisabled: 1
+  values:
+    BeginDbErrors: 20010
+    BeginProxyErrors: 17
+    DbAccountDoesNotOwnCharacter: 20017
+    DbAllianceNotEligible: 20027
+    DbAlreadyRenameFlagged: 20055
+    DbAuthenticatorInsufficient: 20073
+    DbBatchProcessingDisabled: 20028
+    DbBatchStateInvalid: 20067
+    DbBnetAccountNotProvided: 20077
+    DbBoostProcessingDisabled: 20095
+    DbBpayDeliveryPending: 20078
+    DbCagedPetInInventory: 20084
+    DbCannotMoveArenaCaptn: 20064
+    DbCannotMoveGuildmaster: 20012
+    DbCharacterDoesNotExist: 20019
+    DbCharacterWithoutGuild: 20070
+    DbCharLocked: 20026
+    DbCharNotLocked: 20025
+    DbCouldNotObtainCharLock: 20041
+    DbCustomizeAlreadyRequested: 20057
+    DbDeletedGuild: 20071
+    DbDuplicateCharacterName: 20015
+    DbDuplicateSupportRequest: 20063
+    DbEventNotActive: 20068
+    DbEventRealmClosed: 20038
+    DbFactionChangeTooSoon: 20061
+    DbGmSenorityInsufficient: 20072
+    DbGuildLevelInsufficient: 20074
+    DbGuildRankInsufficient: 20069
+    DbHasAuctions: 20033
+    DbHasBpayToken: 20079
+    DbHasCraftingOrders: 20092
+    DbHasHeirloomItem: 20080
+    DbHasMail: 20016
+    DbHasNewPlayerExperienceRestriction: 20091
+    DbHasUnclaimedCacheRewards: 20089
+    DbHouseOwnerRestriction: 20096
+    DbIneligibleMapID: 20076
+    DbIneligibleTargetRealm: 20022
+    DbInvalidName: 20094
+    DbInventoryCorrupt: 20040
+    DbLastCustomizeTooSoon: 20058
+    DbLastRenameTooRecent: 20052
+    DbLastRequestTooSoon: 20054
+    DbLastSaveTooDistant: 20083
+    DbLastSaveTooRecent: 20034
+    DbLockAlreadyRequested: 20044
+    DbLockNotAcknowledged: 20043
+    DbMaxCharactersOnServer: 20013
+    DbMoveInProgress: 20018
+    DbMultipleTransferCn: 20056
+    DbNameChangeSkipped: 20093
+    DbNameNotAvailable: 20051
+    DbNeedsEraChoice: 20090
+    DbNeedsLevelSquish: 20088
+    DbNewLeaderInvalid: 20086
+    DbNewNameTooLong: 20024
+    DbNoCopiesAvailable: 20020
+    DbNoCsiFound: 20065
+    DbNoMixedAlliance: 20014
+    DbNoneBatchQueueID: 20029
+    DbNoneLockID: 20042
+    DbNoneRealmForEvent: 20037
+    DbNoneSupportActionID: 20046
+    DbNoneSupportQueueID: 20045
+    DbNoneTemplateForEvent: 20039
+    DbNotMovebackable: 20048
+    DbNotRollbackable: 20047
+    DbOnBoostCooldown: 20085
+    DbPendingItemAudit: 20066
+    DbPvEPvPTransferNotAllowed: 20087
+    DbRaceClassComboIneligible: 20062
+    DbRealmNotEligible: 20011
+    DbRegionalDbNotFound: 20075
+    DbRenameAlreadyRequested: 20049
+    DbReservationDoesNotMatch: 20053
+    DbReservationExpired: 20050
+    DbResultAccountRestricted: 20082
+    DbResultSourceAccountBanned: 20081
+    DbTooMuchMoneyForLevel: 20032
+    DbTransferDateTooSoon: 20023
+    DbTransferNotCancellable: 20031
+    DbTransferNotFinalized: 20030
+    DbTransferNotLockable: 20035
+    DbTransferNotUnlockable: 20036
+    DbUnableToCustomize: 20060
+    DbUnderMinLevelReq: 20021
+    DbWaitingForPayment: 20059
+    DisallowedDestinationAccount: 9
+    DisallowedSourceAccount: 8
+    EndDbErrors: 20097
+    EndProxyErrors: 56
+    EndServerErrors: 16
+    InvalidBpayDeliverableID: 14
+    InvalidBpayProductID: 13
+    InvalidBpayProductType: 15
+    InvalidDestinationAccount: 6
+    InvalidDestinationRealm: 5
+    InvalidDistribution: 12
+    InvalidSourceAccount: 7
+    LowerBoxLevel: 11
+    None: 0
+    NoneCharacter: 2
+    NoneProduct: 3
+    OnlyOneVasAtATime: 4
+    ProxyAccountDataTooBig: 55
+    ProxyBadDbType: 35
+    ProxyBadObjType: 18
+    ProxyBadRequestContained: 33
+    ProxyBindFailed: 51
+    ProxyCannotDeleteArenaCaptain: 31
+    ProxyCannotDeleteGuildLeader: 30
+    ProxyCannotInsertNull: 45
+    ProxyCannotUndeleteTrialBoostCharacter: 46
+    ProxyCharacterHasWoWToken: 53
+    ProxyCharacterLevelTooHigh: 38
+    ProxyCharacterTransferred: 39
+    ProxyCharacterTransferredNoBoostInProgress: 40
+    ProxyDataInvalid: 22
+    ProxyDbError: 21
+    ProxyDeleteNotSupported: 28
+    ProxyExternalUpdateDetected: 37
+    ProxyGenericError: 44
+    ProxyInsertRequestContainedNoData: 49
+    ProxyInvalidKey: 50
+    ProxyIsReadonly: 34
+    ProxyLockedForToken: 42
+    ProxyLockedForTransfer: 26
+    ProxyLockedForUpgrade: 41
+    ProxyLockedForVas: 43
+    ProxyLocksFailed: 24
+    ProxyLostProxyConnection: 23
+    ProxyMissingResultsPtr: 25
+    ProxyMoneyLimitExceeded: 32
+    ProxyNoReturnValue: 27
+    ProxyObjDropped: 29
+    ProxyObjNotInDb: 19
+    ProxyOperationAlreadyInProgress: 36
+    ProxyPredicateFailed: 47
+    ProxyTooBusyBackOff: 54
+    ProxyTooManyRows: 52
+    ProxyUniqueKey: 20
+    ProxyWeeklyRewardNotFound: 48
+    UnknownError: 10
+    VasPurchaseDisabled: 1
 ViewArenaSize:
-  Three: 1
-  Two: 0
+  values:
+    Three: 1
+    Two: 0
 ViewRaidSize:
-  Forty: 2
-  Ten: 0
-  TwentyFive: 1
+  values:
+    Forty: 2
+    Ten: 0
+    TwentyFive: 1
 VignetteObjectiveType:
-  Defeat: 1
-  DefeatShowRemainingHealth: 2
-  None: 0
+  values:
+    Defeat: 1
+    DefeatShowRemainingHealth: 2
+    None: 0
 VignetteType:
-  FyrakkFlight: 4
-  Normal: 0
-  PvPBounty: 1
-  Torghast: 2
-  Treasure: 3
+  values:
+    FyrakkFlight: 4
+    Normal: 0
+    PvPBounty: 1
+    Torghast: 2
+    Treasure: 3
 Vocalerrorsounds:
-  Abilitycooling: 50
-  Alreadyingroup: 20
-  Alreadyinguild: 21
-  Ammoonlyinbag: 28
-  Bagfull: 29
-  BoundNodrop: 4
-  Cantaffordbankslot: 22
-  CantattackNotarget: 38
-  CantattackNotstandingObsolete: 37
-  Cantattackrongdirection: 36
-  CantcastOutofrange: 46
-  Cantcreate: 18
-  Cantdrinkmore: 6
-  Canteatmore: 7
-  CanteatMoving: 24
-  Cantequip2Hequipped: 42
-  Cantequip2HNoskill: 43
-  Cantequip2HSkill: 41
-  Cantflyhere: 60
-  Cantinvite: 8
-  CantlearnLevel: 13
-  Cantloot: 17
-  CantlootDidntkill: 31
-  CantlootLocked: 33
-  CantlootNotstandingObsolete: 34
-  CantlootToofar: 35
-  CantlootWrongfacing: 32
-  Cantputbag: 26
-  Cantswap: 58
-  CanttaxiNomoney: 54
-  CanttradeSoulbound: 59
-  Cantuseitem: 51
-  Cantuselocked: 55
-  Cantusetoofar: 57
-  Chestinuse: 52
-  Declinegroup: 19
-  ExhaustedObsolete: 67
-  FoodcoolingObsolete: 53
-  Genericnotarget: 45
-  Guildpermissions: 62
-  Invaliditemtarget: 66
-  Invalidtarget: 11
-  Inventoryfull: 0
-  Inviteebusy: 9
-  Itemcooling: 5
-  Itemlocked: 61
-  Itemmaxcount: 30
-  Locked: 14
-  Mustequippitem: 49
-  Noenergy: 64
-  NoequipEver: 3
-  NoequipLevel: 2
-  Noequipslotavailable: 56
-  Noessence: 65
-  Nomana: 15
-  Norage: 63
-  Notabag: 25
-  Notenoughgold: 39
-  Notenoughmoney: 40
-  Notequippable: 44
-  Notwhiledead: 16
-  Outofammo: 1
-  Potioncooling: 47
-  Proficiencyneeded: 48
-  Spellcooling: 12
-  Targettoofar: 10
-  Toomanybankslots: 23
-  Wrongslot: 27
+  values:
+    Abilitycooling: 50
+    Alreadyingroup: 20
+    Alreadyinguild: 21
+    Ammoonlyinbag: 28
+    Bagfull: 29
+    BoundNodrop: 4
+    Cantaffordbankslot: 22
+    CantattackNotarget: 38
+    CantattackNotstandingObsolete: 37
+    Cantattackrongdirection: 36
+    CantcastOutofrange: 46
+    Cantcreate: 18
+    Cantdrinkmore: 6
+    Canteatmore: 7
+    CanteatMoving: 24
+    Cantequip2Hequipped: 42
+    Cantequip2HNoskill: 43
+    Cantequip2HSkill: 41
+    Cantflyhere: 60
+    Cantinvite: 8
+    CantlearnLevel: 13
+    Cantloot: 17
+    CantlootDidntkill: 31
+    CantlootLocked: 33
+    CantlootNotstandingObsolete: 34
+    CantlootToofar: 35
+    CantlootWrongfacing: 32
+    Cantputbag: 26
+    Cantswap: 58
+    CanttaxiNomoney: 54
+    CanttradeSoulbound: 59
+    Cantuseitem: 51
+    Cantuselocked: 55
+    Cantusetoofar: 57
+    Chestinuse: 52
+    Declinegroup: 19
+    ExhaustedObsolete: 67
+    FoodcoolingObsolete: 53
+    Genericnotarget: 45
+    Guildpermissions: 62
+    Invaliditemtarget: 66
+    Invalidtarget: 11
+    Inventoryfull: 0
+    Inviteebusy: 9
+    Itemcooling: 5
+    Itemlocked: 61
+    Itemmaxcount: 30
+    Locked: 14
+    Mustequippitem: 49
+    Noenergy: 64
+    NoequipEver: 3
+    NoequipLevel: 2
+    Noequipslotavailable: 56
+    Noessence: 65
+    Nomana: 15
+    Norage: 63
+    Notabag: 25
+    Notenoughgold: 39
+    Notenoughmoney: 40
+    Notequippable: 44
+    Notwhiledead: 16
+    Outofammo: 1
+    Potioncooling: 47
+    Proficiencyneeded: 48
+    Spellcooling: 12
+    Targettoofar: 10
+    Toomanybankslots: 23
+    Wrongslot: 27
 VoiceChatStatusCode:
-  AlreadyInChannel: 10
-  ChannelAlreadyExists: 9
-  ChannelNameTooLong: 8
-  ChannelNameTooShort: 7
-  ClientAlreadyLoggedIn: 6
-  ClientNotInitialized: 4
-  ClientNotLoggedIn: 5
-  Disabled: 18
-  Failure: 12
-  InvalidCommunityStream: 20
-  InvalidInputDevice: 23
-  InvalidOutputDevice: 24
-  LoginProhibited: 3
-  OperationPending: 1
-  PlayerSilenced: 21
-  PlayerVoiceChatParentalDisabled: 22
-  ProxyConnectionTimeOut: 15
-  ProxyConnectionUnableToConnect: 16
-  ProxyConnectionUnexpectedDisconnect: 17
-  ServiceLost: 13
-  Success: 0
-  TargetNotFound: 11
-  TooManyRequests: 2
-  UnableToLaunchProxy: 14
-  UnsupportedChatChannelType: 19
+  values:
+    AlreadyInChannel: 10
+    ChannelAlreadyExists: 9
+    ChannelNameTooLong: 8
+    ChannelNameTooShort: 7
+    ClientAlreadyLoggedIn: 6
+    ClientNotInitialized: 4
+    ClientNotLoggedIn: 5
+    Disabled: 18
+    Failure: 12
+    InvalidCommunityStream: 20
+    InvalidInputDevice: 23
+    InvalidOutputDevice: 24
+    LoginProhibited: 3
+    OperationPending: 1
+    PlayerSilenced: 21
+    PlayerVoiceChatParentalDisabled: 22
+    ProxyConnectionTimeOut: 15
+    ProxyConnectionUnableToConnect: 16
+    ProxyConnectionUnexpectedDisconnect: 17
+    ServiceLost: 13
+    Success: 0
+    TargetNotFound: 11
+    TooManyRequests: 2
+    UnableToLaunchProxy: 14
+    UnsupportedChatChannelType: 19
 VoiceTtsStatusCode:
-  DestinationQueueFull: 8
-  EngineAllocationFailed: 2
-  EnqueueNotNecessary: 9
-  InputTextEnqueued: 6
-  InternalError: 13
-  InvalidArgument: 12
-  InvalidEngineType: 1
-  ManagerNotFound: 11
-  MaxCharactersExceeded: 4
-  NotSupported: 3
-  SdkNotInitialized: 7
-  Success: 0
-  UtteranceBelowMinimumDuration: 5
-  UtteranceNotFound: 10
+  values:
+    DestinationQueueFull: 8
+    EngineAllocationFailed: 2
+    EnqueueNotNecessary: 9
+    InputTextEnqueued: 6
+    InternalError: 13
+    InvalidArgument: 12
+    InvalidEngineType: 1
+    ManagerNotFound: 11
+    MaxCharactersExceeded: 4
+    NotSupported: 3
+    SdkNotInitialized: 7
+    Success: 0
+    UtteranceBelowMinimumDuration: 5
+    UtteranceNotFound: 10
 WarbandSceneFlags:
-  AwardedAutomatically: 8
-  CannotBeSaved: 4
-  DoNotInclude: 1
-  HiddenUntilCollected: 2
-  IsDefault: 16
+  values:
+    AwardedAutomatically: 8
+    CannotBeSaved: 4
+    DoNotInclude: 1
+    HiddenUntilCollected: 2
+    IsDefault: 16
 WeaponSlot:
-  MainHand: 0
-  OffHand: 1
+  values:
+    MainHand: 0
+    OffHand: 1
 WeeklyRewardChestActivityType:
-  LFGDungeons: 1
-  Scenario: 0
-  World: 2
+  values:
+    LFGDungeons: 1
+    Scenario: 0
+    World: 2
 WeeklyRewardChestClaimRewardResult:
-  CountExceeded: 7
-  DbError: 5
-  InvalidSlot: 3
-  InvalidThreshold: 1
-  LockFailure: 6
-  PlayerNotFound: 2
-  Success: 0
-  TooManyItems: 4
+  values:
+    CountExceeded: 7
+    DbError: 5
+    InvalidSlot: 3
+    InvalidThreshold: 1
+    LockFailure: 6
+    PlayerNotFound: 2
+    Success: 0
+    TooManyItems: 4
 WeeklyRewardChestThresholdType:
-  Activities: 1
-  AlsoReceive: 4
-  Concession: 5
-  None: 0
-  Raid: 3
-  RankedPvP: 2
-  World: 6
+  values:
+    Activities: 1
+    AlsoReceive: 4
+    Concession: 5
+    None: 0
+    Raid: 3
+    RankedPvP: 2
+    World: 6
 WeeklyRewardProgressResult:
-  DbError: 3
-  NoPlayer: 4
-  NoSeason: 1
-  Success: 0
-  TimedOut: 2
+  values:
+    DbError: 3
+    NoPlayer: 4
+    NoSeason: 1
+    Success: 0
+    TimedOut: 2
 WidgetAnimationType:
-  Fade: 1
-  None: 0
+  values:
+    Fade: 1
+    None: 0
 WidgetCurrencyClass:
-  Currency: 0
-  Item: 1
+  values:
+    Currency: 0
+    Item: 1
 WidgetEnabledState:
-  Artifact: 5
-  Black: 6
-  BrightBlue: 7
-  Disabled: 0
-  Green: 4
-  Red: 2
-  White: 3
-  Yellow: 1
+  values:
+    Artifact: 5
+    Black: 6
+    BrightBlue: 7
+    Disabled: 0
+    Green: 4
+    Red: 2
+    White: 3
+    Yellow: 1
 WidgetGlowAnimType:
-  None: 0
-  Pulse: 1
+  values:
+    None: 0
+    Pulse: 1
 WidgetIconSizeType:
-  Large: 2
-  Medium: 1
-  Small: 0
-  Standard: 3
+  values:
+    Large: 2
+    Medium: 1
+    Small: 0
+    Standard: 3
 WidgetIconSourceType:
-  Item: 1
-  Spell: 0
+  values:
+    Item: 1
+    Spell: 0
 WidgetOpacityType:
-  Eighty: 2
-  Fifty: 5
-  Forty: 6
-  Ninety: 1
-  OneHundred: 0
-  Seventy: 3
-  Sixty: 4
-  Ten: 9
-  Thirty: 7
-  Twenty: 8
-  Zero: 10
+  values:
+    Eighty: 2
+    Fifty: 5
+    Forty: 6
+    Ninety: 1
+    OneHundred: 0
+    Seventy: 3
+    Sixty: 4
+    Ten: 9
+    Thirty: 7
+    Twenty: 8
+    Zero: 10
 WidgetShowGlowState:
-  HideGlow: 0
-  ShowGlow: 1
+  values:
+    HideGlow: 0
+    ShowGlow: 1
 WidgetShownState:
-  Hidden: 0
-  Shown: 1
+  values:
+    Hidden: 0
+    Shown: 1
 WidgetTextHorizontalAlignmentType:
-  Center: 1
-  Left: 0
-  Right: 2
+  values:
+    Center: 1
+    Left: 0
+    Right: 2
 WidgetUnitPowerBarFlashMomentType:
-  FlashWhenMax: 0
-  FlashWhenMin: 1
-  NeverFlash: 2
+  values:
+    FlashWhenMax: 0
+    FlashWhenMin: 1
+    NeverFlash: 2
 WorldCursorAnchorType:
-  Cursor: 2
-  Default: 1
-  Nameplate: 3
-  None: 0
+  values:
+    Cursor: 2
+    Default: 1
+    Nameplate: 3
+    None: 0
 WorldElapsedTimerTypes:
-  ChallengeMode: 1
-  None: 0
-  ProvingGround: 2
+  values:
+    ChallengeMode: 1
+    None: 0
+    ProvingGround: 2
 WorldTierDifficulty:
-  Heroic: 2
-  Mythic: 3
-  Normal: 1
+  values:
+    Heroic: 2
+    Mythic: 3
+    Normal: 1
 WoWClientCursorSize:
-  ExtraLarge: 3
-  Large: 2
-  Massive: 4
-  Medium: 1
-  Standard: 0
+  values:
+    ExtraLarge: 3
+    Large: 2
+    Massive: 4
+    Medium: 1
+    Standard: 0
 WoWEntitlementType:
-  Appearance: 4
-  AppearanceSet: 5
-  Battlepet: 2
-  GameTime: 6
-  Illusion: 8
-  Invalid: 9
-  Item: 0
-  Mount: 1
-  Title: 7
-  Toy: 3
+  values:
+    Appearance: 4
+    AppearanceSet: 5
+    Battlepet: 2
+    GameTime: 6
+    Illusion: 8
+    Invalid: 9
+    Item: 0
+    Mount: 1
+    Title: 7
+    Toy: 3
 WoWLabsAreaType:
-  PlunderstormDropDense: 2
-  PlunderstormDropMedium: 1
-  PlunderstormDropSparse: 0
+  values:
+    PlunderstormDropDense: 2
+    PlunderstormDropMedium: 1
+    PlunderstormDropSparse: 0
 ZoneControlActiveState:
-  Active: 1
-  Inactive: 0
+  values:
+    Active: 1
+    Inactive: 0
 ZoneControlDangerFlashType:
-  ShowOnBadStates: 1
-  ShowOnBoth: 2
-  ShowOnGoodStates: 0
-  ShowOnNeither: 3
+  values:
+    ShowOnBadStates: 1
+    ShowOnBoth: 2
+    ShowOnGoodStates: 0
+    ShowOnNeither: 3
 ZoneControlFillType:
-  DoubleFillClockwise: 2
-  DoubleFillCounterClockwise: 3
-  SingleFillClockwise: 0
-  SingleFillCounterClockwise: 1
+  values:
+    DoubleFillClockwise: 2
+    DoubleFillCounterClockwise: 3
+    SingleFillClockwise: 0
+    SingleFillCounterClockwise: 1
 ZoneControlLeadingEdgeType:
-  NoLeadingEdge: 0
-  UseLeadingEdge: 1
+  values:
+    NoLeadingEdge: 0
+    UseLeadingEdge: 1
 ZoneControlMode:
-  BothStatesAreGood: 0
-  NeitherStateIsGood: 3
-  State1IsGood: 1
-  State2IsGood: 2
+  values:
+    BothStatesAreGood: 0
+    NeitherStateIsGood: 3
+    State1IsGood: 1
+    State2IsGood: 2
 ZoneControlState:
-  State1: 0
-  State2: 1
+  values:
+    State1: 0
+    State2: 1

--- a/data/products/wowt/enums.yaml
+++ b/data/products/wowt/enums.yaml
@@ -1,7841 +1,8737 @@
 AbbreviationDataError:
-  InvalidBreakpoint: 1
-  InvalidFractionDivisor: 4
-  InvalidSignificandDivisor: 2
-  NotMultipleOfTen: 8
+  values:
+    InvalidBreakpoint: 1
+    InvalidFractionDivisor: 4
+    InvalidSignificandDivisor: 2
+    NotMultipleOfTen: 8
 AccountCurrencyTransferResult:
-  CannotUseCurrency: 8
-  CharacterLoggedIn: 2
-  CurrencyTransferDisabled: 10
-  InsufficientCurrency: 3
-  InvalidCharacter: 1
-  InvalidCurrency: 5
-  MaxQuantity: 4
-  NoValidSourceCharacter: 6
-  ServerError: 7
-  Success: 0
-  TransactionInProgress: 9
+  values:
+    CannotUseCurrency: 8
+    CharacterLoggedIn: 2
+    CurrencyTransferDisabled: 10
+    InsufficientCurrency: 3
+    InvalidCharacter: 1
+    InvalidCurrency: 5
+    MaxQuantity: 4
+    NoValidSourceCharacter: 6
+    ServerError: 7
+    Success: 0
+    TransactionInProgress: 9
 AccountData:
-  Bindings: 2
-  Bindings2: 3
-  CharacterListOrder: 16
-  ChatSettings: 7
-  ClickBindings: 12
-  Config: 0
-  Config2: 1
-  CooldownManager: 17
-  CooldownManager2: 18
-  FlaggedIDs: 10
-  FlaggedIDs2: 11
-  FrontendChatSettings: 15
-  Macros: 4
-  Macros2: 5
-  Shop2PendingOrders: 19
-  TtsSettings: 8
-  TtsSettings2: 9
-  UIEditModeAccount: 13
-  UIEditModeChar: 14
-  UILayout: 6
+  values:
+    Bindings: 2
+    Bindings2: 3
+    CharacterListOrder: 16
+    ChatSettings: 7
+    ClickBindings: 12
+    Config: 0
+    Config2: 1
+    CooldownManager: 17
+    CooldownManager2: 18
+    FlaggedIDs: 10
+    FlaggedIDs2: 11
+    FrontendChatSettings: 15
+    Macros: 4
+    Macros2: 5
+    Shop2PendingOrders: 19
+    TtsSettings: 8
+    TtsSettings2: 9
+    UIEditModeAccount: 13
+    UIEditModeChar: 14
+    UILayout: 6
 AccountDataUpdateStatus:
-  Corrupt: 2
-  Failed: 1
-  Success: 0
-  Toobig: 3
+  values:
+    Corrupt: 2
+    Failed: 1
+    Success: 0
+    Toobig: 3
 AccountExportResult:
-  AlreadyInProgress: 11
-  Cancelled: 2
-  FailedToGenerateFile: 13
-  FailedToLockAccount: 12
-  FileInvalid: 8
-  FileWriteFailed: 9
-  NoAccountFound: 5
-  RequestedInvalidCharacter: 6
-  RpcError: 7
-  ShuttingDown: 3
-  Success: 0
-  TimedOut: 4
-  Unavailable: 10
-  UnknownError: 1
+  values:
+    AlreadyInProgress: 11
+    Cancelled: 2
+    FailedToGenerateFile: 13
+    FailedToLockAccount: 12
+    FileInvalid: 8
+    FileWriteFailed: 9
+    NoAccountFound: 5
+    RequestedInvalidCharacter: 6
+    RpcError: 7
+    ShuttingDown: 3
+    Success: 0
+    TimedOut: 4
+    Unavailable: 10
+    UnknownError: 1
 AccountGetListRequestType:
-  Battlepets: 1
-  None: 0
+  values:
+    Battlepets: 1
+    None: 0
 AccountSequenceCacheType:
-  HouseDecor: 2
-  Invalid: 0
-  Local: 1
+  values:
+    HouseDecor: 2
+    Invalid: 0
+    Local: 1
 AccountStateFlags:
-  AccountUpgradeComplete: 4
-  InPetCombat: 2
-  LoadFailed: 1
-  None: 0
-  TokenEligCheckComplete: 8
+  values:
+    AccountUpgradeComplete: 4
+    InPetCombat: 2
+    LoadFailed: 1
+    None: 0
+    TokenEligCheckComplete: 8
 AccountStateLoadedFlags:
-  AccountCurrenciesLoaded: '0x0000000000200000'
-  AccountFactionsLoaded: '0x0000000200000000'
-  AccountItemsLoaded: '0x0000000400000000'
-  AccountMappingLoaded: '0x0000008000000000'
-  AccountNotificationsLoaded: '0x0000000008000000'
-  AccountWowlabsLoaded: '0x0000000020000000'
-  AchievementsLoaded: '0x0000000000000001'
-  ArchivedPurchasesLoaded: '0x0000000000000200'
-  AuctionableTokensLoaded: '0x0000000000002000'
-  BanktabSettingsLoaded: '0x0000004000000000'
-  BattleNetAccountLoaded: '0x0000000000100000'
-  BitVectorsLoaded: '0x0000000100000000'
-  BpayAddLicenseObjectsLoaded: '0x0000000000000800'
-  BpayDistributionObjectsLoaded: '0x0000000000000100'
-  BpayProductitemObjectsLoaded: '0x0000000000020000'
-  CharacterItemsLoaded: '0x0000010000000000'
-  CharactersLoaded: '0x0000000000000040'
-  CombinedQuestLogLoaded: '0x0000000800000000'
-  ConsumableTokensLoaded: '0x0000000000004000'
-  CriteriaLoaded: '0x0000000000000002'
-  CurrencyCapsLoaded: '0x0000000000000010'
-  CurrencyTransferLogLoaded: '0x0000020000000000'
-  DataElementsLoaded: '0x0000001000000000'
-  DynamicCriteriaLoaded: '0x0000000001000000'
-  EventRecordsLoaded: '0x0000200000000000'
-  HousingDataLoaded: '0x0000080000000000'
-  ItemCollectionsLoaded: '0x0000000000001000'
-  LgVendorPurchaseLoaded: '0x0000040000000000'
-  LoadedNone: '0x0000000000000000'
-  MountsLoaded: '0x0000000000000004'
-  PerksHeldItemLoaded: '0x0000000040000000'
-  PerksPastRewardsLoaded: '0x0000000000008000'
-  PerksPendingPurchaseLoaded: '0x0000000010000000'
-  PerksPendingRewardsLoaded: '0x0000000080000000'
-  PetjournalInitialized: '0x0000000000000008'
-  PurchasesLoaded: '0x0000000000000080'
-  QuestCriteriaLoaded: '0x0000000000080000'
-  QuestLogLoaded: '0x0000000000000020'
-  RafActivityLoaded: '0x0000000002000000'
-  RafBalanceLoaded: '0x0000000000400000'
-  RafRewardsLoaded: '0x0000000000800000'
-  RevokedRafRewardsLoaded: '0x0000000004000000'
-  SettingsLoaded: '0x0000000000000400'
-  TransmogOutfitsLoaded: '0x0000400000000000'
-  TrialBoostHistoryLoaded: '0x0000000000040000'
-  VasTransactionsLoaded: '0x0000000000010000'
-  WarbandScenesLoaded: '0x0000100000000000'
-  WarbandsLoaded: '0x0000002000000000'
+  values:
+    AccountCurrenciesLoaded: '0x0000000000200000'
+    AccountFactionsLoaded: '0x0000000200000000'
+    AccountItemsLoaded: '0x0000000400000000'
+    AccountMappingLoaded: '0x0000008000000000'
+    AccountNotificationsLoaded: '0x0000000008000000'
+    AccountWowlabsLoaded: '0x0000000020000000'
+    AchievementsLoaded: '0x0000000000000001'
+    ArchivedPurchasesLoaded: '0x0000000000000200'
+    AuctionableTokensLoaded: '0x0000000000002000'
+    BanktabSettingsLoaded: '0x0000004000000000'
+    BattleNetAccountLoaded: '0x0000000000100000'
+    BitVectorsLoaded: '0x0000000100000000'
+    BpayAddLicenseObjectsLoaded: '0x0000000000000800'
+    BpayDistributionObjectsLoaded: '0x0000000000000100'
+    BpayProductitemObjectsLoaded: '0x0000000000020000'
+    CharacterItemsLoaded: '0x0000010000000000'
+    CharactersLoaded: '0x0000000000000040'
+    CombinedQuestLogLoaded: '0x0000000800000000'
+    ConsumableTokensLoaded: '0x0000000000004000'
+    CriteriaLoaded: '0x0000000000000002'
+    CurrencyCapsLoaded: '0x0000000000000010'
+    CurrencyTransferLogLoaded: '0x0000020000000000'
+    DataElementsLoaded: '0x0000001000000000'
+    DynamicCriteriaLoaded: '0x0000000001000000'
+    EventRecordsLoaded: '0x0000200000000000'
+    HousingDataLoaded: '0x0000080000000000'
+    ItemCollectionsLoaded: '0x0000000000001000'
+    LgVendorPurchaseLoaded: '0x0000040000000000'
+    LoadedNone: '0x0000000000000000'
+    MountsLoaded: '0x0000000000000004'
+    PerksHeldItemLoaded: '0x0000000040000000'
+    PerksPastRewardsLoaded: '0x0000000000008000'
+    PerksPendingPurchaseLoaded: '0x0000000010000000'
+    PerksPendingRewardsLoaded: '0x0000000080000000'
+    PetjournalInitialized: '0x0000000000000008'
+    PurchasesLoaded: '0x0000000000000080'
+    QuestCriteriaLoaded: '0x0000000000080000'
+    QuestLogLoaded: '0x0000000000000020'
+    RafActivityLoaded: '0x0000000002000000'
+    RafBalanceLoaded: '0x0000000000400000'
+    RafRewardsLoaded: '0x0000000000800000'
+    RevokedRafRewardsLoaded: '0x0000000004000000'
+    SettingsLoaded: '0x0000000000000400'
+    TransmogOutfitsLoaded: '0x0000400000000000'
+    TrialBoostHistoryLoaded: '0x0000000000040000'
+    VasTransactionsLoaded: '0x0000000000010000'
+    WarbandScenesLoaded: '0x0000100000000000'
+    WarbandsLoaded: '0x0000002000000000'
 AccountStoreCategoryType:
-  Creature: 1
-  Icon: 4
-  Mount: 3
-  TransmogSet: 2
+  values:
+    Creature: 1
+    Icon: 4
+    Mount: 3
+    TransmogSet: 2
 AccountStoreFrontFlag:
-  Enabled: 1
-  PurchaseEnabled: 2
-  RefundEnabled: 4
+  values:
+    Enabled: 1
+    PurchaseEnabled: 2
+    RefundEnabled: 4
 AccountStoreItemFlag:
-  DisplayAsNew: 4
-  DisplayDefaultArmor: 1
-  DisplayOnly: 8
-  NotInGameReward: 2
+  values:
+    DisplayAsNew: 4
+    DisplayDefaultArmor: 1
+    DisplayOnly: 8
+    NotInGameReward: 2
 AccountStoreItemMode:
-  Hidden: 2
-  Locked: 3
-  Normal: 1
+  values:
+    Hidden: 2
+    Locked: 3
+    Normal: 1
 AccountStoreItemRewardType:
-  Illusion: 7
-  Misc: 10
-  Mount: 2
-  Pet: 3
-  Tender: 9
-  Toy: 5
-  Transmog: 1
-  TransmogSet: 8
-  WarbandScene: 11
+  values:
+    Illusion: 7
+    Misc: 10
+    Mount: 2
+    Pet: 3
+    Tender: 9
+    Toy: 5
+    Transmog: 1
+    TransmogSet: 8
+    WarbandScene: 11
 AccountStoreItemStatus:
-  Owned: 3
-  Refundable: 2
-  Unowned: 1
+  values:
+    Owned: 3
+    Refundable: 2
+    Unowned: 1
 AccountStoreSettlementAction:
-  Give: 1
-  NotSet: 0
-  Remove: 2
+  values:
+    Give: 1
+    NotSet: 0
+    Remove: 2
 AccountStoreState:
-  Available: 0
-  Unavailable: 2
-  Unknown: 1
+  values:
+    Available: 0
+    Unavailable: 2
+    Unknown: 1
 AccountStoreTransactionResult:
-  Incomplete: 1
-  InsufficientFunds: 4
-  InvalidCurrencyType: 8
-  ItemAlreadyOwned: 6
-  ItemNotOwned: 7
-  ItemUnknown: 5
-  NotSupported: 10
-  OwnedButRefundTimeExpired: 9
-  ProxyError: 12
-  Success: 0
-  TransactionInProgress: 3
-  Unavailable: 11
-  UnknownError: 2
+  values:
+    Incomplete: 1
+    InsufficientFunds: 4
+    InvalidCurrencyType: 8
+    ItemAlreadyOwned: 6
+    ItemNotOwned: 7
+    ItemUnknown: 5
+    NotSupported: 10
+    OwnedButRefundTimeExpired: 9
+    ProxyError: 12
+    Success: 0
+    TransactionInProgress: 3
+    Unavailable: 11
+    UnknownError: 2
 AccountStoreTransactionType:
-  DebugRemoveItem: 4
-  DebugResetHistory: 3
-  Purchase: 1
-  Refund: 2
-  Undefined: 0
+  values:
+    DebugRemoveItem: 4
+    DebugResetHistory: 3
+    Purchase: 1
+    Refund: 2
+    Undefined: 0
 AccountTransType:
-  AccountCurrencies: 26
-  AccountNotifications: 38
-  AccountStore: 54
-  Achievements: 4
-  AddLicense: 16
-  ArchivedPurchases: 9
-  AuctionableToken: 18
-  BankTab: 48
-  BattlenetAccount: 25
-  Battlepet: 3
-  BitVectors: 50
-  CharacterDataMerge: 53
-  CharacterItems: 57
-  Characters: 7
-  CombinedQuestLog: 51
-  ConsumableToken: 19
-  CreateOrderInfo: 32
-  Criteria: 5
-  CriteriaNotif: 13
-  CurrencyCaps: 11
-  CurrencyTransferLog: 58
-  Distribution: 2
-  Distributions: 10
-  DynamicCriteria: 30
-  EventRecords: 63
-  Factions: 49
-  FixedLicense: 15
-  GetOrderStatusByPurchaseID: 46
-  HouseInitiativeFavor: 66
-  HousingItem: 64
-  ItemCollections: 17
-  Items: 47
-  LgVendorPurchase: 59
-  LoadWowlabs: 44
-  Mapping: 56
-  Mounts: 6
-  OutstandingRpc: 43
-  PerkItemHold: 39
-  PerkPastRewards: 41
-  PerkPendingRewards: 40
-  PerkTransaction: 42
-  PlayerDataElements: 52
-  Productitem: 21
-  Profile: 61
-  ProxyCreateAccountHonor: 34
-  ProxyForwarder: 0
-  ProxyGenerateBpayID: 37
-  ProxyGmSetHonor: 36
-  ProxyHonorInitialConversion: 33
-  ProxyValidateAccountHonor: 35
-  Purchase: 1
-  Purchases: 8
-  QuestCriteria: 24
-  QuestLog: 12
-  RafActivity: 31
-  RafFriendMonth: 28
-  RafRecruiterAcceptances: 27
-  RafReward: 29
-  SaveWarbandGroups: 60
-  Settings: 14
-  TransmogOutfitCollection: 65
-  TrialBoostHistories: 23
-  TrialBoostHistory: 22
-  UpgradeAccount: 45
-  VasTransaction: 20
-  WarbandGroups: 55
-  WarbandSceneCollection: 62
+  values:
+    AccountCurrencies: 26
+    AccountNotifications: 38
+    AccountStore: 54
+    Achievements: 4
+    AddLicense: 16
+    ArchivedPurchases: 9
+    AuctionableToken: 18
+    BankTab: 48
+    BattlenetAccount: 25
+    Battlepet: 3
+    BitVectors: 50
+    CharacterDataMerge: 53
+    CharacterItems: 57
+    Characters: 7
+    CombinedQuestLog: 51
+    ConsumableToken: 19
+    CreateOrderInfo: 32
+    Criteria: 5
+    CriteriaNotif: 13
+    CurrencyCaps: 11
+    CurrencyTransferLog: 58
+    Distribution: 2
+    Distributions: 10
+    DynamicCriteria: 30
+    EventRecords: 63
+    Factions: 49
+    FixedLicense: 15
+    GetOrderStatusByPurchaseID: 46
+    HouseInitiativeFavor: 66
+    HousingItem: 64
+    ItemCollections: 17
+    Items: 47
+    LgVendorPurchase: 59
+    LoadWowlabs: 44
+    Mapping: 56
+    Mounts: 6
+    OutstandingRpc: 43
+    PerkItemHold: 39
+    PerkPastRewards: 41
+    PerkPendingRewards: 40
+    PerkTransaction: 42
+    PlayerDataElements: 52
+    Productitem: 21
+    Profile: 61
+    ProxyCreateAccountHonor: 34
+    ProxyForwarder: 0
+    ProxyGenerateBpayID: 37
+    ProxyGmSetHonor: 36
+    ProxyHonorInitialConversion: 33
+    ProxyValidateAccountHonor: 35
+    Purchase: 1
+    Purchases: 8
+    QuestCriteria: 24
+    QuestLog: 12
+    RafActivity: 31
+    RafFriendMonth: 28
+    RafRecruiterAcceptances: 27
+    RafReward: 29
+    SaveWarbandGroups: 60
+    Settings: 14
+    TransmogOutfitCollection: 65
+    TrialBoostHistories: 23
+    TrialBoostHistory: 22
+    UpgradeAccount: 45
+    VasTransaction: 20
+    WarbandGroups: 55
+    WarbandSceneCollection: 62
 ActionBarOrientation:
-  Horizontal: 0
-  Vertical: 1
+  values:
+    Horizontal: 0
+    Vertical: 1
 ActionBarVisibleSetting:
-  Always: 0
-  Hidden: 3
-  InCombat: 1
-  OutOfCombat: 2
+  values:
+    Always: 0
+    Hidden: 3
+    InCombat: 1
+    OutOfCombat: 2
 AddOnEnableState:
-  All: 2
-  None: 0
-  Some: 1
+  values:
+    All: 2
+    None: 0
+    Some: 1
 AddOnPerformanceMessageType:
-  OverallAddOnErrorDialog: 2
-  SpecificAddOnChatWarning: 0
-  SpecificAddOnErrorDialog: 1
+  values:
+    OverallAddOnErrorDialog: 2
+    SpecificAddOnChatWarning: 0
+    SpecificAddOnErrorDialog: 1
 AddOnProfilerMetric:
-  CountTimeOver1000Ms: 11
-  CountTimeOver100Ms: 9
-  CountTimeOver10Ms: 7
-  CountTimeOver1Ms: 5
-  CountTimeOver500Ms: 10
-  CountTimeOver50Ms: 8
-  CountTimeOver5Ms: 6
-  EncounterAverageTime: 2
-  LastTime: 3
-  PeakTime: 4
-  RecentAverageTime: 1
-  SessionAverageTime: 0
+  values:
+    CountTimeOver1000Ms: 11
+    CountTimeOver100Ms: 9
+    CountTimeOver10Ms: 7
+    CountTimeOver1Ms: 5
+    CountTimeOver500Ms: 10
+    CountTimeOver50Ms: 8
+    CountTimeOver5Ms: 6
+    EncounterAverageTime: 2
+    LastTime: 3
+    PeakTime: 4
+    RecentAverageTime: 1
+    SessionAverageTime: 0
 AddOnRestrictionState:
-  Activating: 1
-  Active: 2
-  Inactive: 0
+  values:
+    Activating: 1
+    Active: 2
+    Inactive: 0
 AddOnRestrictionType:
-  ChallengeMode: 2
-  Chat: 5
-  Combat: 0
-  Encounter: 1
-  Map: 4
-  PvPMatch: 3
+  values:
+    ChallengeMode: 2
+    Chat: 5
+    Combat: 0
+    Encounter: 1
+    Map: 4
+    PvPMatch: 3
 AddOnSecurityStatus:
-  Banned: 2
-  Insecure: 1
-  NotAvailable: 3
-  Secure: 0
+  values:
+    Banned: 2
+    Insecure: 1
+    NotAvailable: 3
+    Secure: 0
 AddSoulbindConduitReason:
-  Cheat: 1
-  None: 0
-  SpellEffect: 2
-  Upgrade: 3
+  values:
+    Cheat: 1
+    None: 0
+    SpellEffect: 2
+    Upgrade: 3
 AnimaDiversionNodeState:
-  Available: 1
-  Cooldown: 4
-  SelectedPermanent: 3
-  SelectedTemporary: 2
-  Unavailable: 0
+  values:
+    Available: 1
+    Cooldown: 4
+    SelectedPermanent: 3
+    SelectedTemporary: 2
+    Unavailable: 0
 ArrowCalloutDirection:
-  Down: 1
-  Left: 2
-  Right: 3
-  Up: 0
+  values:
+    Down: 1
+    Left: 2
+    Right: 3
+    Up: 0
 ArrowCalloutType:
-  Generic: 1
-  None: 0
-  Tutorial: 3
-  WidgetContainerNoBorder: 4
-  WorldLootObject: 2
+  values:
+    Generic: 1
+    None: 0
+    Tutorial: 3
+    WidgetContainerNoBorder: 4
+    WorldLootObject: 2
 AssistActionType:
-  CapturedBuff: 6
-  GraveMarker: 2
-  LoungingPlayer: 1
-  None: 0
-  PlacedVo: 3
-  PlayerGuardian: 4
-  PlayerSlayer: 5
+  values:
+    CapturedBuff: 6
+    GraveMarker: 2
+    LoungingPlayer: 1
+    None: 0
+    PlacedVo: 3
+    PlayerGuardian: 4
+    PlayerSlayer: 5
 AuctionHouseCommoditySortOrder:
-  Quantity: 1
-  UnitPrice: 0
+  values:
+    Quantity: 1
+    UnitPrice: 0
 AuctionHouseError:
-  BidIncrement: 2
-  BidOwn: 3
-  BoundItem: 16
-  ConjuredItem: 17
-  DatabaseError: 10
-  DoubleBid: 23
-  EquippedBag: 20
-  FavoritesMaxed: 24
-  HasRestriction: 6
-  HigherBid: 1
-  IsBag: 19
-  IsBusy: 7
-  ItemBoundToAccountUntilEquip: 26
-  ItemHasQuote: 9
-  ItemNotAvailable: 25
-  ItemNotFound: 4
-  LimitedDurationItem: 18
-  LootItem: 22
-  MinBid: 11
-  NotEnoughItems: 12
-  NotEnoughMoney: 0
-  QuestItem: 15
-  RepairItem: 13
-  RestrictedAccountTrial: 5
-  Unavailable: 8
-  UsedCharges: 14
-  WrappedItem: 21
+  values:
+    BidIncrement: 2
+    BidOwn: 3
+    BoundItem: 16
+    ConjuredItem: 17
+    DatabaseError: 10
+    DoubleBid: 23
+    EquippedBag: 20
+    FavoritesMaxed: 24
+    HasRestriction: 6
+    HigherBid: 1
+    IsBag: 19
+    IsBusy: 7
+    ItemBoundToAccountUntilEquip: 26
+    ItemHasQuote: 9
+    ItemNotAvailable: 25
+    ItemNotFound: 4
+    LimitedDurationItem: 18
+    LootItem: 22
+    MinBid: 11
+    NotEnoughItems: 12
+    NotEnoughMoney: 0
+    QuestItem: 15
+    RepairItem: 13
+    RestrictedAccountTrial: 5
+    Unavailable: 8
+    UsedCharges: 14
+    WrappedItem: 21
 AuctionHouseExtraColumn:
-  Ilvl: 1
-  Level: 3
-  None: 0
-  Skill: 4
-  Slots: 2
+  values:
+    Ilvl: 1
+    Level: 3
+    None: 0
+    Skill: 4
+    Slots: 2
 AuctionHouseFilter:
-  ArtifactQuality: 12
-  CommonQuality: 7
-  CurrentExpansionOnly: 3
-  EpicQuality: 10
-  ExactMatch: 5
-  LegendaryCraftedItemOnly: 13
-  LegendaryQuality: 11
-  None: 0
-  PoorQuality: 6
-  RareQuality: 9
-  UncollectedOnly: 1
-  UncommonQuality: 8
-  UpgradesOnly: 4
-  UsableOnly: 2
+  values:
+    ArtifactQuality: 12
+    CommonQuality: 7
+    CurrentExpansionOnly: 3
+    EpicQuality: 10
+    ExactMatch: 5
+    LegendaryCraftedItemOnly: 13
+    LegendaryQuality: 11
+    None: 0
+    PoorQuality: 6
+    RareQuality: 9
+    UncollectedOnly: 1
+    UncommonQuality: 8
+    UpgradesOnly: 4
+    UsableOnly: 2
 AuctionHouseFilterCategory:
-  Equipment: 1
-  Rarity: 2
-  Uncategorized: 0
+  values:
+    Equipment: 1
+    Rarity: 2
+    Uncategorized: 0
 AuctionHouseItemSortOrder:
-  Bid: 0
-  Buyout: 1
+  values:
+    Bid: 0
+    Buyout: 1
 AuctionHouseNotification:
-  AuctionExpired: 5
-  AuctionOutbid: 3
-  AuctionRemoved: 1
-  AuctionSold: 4
-  AuctionWon: 2
-  BidPlaced: 0
+  values:
+    AuctionExpired: 5
+    AuctionOutbid: 3
+    AuctionRemoved: 1
+    AuctionSold: 4
+    AuctionWon: 2
+    BidPlaced: 0
 AuctionHouseSortOrder:
-  Bid: 3
-  Buyout: 4
-  Level: 2
-  Name: 1
-  Price: 0
-  TimeRemaining: 5
+  values:
+    Bid: 3
+    Buyout: 4
+    Level: 2
+    Name: 1
+    Price: 0
+    TimeRemaining: 5
 AuctionHouseTimeLeftBand:
-  Long: 2
-  Medium: 1
-  Short: 0
-  VeryLong: 3
+  values:
+    Long: 2
+    Medium: 1
+    Short: 0
+    VeryLong: 3
 AuctionStatus:
-  Active: 0
-  Sold: 1
+  values:
+    Active: 0
+    Sold: 1
 AuraFrameIconDirection:
-  Down: 0
-  Left: 0
-  Right: 1
-  Up: 1
+  values:
+    Down: 0
+    Left: 0
+    Right: 1
+    Up: 1
 AuraFrameIconWrap:
-  Down: 0
-  Left: 0
-  Right: 1
-  Up: 1
+  values:
+    Down: 0
+    Left: 0
+    Right: 1
+    Up: 1
 AuraFrameOrientation:
-  Horizontal: 0
-  Vertical: 1
+  values:
+    Horizontal: 0
+    Vertical: 1
 AuraFrameVisibleSetting:
-  Always: 0
-  Hidden: 2
-  InCombat: 1
+  values:
+    Always: 0
+    Hidden: 2
+    InCombat: 1
 AutoCompleteEntryFlag:
-  AccountCharacter: 128
-  Bnet: 8
-  Friend: 4
-  InAOI: 64
-  InGroup: 1
-  InGuild: 2
-  InteractedWith: 16
-  Online: 32
-  RecentPlayer: 256
+  values:
+    AccountCharacter: 128
+    Bnet: 8
+    Friend: 4
+    InAOI: 64
+    InGroup: 1
+    InGuild: 2
+    InteractedWith: 16
+    Online: 32
+    RecentPlayer: 256
 AutoCompletePriority:
-  AccountCharacter: 5
-  AccountCharacterSameRealm: 6
-  Friend: 4
-  Guild: 3
-  InGroup: 2
-  Interacted: 1
-  Other: 0
+  values:
+    AccountCharacter: 5
+    AccountCharacterSameRealm: 6
+    Friend: 4
+    Guild: 3
+    InGroup: 2
+    Interacted: 1
+    Other: 0
 AvgItemLevelCategories:
-  Base: 0
-  EquippedBase: 1
-  EquippedEffective: 2
-  EquippedEffectiveWeighted: 5
-  PvP: 3
-  PvPWeighted: 4
+  values:
+    Base: 0
+    EquippedBase: 1
+    EquippedEffective: 2
+    EquippedEffectiveWeighted: 5
+    PvP: 3
+    PvPWeighted: 4
 AzeriteEssenceSlot:
-  MainSlot: 0
-  PassiveOneSlot: 1
-  PassiveThreeSlot: 3
-  PassiveTwoSlot: 2
+  values:
+    MainSlot: 0
+    PassiveOneSlot: 1
+    PassiveThreeSlot: 3
+    PassiveTwoSlot: 2
 AzeritePowerLevel:
-  Base: 0
-  Downgraded: 2
-  Upgraded: 1
+  values:
+    Base: 0
+    Downgraded: 2
+    Upgraded: 1
 BagFlag:
-  AllowBagsInNonBagSlots: 1024
-  AllowBuyback: 65536
-  AllowPartialStack: 16384
-  AllowSoulboundItemInAccountBank: 134217728
-  AlreadyBound: 4
-  AlreadyOwner: 2
-  AsymmetricSwap: 1048576
-  BagIsEmpty: 16
-  DontFindStack: 1
-  HasRefund: 33554432
-  IgnoreBankcheck: 512
-  IgnoreBoundItemCheck: 64
-  IgnoreExisting: 8192
-  IgnorePetBankcheck: 131072
-  IgnoreReagentBags: 8388608
-  IgnoreSoulbound: 4194304
-  LookInAccountBankOnly: 16777216
-  LookInCharacterBankOnly: 32768
-  LookInInventory: 32
-  PreferNeutralPriorityBags: 524288
-  PreferPriorityBags: 262144
-  PreferQuivers: 2048
-  PreferReagentBags: 2097152
-  RecurseQuivers: 256
-  SkipValidCountCheck: 67108864
-  StackOnly: 128
-  Swap: 8
-  SwapBags: 4096
+  values:
+    AllowBagsInNonBagSlots: 1024
+    AllowBuyback: 65536
+    AllowPartialStack: 16384
+    AllowSoulboundItemInAccountBank: 134217728
+    AlreadyBound: 4
+    AlreadyOwner: 2
+    AsymmetricSwap: 1048576
+    BagIsEmpty: 16
+    DontFindStack: 1
+    HasRefund: 33554432
+    IgnoreBankcheck: 512
+    IgnoreBoundItemCheck: 64
+    IgnoreExisting: 8192
+    IgnorePetBankcheck: 131072
+    IgnoreReagentBags: 8388608
+    IgnoreSoulbound: 4194304
+    LookInAccountBankOnly: 16777216
+    LookInCharacterBankOnly: 32768
+    LookInInventory: 32
+    PreferNeutralPriorityBags: 524288
+    PreferPriorityBags: 262144
+    PreferQuivers: 2048
+    PreferReagentBags: 2097152
+    RecurseQuivers: 256
+    SkipValidCountCheck: 67108864
+    StackOnly: 128
+    Swap: 8
+    SwapBags: 4096
 BagIndex:
-  Accountbanktab: -3
-  AccountBankTab_1: 12
-  AccountBankTab_2: 13
-  AccountBankTab_3: 14
-  AccountBankTab_4: 15
-  AccountBankTab_5: 16
-  Backpack: 0
-  Bag_1: 1
-  Bag_2: 2
-  Bag_3: 3
-  Bag_4: 4
-  Characterbanktab: -2
-  CharacterBankTab_1: 6
-  CharacterBankTab_2: 7
-  CharacterBankTab_3: 8
-  CharacterBankTab_4: 9
-  CharacterBankTab_5: 10
-  CharacterBankTab_6: 11
-  Keyring: -1
-  ReagentBag: 5
+  values:
+    Accountbanktab: -3
+    AccountBankTab_1: 12
+    AccountBankTab_2: 13
+    AccountBankTab_3: 14
+    AccountBankTab_4: 15
+    AccountBankTab_5: 16
+    Backpack: 0
+    Bag_1: 1
+    Bag_2: 2
+    Bag_3: 3
+    Bag_4: 4
+    Characterbanktab: -2
+    CharacterBankTab_1: 6
+    CharacterBankTab_2: 7
+    CharacterBankTab_3: 8
+    CharacterBankTab_4: 9
+    CharacterBankTab_5: 10
+    CharacterBankTab_6: 11
+    Keyring: -1
+    ReagentBag: 5
 BagsDirection:
-  Down: 1
-  Left: 0
-  Right: 1
-  Up: 0
+  values:
+    Down: 1
+    Left: 0
+    Right: 1
+    Up: 0
 BagSlotFlags:
-  ClassConsumables: 4
-  ClassEquipment: 2
-  ClassJunk: 16
-  ClassProfessionGoods: 8
-  ClassQuestItems: 32
-  ClassReagents: 128
-  DisableAutoSort: 1
-  ExcludeJunkSell: 64
-  ExpansionCurrent: 256
-  ExpansionLegacy: 512
+  values:
+    ClassConsumables: 4
+    ClassEquipment: 2
+    ClassJunk: 16
+    ClassProfessionGoods: 8
+    ClassQuestItems: 32
+    ClassReagents: 128
+    DisableAutoSort: 1
+    ExcludeJunkSell: 64
+    ExpansionCurrent: 256
+    ExpansionLegacy: 512
 BagsOrientation:
-  Horizontal: 0
-  Vertical: 1
+  values:
+    Horizontal: 0
+    Vertical: 1
 BalanceType:
-  Eclipse: 0
-  None: -1
+  values:
+    Eclipse: 0
+    None: -1
 BankLockedReason:
-  BankConversionFailed: 3
-  BankDisabled: 2
-  NoAccountInventoryLock: 1
-  None: 0
+  values:
+    BankConversionFailed: 3
+    BankDisabled: 2
+    NoAccountInventoryLock: 1
+    None: 0
 BankType:
-  Account: 2
-  Character: 0
-  Guild: 1
+  values:
+    Account: 2
+    Character: 0
+    Guild: 1
 Base64Variant:
-  Standard: 0
-  StandardUrlSafe: 1
+  values:
+    Standard: 0
+    StandardUrlSafe: 1
 BattleNetFriendLevel:
-  BattleTag: 1
-  RealID: 2
-  Title: 3
+  values:
+    BattleTag: 1
+    RealID: 2
+    Title: 3
 BattleNetFriendTag:
-  DamagerRole: 7
-  Delves: 4
-  Dungeons: 3
-  HealerRole: 8
-  Professions: 0
-  PvP: 1
-  Questing: 5
-  Raiding: 2
-  Roleplaying: 6
-  TankRole: 9
+  values:
+    DamagerRole: 7
+    Delves: 4
+    Dungeons: 3
+    HealerRole: 8
+    Professions: 0
+    PvP: 1
+    Questing: 5
+    Raiding: 2
+    Roleplaying: 6
+    TankRole: 9
 BattlepayBannerType:
-  Discount: 1
-  Featured: 2
-  New: 3
-  None: 0
+  values:
+    Discount: 1
+    Featured: 2
+    New: 3
+    None: 0
 BattlepayCardType:
-  FullCardWithBuyButton: 4
-  FullCardWithNydusLinkButton: 8
-  LargeHorizontalCard: 2
-  LargeHorizontalCardWithBuyButton: 6
-  LargeVeritcalCard: 3
-  LargeVeritcalCardWithBuyButton: 7
-  LargeVeritcalPageableCardWithBuyButton: 9
-  MediumCard: 1
-  MediumCardWithBuyButton: 5
-  SmallCard: 0
+  values:
+    FullCardWithBuyButton: 4
+    FullCardWithNydusLinkButton: 8
+    LargeHorizontalCard: 2
+    LargeHorizontalCardWithBuyButton: 6
+    LargeVeritcalCard: 3
+    LargeVeritcalCardWithBuyButton: 7
+    LargeVeritcalPageableCardWithBuyButton: 9
+    MediumCard: 1
+    MediumCardWithBuyButton: 5
+    SmallCard: 0
 BattlepayDisplayFlags:
-  CardAlwaysShowsTexture: 4
-  CardDoesNotShowModel: 2
-  Deprecated1: 32
-  Deprecated2: 64
-  Expansion: 1
-  HiddenPrice: 8
-  HideWhenOwned: 256
-  RafReward: 512
-  ShowFancyToast: 1024
-  UseHorizontalLayoutForFullCard: 16
-  UseIconBorderWithOverrideTexture: 2048
-  UseSquareIconBorder: 128
+  values:
+    CardAlwaysShowsTexture: 4
+    CardDoesNotShowModel: 2
+    Deprecated1: 32
+    Deprecated2: 64
+    Expansion: 1
+    HiddenPrice: 8
+    HideWhenOwned: 256
+    RafReward: 512
+    ShowFancyToast: 1024
+    UseHorizontalLayoutForFullCard: 16
+    UseIconBorderWithOverrideTexture: 2048
+    UseSquareIconBorder: 128
 BattlepayGroupDisplayType:
-  ActiveTimeOnly: 2
-  Everyone: 0
-  TrialAndVeteranOnly: 1
+  values:
+    ActiveTimeOnly: 2
+    Everyone: 0
+    TrialAndVeteranOnly: 1
 BattlepayLicenseSynthesisFlags:
-  ForceToGameAccount: 1
+  values:
+    ForceToGameAccount: 1
 BattlepayProductChoiceType:
-  ChoiceNone: 0
-  ChoiceOne: 1
-  SpecAndFaction: 2
-  VasCharacter: 3
-  VasCharacterAndName: 4
+  values:
+    ChoiceNone: 0
+    ChoiceOne: 1
+    SpecAndFaction: 2
+    VasCharacter: 3
+    VasCharacterAndName: 4
 BattlepayProductDecorator:
-  Boost: 0
-  Expansion: 1
-  VasService: 3
-  WoWToken: 2
+  values:
+    Boost: 0
+    Expansion: 1
+    VasService: 3
+    WoWToken: 2
 BattlepayProductGroupFlags:
-  DisableOwnedProducts: 4
-  EnabledForTrial: 2
-  EnabledForVeteran: 8
-  HideOwnedProducts: 1
-  None: 0
+  values:
+    DisableOwnedProducts: 4
+    EnabledForTrial: 2
+    EnabledForVeteran: 8
+    HideOwnedProducts: 1
+    None: 0
 BattlepayShopEntryBannerType:
-  Discount: 1
-  Featured: 0
-  New: 2
+  values:
+    Discount: 1
+    Featured: 0
+    New: 2
 BattlepayShopEntryFlags:
-  None: 0
+  values:
+    None: 0
 BattlePetAction:
-  Ability: 1
-  None: 0
-  Skip: 4
-  SwitchPet: 2
-  Trap: 3
+  values:
+    Ability: 1
+    None: 0
+    Skip: 4
+    SwitchPet: 2
+    Trap: 3
 BattlePetBreedQuality:
-  Common: 1
-  Epic: 4
-  Legendary: 5
-  Poor: 0
-  Rare: 3
-  Uncommon: 2
+  values:
+    Common: 1
+    Epic: 4
+    Legendary: 5
+    Poor: 0
+    Rare: 3
+    Uncommon: 2
 BattlePetOwner:
-  Ally: 1
-  Enemy: 2
-  Weather: 0
+  values:
+    Ally: 1
+    Enemy: 2
+    Weather: 0
 BattlePetSources:
-  Achievement: 5
-  Discovery: 10
-  Drop: 0
-  PetStore: 9
-  Profession: 3
-  Promotion: 7
-  Quest: 1
-  Tcg: 8
-  TradingPost: 11
-  Vendor: 2
-  WildPet: 4
-  WorldEvent: 6
+  values:
+    Achievement: 5
+    Discovery: 10
+    Drop: 0
+    PetStore: 9
+    Profession: 3
+    Promotion: 7
+    Quest: 1
+    Tcg: 8
+    TradingPost: 11
+    Vendor: 2
+    WildPet: 4
+    WorldEvent: 6
 BindingContext:
-  HousingEditor: 1
-  HousingEditorBasicAndExpertDecorMode: 7
-  HousingEditorBasicDecorMode: 2
-  HousingEditorCleanupMode: 5
-  HousingEditorCustomizeMode: 4
-  HousingEditorExpertDecorMode: 3
-  HousingEditorExteriorCustomizationMode: 8
-  HousingEditorLayoutMode: 6
-  None: 0
-  ReservedFutureFeatureBinding01: 9
+  values:
+    HousingEditor: 1
+    HousingEditorBasicAndExpertDecorMode: 7
+    HousingEditorBasicDecorMode: 2
+    HousingEditorCleanupMode: 5
+    HousingEditorCustomizeMode: 4
+    HousingEditorExpertDecorMode: 3
+    HousingEditorExteriorCustomizationMode: 8
+    HousingEditorLayoutMode: 6
+    None: 0
+    ReservedFutureFeatureBinding01: 9
 BindingSet:
-  Account: 1
-  Character: 2
-  Current: 3
-  Default: 0
+  values:
+    Account: 1
+    Character: 2
+    Current: 3
+    Default: 0
 BnetAccountFlag:
-  AccountQuestBitFixUp: 64
-  AchievementsToBi: 128
-  BattlePetTrainer: 1
-  CanBuyAhGameTimeTokens: 32768
-  CataLegendaryMountChecked: 262144
-  CataLegendaryMountObtained: 524288
-  DarkRealmLightCopy: 2048
-  Employee: 16
-  EmployeeFlagIsManual: 32
-  GdprErased: 1024
-  InvalidTransmogsFixUp: 256
-  InvalidTransmogsFixUp2: 512
-  IsLegacy: 131072
-  LockedForExport: 16384
-  MopQuestLogFlagsFixUp: 1048576
-  None: 0
-  PetAchievementFixUp: 65536
-  QuestLogFlagsFixUp: 4096
-  RafVeteranNotified: 2
-  TwitterHasTempSecret: 8
-  TwitterLinked: 4
-  WasSecured: 8192
+  values:
+    AccountQuestBitFixUp: 64
+    AchievementsToBi: 128
+    BattlePetTrainer: 1
+    CanBuyAhGameTimeTokens: 32768
+    CataLegendaryMountChecked: 262144
+    CataLegendaryMountObtained: 524288
+    DarkRealmLightCopy: 2048
+    Employee: 16
+    EmployeeFlagIsManual: 32
+    GdprErased: 1024
+    InvalidTransmogsFixUp: 256
+    InvalidTransmogsFixUp2: 512
+    IsLegacy: 131072
+    LockedForExport: 16384
+    MopQuestLogFlagsFixUp: 1048576
+    None: 0
+    PetAchievementFixUp: 65536
+    QuestLogFlagsFixUp: 4096
+    RafVeteranNotified: 2
+    TwitterHasTempSecret: 8
+    TwitterLinked: 4
+    WasSecured: 8192
 BonusStatIndex:
-  Agility: 3
-  AgilityOrIntellect: 73
-  AgilityOrStrength: 72
-  AgilityOrStrengthOrIntellect: 71
-  ArcaneResistance: 56
-  AttackPower: 38
-  BlockRating: 15
-  BlockValueObsolete: 48
-  CombatRatingAvoidance: 63
-  CombatRatingLifesteal: 62
-  CombatRatingSpeed: 61
-  CombatRatingSturdiness: 64
-  CombatRatingUnused_0: 58
-  CombatRatingUnused_10: 68
-  CombatRatingUnused_11: 69
-  CombatRatingUnused_12: 70
-  CombatRatingUnused_2: 59
-  CombatRatingUnused_27: 66
-  CombatRatingUnused_3: 60
-  CombatRatingUnused_7: 65
-  CombatRatingUnused_9: 67
-  Corruption: 22
-  CorruptionResistance: 23
-  CritMeleeRating: 19
-  CritRangedRating: 20
-  CritRating: 32
-  CritSpellRating: 21
-  CritTakenRangedRatingObsolete: 26
-  CritTakenRatingObsolete: 34
-  CritTakenSpellRatingObsolete: 27
-  DefenseSkillRating: 12
-  DodgeRating: 13
-  Endurance: 2
-  Energy: 8
-  ExpertiseRating: 37
-  ExtraArmor: 50
-  FireResistance: 51
-  Focus: 10
-  FrostResistance: 52
-  HasteMeleeRatingObsolete: 28
-  HasteRangedRatingObsolete: 29
-  HasteRating: 36
-  HasteSpellRatingObsolete: 30
-  Health: 1
-  HealthRegen: 46
-  HitMeleeRating: 16
-  HitRangedRating: 17
-  HitRating: 31
-  HitSpellRating: 18
-  HitTakenRatingObsolete: 33
-  HolyResistance: 53
-  Intellect: 5
-  Mana: 0
-  ManaRegenerationObsolete: 43
-  MasteryRating: 49
-  ModifiedCraftingStat_1: 24
-  ModifiedCraftingStat_2: 25
-  NatureResistance: 55
-  ParryRating: 14
-  ProfessionCraftingSpeed: 80
-  ProfessionDeftness: 78
-  ProfessionFinesse: 77
-  ProfessionIngenuity: 82
-  ProfessionInspiration: 75
-  ProfessionMulticraft: 81
-  ProfessionPerception: 79
-  ProfessionResourcefulness: 76
-  PvPPower: 57
-  Rage: 9
-  RangedAttackPower: 39
-  ResilienceRating: 35
-  ShadowResistance: 54
-  SpellDamageDone: 42
-  SpellHealingDone: 41
-  SpellPenetration: 47
-  SpellPower: 45
-  Spirit: 6
-  Stamina: 7
-  Strength: 4
-  StrengthOrIntellect: 74
-  Unused: 44
-  Versatility: 40
-  WeaponSkillRatingObsolete: 11
+  values:
+    Agility: 3
+    AgilityOrIntellect: 73
+    AgilityOrStrength: 72
+    AgilityOrStrengthOrIntellect: 71
+    ArcaneResistance: 56
+    AttackPower: 38
+    BlockRating: 15
+    BlockValueObsolete: 48
+    CombatRatingAvoidance: 63
+    CombatRatingLifesteal: 62
+    CombatRatingSpeed: 61
+    CombatRatingSturdiness: 64
+    CombatRatingUnused_0: 58
+    CombatRatingUnused_10: 68
+    CombatRatingUnused_11: 69
+    CombatRatingUnused_12: 70
+    CombatRatingUnused_2: 59
+    CombatRatingUnused_27: 66
+    CombatRatingUnused_3: 60
+    CombatRatingUnused_7: 65
+    CombatRatingUnused_9: 67
+    Corruption: 22
+    CorruptionResistance: 23
+    CritMeleeRating: 19
+    CritRangedRating: 20
+    CritRating: 32
+    CritSpellRating: 21
+    CritTakenRangedRatingObsolete: 26
+    CritTakenRatingObsolete: 34
+    CritTakenSpellRatingObsolete: 27
+    DefenseSkillRating: 12
+    DodgeRating: 13
+    Endurance: 2
+    Energy: 8
+    ExpertiseRating: 37
+    ExtraArmor: 50
+    FireResistance: 51
+    Focus: 10
+    FrostResistance: 52
+    HasteMeleeRatingObsolete: 28
+    HasteRangedRatingObsolete: 29
+    HasteRating: 36
+    HasteSpellRatingObsolete: 30
+    Health: 1
+    HealthRegen: 46
+    HitMeleeRating: 16
+    HitRangedRating: 17
+    HitRating: 31
+    HitSpellRating: 18
+    HitTakenRatingObsolete: 33
+    HolyResistance: 53
+    Intellect: 5
+    Mana: 0
+    ManaRegenerationObsolete: 43
+    MasteryRating: 49
+    ModifiedCraftingStat_1: 24
+    ModifiedCraftingStat_2: 25
+    NatureResistance: 55
+    ParryRating: 14
+    ProfessionCraftingSpeed: 80
+    ProfessionDeftness: 78
+    ProfessionFinesse: 77
+    ProfessionIngenuity: 82
+    ProfessionInspiration: 75
+    ProfessionMulticraft: 81
+    ProfessionPerception: 79
+    ProfessionResourcefulness: 76
+    PvPPower: 57
+    Rage: 9
+    RangedAttackPower: 39
+    ResilienceRating: 35
+    ShadowResistance: 54
+    SpellDamageDone: 42
+    SpellHealingDone: 41
+    SpellPenetration: 47
+    SpellPower: 45
+    Spirit: 6
+    Stamina: 7
+    Strength: 4
+    StrengthOrIntellect: 74
+    Unused: 44
+    Versatility: 40
+    WeaponSkillRatingObsolete: 11
 BrawlType:
-  Arena: 2
-  Battleground: 1
-  LFG: 3
-  None: 0
-  SoloRbg: 5
-  SoloShuffle: 4
+  values:
+    Arena: 2
+    Battleground: 1
+    LFG: 3
+    None: 0
+    SoloRbg: 5
+    SoloShuffle: 4
 BulkPurchaseResult:
-  ResultFailed: 3
-  ResultInProgress: 1
-  ResultInsufficientFunds: 6
-  ResultOk: 0
-  ResultPartialSuccess: 2
-  ResultPurchaseTimeout: 7
-  ResultSystemDisabled: 5
-  ResultTooManyProducts: 4
+  values:
+    ResultFailed: 3
+    ResultInProgress: 1
+    ResultInsufficientFunds: 6
+    ResultOk: 0
+    ResultPartialSuccess: 2
+    ResultPurchaseTimeout: 7
+    ResultSystemDisabled: 5
+    ResultTooManyProducts: 4
 BulkPurchaseStatus:
-  Done: 3
-  Failed: 4
-  FetchEntitlements: 2
-  PlacingOrders: 0
-  PurchasesPending: 1
+  values:
+    Done: 3
+    Failed: 4
+    FetchEntitlements: 2
+    PlacingOrders: 0
+    PurchasesPending: 1
 BulkRefundResult:
-  ResultFailed: 1
-  ResultInvalidRequest: 2
-  ResultOk: 0
-  ResultRefundWindowExpired: 3
-  ResultSystemDisabled: 4
-  ResultTimeout: 5
+  values:
+    ResultFailed: 1
+    ResultInvalidRequest: 2
+    ResultOk: 0
+    ResultRefundWindowExpired: 3
+    ResultSystemDisabled: 4
+    ResultTimeout: 5
 CachedRewardType:
-  Currency: 2
-  Item: 1
-  None: 0
-  Quest: 3
+  values:
+    Currency: 2
+    Item: 1
+    None: 0
+    Quest: 3
 CalendarCommandType:
-  Complain: 10
-  Create: 0
-  GetCalendar: 7
-  GetEvent: 8
-  Invite: 1
-  ModeratorStatus: 6
-  Notes: 11
-  RemoveEvent: 4
-  RemoveInvite: 3
-  Rsvp: 2
-  Status: 5
-  UpdateEvent: 9
+  values:
+    Complain: 10
+    Create: 0
+    GetCalendar: 7
+    GetEvent: 8
+    Invite: 1
+    ModeratorStatus: 6
+    Notes: 11
+    RemoveEvent: 4
+    RemoveInvite: 3
+    Rsvp: 2
+    Status: 5
+    UpdateEvent: 9
 CalendarErrorType:
-  ArenaEventsExceeded: 27
-  CalendarDisabled: 25
-  CommunityEventsExceeded: 1
-  ComplaintAdded: 50
-  ComplaintDisabled: 31
-  ComplaintGm: 34
-  ComplaintLimit: 35
-  ComplaintNotFound: 36
-  ComplaintSameGuild: 33
-  ComplaintSelf: 32
-  CreatorNotFound: 46
-  DataAlreadySet: 24
-  DeleteCreatorFailed: 23
-  EventInvalid: 6
-  EventLocked: 22
-  EventPassed: 21
-  EventsExceeded: 2
-  EventThrottled: 47
-  EventWrongServer: 37
-  Ignored: 14
-  Internal: 49
-  InvalidClub: 45
-  InvalidDate: 17
-  InvalidDescription: 44
-  InvalidMaxSize: 16
-  InvalidNotes: 42
-  InvalidSignup: 39
-  InvalidTime: 18
-  InvalidTitle: 43
-  InvitesExceeded: 15
-  InviteThrottled: 48
-  ModeratorRestricted: 41
-  NameNotFound: 12
-  NeedsTitle: 20
-  NoCommunityInvites: 38
-  NoInvite: 30
-  NoInvites: 19
-  NoModerator: 40
-  NoPermission: 5
-  NotInCommunity: 10
-  NotInGuild: 9
-  NotInvited: 7
-  OtherInvitesExceeded: 4
-  RestrictedAccount: 26
-  RestrictedLevel: 28
-  SelfInvitesExceeded: 3
-  Squelched: 29
-  Success: 0
-  TargetAlreadyInvited: 11
-  UnknownError: 8
-  WrongFaction: 13
+  values:
+    ArenaEventsExceeded: 27
+    CalendarDisabled: 25
+    CommunityEventsExceeded: 1
+    ComplaintAdded: 50
+    ComplaintDisabled: 31
+    ComplaintGm: 34
+    ComplaintLimit: 35
+    ComplaintNotFound: 36
+    ComplaintSameGuild: 33
+    ComplaintSelf: 32
+    CreatorNotFound: 46
+    DataAlreadySet: 24
+    DeleteCreatorFailed: 23
+    EventInvalid: 6
+    EventLocked: 22
+    EventPassed: 21
+    EventsExceeded: 2
+    EventThrottled: 47
+    EventWrongServer: 37
+    Ignored: 14
+    Internal: 49
+    InvalidClub: 45
+    InvalidDate: 17
+    InvalidDescription: 44
+    InvalidMaxSize: 16
+    InvalidNotes: 42
+    InvalidSignup: 39
+    InvalidTime: 18
+    InvalidTitle: 43
+    InvitesExceeded: 15
+    InviteThrottled: 48
+    ModeratorRestricted: 41
+    NameNotFound: 12
+    NeedsTitle: 20
+    NoCommunityInvites: 38
+    NoInvite: 30
+    NoInvites: 19
+    NoModerator: 40
+    NoPermission: 5
+    NotInCommunity: 10
+    NotInGuild: 9
+    NotInvited: 7
+    OtherInvitesExceeded: 4
+    RestrictedAccount: 26
+    RestrictedLevel: 28
+    SelfInvitesExceeded: 3
+    Squelched: 29
+    Success: 0
+    TargetAlreadyInvited: 11
+    UnknownError: 8
+    WrongFaction: 13
 CalendarEventBits:
-  ArenaDeprecated: 256
-  AutoApprove: 32
-  CantComplain: 3788
-  CommunityAnnouncement: 64
-  CommunitySignup: 1024
-  CommunityWide: 3136
-  GuildDeprecated: 2
-  GuildSignup: 2048
-  Holiday: 8
-  Locked: 16
-  Player: 1
-  PlayerCreated: 3395
-  RaidLockout: 128
-  RaidResetDeprecated: 512
-  System: 4
+  values:
+    ArenaDeprecated: 256
+    AutoApprove: 32
+    CantComplain: 3788
+    CommunityAnnouncement: 64
+    CommunitySignup: 1024
+    CommunityWide: 3136
+    GuildDeprecated: 2
+    GuildSignup: 2048
+    Holiday: 8
+    Locked: 16
+    Player: 1
+    PlayerCreated: 3395
+    RaidLockout: 128
+    RaidResetDeprecated: 512
+    System: 4
 CalendarEventRepeatOptions:
-  Biweekly: 2
-  Monthly: 3
-  Never: 0
-  Weekly: 1
+  values:
+    Biweekly: 2
+    Monthly: 3
+    Never: 0
+    Weekly: 1
 CalendarEventType:
-  Dungeon: 1
-  HeroicDeprecated: 5
-  Meeting: 3
-  Other: 4
-  PvP: 2
-  Raid: 0
+  values:
+    Dungeon: 1
+    HeroicDeprecated: 5
+    Meeting: 3
+    Other: 4
+    PvP: 2
+    Raid: 0
 CalendarFilterFlags:
-  Battleground: 4
-  Darkmoon: 2
-  RaidLockout: 8
-  RaidReset: 16
-  WeeklyHoliday: 1
+  values:
+    Battleground: 4
+    Darkmoon: 2
+    RaidLockout: 8
+    RaidReset: 16
+    WeeklyHoliday: 1
 CalendarGetEventType:
-  Add: 1
-  Copy: 2
-  Get: 0
+  values:
+    Add: 1
+    Copy: 2
+    Get: 0
 CalendarHolidayFilterType:
-  Battleground: 2
-  Darkmoon: 1
-  Weekly: 0
+  values:
+    Battleground: 2
+    Darkmoon: 1
+    Weekly: 0
 CalendarInviteBits:
-  Creator: 4
-  Moderator: 2
-  None: 0
-  PendingInvite: 1
-  Signup: 8
+  values:
+    Creator: 4
+    Moderator: 2
+    None: 0
+    PendingInvite: 1
+    Signup: 8
 CalendarInviteSortType:
-  Class: 2
-  Level: 1
-  Name: 0
-  Notes: 5
-  Party: 4
-  Status: 3
+  values:
+    Class: 2
+    Level: 1
+    Name: 0
+    Notes: 5
+    Party: 4
+    Status: 3
 CalendarInviteType:
-  Normal: 0
-  Signup: 1
+  values:
+    Normal: 0
+    Signup: 1
 CalendarModeratorStatus:
-  Creator: 2
-  Moderator: 1
-  None: 0
+  values:
+    Creator: 2
+    Moderator: 1
+    None: 0
 CalendarStatus:
-  Available: 1
-  Confirmed: 3
-  Declined: 2
-  Invited: 0
-  NotSignedup: 7
-  Out: 4
-  Signedup: 6
-  Standby: 5
-  Tentative: 8
+  values:
+    Available: 1
+    Confirmed: 3
+    Declined: 2
+    Invited: 0
+    NotSignedup: 7
+    Out: 4
+    Signedup: 6
+    Standby: 5
+    Tentative: 8
 CalendarTexturesType:
-  Dungeons: 0
-  Raid: 1
+  values:
+    Dungeons: 0
+    Raid: 1
 CalendarType:
-  Community: 1
-  Holiday: 4
-  HolidayBattleground: 7
-  HolidayDarkmoon: 6
-  HolidayWeekly: 5
-  Player: 0
-  RaidLockout: 2
-  RaidResetDeprecated: 3
+  values:
+    Community: 1
+    Holiday: 4
+    HolidayBattleground: 7
+    HolidayDarkmoon: 6
+    HolidayWeekly: 5
+    Player: 0
+    RaidLockout: 2
+    RaidResetDeprecated: 3
 CalendarWebActionType:
-  Accept: 0
-  Decline: 1
-  Remove: 2
-  ReportSpam: 3
-  Signup: 4
-  Tentative: 5
-  TentativeSignup: 6
+  values:
+    Accept: 0
+    Decline: 1
+    Remove: 2
+    ReportSpam: 3
+    Signup: 4
+    Tentative: 5
+    TentativeSignup: 6
 CallingStates:
-  QuestActive: 1
-  QuestCompleted: 2
-  QuestOffer: 0
+  values:
+    QuestActive: 1
+    QuestCompleted: 2
+    QuestOffer: 0
 CameraModeAspectRatio:
-  Cinemascope_2_Dot_4_X_1: 3
-  Default: 0
-  HighDefinition_16_X_9: 2
-  LegacyLetterbox: 1
+  values:
+    Cinemascope_2_Dot_4_X_1: 3
+    Default: 0
+    HighDefinition_16_X_9: 2
+    LegacyLetterbox: 1
 CampaignState:
-  Complete: 1
-  InProgress: 2
-  Invalid: 0
-  Stalled: 3
+  values:
+    Complete: 1
+    InProgress: 2
+    Invalid: 0
+    Stalled: 3
 CanRedeemTokenForBalanceResult:
-  FailureCap: 1
-  Ok: 0
+  values:
+    FailureCap: 1
+    Ok: 0
 CaptureBarWidgetFillDirectionType:
-  LeftToRight: 1
-  RightToLeft: 0
+  values:
+    LeftToRight: 1
+    RightToLeft: 0
 Causeofdeath:
-  Creature: 3
-  Drowning: 5
-  Falling: 4
-  Fatigue: 6
-  Fire: 9
-  Lava: 8
-  None: 0
-  PlayerDuel: 2
-  PlayerPvP: 1
-  Slime: 7
+  values:
+    Creature: 3
+    Drowning: 5
+    Falling: 4
+    Fatigue: 6
+    Fire: 9
+    Lava: 8
+    None: 0
+    PlayerDuel: 2
+    PlayerPvP: 1
+    Slime: 7
 CauseofdeathFlags:
-  CreatureNameNeeded: 2
-  NoneNeeded: 0
-  PlayerNameNeeded: 1
-  ZoneNameNeeded: 4
+  values:
+    CreatureNameNeeded: 2
+    NoneNeeded: 0
+    PlayerNameNeeded: 1
+    ZoneNameNeeded: 4
 ChallengeModeHistoryFlags:
-  ConfirmedLeaver: 1
-  None: 0
+  values:
+    ConfirmedLeaver: 1
+    None: 0
 ChallengeModeHistoryResult:
-  Leaver: 1
-  Successful: 0
+  values:
+    Leaver: 1
+    Successful: 0
 ChallengeModeHistoryStatus:
-  Leaver: 1
-  Normal: 0
+  values:
+    Leaver: 1
+    Normal: 0
 ChannelPlayerFlags:
-  ChannelPlayerHidden: 8
-  ChannelPlayerModerator: 2
-  ChannelPlayerNone: 0
-  ChannelPlayerOwner: 1
-  ChannelPlayerTextAllow: 4
+  values:
+    ChannelPlayerHidden: 8
+    ChannelPlayerModerator: 2
+    ChannelPlayerNone: 0
+    ChannelPlayerOwner: 1
+    ChannelPlayerTextAllow: 4
 CharacterServiceInfoFlag:
-  AllowMaxLevelBoost: 2
-  RestrictToRecommendedSpecs: 1
+  values:
+    AllowMaxLevelBoost: 2
+    RestrictToRecommendedSpecs: 1
 CharCustomizationType:
-  CustomOptionFacewear: 7
-  CustomOptionHorn: 6
-  CustomOptionTattoo: 5
-  CustomOptionTattooColor: 8
-  Face: 1
-  FacialHair: 4
-  Hair: 2
-  HairColor: 3
-  Skin: 0
+  values:
+    CustomOptionFacewear: 7
+    CustomOptionHorn: 6
+    CustomOptionTattoo: 5
+    CustomOptionTattooColor: 8
+    Face: 1
+    FacialHair: 4
+    Hair: 2
+    HairColor: 3
+    Skin: 0
 ChatChannelRuleset:
-  ChromieTimeBuringCrusade: 4
-  ChromieTimeCataclysm: 3
-  ChromieTimeLegion: 8
-  ChromieTimeMists: 6
-  ChromieTimeWoD: 7
-  ChromieTimeWrath: 5
-  Disabled: 2
-  Mentor: 1
-  None: 0
+  values:
+    ChromieTimeBuringCrusade: 4
+    ChromieTimeCataclysm: 3
+    ChromieTimeLegion: 8
+    ChromieTimeMists: 6
+    ChromieTimeWoD: 7
+    ChromieTimeWrath: 5
+    Disabled: 2
+    Mentor: 1
+    None: 0
 ChatChannelType:
-  Communities: 4
-  Custom: 1
-  None: 0
-  PrivateParty: 2
-  PublicParty: 3
+  values:
+    Communities: 4
+    Custom: 1
+    None: 0
+    PrivateParty: 2
+    PublicParty: 3
 ChatToxityFilterOptOut:
-  ExcludeFilterAll: 4294967295
-  ExcludeFilterFriend: 1
-  ExcludeFilterGuild: 2
-  FilterAll: 0
+  values:
+    ExcludeFilterAll: 4294967295
+    ExcludeFilterFriend: 1
+    ExcludeFilterGuild: 2
+    FilterAll: 0
 ChatWhisperTargetStatus:
-  CanWhisper: 0
-  CanWhisperGuild: 1
-  Offline: 2
-  WrongFaction: 3
+  values:
+    CanWhisper: 0
+    CanWhisperGuild: 1
+    Offline: 2
+    WrongFaction: 3
 ChrCustomizationCategoryFlag:
-  Subcategory: 2
-  UndressModel: 1
+  values:
+    Subcategory: 2
+    UndressModel: 1
 ChrCustomizationOptionType:
-  Checkbox: 1
-  Dropdown: 0
-  Slider: 2
+  values:
+    Checkbox: 1
+    Dropdown: 0
+    Slider: 2
 ChrModelFeatureFlags:
-  Deprecated0: 8
-  Forms: 2
-  HunterPets: 32
-  Identity: 4
-  Mounts: 16
-  None: 0
-  Players: 64
-  Summons: 1
+  values:
+    Deprecated0: 8
+    Forms: 2
+    HunterPets: 32
+    Identity: 4
+    Mounts: 16
+    None: 0
+    Players: 64
+    Summons: 1
 ChrRacesAllianceType:
-  Alliance: 0
-  Horde: 1
-  NeutralOrNpc: 2
+  values:
+    Alliance: 0
+    Horde: 1
+    NeutralOrNpc: 2
 CinematicType:
-  GameCinematicSequence: 3
-  GameClientScene: 2
-  GameMovie: 1
-  GlueMovie: 0
+  values:
+    GameCinematicSequence: 3
+    GameClientScene: 2
+    GameMovie: 1
+    GlueMovie: 0
 ClickBindingInteraction:
-  OpenContextMenu: 2
-  Target: 1
+  values:
+    OpenContextMenu: 2
+    Target: 1
 ClickBindingType:
-  Interaction: 3
-  Macro: 2
-  None: 0
-  PetAction: 4
-  Spell: 1
+  values:
+    Interaction: 3
+    Macro: 2
+    None: 0
+    PetAction: 4
+    Spell: 1
 ClientPlatformType:
-  Macintosh: 1
-  Windows: 0
+  values:
+    Macintosh: 1
+    Windows: 0
 ClientSceneType:
-  DefaultSceneType: 0
-  MinigameSceneType: 1
+  values:
+    DefaultSceneType: 0
+    MinigameSceneType: 1
 ClientSettingsConfigFlag:
-  ClientSettingsConfigBeta: 64
-  ClientSettingsConfigBetaRetail: 128
-  ClientSettingsConfigDebug: 1
-  ClientSettingsConfigGm: 8
-  ClientSettingsConfigInternal: 2
-  ClientSettingsConfigPerf: 4
-  ClientSettingsConfigRetail: 256
-  ClientSettingsConfigTest: 16
-  ClientSettingsConfigTestRetail: 32
+  values:
+    ClientSettingsConfigBeta: 64
+    ClientSettingsConfigBetaRetail: 128
+    ClientSettingsConfigDebug: 1
+    ClientSettingsConfigGm: 8
+    ClientSettingsConfigInternal: 2
+    ClientSettingsConfigPerf: 4
+    ClientSettingsConfigRetail: 256
+    ClientSettingsConfigTest: 16
+    ClientSettingsConfigTestRetail: 32
 ClubActionType:
-  ErrorClubActionAcceptInvitation: 13
-  ErrorClubActionAddBan: 22
-  ErrorClubActionCreate: 1
-  ErrorClubActionCreateMessage: 24
-  ErrorClubActionCreateStream: 15
-  ErrorClubActionCreateTicket: 5
-  ErrorClubActionDeclineInvitation: 14
-  ErrorClubActionDestroy: 3
-  ErrorClubActionDestroyMessage: 26
-  ErrorClubActionDestroyStream: 17
-  ErrorClubActionDestroyTicket: 6
-  ErrorClubActionEdit: 2
-  ErrorClubActionEditMember: 19
-  ErrorClubActionEditMemberNote: 20
-  ErrorClubActionEditMessage: 25
-  ErrorClubActionEditStream: 16
-  ErrorClubActionGetBans: 10
-  ErrorClubActionGetInvitations: 11
-  ErrorClubActionGetTicket: 8
-  ErrorClubActionGetTickets: 9
-  ErrorClubActionInviteMember: 18
-  ErrorClubActionKickMember: 21
-  ErrorClubActionLeave: 4
-  ErrorClubActionRedeemTicket: 7
-  ErrorClubActionRemoveBan: 23
-  ErrorClubActionRevokeInvitation: 12
-  ErrorClubActionSubscribe: 0
+  values:
+    ErrorClubActionAcceptInvitation: 13
+    ErrorClubActionAddBan: 22
+    ErrorClubActionCreate: 1
+    ErrorClubActionCreateMessage: 24
+    ErrorClubActionCreateStream: 15
+    ErrorClubActionCreateTicket: 5
+    ErrorClubActionDeclineInvitation: 14
+    ErrorClubActionDestroy: 3
+    ErrorClubActionDestroyMessage: 26
+    ErrorClubActionDestroyStream: 17
+    ErrorClubActionDestroyTicket: 6
+    ErrorClubActionEdit: 2
+    ErrorClubActionEditMember: 19
+    ErrorClubActionEditMemberNote: 20
+    ErrorClubActionEditMessage: 25
+    ErrorClubActionEditStream: 16
+    ErrorClubActionGetBans: 10
+    ErrorClubActionGetInvitations: 11
+    ErrorClubActionGetTicket: 8
+    ErrorClubActionGetTickets: 9
+    ErrorClubActionInviteMember: 18
+    ErrorClubActionKickMember: 21
+    ErrorClubActionLeave: 4
+    ErrorClubActionRedeemTicket: 7
+    ErrorClubActionRemoveBan: 23
+    ErrorClubActionRevokeInvitation: 12
+    ErrorClubActionSubscribe: 0
 ClubErrorType:
-  ErrorClubAlreadyMember: 19
-  ErrorClubBanAlreadyExists: 35
-  ErrorClubBanCountAtMax: 36
-  ErrorClubDoesntAllowCrossFaction: 40
-  ErrorClubEditHasCrossFactionMembers: 41
-  ErrorClubFull: 16
-  ErrorClubInsufficientPrivileges: 24
-  ErrorClubInvalidRoleID: 23
-  ErrorClubInvitationAlreadyExists: 22
-  ErrorClubMemberHasRequiredRole: 31
-  ErrorClubNoClub: 17
-  ErrorClubNoSuchInvitation: 21
-  ErrorClubNoSuchMember: 20
-  ErrorClubNotMember: 18
-  ErrorClubReceivedInvitationCountAtMax: 33
-  ErrorClubSentInvitationCountAtMax: 32
-  ErrorClubStreamCountAtMax: 30
-  ErrorClubStreamCountAtMin: 29
-  ErrorClubStreamInvalidName: 28
-  ErrorClubStreamNoStream: 27
-  ErrorClubTargetIsBanned: 34
-  ErrorClubTicketCountAtMax: 37
-  ErrorClubTicketHasConsumedAllowedRedeemCount: 39
-  ErrorClubTicketNoSuchTicket: 38
-  ErrorClubTooManyClubsJoined: 25
-  ErrorClubVoiceFull: 26
-  ErrorCommunitiesBadTarget: 4
-  ErrorCommunitiesChatMute: 15
-  ErrorCommunitiesGuild: 8
-  ErrorCommunitiesIgnored: 7
-  ErrorCommunitiesMissingShortName: 11
-  ErrorCommunitiesNeutralFaction: 2
-  ErrorCommunitiesNone: 0
-  ErrorCommunitiesProfanity: 12
-  ErrorCommunitiesRestricted: 6
-  ErrorCommunitiesTrial: 13
-  ErrorCommunitiesUnknown: 1
-  ErrorCommunitiesUnknownRealm: 3
-  ErrorCommunitiesUnknownTicket: 10
-  ErrorCommunitiesVeteranTrial: 14
-  ErrorCommunitiesWrongFaction: 5
-  ErrorCommunitiesWrongRegion: 9
+  values:
+    ErrorClubAlreadyMember: 19
+    ErrorClubBanAlreadyExists: 35
+    ErrorClubBanCountAtMax: 36
+    ErrorClubDoesntAllowCrossFaction: 40
+    ErrorClubEditHasCrossFactionMembers: 41
+    ErrorClubFull: 16
+    ErrorClubInsufficientPrivileges: 24
+    ErrorClubInvalidRoleID: 23
+    ErrorClubInvitationAlreadyExists: 22
+    ErrorClubMemberHasRequiredRole: 31
+    ErrorClubNoClub: 17
+    ErrorClubNoSuchInvitation: 21
+    ErrorClubNoSuchMember: 20
+    ErrorClubNotMember: 18
+    ErrorClubReceivedInvitationCountAtMax: 33
+    ErrorClubSentInvitationCountAtMax: 32
+    ErrorClubStreamCountAtMax: 30
+    ErrorClubStreamCountAtMin: 29
+    ErrorClubStreamInvalidName: 28
+    ErrorClubStreamNoStream: 27
+    ErrorClubTargetIsBanned: 34
+    ErrorClubTicketCountAtMax: 37
+    ErrorClubTicketHasConsumedAllowedRedeemCount: 39
+    ErrorClubTicketNoSuchTicket: 38
+    ErrorClubTooManyClubsJoined: 25
+    ErrorClubVoiceFull: 26
+    ErrorCommunitiesBadTarget: 4
+    ErrorCommunitiesChatMute: 15
+    ErrorCommunitiesGuild: 8
+    ErrorCommunitiesIgnored: 7
+    ErrorCommunitiesMissingShortName: 11
+    ErrorCommunitiesNeutralFaction: 2
+    ErrorCommunitiesNone: 0
+    ErrorCommunitiesProfanity: 12
+    ErrorCommunitiesRestricted: 6
+    ErrorCommunitiesTrial: 13
+    ErrorCommunitiesUnknown: 1
+    ErrorCommunitiesUnknownRealm: 3
+    ErrorCommunitiesUnknownTicket: 10
+    ErrorCommunitiesVeteranTrial: 14
+    ErrorCommunitiesWrongFaction: 5
+    ErrorCommunitiesWrongRegion: 9
 ClubFieldType:
-  ClubBroadcast: 3
-  ClubDescription: 2
-  ClubName: 0
-  ClubShortName: 1
-  ClubStreamName: 4
-  ClubStreamSubject: 5
-  NumTypes: 6
+  values:
+    ClubBroadcast: 3
+    ClubDescription: 2
+    ClubName: 0
+    ClubShortName: 1
+    ClubStreamName: 4
+    ClubStreamSubject: 5
+    NumTypes: 6
 ClubFinderApplicationUpdateType:
-  AcceptInvite: 1
-  Cancel: 3
-  DeclineInvite: 2
-  None: 0
+  values:
+    AcceptInvite: 1
+    Cancel: 3
+    DeclineInvite: 2
+    None: 0
 ClubFinderClubPostingStatusFlags:
-  Banned: 5
-  FakePost: 6
-  ForceDescriptionChange: 2
-  ForceNameChange: 3
-  NeedsCacheUpdate: 1
-  None: 0
-  PendingDelete: 7
-  PostDelisted: 8
-  UnderReview: 4
+  values:
+    Banned: 5
+    FakePost: 6
+    ForceDescriptionChange: 2
+    ForceNameChange: 3
+    NeedsCacheUpdate: 1
+    None: 0
+    PendingDelete: 7
+    PostDelisted: 8
+    UnderReview: 4
 ClubFinderDisableReason:
-  Muted: 0
-  Silenced: 1
-  VeteranTrial: 2
+  values:
+    Muted: 0
+    Silenced: 1
+    VeteranTrial: 2
 ClubFinderPostingReportType:
-  ApplicantsName: 3
-  ClubName: 1
-  JoinNote: 4
-  PostersName: 0
-  PostingDescription: 2
+  values:
+    ApplicantsName: 3
+    ClubName: 1
+    JoinNote: 4
+    PostersName: 0
+    PostingDescription: 2
 ClubFinderRequestType:
-  All: 3
-  Community: 2
-  Guild: 1
-  None: 0
+  values:
+    All: 3
+    Community: 2
+    Guild: 1
+    None: 0
 ClubFinderSettingFlags:
-  AutoAccept: 14
-  Damage: 11
-  Dungeons: 1
-  EnableListing: 12
-  FactionAlliance: 16
-  FactionHorde: 15
-  FactionNeutral: 17
-  Healer: 10
-  LanguageReserved1: 21
-  LanguageReserved2: 22
-  LanguageReserved3: 23
-  LanguageReserved4: 24
-  LanguageReserved5: 25
-  Large: 8
-  MaxLevelOnly: 13
-  Medium: 7
-  None: 0
-  PvP: 3
-  Raids: 2
-  RP: 4
-  Small: 6
-  Social: 5
-  SortMemberCount: 19
-  SortNewest: 20
-  SortRelevance: 18
-  Tank: 9
+  values:
+    AutoAccept: 14
+    Damage: 11
+    Dungeons: 1
+    EnableListing: 12
+    FactionAlliance: 16
+    FactionHorde: 15
+    FactionNeutral: 17
+    Healer: 10
+    LanguageReserved1: 21
+    LanguageReserved2: 22
+    LanguageReserved3: 23
+    LanguageReserved4: 24
+    LanguageReserved5: 25
+    Large: 8
+    MaxLevelOnly: 13
+    Medium: 7
+    None: 0
+    PvP: 3
+    Raids: 2
+    RP: 4
+    Small: 6
+    Social: 5
+    SortMemberCount: 19
+    SortNewest: 20
+    SortRelevance: 18
+    Tank: 9
 ClubInvitationCandidateStatus:
-  AlreadyMember: 2
-  Available: 0
-  InvitePending: 1
+  values:
+    AlreadyMember: 2
+    Available: 0
+    InvitePending: 1
 ClubMemberPresence:
-  Away: 4
-  Busy: 5
-  Offline: 3
-  Online: 1
-  OnlineMobile: 2
-  Unknown: 0
+  values:
+    Away: 4
+    Busy: 5
+    Offline: 3
+    Online: 1
+    OnlineMobile: 2
+    Unknown: 0
 ClubRemovedReason:
-  Banned: 1
-  ClubDestroyed: 3
-  None: 0
-  Removed: 2
+  values:
+    Banned: 1
+    ClubDestroyed: 3
+    None: 0
+    Removed: 2
 ClubRestrictionReason:
-  None: 0
-  Unavailable: 1
+  values:
+    None: 0
+    Unavailable: 1
 ClubRoleIdentifier:
-  Leader: 2
-  Member: 4
-  Moderator: 3
-  Owner: 1
+  values:
+    Leader: 2
+    Member: 4
+    Moderator: 3
+    Owner: 1
 ClubStreamNotificationFilter:
-  All: 2
-  Mention: 1
-  None: 0
+  values:
+    All: 2
+    Mention: 1
+    None: 0
 ClubStreamType:
-  Discord: 3
-  General: 0
-  Guild: 1
-  Officer: 2
-  Other: 4
+  values:
+    Discord: 3
+    General: 0
+    Guild: 1
+    Officer: 2
+    Other: 4
 ClubType:
-  BattleNet: 0
-  Character: 1
-  Guild: 2
-  Other: 3
+  values:
+    BattleNet: 0
+    Character: 1
+    Guild: 2
+    Other: 3
 ColorOverride:
-  ItemQualityAccount: 7
-  ItemQualityArtifact: 6
-  ItemQualityCommon: 1
-  ItemQualityEpic: 4
-  ItemQualityLegendary: 5
-  ItemQualityPoor: 0
-  ItemQualityRare: 3
-  ItemQualityUncommon: 2
+  values:
+    ItemQualityAccount: 7
+    ItemQualityArtifact: 6
+    ItemQualityCommon: 1
+    ItemQualityEpic: 4
+    ItemQualityLegendary: 5
+    ItemQualityPoor: 0
+    ItemQualityRare: 3
+    ItemQualityUncommon: 2
 CombatAudioAlertCastState:
-  Off: 0
-  OnCastEnd: 2
-  OnCastStart: 1
+  values:
+    Off: 0
+    OnCastEnd: 2
+    OnCastStart: 1
 CombatAudioAlertCategory:
-  General: 0
-  PartyHealth: 7
-  PlayerCast: 3
-  PlayerDebuffs: 8
-  PlayerHealth: 1
-  PlayerResource1: 5
-  PlayerResource2: 6
-  TargetCast: 4
-  TargetHealth: 2
+  values:
+    General: 0
+    PartyHealth: 7
+    PlayerCast: 3
+    PlayerDebuffs: 8
+    PlayerHealth: 1
+    PlayerResource1: 5
+    PlayerResource2: 6
+    TargetCast: 4
+    TargetHealth: 2
 CombatAudioAlertDebuffSelfAlertValues:
-  DispelType: 1
-  Off: 0
+  values:
+    DispelType: 1
+    Off: 0
 CombatAudioAlertPartyPercentValues:
-  Off: 0
-  Under100Percent: 1
-  Under10Percent: 10
-  Under20Percent: 9
-  Under30Percent: 8
-  Under40Percent: 7
-  Under50Percent: 6
-  Under60Percent: 5
-  Under70Percent: 4
-  Under80Percent: 3
-  Under90Percent: 2
+  values:
+    Off: 0
+    Under100Percent: 1
+    Under10Percent: 10
+    Under20Percent: 9
+    Under30Percent: 8
+    Under40Percent: 7
+    Under50Percent: 6
+    Under60Percent: 5
+    Under70Percent: 4
+    Under80Percent: 3
+    Under90Percent: 2
 CombatAudioAlertPercentValues:
-  Every10Percent: 1
-  Every20Percent: 2
-  Every30Percent: 3
-  Every40Percent: 4
-  Every50Percent: 5
-  Off: 0
+  values:
+    Every10Percent: 1
+    Every20Percent: 2
+    Every30Percent: 3
+    Every40Percent: 4
+    Every50Percent: 5
+    Off: 0
 CombatAudioAlertPlayerCastFormatValues:
-  Cast: 3
-  Casting: 2
-  CastingSpellname: 0
-  CastSpellname: 1
-  Spellname: 4
+  values:
+    Cast: 3
+    Casting: 2
+    CastingSpellname: 0
+    CastSpellname: 1
+    Spellname: 4
 CombatAudioAlertPlayerDebuffFormatValues:
-  Full: 0
-  NoSpellname: 1
+  values:
+    Full: 0
+    NoSpellname: 1
 CombatAudioAlertPlayerHealthFormatValues:
-  HealthFull: 0
-  HealthNoPercent: 1
-  HealthNoPercentDiv10: 2
-  NoHealthFull: 3
-  NoHealthNoPercent: 4
-  NoHealthNoPercentDiv10: 5
+  values:
+    HealthFull: 0
+    HealthNoPercent: 1
+    HealthNoPercentDiv10: 2
+    NoHealthFull: 3
+    NoHealthNoPercent: 4
+    NoHealthNoPercentDiv10: 5
 CombatAudioAlertPlayerResourceFormatValues:
-  NoResourceFull: 3
-  NoResourceNoPercent: 4
-  NoResourceNoPercentDiv10: 5
-  ResourceFull: 0
-  ResourceNoPercent: 1
-  ResourceNoPercentDiv10: 2
+  values:
+    NoResourceFull: 3
+    NoResourceNoPercent: 4
+    NoResourceNoPercentDiv10: 5
+    ResourceFull: 0
+    ResourceNoPercent: 1
+    ResourceNoPercentDiv10: 2
 CombatAudioAlertSayIfTargetedType:
-  Aggro: 1
-  None: 0
-  Targeted: 2
-  TargetedBy: 3
+  values:
+    Aggro: 1
+    None: 0
+    Targeted: 2
+    TargetedBy: 3
 CombatAudioAlertSpecSetting:
-  Resource1Format: 1
-  Resource1Percent: 0
-  Resource1Voice: 2
-  Resource1Volume: 3
-  Resource2Format: 5
-  Resource2Percent: 4
-  Resource2Voice: 6
-  Resource2Volume: 7
-  SayIfTargeted: 8
+  values:
+    Resource1Format: 1
+    Resource1Percent: 0
+    Resource1Voice: 2
+    Resource1Volume: 3
+    Resource2Format: 5
+    Resource2Percent: 4
+    Resource2Voice: 6
+    Resource2Volume: 7
+    SayIfTargeted: 8
 CombatAudioAlertTargetCastFormatValues:
-  Cast: 5
-  Casting: 4
-  CastingSpellname: 2
-  CastSpellname: 3
-  Spellname: 6
-  TargetCastingSpellname: 0
-  TargetCastSpellname: 1
+  values:
+    Cast: 5
+    Casting: 4
+    CastingSpellname: 2
+    CastSpellname: 3
+    Spellname: 6
+    TargetCastingSpellname: 0
+    TargetCastSpellname: 1
 CombatAudioAlertTargetDeathBehavior:
-  Default: 0
-  SayTargetDead: 1
+  values:
+    Default: 0
+    SayTargetDead: 1
 CombatAudioAlertTargetHealthFormatValues:
-  HealthFull: 3
-  HealthNoPercent: 4
-  HealthNoPercentDiv10: 5
-  NoHealthFull: 0
-  NoHealthNoPercent: 1
-  NoHealthNoPercentDiv10: 2
-  TargetFull: 6
-  TargetNoPercent: 7
-  TargetNoPercentDiv10: 8
+  values:
+    HealthFull: 3
+    HealthNoPercent: 4
+    HealthNoPercentDiv10: 5
+    NoHealthFull: 0
+    NoHealthNoPercent: 1
+    NoHealthNoPercentDiv10: 2
+    TargetFull: 6
+    TargetNoPercent: 7
+    TargetNoPercentDiv10: 8
 CombatAudioAlertThrottle:
-  PlayerCast: 3
-  PlayerHealth: 1
-  PlayerHealthSamePercent: 7
-  PlayerResource1: 5
-  PlayerResource1SamePercent: 9
-  PlayerResource2: 6
-  PlayerResource2SamePercent: 10
-  Sample: 0
-  TargetCast: 4
-  TargetHealth: 2
-  TargetHealthSamePercent: 8
+  values:
+    PlayerCast: 3
+    PlayerHealth: 1
+    PlayerHealthSamePercent: 7
+    PlayerResource1: 5
+    PlayerResource1SamePercent: 9
+    PlayerResource2: 6
+    PlayerResource2SamePercent: 10
+    Sample: 0
+    TargetCast: 4
+    TargetHealth: 2
+    TargetHealthSamePercent: 8
 CombatAudioAlertType:
-  Cast: 1
-  Health: 0
+  values:
+    Cast: 1
+    Health: 0
 CombatAudioAlertUnit:
-  Player: 0
-  Target: 1
+  values:
+    Player: 0
+    Target: 1
 CombatLogMessageOrder:
-  Newest: 0
-  Oldest: 1
+  values:
+    Newest: 0
+    Oldest: 1
 CombatLogObject:
-  AffiliationMine: 1
-  AffiliationOutsider: 8
-  AffiliationParty: 2
-  AffiliationRaid: 4
-  ControlNpc: 512
-  ControlPlayer: 256
-  Empty: 0
-  Focus: 131072
-  Mainassist: 524288
-  Maintank: 262144
-  None: 2147483648
-  ReactionFriendly: 16
-  ReactionHostile: 64
-  ReactionNeutral: 32
-  Target: 65536
-  TypeGuardian: 8192
-  TypeNpc: 2048
-  TypeObject: 16384
-  TypePet: 4096
-  TypePlayer: 1024
+  values:
+    AffiliationMine: 1
+    AffiliationOutsider: 8
+    AffiliationParty: 2
+    AffiliationRaid: 4
+    ControlNpc: 512
+    ControlPlayer: 256
+    Empty: 0
+    Focus: 131072
+    Mainassist: 524288
+    Maintank: 262144
+    None: 2147483648
+    ReactionFriendly: 16
+    ReactionHostile: 64
+    ReactionNeutral: 32
+    Target: 65536
+    TypeGuardian: 8192
+    TypeNpc: 2048
+    TypeObject: 16384
+    TypePet: 4096
+    TypePlayer: 1024
 CombatLogObjectTarget:
-  RaidNone: 2147483648
-  Raidtarget1: 1
-  Raidtarget2: 2
-  Raidtarget3: 4
-  Raidtarget4: 8
-  Raidtarget5: 16
-  Raidtarget6: 32
-  Raidtarget7: 64
-  Raidtarget8: 128
+  values:
+    RaidNone: 2147483648
+    Raidtarget1: 1
+    Raidtarget2: 2
+    Raidtarget3: 4
+    Raidtarget4: 8
+    Raidtarget5: 16
+    Raidtarget6: 32
+    Raidtarget7: 64
+    Raidtarget8: 128
 CombinedQuestLogStatus:
-  Available: 0
-  Complete: 1
-  CompleteDaily: 2
-  CompleteGameReset: 6
-  CompleteMonthly: 4
-  CompleteWeekly: 3
-  CompleteYearly: 5
-  Reset: 7
+  values:
+    Available: 0
+    Complete: 1
+    CompleteDaily: 2
+    CompleteGameReset: 6
+    CompleteMonthly: 4
+    CompleteWeekly: 3
+    CompleteYearly: 5
+    Reset: 7
 CombinedQuestStatus:
-  Completed: 1
-  Invalid: 0
-  NotCompleted: 2
+  values:
+    Completed: 1
+    Invalid: 0
+    NotCompleted: 2
 CommunicationMode:
-  OpenMic: 1
-  PushToTalk: 0
+  values:
+    OpenMic: 1
+    PushToTalk: 0
 CompanionConfigSlotTypes:
-  Combat: 2
-  Flavor: 3
-  Role: 0
-  Utility: 1
+  values:
+    Combat: 2
+    Flavor: 3
+    Role: 0
+    Utility: 1
 CompanionRoleType:
-  Dps: 0
-  Heal: 1
-  Tank: 2
+  values:
+    Dps: 0
+    Heal: 1
+    Tank: 2
 CompressionLevel:
-  Default: 0
-  OptimizeForSize: 2
-  OptimizeForSpeed: 1
+  values:
+    Default: 0
+    OptimizeForSize: 2
+    OptimizeForSpeed: 1
 CompressionMethod:
-  Deflate: 0
-  Gzip: 2
-  Zlib: 1
+  values:
+    Deflate: 0
+    Gzip: 2
+    Zlib: 1
 ConfirmationPromptUIType:
-  BonusRoll: 1
-  SimpleWarning: 2
-  SimpleWarningAlert: 4
-  StaticText: 0
-  StaticTextAlert: 3
+  values:
+    BonusRoll: 1
+    SimpleWarning: 2
+    SimpleWarningAlert: 4
+    StaticText: 0
+    StaticTextAlert: 3
 ConquestProgressBarDisplayType:
-  AdditionalChest: 1
-  FirstChest: 0
-  Seasonal: 2
+  values:
+    AdditionalChest: 1
+    FirstChest: 0
+    Seasonal: 2
 ConsoleCategory:
-  Combat: 3
-  Console: 2
-  Debug: 0
-  Default: 5
-  Game: 4
-  Gm: 8
-  Graphics: 1
-  Net: 6
-  None: 10
-  Reveal: 9
-  Sound: 7
+  values:
+    Combat: 3
+    Console: 2
+    Debug: 0
+    Default: 5
+    Game: 4
+    Gm: 8
+    Graphics: 1
+    Net: 6
+    None: 10
+    Reveal: 9
+    Sound: 7
 ConsoleColorType:
-  AdminColor: 6
-  BackgroundColor: 8
-  ClickbufferColor: 9
-  DefaultColor: 0
-  DefaultGreen: 11
-  EchoColor: 2
-  ErrorColor: 3
-  GlobalColor: 5
-  HighlightColor: 7
-  InputColor: 1
-  PrivateColor: 10
-  WarningColor: 4
+  values:
+    AdminColor: 6
+    BackgroundColor: 8
+    ClickbufferColor: 9
+    DefaultColor: 0
+    DefaultGreen: 11
+    EchoColor: 2
+    ErrorColor: 3
+    GlobalColor: 5
+    HighlightColor: 7
+    InputColor: 1
+    PrivateColor: 10
+    WarningColor: 4
 ConsoleCommandType:
-  Command: 1
-  Cvar: 0
-  Macro: 2
-  Script: 3
+  values:
+    Command: 1
+    Cvar: 0
+    Macro: 2
+    Script: 3
 ContentTrackingError:
-  AlreadyTracked: 2
-  MaxTracked: 1
-  Untrackable: 0
+  values:
+    AlreadyTracked: 2
+    MaxTracked: 1
+    Untrackable: 0
 ContentTrackingResult:
-  DataPending: 1
-  Failure: 2
-  Success: 0
+  values:
+    DataPending: 1
+    Failure: 2
+    Success: 0
 ContentTrackingStopType:
-  Collected: 1
-  Invalidated: 0
-  Manual: 2
+  values:
+    Collected: 1
+    Invalidated: 0
+    Manual: 2
 ContentTrackingTargetType:
-  Achievement: 2
-  JournalEncounter: 0
-  Profession: 3
-  Quest: 4
-  Vendor: 1
+  values:
+    Achievement: 2
+    JournalEncounter: 0
+    Profession: 3
+    Quest: 4
+    Vendor: 1
 ContentTrackingType:
-  Achievement: 2
-  Appearance: 0
-  Decor: 3
-  Mount: 1
+  values:
+    Achievement: 2
+    Appearance: 0
+    Decor: 3
+    Mount: 1
 ContributionAppearanceFlags:
-  TooltipUseTimeRemaining: 0
+  values:
+    TooltipUseTimeRemaining: 0
 ContributionResult:
-  FailedConditionCheck: 5
-  IncorrectState: 2
-  InternalError: 7
-  InvalidID: 3
-  MustBeNearNpc: 1
-  QuestDataMissing: 4
-  Success: 0
-  UnableToCompleteTurnIn: 6
+  values:
+    FailedConditionCheck: 5
+    IncorrectState: 2
+    InternalError: 7
+    InvalidID: 3
+    MustBeNearNpc: 1
+    QuestDataMissing: 4
+    Success: 0
+    UnableToCompleteTurnIn: 6
 ContributionState:
-  Active: 2
-  Building: 1
-  Destroyed: 4
-  None: 0
-  UnderAttack: 3
+  values:
+    Active: 2
+    Building: 1
+    Destroyed: 4
+    None: 0
+    UnderAttack: 3
 CooldownSetLinkedSpellFlags:
-  UseAsTooltip: 1
+  values:
+    UseAsTooltip: 1
 CooldownSetSpellFlags:
-  HideAura: 1
-  HideByDefault: 2
+  values:
+    HideAura: 1
+    HideByDefault: 2
 CooldownViewerAddAlertStatus:
-  DuplicateAlert: 3
-  InvalidAlertType: 1
-  InvalidEventType: 2
-  Success: 0
+  values:
+    DuplicateAlert: 3
+    InvalidAlertType: 1
+    InvalidEventType: 2
+    Success: 0
 CooldownViewerAlertEventType:
-  Available: 1
-  ChargeGained: 4
-  OnAuraApplied: 5
-  OnAuraRemoved: 6
-  OnCooldown: 3
-  PandemicTime: 2
+  values:
+    Available: 1
+    ChargeGained: 4
+    OnAuraApplied: 5
+    OnAuraRemoved: 6
+    OnCooldown: 3
+    PandemicTime: 2
 CooldownViewerAlertType:
-  Sound: 1
-  Visual: 2
+  values:
+    Sound: 1
+    Visual: 2
 CooldownViewerBarContent:
-  IconAndName: 0
-  IconOnly: 1
-  NameOnly: 2
+  values:
+    IconAndName: 0
+    IconOnly: 1
+    NameOnly: 2
 CooldownViewerCategory:
-  EquipSlotEssential: 7
-  EquipSlotTracked: 8
-  Essential: 0
-  GroupBuff: 4
-  SpecAgnosticEssential: 5
-  SpecAgnosticTracked: 6
-  TrackedBar: 3
-  TrackedBuff: 2
-  Utility: 1
+  values:
+    EquipSlotEssential: 7
+    EquipSlotTracked: 8
+    Essential: 0
+    GroupBuff: 4
+    SpecAgnosticEssential: 5
+    SpecAgnosticTracked: 6
+    TrackedBar: 3
+    TrackedBuff: 2
+    Utility: 1
 CooldownViewerIconDirection:
-  Left: 0
-  Right: 1
+  values:
+    Left: 0
+    Right: 1
 CooldownViewerOrientation:
-  Horizontal: 0
-  Vertical: 1
+  values:
+    Horizontal: 0
+    Vertical: 1
 CooldownViewerSound:
-  AnimalsCat: 1
-  AnimalsChicken: 2
-  AnimalsCow: 3
-  AnimalsGnoll: 4
-  AnimalsGoat: 5
-  AnimalsLion: 6
-  AnimalsPanther: 7
-  AnimalsRattlesnake: 8
-  AnimalsSheep: 9
-  AnimalsWolf: 10
-  DevicesAirHorn: 12
-  DevicesBikeHorn: 13
-  DevicesBoatHorn: 11
-  DevicesCashRegister: 14
-  DevicesJackpotBell: 15
-  DevicesJackpotCoins: 16
-  DevicesJackpotFail: 17
-  DevicesRotaryPhoneDial: 18
-  DevicesRotaryPhoneRing: 19
-  DevicesStovePipe: 20
-  DevicesTrashcanLid: 21
-  ImpactsAnvilStrike: 22
-  ImpactsBubbleSmash: 23
-  ImpactsLowThud: 24
-  ImpactsMetalClanks: 25
-  ImpactsMetalRattle: 26
-  ImpactsMetalScrape: 27
-  ImpactsMetalWarble: 28
-  ImpactsPopClick: 29
-  ImpactsStrangeClang: 30
-  ImpactsSwordScrape: 31
-  InstrumentsBellRing: 32
-  InstrumentsBellTrill: 33
-  InstrumentsBrass: 34
-  InstrumentsChimeAscending: 35
-  InstrumentsGuitarChug: 36
-  InstrumentsGuitarPinch: 37
-  InstrumentsPitchPipeDistressed: 38
-  InstrumentsPitchPipeNote: 39
-  InstrumentsSynthBig: 40
-  InstrumentsSynthBuzz: 41
-  InstrumentsSynthHigh: 42
-  InstrumentsWarhorn: 43
-  ShortBellStrike: 68
-  ShortBellTree: 69
-  ShortBigPot: 70
-  ShortBlades: 71
-  ShortCoffeeMug: 72
-  ShortCowBell: 73
-  ShortFingerSnap: 74
-  ShortGuitar: 75
-  ShortKalimba: 76
-  ShortMetalBladeDrop: 77
-  ShortMetalBladeOnRod: 78
-  ShortMetalImpact: 79
-  ShortMiniWoodXylophone: 80
-  ShortPaperCup: 81
-  ShortSheetMetal: 82
-  ShortStovePipe: 83
-  ShortStovePipeBlade: 84
-  ShortSwordShing: 85
-  ShortSynthBleep: 86
-  ShortSynthBlurp: 87
-  ShortSynthError: 88
-  ShortSynthHigh: 89
-  ShortTriangle: 90
-  ShortWaterDrop: 91
-  ShortWineBottle: 92
-  ShortWoodXylophone: 93
-  TextToSpeech: 0
-  War2AbstractWhoosh: 44
-  War2Choir: 45
-  War2Construction: 46
-  War2MagicChimes: 47
-  War2PigSqueal: 48
-  War2Saws: 49
-  War2Seal: 50
-  War2Slow: 51
-  War2Smith: 52
-  War2SynthStinger: 53
-  War2TrumpetRally: 54
-  War2ZippyMagic: 55
-  War3Bell: 56
-  War3CrunchyBell: 57
-  War3DrumSplash: 58
-  War3Error: 59
-  War3Fanfare: 60
-  War3GateOpen: 61
-  War3Gold: 62
-  War3MagicShimmer: 63
-  War3Ringout: 64
-  War3Rooster: 65
-  War3ShimmerBell: 66
-  War3WolfHowl: 67
+  values:
+    AnimalsCat: 1
+    AnimalsChicken: 2
+    AnimalsCow: 3
+    AnimalsGnoll: 4
+    AnimalsGoat: 5
+    AnimalsLion: 6
+    AnimalsPanther: 7
+    AnimalsRattlesnake: 8
+    AnimalsSheep: 9
+    AnimalsWolf: 10
+    DevicesAirHorn: 12
+    DevicesBikeHorn: 13
+    DevicesBoatHorn: 11
+    DevicesCashRegister: 14
+    DevicesJackpotBell: 15
+    DevicesJackpotCoins: 16
+    DevicesJackpotFail: 17
+    DevicesRotaryPhoneDial: 18
+    DevicesRotaryPhoneRing: 19
+    DevicesStovePipe: 20
+    DevicesTrashcanLid: 21
+    ImpactsAnvilStrike: 22
+    ImpactsBubbleSmash: 23
+    ImpactsLowThud: 24
+    ImpactsMetalClanks: 25
+    ImpactsMetalRattle: 26
+    ImpactsMetalScrape: 27
+    ImpactsMetalWarble: 28
+    ImpactsPopClick: 29
+    ImpactsStrangeClang: 30
+    ImpactsSwordScrape: 31
+    InstrumentsBellRing: 32
+    InstrumentsBellTrill: 33
+    InstrumentsBrass: 34
+    InstrumentsChimeAscending: 35
+    InstrumentsGuitarChug: 36
+    InstrumentsGuitarPinch: 37
+    InstrumentsPitchPipeDistressed: 38
+    InstrumentsPitchPipeNote: 39
+    InstrumentsSynthBig: 40
+    InstrumentsSynthBuzz: 41
+    InstrumentsSynthHigh: 42
+    InstrumentsWarhorn: 43
+    ShortBellStrike: 68
+    ShortBellTree: 69
+    ShortBigPot: 70
+    ShortBlades: 71
+    ShortCoffeeMug: 72
+    ShortCowBell: 73
+    ShortFingerSnap: 74
+    ShortGuitar: 75
+    ShortKalimba: 76
+    ShortMetalBladeDrop: 77
+    ShortMetalBladeOnRod: 78
+    ShortMetalImpact: 79
+    ShortMiniWoodXylophone: 80
+    ShortPaperCup: 81
+    ShortSheetMetal: 82
+    ShortStovePipe: 83
+    ShortStovePipeBlade: 84
+    ShortSwordShing: 85
+    ShortSynthBleep: 86
+    ShortSynthBlurp: 87
+    ShortSynthError: 88
+    ShortSynthHigh: 89
+    ShortTriangle: 90
+    ShortWaterDrop: 91
+    ShortWineBottle: 92
+    ShortWoodXylophone: 93
+    TextToSpeech: 0
+    War2AbstractWhoosh: 44
+    War2Choir: 45
+    War2Construction: 46
+    War2MagicChimes: 47
+    War2PigSqueal: 48
+    War2Saws: 49
+    War2Seal: 50
+    War2Slow: 51
+    War2Smith: 52
+    War2SynthStinger: 53
+    War2TrumpetRally: 54
+    War2ZippyMagic: 55
+    War3Bell: 56
+    War3CrunchyBell: 57
+    War3DrumSplash: 58
+    War3Error: 59
+    War3Fanfare: 60
+    War3GateOpen: 61
+    War3Gold: 62
+    War3MagicShimmer: 63
+    War3Ringout: 64
+    War3Rooster: 65
+    War3ShimmerBell: 66
+    War3WolfHowl: 67
 CooldownViewerVisibleSetting:
-  Always: 0
-  Hidden: 2
-  InCombat: 1
+  values:
+    Always: 0
+    Hidden: 2
+    InCombat: 1
 CornerstonePurchaseMode:
-  Basic: 0
-  Import: 1
-  Move: 2
+  values:
+    Basic: 0
+    Import: 1
+    Move: 2
 CovenantAbilityType:
-  Class: 0
-  Signature: 1
-  Soulbind: 2
+  values:
+    Class: 0
+    Signature: 1
+    Soulbind: 2
 CovenantSkill:
-  Kyrian: 2730
-  Necrolord: 2733
-  NightFae: 2732
-  Venthyr: 2731
+  values:
+    Kyrian: 2730
+    Necrolord: 2733
+    NightFae: 2732
+    Venthyr: 2731
 CovenantType:
-  Kyrian: 1
-  Necrolord: 4
-  NightFae: 3
-  None: 0
-  Venthyr: 2
+  values:
+    Kyrian: 1
+    Necrolord: 4
+    NightFae: 3
+    None: 0
+    Venthyr: 2
 CraftingOrderCustomerCategoryType:
-  Primary: 0
-  Secondary: 1
-  Tertiary: 2
+  values:
+    Primary: 0
+    Secondary: 1
+    Tertiary: 2
 CraftingOrderDuration:
-  Long: 2
-  Medium: 1
-  Short: 0
+  values:
+    Long: 2
+    Medium: 1
+    Short: 0
 CraftingOrderFlags:
-  HasAllReagents: 8
-  HasNoneReagents: 2
-  HasSomeReagents: 4
-  IsFulfillable: 16
-  IsRecraft: 1
-  None: 0
+  values:
+    HasAllReagents: 8
+    HasNoneReagents: 2
+    HasSomeReagents: 4
+    IsFulfillable: 16
+    IsRecraft: 1
+    None: 0
 CraftingOrderItemFlags:
-  HasEnchantmentData: 2
-  None: 0
-  NpcProvided: 1
+  values:
+    HasEnchantmentData: 2
+    None: 0
+    NpcProvided: 1
 CraftingOrderItemType:
-  CraftedResult: 2
-  Currency: 5
-  Deprecated: 4
-  Item: 0
-  Recraft: 1
-  RemoveReagent: 3
+  values:
+    CraftedResult: 2
+    Currency: 5
+    Deprecated: 4
+    Item: 0
+    Recraft: 1
+    RemoveReagent: 3
 CraftingOrderReagentSource:
-  Any: 0
-  Crafter: 2
-  Customer: 1
-  None: 3
+  values:
+    Any: 0
+    Crafter: 2
+    Customer: 1
+    None: 3
 CraftingOrderReagentsType:
-  All: 0
-  None: 2
-  Some: 1
+  values:
+    All: 0
+    None: 2
+    Some: 1
 CraftingOrderResult:
-  Aborted: 1
-  AlreadyClaimed: 2
-  AlreadyCrafted: 3
-  CannotBeOrdered: 4
-  CannotCancel: 5
-  CannotClaim: 6
-  CannotClaimOwnOrder: 7
-  CannotCraft: 8
-  CannotCreate: 9
-  CannotFulfill: 10
-  CannotRecraft: 11
-  CannotReject: 12
-  CannotRelease: 13
-  CrafterIsIgnored: 14
-  DatabaseError: 15
-  Expired: 16
-  InvalidDuration: 18
-  InvalidMinQuality: 19
-  InvalidNotes: 20
-  InvalidReagent: 21
-  InvalidRealm: 22
-  InvalidRecipe: 23
-  InvalidRecraftItem: 24
-  InvalidSort: 25
-  InvalidTarget: 26
-  InvalidType: 27
-  Locked: 17
-  MaxOrdersReached: 28
-  MissingCraftingTable: 29
-  MissingCurrency: 30
-  MissingItem: 31
-  MissingNpc: 32
-  MissingOrder: 33
-  MissingRecraftItem: 34
-  NoAccountItems: 35
-  NotClaimed: 36
-  NotCrafted: 37
-  NotInGuild: 38
-  NotYetImplemented: 39
-  Ok: 0
-  OutOfPublicOrderCapacity: 40
-  ServerIsNotAvailable: 41
-  TargetCannotCraft: 43
-  TargetLocked: 44
-  ThrottleViolation: 42
-  Timeout: 45
-  TooManyCurrencies: 46
-  TooManyItems: 47
-  WrongVersion: 48
+  values:
+    Aborted: 1
+    AlreadyClaimed: 2
+    AlreadyCrafted: 3
+    CannotBeOrdered: 4
+    CannotCancel: 5
+    CannotClaim: 6
+    CannotClaimOwnOrder: 7
+    CannotCraft: 8
+    CannotCreate: 9
+    CannotFulfill: 10
+    CannotRecraft: 11
+    CannotReject: 12
+    CannotRelease: 13
+    CrafterIsIgnored: 14
+    DatabaseError: 15
+    Expired: 16
+    InvalidDuration: 18
+    InvalidMinQuality: 19
+    InvalidNotes: 20
+    InvalidReagent: 21
+    InvalidRealm: 22
+    InvalidRecipe: 23
+    InvalidRecraftItem: 24
+    InvalidSort: 25
+    InvalidTarget: 26
+    InvalidType: 27
+    Locked: 17
+    MaxOrdersReached: 28
+    MissingCraftingTable: 29
+    MissingCurrency: 30
+    MissingItem: 31
+    MissingNpc: 32
+    MissingOrder: 33
+    MissingRecraftItem: 34
+    NoAccountItems: 35
+    NotClaimed: 36
+    NotCrafted: 37
+    NotInGuild: 38
+    NotYetImplemented: 39
+    Ok: 0
+    OutOfPublicOrderCapacity: 40
+    ServerIsNotAvailable: 41
+    TargetCannotCraft: 43
+    TargetLocked: 44
+    ThrottleViolation: 42
+    Timeout: 45
+    TooManyCurrencies: 46
+    TooManyItems: 47
+    WrongVersion: 48
 CraftingOrderSortType:
-  AveTip: 1
-  ItemName: 0
-  MaxTip: 2
-  Quantity: 3
-  Reagents: 4
-  Status: 7
-  TimeRemaining: 6
-  Tip: 5
+  values:
+    AveTip: 1
+    ItemName: 0
+    MaxTip: 2
+    Quantity: 3
+    Reagents: 4
+    Status: 7
+    TimeRemaining: 6
+    Tip: 5
 CraftingOrderState:
-  Canceled: 13
-  Canceling: 12
-  Claimed: 4
-  Claiming: 3
-  Crafting: 8
-  Created: 2
-  Creating: 1
-  Expired: 15
-  Expiring: 14
-  Fulfilled: 11
-  Fulfilling: 10
-  None: 0
-  Recrafting: 9
-  Rejected: 6
-  Rejecting: 5
-  Releasing: 7
+  values:
+    Canceled: 13
+    Canceling: 12
+    Claimed: 4
+    Claiming: 3
+    Crafting: 8
+    Created: 2
+    Creating: 1
+    Expired: 15
+    Expiring: 14
+    Fulfilled: 11
+    Fulfilling: 10
+    None: 0
+    Recrafting: 9
+    Rejected: 6
+    Rejecting: 5
+    Releasing: 7
 CraftingOrderType:
-  Guild: 1
-  Npc: 3
-  Personal: 2
-  Public: 0
+  values:
+    Guild: 1
+    Npc: 3
+    Personal: 2
+    Public: 0
 CraftingReagentItemFlag:
-  TooltipShowsAsStatModifications: 1
+  values:
+    TooltipShowsAsStatModifications: 1
 CraftingReagentType:
-  Automatic: 3
-  Basic: 1
-  Finishing: 2
-  Modifying: 0
+  values:
+    Automatic: 3
+    Basic: 1
+    Finishing: 2
+    Modifying: 0
 CreateAllAccountData:
-  AccountCurrenciesDone: '0x0000000000200000'
-  AccountDynamicCriteriaDone: '0x0000000001000000'
-  AccountFactionsDone: '0x0000000200000000'
-  AccountItemsDone: '0x0000000400000000'
-  AccountMappingDone: '0x0000008000000000'
-  AccountNotificationsDone: '0x0000000008000000'
-  AccountStateHousingData: '0x0000080000000000'
-  AchievementsDone: '0x0000000000000001'
-  ArchivedPurchasesDone: '0x0000000000000200'
-  AuctionableTokensDone: '0x0000000000002000'
-  BanktabSettingsDone: '0x0000004000000000'
-  BattlepetsDone: '0x0000000000000008'
-  BitVectorsDone: '0x0000000100000000'
-  BpayAddLicenseObjectsDone: '0x0000000000000800'
-  BpayDistributionObjectsDone: '0x0000000000000100'
-  BpayProductitemObjectsDone: '0x0000000000020000'
-  CharacterItemsDone: '0x0000010000000000'
-  CharactersDone: '0x0000000000000040'
-  CombinedQuestLogEntriesDone: '0x0000000800000000'
-  ConsumableTokensDone: '0x0000000000004000'
-  CriteriaDone: '0x0000000000000002'
-  CurrencycapsDone: '0x0000000000000010'
-  CurrencyTransferLogDone: '0x0000020000000000'
-  DataElementsDone: '0x0000001000000000'
-  EventRecordsDone: '0x0000200000000000'
-  ItemCollectionItemsDone: '0x0000000000001000'
-  LgVendorPurchaseDone: '0x0000040000000000'
-  MountsDone: '0x0000000000000004'
-  None: '0x0000000000000000'
-  Object: '0x0000000000100000'
-  PerkHeldItemsDone: '0x0000000040000000'
-  PerkPastRewardsDone: '0x0000000000008000'
-  PerkPendingPurchasesDone: '0x0000000010000000'
-  PerkPendingRewardsDone: '0x0000000080000000'
-  PurchasesDone: '0x0000000000000080'
-  QuestCriteriaDone: '0x0000000000080000'
-  QuestLogDone: '0x0000000000000020'
-  RafActivitiesDone: '0x0000000002000000'
-  RafBalanceDone: '0x0000000000400000'
-  RafRewardsDone: '0x0000000000800000'
-  RevokedRafRewardsDone: '0x0000000004000000'
-  SettingsDone: '0x0000000000000400'
-  TransmogOutfitsLoadedDone: '0x0000400000000000'
-  TrialBoostHistoryDone: '0x0000000000040000'
-  VasTransactionsDone: '0x0000000000010000'
-  WarbandGroupsDone: '0x0000002000000000'
-  WarbandScenesLoadedDone: '0x0000100000000000'
-  WowlabsDataDone: '0x0000000020000000'
+  values:
+    AccountCurrenciesDone: '0x0000000000200000'
+    AccountDynamicCriteriaDone: '0x0000000001000000'
+    AccountFactionsDone: '0x0000000200000000'
+    AccountItemsDone: '0x0000000400000000'
+    AccountMappingDone: '0x0000008000000000'
+    AccountNotificationsDone: '0x0000000008000000'
+    AccountStateHousingData: '0x0000080000000000'
+    AchievementsDone: '0x0000000000000001'
+    ArchivedPurchasesDone: '0x0000000000000200'
+    AuctionableTokensDone: '0x0000000000002000'
+    BanktabSettingsDone: '0x0000004000000000'
+    BattlepetsDone: '0x0000000000000008'
+    BitVectorsDone: '0x0000000100000000'
+    BpayAddLicenseObjectsDone: '0x0000000000000800'
+    BpayDistributionObjectsDone: '0x0000000000000100'
+    BpayProductitemObjectsDone: '0x0000000000020000'
+    CharacterItemsDone: '0x0000010000000000'
+    CharactersDone: '0x0000000000000040'
+    CombinedQuestLogEntriesDone: '0x0000000800000000'
+    ConsumableTokensDone: '0x0000000000004000'
+    CriteriaDone: '0x0000000000000002'
+    CurrencycapsDone: '0x0000000000000010'
+    CurrencyTransferLogDone: '0x0000020000000000'
+    DataElementsDone: '0x0000001000000000'
+    EventRecordsDone: '0x0000200000000000'
+    ItemCollectionItemsDone: '0x0000000000001000'
+    LgVendorPurchaseDone: '0x0000040000000000'
+    MountsDone: '0x0000000000000004'
+    None: '0x0000000000000000'
+    Object: '0x0000000000100000'
+    PerkHeldItemsDone: '0x0000000040000000'
+    PerkPastRewardsDone: '0x0000000000008000'
+    PerkPendingPurchasesDone: '0x0000000010000000'
+    PerkPendingRewardsDone: '0x0000000080000000'
+    PurchasesDone: '0x0000000000000080'
+    QuestCriteriaDone: '0x0000000000080000'
+    QuestLogDone: '0x0000000000000020'
+    RafActivitiesDone: '0x0000000002000000'
+    RafBalanceDone: '0x0000000000400000'
+    RafRewardsDone: '0x0000000000800000'
+    RevokedRafRewardsDone: '0x0000000004000000'
+    SettingsDone: '0x0000000000000400'
+    TransmogOutfitsLoadedDone: '0x0000400000000000'
+    TrialBoostHistoryDone: '0x0000000000040000'
+    VasTransactionsDone: '0x0000000000010000'
+    WarbandGroupsDone: '0x0000002000000000'
+    WarbandScenesLoadedDone: '0x0000100000000000'
+    WowlabsDataDone: '0x0000000020000000'
 CreateNeighborhoodErrorType:
-  None: 0
-  OversizedGuild: 3
-  Profanity: 1
-  UndersizedGuild: 2
+  values:
+    None: 0
+    OversizedGuild: 3
+    Profanity: 1
+    UndersizedGuild: 2
 CurioRarity:
-  Common: 1
-  Epic: 4
-  Rare: 3
-  Uncommon: 2
+  values:
+    Common: 1
+    Epic: 4
+    Rare: 3
+    Uncommon: 2
 CurioType:
-  Combat: 0
-  Utility: 1
+  values:
+    Combat: 0
+    Utility: 1
 CurrencyConversionResult:
-  Conversion: 1
-  NoConversion: 0
-  SkippedAccountCurrency: 2
+  values:
+    Conversion: 1
+    NoConversion: 0
+    SkippedAccountCurrency: 2
 CurrencyDestroyReason:
-  AccountServerConversion: 17
-  AccountTransfer: 14
-  BonusRoll: 9
-  Capped: 6
-  Cheat: 0
-  ConcentrationCast: 13
-  CraftingOrderReagent: 16
-  DroppedToCorpse: 8
-  FactionConversion: 10
-  FulfillCraftingOrder: 11
-  Garrison: 7
-  HonorLoss: 15
-  QuestTurnin: 3
-  Script: 12
-  Spell: 1
-  Trade: 5
-  Vendor: 4
-  VersionUpdate: 2
+  values:
+    AccountServerConversion: 17
+    AccountTransfer: 14
+    BonusRoll: 9
+    Capped: 6
+    Cheat: 0
+    ConcentrationCast: 13
+    CraftingOrderReagent: 16
+    DroppedToCorpse: 8
+    FactionConversion: 10
+    FulfillCraftingOrder: 11
+    Garrison: 7
+    HonorLoss: 15
+    QuestTurnin: 3
+    Script: 12
+    Spell: 1
+    Trade: 5
+    Vendor: 4
+    VersionUpdate: 2
 CurrencyFilterType:
-  DiscoveredAndAllAccountTransferable: 2
-  DiscoveredOnly: 1
-  None: 0
+  values:
+    DiscoveredAndAllAccountTransferable: 2
+    DiscoveredOnly: 1
+    None: 0
 CurrencyFlags:
-  Currency_100_Scaler: 8
-  CurrencyAccountWide: 16777216
-  CurrencyAllowOverflowMailer: 33554432
-  CurrencyAppearsInLootWindow: 2
-  CurrencyComputedWeeklyMaximum: 4
-  CurrencyDeprecated: 131072
-  CurrencyDestroyExtraOnLoot: 2097152
-  CurrencyDoNotCompressChat: 8192
-  CurrencyDoNotLogAcquisitionToBi: 16384
-  CurrencyDoNotToast: 1048576
-  CurrencyDontCoalesceInLootWindow: 8388608
-  CurrencyDontShowTotalInTooltip: 4194304
-  CurrencyDynamicMaximum: 262144
-  CurrencyHasWarmodeBonus: 134217728
-  CurrencyHasWeeklyCatchup: 4096
-  CurrencyHideAsReward: 67108864
-  CurrencyIgnoreMaxQtyOnLoad: 32
-  CurrencyIsAllianceOnly: 268435456
-  CurrencyIsHordeOnly: 536870912
-  CurrencyLimitWarmodeBonusOncePerTooltip: 1073741824
-  CurrencyLogOnWorldChange: 64
-  CurrencyNoLowLevelDrop: 16
-  CurrencyNoRaidDrop: 32768
-  CurrencyNotPersistent: 65536
-  CurrencyResetTrackedQuantity: 256
-  CurrencySingleDropInLoot: 2048
-  CurrencySuppressChatMessageOnVersionChange: 1024
-  CurrencySuppressChatMessages: 524288
-  CurrencyTrackQuantity: 128
-  CurrencyTradable: 1
-  CurrencyUpdateVersionIgnoreMax: 512
-  CurrencyUsesLedgerBalance: 2147483648
+  values:
+    Currency_100_Scaler: 8
+    CurrencyAccountWide: 16777216
+    CurrencyAllowOverflowMailer: 33554432
+    CurrencyAppearsInLootWindow: 2
+    CurrencyComputedWeeklyMaximum: 4
+    CurrencyDeprecated: 131072
+    CurrencyDestroyExtraOnLoot: 2097152
+    CurrencyDoNotCompressChat: 8192
+    CurrencyDoNotLogAcquisitionToBi: 16384
+    CurrencyDoNotToast: 1048576
+    CurrencyDontCoalesceInLootWindow: 8388608
+    CurrencyDontShowTotalInTooltip: 4194304
+    CurrencyDynamicMaximum: 262144
+    CurrencyHasWarmodeBonus: 134217728
+    CurrencyHasWeeklyCatchup: 4096
+    CurrencyHideAsReward: 67108864
+    CurrencyIgnoreMaxQtyOnLoad: 32
+    CurrencyIsAllianceOnly: 268435456
+    CurrencyIsHordeOnly: 536870912
+    CurrencyLimitWarmodeBonusOncePerTooltip: 1073741824
+    CurrencyLogOnWorldChange: 64
+    CurrencyNoLowLevelDrop: 16
+    CurrencyNoRaidDrop: 32768
+    CurrencyNotPersistent: 65536
+    CurrencyResetTrackedQuantity: 256
+    CurrencySingleDropInLoot: 2048
+    CurrencySuppressChatMessageOnVersionChange: 1024
+    CurrencySuppressChatMessages: 524288
+    CurrencyTrackQuantity: 128
+    CurrencyTradable: 1
+    CurrencyUpdateVersionIgnoreMax: 512
+    CurrencyUsesLedgerBalance: 2147483648
 CurrencyFlagsB:
-  CurrencyBAllowReductionByResourcefulness: 1024
-  CurrencyBBattlenetVirtualCurrency: 8
-  CurrencyBDontDisplayIfZero: 32
-  CurrencyBForceMaxQuantityOnConversion: 256
-  CurrencyBNoBonusXP: 2048
-  CurrencyBNoNotificationMailOnOfflineProgress: 4
-  CurrencyBScaleMaxQuantityBySeasonWeeks: 64
-  CurrencyBScaleMaxQuantityByWeeksSinceStart: 128
-  CurrencyBShowQuestXPGainInTooltip: 2
-  CurrencyBUnearnableBeforeMaxQuantityStart: 512
-  CurrencyBUseTotalEarnedForEarned: 1
-  FutureCurrencyFlag: 16
+  values:
+    CurrencyBAllowReductionByResourcefulness: 1024
+    CurrencyBBattlenetVirtualCurrency: 8
+    CurrencyBDontDisplayIfZero: 32
+    CurrencyBForceMaxQuantityOnConversion: 256
+    CurrencyBNoBonusXP: 2048
+    CurrencyBNoNotificationMailOnOfflineProgress: 4
+    CurrencyBScaleMaxQuantityBySeasonWeeks: 64
+    CurrencyBScaleMaxQuantityByWeeksSinceStart: 128
+    CurrencyBShowQuestXPGainInTooltip: 2
+    CurrencyBUnearnableBeforeMaxQuantityStart: 512
+    CurrencyBUseTotalEarnedForEarned: 1
+    FutureCurrencyFlag: 16
 CurrencyGainFlags:
-  Autotracking: 8
-  BonusAward: 1
-  DroppedFromDeath: 2
-  FromAccountServer: 4
-  None: 0
+  values:
+    Autotracking: 8
+    BonusAward: 1
+    DroppedFromDeath: 2
+    FromAccountServer: 4
+    None: 0
 CurrencyTokenCategoryFlags:
-  FlagPlayerItemAssignment: 2
-  FlagSortLast: 1
-  Hidden: 4
-  StartsCollapsed: 16
-  Virtual: 8
+  values:
+    FlagPlayerItemAssignment: 2
+    FlagSortLast: 1
+    Hidden: 4
+    StartsCollapsed: 16
+    Virtual: 8
 CurrencyType:
-  Copper: 0
-  Gold: 2
-  Silver: 1
+  values:
+    Copper: 0
+    Gold: 2
+    Silver: 1
 Cursormode:
-  AttackCursor: 4
-  AttackErrorCursor: 50
-  BroomCursor: 42
-  BroomErrorCursor: 88
-  BuyCursor: 3
-  BuyErrorCursor: 49
-  CampaignQuestCursor: 23
-  CampaignQuestErrorCursor: 69
-  CampaignQuestTurninCursor: 24
-  CampaignQuestTurninErrorCursor: 70
-  CastCursor: 2
-  CastErrorCursor: 48
-  CustomCursor: 91
-  EnchantCursor: 39
-  EnchantErrorCursor: 85
-  GatherCursor: 13
-  GatherErrorCursor: 59
-  GrabbingHandCursor: 44
-  GrabbingHandErrorCursor: 90
-  HoldingHandCursor: 43
-  HoldingHandErrorCursor: 89
-  InnkeeperCursor: 22
-  InnkeeperErrorCursor: 68
-  InspectCursor: 7
-  InspectErrorCursor: 53
-  InteractCursor: 5
-  InteractErrorCursor: 51
-  ItemCursor: 19
-  ItemErrorCursor: 65
-  LockCursor: 14
-  LockErrorCursor: 60
-  LootAllCursor: 16
-  LootAllErrorCursor: 62
-  MailCursor: 15
-  MailErrorCursor: 61
-  MapPinCursor: 37
-  MapPinErrorCursor: 83
-  MineCursor: 11
-  MineErrorCursor: 57
-  NoCursor: 0
-  PaletteCursor: 41
-  PaletteErrorCursor: 87
-  PickupCursor: 8
-  PickupErrorCursor: 54
-  PingCursor: 38
-  PingErrorCursor: 84
-  PointCursor: 1
-  PointErrorCursor: 47
-  QuestCursor: 25
-  QuestErrorCursor: 71
-  QuestImportantCursor: 30
-  QuestImportantErrorCursor: 76
-  QuestImportantTurninCursor: 31
-  QuestImportantTurninErrorCursor: 77
-  QuestLegendaryCursor: 28
-  QuestLegendaryErrorCursor: 74
-  QuestLegendaryTurninCursor: 29
-  QuestLegendaryTurninErrorCursor: 75
-  QuestMetaCursor: 32
-  QuestMetaErrorCursor: 78
-  QuestMetaTurninCursor: 33
-  QuestMetaTurninErrorCursor: 79
-  QuestRecurringCursor: 34
-  QuestRecurringErrorCursor: 80
-  QuestRecurringTurninCursor: 35
-  QuestRecurringTurninErrorCursor: 81
-  QuestRepeatableCursor: 26
-  QuestRepeatableErrorCursor: 72
-  QuestTurninCursor: 27
-  QuestTurninErrorCursor: 73
-  RepairCursor: 17
-  RepairErrorCursor: 63
-  RepairnpcCursor: 18
-  RepairnpcErrorCursor: 64
-  SkinAllianceCursor: 21
-  SkinAllianceErrorCursor: 67
-  SkinCursor: 12
-  SkinErrorCursor: 58
-  SkinHordeCursor: 20
-  SkinHordeErrorCursor: 66
-  SpeakCursor: 6
-  SpeakErrorCursor: 52
-  StablemasterCursor: 40
-  StablemasterErrorCursor: 86
-  TaxiCursor: 9
-  TaxiErrorCursor: 55
-  TrainerCursor: 10
-  TrainerErrorCursor: 56
-  UIMoveCursor: 45
-  UIResizeCursor: 46
-  VehicleCursor: 36
-  VehicleErrorCursor: 82
+  values:
+    AttackCursor: 4
+    AttackErrorCursor: 50
+    BroomCursor: 42
+    BroomErrorCursor: 88
+    BuyCursor: 3
+    BuyErrorCursor: 49
+    CampaignQuestCursor: 23
+    CampaignQuestErrorCursor: 69
+    CampaignQuestTurninCursor: 24
+    CampaignQuestTurninErrorCursor: 70
+    CastCursor: 2
+    CastErrorCursor: 48
+    CustomCursor: 91
+    EnchantCursor: 39
+    EnchantErrorCursor: 85
+    GatherCursor: 13
+    GatherErrorCursor: 59
+    GrabbingHandCursor: 44
+    GrabbingHandErrorCursor: 90
+    HoldingHandCursor: 43
+    HoldingHandErrorCursor: 89
+    InnkeeperCursor: 22
+    InnkeeperErrorCursor: 68
+    InspectCursor: 7
+    InspectErrorCursor: 53
+    InteractCursor: 5
+    InteractErrorCursor: 51
+    ItemCursor: 19
+    ItemErrorCursor: 65
+    LockCursor: 14
+    LockErrorCursor: 60
+    LootAllCursor: 16
+    LootAllErrorCursor: 62
+    MailCursor: 15
+    MailErrorCursor: 61
+    MapPinCursor: 37
+    MapPinErrorCursor: 83
+    MineCursor: 11
+    MineErrorCursor: 57
+    NoCursor: 0
+    PaletteCursor: 41
+    PaletteErrorCursor: 87
+    PickupCursor: 8
+    PickupErrorCursor: 54
+    PingCursor: 38
+    PingErrorCursor: 84
+    PointCursor: 1
+    PointErrorCursor: 47
+    QuestCursor: 25
+    QuestErrorCursor: 71
+    QuestImportantCursor: 30
+    QuestImportantErrorCursor: 76
+    QuestImportantTurninCursor: 31
+    QuestImportantTurninErrorCursor: 77
+    QuestLegendaryCursor: 28
+    QuestLegendaryErrorCursor: 74
+    QuestLegendaryTurninCursor: 29
+    QuestLegendaryTurninErrorCursor: 75
+    QuestMetaCursor: 32
+    QuestMetaErrorCursor: 78
+    QuestMetaTurninCursor: 33
+    QuestMetaTurninErrorCursor: 79
+    QuestRecurringCursor: 34
+    QuestRecurringErrorCursor: 80
+    QuestRecurringTurninCursor: 35
+    QuestRecurringTurninErrorCursor: 81
+    QuestRepeatableCursor: 26
+    QuestRepeatableErrorCursor: 72
+    QuestTurninCursor: 27
+    QuestTurninErrorCursor: 73
+    RepairCursor: 17
+    RepairErrorCursor: 63
+    RepairnpcCursor: 18
+    RepairnpcErrorCursor: 64
+    SkinAllianceCursor: 21
+    SkinAllianceErrorCursor: 67
+    SkinCursor: 12
+    SkinErrorCursor: 58
+    SkinHordeCursor: 20
+    SkinHordeErrorCursor: 66
+    SpeakCursor: 6
+    SpeakErrorCursor: 52
+    StablemasterCursor: 40
+    StablemasterErrorCursor: 86
+    TaxiCursor: 9
+    TaxiErrorCursor: 55
+    TrainerCursor: 10
+    TrainerErrorCursor: 56
+    UIMoveCursor: 45
+    UIResizeCursor: 46
+    VehicleCursor: 36
+    VehicleErrorCursor: 82
 CursorStyle:
-  Crosshair: 1
-  Mouse: 0
+  values:
+    Crosshair: 1
+    Mouse: 0
 CustomAuraButtonDispelTypeTextureStyle:
-  Border: 0
-  BorderWithIcon: 1
-  CustomAsset: 4
-  Icon: 2
-  PreserveAsset: 3
+  values:
+    Border: 0
+    BorderWithIcon: 1
+    CustomAsset: 4
+    Icon: 2
+    PreserveAsset: 3
 CustomAuraButtonUpdateMode:
-  Assignment: 0
-  Update: 1
+  values:
+    Assignment: 0
+    Update: 1
 CustomBindingType:
-  VoicePushToTalk: 0
+  values:
+    VoicePushToTalk: 0
 Damageclass:
-  All: 127
-  AllMagical: 126
-  AllPhysical: 1
-  Arcane: 6
-  Fire: 2
-  FirstResist: 2
-  Frost: 4
-  Holy: 1
-  LastResist: 6
-  MaskArcane: 64
-  MaskChaos: 124
-  MaskChromatic: 62
-  MaskCosmic: 106
-  MaskDivine: 66
-  MaskElemental: 28
-  MaskFire: 4
-  MaskFirestorm: 12
-  MaskFlamestrike: 5
-  MaskFrost: 16
-  MaskFrostfire: 20
-  MaskFroststorm: 24
-  MaskFroststrike: 17
-  MaskHoly: 2
-  MaskHolyfire: 6
-  MaskHolyfrost: 18
-  MaskHolystorm: 10
-  MaskHolystrike: 3
-  MaskMagical: 126
-  MaskNature: 8
-  MaskNone: 0
-  MaskPhysical: 1
-  MaskShadow: 32
-  MaskShadowflame: 36
-  MaskShadowfrost: 48
-  MaskShadowstorm: 40
-  MaskShadowstrike: 33
-  MaskSpellfire: 68
-  MaskSpellfrost: 80
-  MaskSpellshadow: 96
-  MaskSpellstorm: 72
-  MaskSpellstrike: 65
-  MaskStormstrike: 9
-  MaskTwilight: 34
-  Nature: 3
-  Physical: 0
-  Shadow: 5
+  values:
+    All: 127
+    AllMagical: 126
+    AllPhysical: 1
+    Arcane: 6
+    Fire: 2
+    FirstResist: 2
+    Frost: 4
+    Holy: 1
+    LastResist: 6
+    MaskArcane: 64
+    MaskChaos: 124
+    MaskChromatic: 62
+    MaskCosmic: 106
+    MaskDivine: 66
+    MaskElemental: 28
+    MaskFire: 4
+    MaskFirestorm: 12
+    MaskFlamestrike: 5
+    MaskFrost: 16
+    MaskFrostfire: 20
+    MaskFroststorm: 24
+    MaskFroststrike: 17
+    MaskHoly: 2
+    MaskHolyfire: 6
+    MaskHolyfrost: 18
+    MaskHolystorm: 10
+    MaskHolystrike: 3
+    MaskMagical: 126
+    MaskNature: 8
+    MaskNone: 0
+    MaskPhysical: 1
+    MaskShadow: 32
+    MaskShadowflame: 36
+    MaskShadowfrost: 48
+    MaskShadowstorm: 40
+    MaskShadowstrike: 33
+    MaskSpellfire: 68
+    MaskSpellfrost: 80
+    MaskSpellshadow: 96
+    MaskSpellstorm: 72
+    MaskSpellstrike: 65
+    MaskStormstrike: 9
+    MaskTwilight: 34
+    Nature: 3
+    Physical: 0
+    Shadow: 5
 DamageclassType:
-  Magical: 1
-  Physical: 0
+  values:
+    Magical: 1
+    Physical: 0
 DamageMeterCombineSessionType:
-  Arena: 2
-  ArenaMultiRound: 3
-  ChallengeMode: 1
-  None: 0
+  values:
+    Arena: 2
+    ArenaMultiRound: 3
+    ChallengeMode: 1
+    None: 0
 DamageMeterNumbers:
-  Compact: 1
-  Complete: 2
-  Minimal: 0
+  values:
+    Compact: 1
+    Complete: 2
+    Minimal: 0
 DamageMeterOverrideType:
-  AllowFriendlyFire: 1
-  Ignore: 0
-  IgnoreForAbsorbSpell: 4
-  RedirectSourceToAuraCaster: 3
-  RedirectSourceToOwner: 2
+  values:
+    AllowFriendlyFire: 1
+    Ignore: 0
+    IgnoreForAbsorbSpell: 4
+    RedirectSourceToAuraCaster: 3
+    RedirectSourceToOwner: 2
 DamageMeterSessionType:
-  Current: 1
-  Expired: 2
-  Overall: 0
+  values:
+    Current: 1
+    Expired: 2
+    Overall: 0
 DamageMeterSourceDisplayType:
-  Ally: 1
-  Enemy: 2
-  None: 0
+  values:
+    Ally: 1
+    Enemy: 2
+    None: 0
 DamageMeterSpellDetailsDisplayType:
-  Deaths: 3
-  EnemyDamageTaken: 4
-  SpellAffected: 2
-  SpellCasted: 0
-  UnitSpecificSpellCasted: 1
+  values:
+    Deaths: 3
+    EnemyDamageTaken: 4
+    SpellAffected: 2
+    SpellCasted: 0
+    UnitSpecificSpellCasted: 1
 DamageMeterStorageType:
-  Absorbs: 2
-  AvoidableDamageTaken: 6
-  Damage: 0
-  DamageTaken: 5
-  Deaths: 7
-  Dispels: 4
-  EnemyDamageTaken: 8
-  HealingAndAbsorbs: 1
-  Interrupts: 3
+  values:
+    Absorbs: 2
+    AvoidableDamageTaken: 6
+    Damage: 0
+    DamageTaken: 5
+    Deaths: 7
+    Dispels: 4
+    EnemyDamageTaken: 8
+    HealingAndAbsorbs: 1
+    Interrupts: 3
 DamageMeterStyle:
-  Bordered: 2
-  Default: 0
-  FullBackground: 3
-  Thin: 1
+  values:
+    Bordered: 2
+    Default: 0
+    FullBackground: 3
+    Thin: 1
 DamageMeterType:
-  Absorbs: 4
-  AvoidableDamageTaken: 8
-  DamageDone: 0
-  DamageTaken: 7
-  Deaths: 9
-  Dispels: 6
-  Dps: 1
-  EnemyDamageTaken: 10
-  HealingDone: 2
-  Hps: 3
-  Interrupts: 5
+  values:
+    Absorbs: 4
+    AvoidableDamageTaken: 8
+    DamageDone: 0
+    DamageTaken: 7
+    Deaths: 9
+    Dispels: 6
+    Dps: 1
+    EnemyDamageTaken: 10
+    HealingDone: 2
+    Hps: 3
+    Interrupts: 5
 DamageMeterVisibility:
-  Always: 0
-  Hidden: 2
-  InCombat: 1
-  InGroup: 3
+  values:
+    Always: 0
+    Hidden: 2
+    InCombat: 1
+    InGroup: 3
 DeveloperLogAssertDomain:
-  Art: 1
-  Design: 2
-  Engineering: 4
-  LiveOperations: 64
-  Performance: 32
-  Sound: 8
-  Tools: 16
+  values:
+    Art: 1
+    Design: 2
+    Engineering: 4
+    LiveOperations: 64
+    Performance: 32
+    Sound: 8
+    Tools: 16
 DeveloperLogErrorDomain:
-  Assert: 0
-  AssertData: 1
-  Frame: 2
-  TestSuite: 3
+  values:
+    Assert: 0
+    AssertData: 1
+    Frame: 2
+    TestSuite: 3
 DeveloperLogTrafficType:
-  ClientToServer: 1
-  GameEvent: 2
-  LuaToClient: 3
-  ServerToClient: 0
+  values:
+    ClientToServer: 1
+    GameEvent: 2
+    LuaToClient: 3
+    ServerToClient: 0
 DisableAccountProfilesFlags:
-  DecorsCollections: 32
-  Document: 1
-  ItemsCollections: 16
-  MountsCollections: 4
-  None: 0
-  PetsCollections: 8
-  SharedCollections: 2
+  values:
+    DecorsCollections: 32
+    Document: 1
+    ItemsCollections: 16
+    MountsCollections: 4
+    None: 0
+    PetsCollections: 8
+    SharedCollections: 2
 DiscordAccountType:
-  Normal: 0
-  Provisional: 1
+  values:
+    Normal: 0
+    Provisional: 1
 DiscordDisplayNameType:
-  Default: 0
-  GlobalName: 2
-  LastOnline: 1
+  values:
+    Default: 0
+    GlobalName: 2
+    LastOnline: 1
 DiscordGuildSettings:
-  SeparateStream: 1
+  values:
+    SeparateStream: 1
 DurationTextBindingProperty:
-  ElapsedDuration: 2
-  ElapsedPercent: 3
-  EndTime: 6
-  RemainingDuration: 0
-  RemainingPercent: 1
-  StartTime: 5
-  TotalDuration: 4
+  values:
+    ElapsedDuration: 2
+    ElapsedPercent: 3
+    EndTime: 6
+    RemainingDuration: 0
+    RemainingPercent: 1
+    StartTime: 5
+    TotalDuration: 4
 DurationTimeModifier:
-  BaseTime: 1
-  RealTime: 0
+  values:
+    BaseTime: 1
+    RealTime: 0
 EditModeAccountSetting:
-  DeprecatedShowDebuffFrame: 11
-  EnableAdvancedOptions: 23
-  EnableSnap: 22
-  GridSpacing: 1
-  SettingsExpanded: 2
-  ShowArchaeologyBar: 27
-  ShowArenaFrames: 17
-  ShowBossFrames: 16
-  ShowBuffsAndDebuffs: 10
-  ShowCastBar: 7
-  ShowCooldownViewer: 28
-  ShowDamageMeter: 31
-  ShowDurabilityFrame: 21
-  ShowEncounterBar: 8
-  ShowEncounterEvents: 30
-  ShowExternalDefensives: 32
-  ShowExtraAbilities: 9
-  ShowGrid: 0
-  ShowHudTooltip: 19
-  ShowLootFrame: 18
-  ShowLossOfControl: 35
-  ShowPartyFrames: 12
-  ShowPersonalResourceDisplay: 29
-  ShowPetActionBar: 5
-  ShowPetFrame: 24
-  ShowPossessActionBar: 6
-  ShowRaidFrames: 13
-  ShowRaidWarning: 33
-  ShowStanceBar: 4
-  ShowStatusTrackingBar2: 20
-  ShowTalkingHeadFrame: 14
-  ShowTargetAndFocus: 3
-  ShowTimerBars: 25
-  ShowTotemActionBar: 34
-  ShowVehicleLeaveButton: 15
-  ShowVehicleSeatIndicator: 26
+  values:
+    DeprecatedShowDebuffFrame: 11
+    EnableAdvancedOptions: 23
+    EnableSnap: 22
+    GridSpacing: 1
+    SettingsExpanded: 2
+    ShowArchaeologyBar: 27
+    ShowArenaFrames: 17
+    ShowBossFrames: 16
+    ShowBuffsAndDebuffs: 10
+    ShowCastBar: 7
+    ShowCooldownViewer: 28
+    ShowDamageMeter: 31
+    ShowDurabilityFrame: 21
+    ShowEncounterBar: 8
+    ShowEncounterEvents: 30
+    ShowExternalDefensives: 32
+    ShowExtraAbilities: 9
+    ShowGrid: 0
+    ShowHudTooltip: 19
+    ShowLootFrame: 18
+    ShowLossOfControl: 35
+    ShowPartyFrames: 12
+    ShowPersonalResourceDisplay: 29
+    ShowPetActionBar: 5
+    ShowPetFrame: 24
+    ShowPossessActionBar: 6
+    ShowRaidFrames: 13
+    ShowRaidWarning: 33
+    ShowStanceBar: 4
+    ShowStatusTrackingBar2: 20
+    ShowTalkingHeadFrame: 14
+    ShowTargetAndFocus: 3
+    ShowTimerBars: 25
+    ShowTotemActionBar: 34
+    ShowVehicleLeaveButton: 15
+    ShowVehicleSeatIndicator: 26
 EditModeActionBarSetting:
-  AlwaysShowButtons: 9
-  DeprecatedSnapToSide: 7
-  HideBarArt: 6
-  HideBarScrolling: 8
-  IconPadding: 4
-  IconSize: 3
-  NumIcons: 2
-  NumRows: 1
-  Orientation: 0
-  VisibleSetting: 5
+  values:
+    AlwaysShowButtons: 9
+    DeprecatedSnapToSide: 7
+    HideBarArt: 6
+    HideBarScrolling: 8
+    IconPadding: 4
+    IconSize: 3
+    NumIcons: 2
+    NumRows: 1
+    Orientation: 0
+    VisibleSetting: 5
 EditModeActionBarSystemIndices:
-  Bar2: 2
-  Bar3: 3
-  ExtraBar1: 6
-  ExtraBar2: 7
-  ExtraBar3: 8
-  MainBar: 1
-  PetActionBar: 12
-  PossessActionBar: 13
-  RightBar1: 4
-  RightBar2: 5
-  StanceBar: 11
+  values:
+    Bar2: 2
+    Bar3: 3
+    ExtraBar1: 6
+    ExtraBar2: 7
+    ExtraBar3: 8
+    MainBar: 1
+    PetActionBar: 12
+    PossessActionBar: 13
+    RightBar1: 4
+    RightBar2: 5
+    StanceBar: 11
 EditModeArchaeologyBarSetting:
-  Size: 0
+  values:
+    Size: 0
 EditModeAuraFrameSetting:
-  DeprecatedShowFull: 7
-  IconDirection: 2
-  IconLimitBuffFrame: 3
-  IconLimitDebuffFrame: 4
-  IconPadding: 6
-  IconSize: 5
-  IconWrap: 1
-  Opacity: 9
-  Orientation: 0
-  ShowDispelType: 10
-  VisibleSetting: 8
+  values:
+    DeprecatedShowFull: 7
+    IconDirection: 2
+    IconLimitBuffFrame: 3
+    IconLimitDebuffFrame: 4
+    IconPadding: 6
+    IconSize: 5
+    IconWrap: 1
+    Opacity: 9
+    Orientation: 0
+    ShowDispelType: 10
+    VisibleSetting: 8
 EditModeAuraFrameSystemIndices:
-  BuffFrame: 1
-  DebuffFrame: 2
-  ExternalDefensivesFrame: 3
+  values:
+    BuffFrame: 1
+    DebuffFrame: 2
+    ExternalDefensivesFrame: 3
 EditModeBagsSetting:
-  BagSlotPadding: 3
-  Direction: 1
-  Orientation: 0
-  Size: 2
+  values:
+    BagSlotPadding: 3
+    Direction: 1
+    Orientation: 0
+    Size: 2
 EditModeCastBarSetting:
-  BarSize: 0
-  LockToPlayerFrame: 1
-  ShowCastTime: 2
+  values:
+    BarSize: 0
+    LockToPlayerFrame: 1
+    ShowCastTime: 2
 EditModeChatFrameSetting:
-  HeightHundreds: 2
-  HeightTensAndOnes: 3
-  WidthHundreds: 0
-  WidthTensAndOnes: 1
+  values:
+    HeightHundreds: 2
+    HeightTensAndOnes: 3
+    WidthHundreds: 0
+    WidthTensAndOnes: 1
 EditModeCooldownViewerSetting:
-  BarContent: 7
-  BarWidthScale: 11
-  HideWhenInactive: 8
-  IconDirection: 2
-  IconLimit: 1
-  IconPadding: 4
-  IconSize: 3
-  Opacity: 5
-  Orientation: 0
-  ShowTimer: 9
-  ShowTooltips: 10
-  VisibleSetting: 6
+  values:
+    BarContent: 7
+    BarWidthScale: 11
+    HideWhenInactive: 8
+    IconDirection: 2
+    IconLimit: 1
+    IconPadding: 4
+    IconSize: 3
+    Opacity: 5
+    Orientation: 0
+    ShowTimer: 9
+    ShowTooltips: 10
+    VisibleSetting: 6
 EditModeCooldownViewerSystemIndices:
-  BuffBar: 4
-  BuffIcon: 3
-  Essential: 1
-  Utility: 2
+  values:
+    BuffBar: 4
+    BuffIcon: 3
+    Essential: 1
+    Utility: 2
 EditModeDamageMeterSetting:
-  BackgroundTransparency: 12
-  BarHeight: 10
-  FrameHeight: 4
-  FrameWidth: 3
-  Numbers: 2
-  ObsoleteReuse1: 7
-  Padding: 5
-  ShowClassColor: 9
-  ShowSpecIcon: 8
-  Style: 1
-  TextSize: 11
-  Transparency: 6
-  Visibility: 0
+  values:
+    BackgroundTransparency: 12
+    BarHeight: 10
+    FrameHeight: 4
+    FrameWidth: 3
+    Numbers: 2
+    ObsoleteReuse1: 7
+    Padding: 5
+    ShowClassColor: 9
+    ShowSpecIcon: 8
+    Style: 1
+    TextSize: 11
+    Transparency: 6
+    Visibility: 0
 EditModeDurabilityFrameSetting:
-  Size: 0
+  values:
+    Size: 0
 EditModeEncounterEventsSetting:
-  BackgroundTransparency: 5
-  BarWidth: 12
-  FlipHorizontally: 11
-  IconDirection: 1
-  IconSize: 3
-  Orientation: 0
-  OverallSize: 4
-  Padding: 13
-  ShowSpellName: 2
-  ShowTimer: 9
-  TooltipAnchor: 8
-  Transparency: 6
-  ViewType: 10
-  Visibility: 7
+  values:
+    BackgroundTransparency: 5
+    BarWidth: 12
+    FlipHorizontally: 11
+    IconDirection: 1
+    IconSize: 3
+    Orientation: 0
+    OverallSize: 4
+    Padding: 13
+    ShowSpellName: 2
+    ShowTimer: 9
+    TooltipAnchor: 8
+    Transparency: 6
+    ViewType: 10
+    Visibility: 7
 EditModeEncounterEventsSystemIndices:
-  CriticalWarnings: 2
-  MediumWarnings: 3
-  NormalWarnings: 4
-  Timeline: 1
+  values:
+    CriticalWarnings: 2
+    MediumWarnings: 3
+    NormalWarnings: 4
+    Timeline: 1
 EditModeLayoutType:
-  Account: 1
-  Character: 2
-  Override: 3
-  Preset: 0
+  values:
+    Account: 1
+    Character: 2
+    Override: 3
+    Preset: 0
 EditModeLossOfControlSetting:
-  Size: 0
+  values:
+    Size: 0
 EditModeMicroMenuSetting:
-  EyeSize: 3
-  Order: 1
-  Orientation: 0
-  Size: 2
+  values:
+    EyeSize: 3
+    Order: 1
+    Orientation: 0
+    Size: 2
 EditModeMinimapSetting:
-  HeaderUnderneath: 0
-  IconScale: 3
-  RotateMinimap: 1
-  Size: 2
+  values:
+    HeaderUnderneath: 0
+    IconScale: 3
+    RotateMinimap: 1
+    Size: 2
 EditModeObjectiveTrackerSetting:
-  Height: 0
-  Opacity: 1
-  TextSize: 2
+  values:
+    Height: 0
+    Opacity: 1
+    TextSize: 2
 EditModePersonalResourceDisplaySetting:
-  BarWidth: 12
-  DeprecatedOnlyShowInCombat: 1
-  HealthBarHeight: 4
-  HideAltPower: 14
-  HideClassInfo: 3
-  HideClassInfoOnPlayerFrame: 10
-  HideHealth: 0
-  HidePower: 2
-  Opacity: 7
-  Padding: 6
-  PowerBarHeight: 5
-  ShowBarText: 13
-  ShowClassColor: 11
-  Size: 9
-  VisibleSetting: 8
+  values:
+    BarWidth: 12
+    DeprecatedOnlyShowInCombat: 1
+    HealthBarHeight: 4
+    HideAltPower: 14
+    HideClassInfo: 3
+    HideClassInfoOnPlayerFrame: 10
+    HideHealth: 0
+    HidePower: 2
+    Opacity: 7
+    Padding: 6
+    PowerBarHeight: 5
+    ShowBarText: 13
+    ShowClassColor: 11
+    Size: 9
+    VisibleSetting: 8
 EditModePresetLayouts:
-  Classic: 1
-  Modern: 0
+  values:
+    Classic: 1
+    Modern: 0
 EditModeRaidWarningSetting:
-  None: 0
+  values:
+    None: 0
 EditModeSettingDisplayType:
-  Checkbox: 1
-  Dropdown: 0
-  Slider: 2
+  values:
+    Checkbox: 1
+    Dropdown: 0
+    Slider: 2
 EditModeStatusTrackingBarSetting:
-  Height: 0
-  Size: 3
-  TextSize: 2
-  Width: 1
+  values:
+    Height: 0
+    Size: 3
+    TextSize: 2
+    Width: 1
 EditModeStatusTrackingBarSystemIndices:
-  StatusTrackingBar1: 1
-  StatusTrackingBar2: 2
+  values:
+    StatusTrackingBar1: 1
+    StatusTrackingBar2: 2
 EditModeSystem:
-  ActionBar: 0
-  ArchaeologyBar: 19
-  AuraFrame: 6
-  Bags: 14
-  CastBar: 1
-  ChatFrame: 8
-  CooldownViewer: 20
-  DamageMeter: 23
-  DurabilityFrame: 16
-  EncounterBar: 4
-  EncounterEvents: 22
-  ExtraAbilities: 5
-  HudTooltip: 11
-  LootFrame: 10
-  LossOfControl: 26
-  MicroMenu: 13
-  Minimap: 2
-  ObjectiveTracker: 12
-  PersonalResourceDisplay: 21
-  RaidWarning: 24
-  StatusTrackingBar: 15
-  TalkingHeadFrame: 7
-  TimerBars: 17
-  TotemActionBar: 25
-  UnitFrame: 3
-  VehicleLeaveButton: 9
-  VehicleSeatIndicator: 18
+  values:
+    ActionBar: 0
+    ArchaeologyBar: 19
+    AuraFrame: 6
+    Bags: 14
+    CastBar: 1
+    ChatFrame: 8
+    CooldownViewer: 20
+    DamageMeter: 23
+    DurabilityFrame: 16
+    EncounterBar: 4
+    EncounterEvents: 22
+    ExtraAbilities: 5
+    HudTooltip: 11
+    LootFrame: 10
+    LossOfControl: 26
+    MicroMenu: 13
+    Minimap: 2
+    ObjectiveTracker: 12
+    PersonalResourceDisplay: 21
+    RaidWarning: 24
+    StatusTrackingBar: 15
+    TalkingHeadFrame: 7
+    TimerBars: 17
+    TotemActionBar: 25
+    UnitFrame: 3
+    VehicleLeaveButton: 9
+    VehicleSeatIndicator: 18
 EditModeTimerBarsSetting:
-  Size: 0
+  values:
+    Size: 0
 EditModeUnitFrameSetting:
-  AuraOrganizationType: 18
-  BigDefensiveIconSize: 21
-  BuffIconSize: 22
-  BuffsOnTop: 2
-  CastBarOnSide: 7
-  CastBarUnderneath: 1
-  DebuffIconSize: 19
-  DisplayBorder: 12
-  FrameHeight: 11
-  FrameSize: 16
-  FrameWidth: 10
-  HidePortrait: 0
-  Opacity: 20
-  RaidGroupDisplayType: 13
-  RowSize: 15
-  ShowCastTime: 8
-  ShowPartyFrameBackground: 5
-  SortPlayersBy: 14
-  UseHorizontalGroups: 6
-  UseLargerFrame: 3
-  UseRaidStylePartyFrames: 4
-  ViewArenaSize: 17
-  ViewRaidSize: 9
+  values:
+    AuraOrganizationType: 18
+    BigDefensiveIconSize: 21
+    BuffIconSize: 22
+    BuffsOnTop: 2
+    CastBarOnSide: 7
+    CastBarUnderneath: 1
+    DebuffIconSize: 19
+    DisplayBorder: 12
+    FrameHeight: 11
+    FrameSize: 16
+    FrameWidth: 10
+    HidePortrait: 0
+    Opacity: 20
+    RaidGroupDisplayType: 13
+    RowSize: 15
+    ShowCastTime: 8
+    ShowPartyFrameBackground: 5
+    SortPlayersBy: 14
+    UseHorizontalGroups: 6
+    UseLargerFrame: 3
+    UseRaidStylePartyFrames: 4
+    ViewArenaSize: 17
+    ViewRaidSize: 9
 EditModeUnitFrameSystemIndices:
-  Arena: 7
-  Boss: 6
-  Focus: 3
-  Party: 4
-  Pet: 8
-  Player: 1
-  Raid: 5
-  Target: 2
+  values:
+    Arena: 7
+    Boss: 6
+    Focus: 3
+    Party: 4
+    Pet: 8
+    Player: 1
+    Raid: 5
+    Target: 2
 EditModeVehicleSeatIndicatorSetting:
-  Size: 0
+  values:
+    Size: 0
 EncounterEventCastState:
-  Casting: 1
-  Expired: 3
-  NotCasting: 2
+  values:
+    Casting: 1
+    Expired: 3
+    NotCasting: 2
 EncounterEventColorTrigger:
-  TextWarning: 0
-  TimelineEvent: 1
-  TimelineEventHighlight: 2
+  values:
+    TextWarning: 0
+    TimelineEvent: 1
+    TimelineEventHighlight: 2
 EncounterEventIconmask:
-  BleedEffect: 4
-  CurseEffect: 32
-  DeadlyEffect: 1
-  DiseaseEffect: 16
-  DpsRole: 512
-  EnrageEffect: 2
-  HealerRole: 256
-  MagicEffect: 8
-  PoisonEffect: 64
-  TankRole: 128
+  values:
+    BleedEffect: 4
+    CurseEffect: 32
+    DeadlyEffect: 1
+    DiseaseEffect: 16
+    DpsRole: 512
+    EnrageEffect: 2
+    HealerRole: 256
+    MagicEffect: 8
+    PoisonEffect: 64
+    TankRole: 128
 EncounterEventSeverity:
-  High: 2
-  Low: 0
-  Medium: 1
+  values:
+    High: 2
+    Low: 0
+    Medium: 1
 EncounterEventsIconDirection:
-  Bottom: 1
-  Left: 0
-  Right: 1
-  Top: 0
+  values:
+    Bottom: 1
+    Left: 0
+    Right: 1
+    Top: 0
 EncounterEventsOrientation:
-  Horizontal: 0
-  Vertical: 1
+  values:
+    Horizontal: 0
+    Vertical: 1
 EncounterEventSoundTrigger:
-  OnTextWarningShown: 0
-  OnTimelineEventFinished: 1
-  OnTimelineEventHighlight: 2
+  values:
+    OnTextWarningShown: 0
+    OnTimelineEventFinished: 1
+    OnTimelineEventHighlight: 2
 EncounterEventsTooltipAnchor:
-  Cursor: 2
-  Default: 1
-  Hidden: 0
+  values:
+    Cursor: 2
+    Default: 1
+    Hidden: 0
 EncounterEventsViewType:
-  Bars: 1
-  Timeline: 0
+  values:
+    Bars: 1
+    Timeline: 0
 EncounterEventsVisibility:
-  Always: 0
-  DeprecatedHidden: 2
-  InEncounter: 1
+  values:
+    Always: 0
+    DeprecatedHidden: 2
+    InEncounter: 1
 EncounterLootDropRollState:
-  Greed: 3
-  NeedMainSpec: 0
-  NeedOffSpec: 1
-  NoRoll: 4
-  Pass: 5
-  Transmog: 2
+  values:
+    Greed: 3
+    NeedMainSpec: 0
+    NeedOffSpec: 1
+    NoRoll: 4
+    Pass: 5
+    Transmog: 2
 EncounterTimelineEventSortDirection:
-  Ascending: 1
-  Descending: 0
+  values:
+    Ascending: 1
+    Descending: 0
 EncounterTimelineEventSource:
-  EditMode: 2
-  Encounter: 0
-  Script: 1
+  values:
+    EditMode: 2
+    Encounter: 0
+    Script: 1
 EncounterTimelineEventState:
-  Active: 0
-  Canceled: 3
-  Finished: 2
-  Paused: 1
+  values:
+    Active: 0
+    Canceled: 3
+    Finished: 2
+    Paused: 1
 EncounterTimelineIconSet:
-  DamageAlert: 3
-  Deadly: 4
-  Dispel: 5
-  Enrage: 6
-  HealerAlert: 2
-  TankAlert: 1
+  values:
+    DamageAlert: 3
+    Deadly: 4
+    Dispel: 5
+    Enrage: 6
+    HealerAlert: 2
+    TankAlert: 1
 EncounterTimelineTrack:
-  Indeterminate: 4
-  Long: 3
-  Medium: 2
-  Queued: 0
-  Short: 1
+  values:
+    Indeterminate: 4
+    Long: 3
+    Medium: 2
+    Queued: 0
+    Short: 1
 EncounterTimelineTrackType:
-  Hidden: 0
-  Linear: 2
-  Sorted: 1
+  values:
+    Hidden: 0
+    Linear: 2
+    Sorted: 1
 EncounterTimelineViewType:
-  Bars: 2
-  None: 0
-  Timeline: 1
+  values:
+    Bars: 2
+    None: 0
+    Timeline: 1
 EndOfMatchType:
-  None: 0
-  Plunderstorm: 1
+  values:
+    None: 0
+    Plunderstorm: 1
 EnvironmentalDamageFlags:
-  DmgIsPct: 2
-  OneTime: 1
+  values:
+    DmgIsPct: 2
+    OneTime: 1
 Environmentaldamagetype:
-  Drowning: 1
-  Falling: 2
-  Fatigue: 0
-  Fire: 5
-  Lava: 3
-  Slime: 4
+  values:
+    Drowning: 1
+    Falling: 2
+    Fatigue: 0
+    Fire: 5
+    Lava: 3
+    Slime: 4
 EventRealmQueues:
-  None: 0
-  PlunderstormDuo: 2
-  PlunderstormSolo: 1
-  PlunderstormTraining: 8
-  PlunderstormTrio: 4
+  values:
+    None: 0
+    PlunderstormDuo: 2
+    PlunderstormSolo: 1
+    PlunderstormTraining: 8
+    PlunderstormTrio: 4
 EventToastDisplayType:
-  CapstoneUnlocked: 12
-  ChallengeMode: 7
-  FlightpointDiscovered: 11
-  HouseUpgradeAvailable: 15
-  LargeTextWithIcon: 4
-  NormalBlockText: 1
-  NormalSingleLine: 0
-  NormalTextWithIcon: 3
-  NormalTextWithIconAndRarity: 5
-  NormalTitleAndSubTitle: 2
-  Scenario: 6
-  ScenarioClickExpand: 8
-  Scoreboard: 14
-  SingleLineWithIcon: 13
-  WeeklyRewardUnlock: 9
-  WeeklyRewardUpgrade: 10
+  values:
+    CapstoneUnlocked: 12
+    ChallengeMode: 7
+    FlightpointDiscovered: 11
+    HouseUpgradeAvailable: 15
+    LargeTextWithIcon: 4
+    NormalBlockText: 1
+    NormalSingleLine: 0
+    NormalTextWithIcon: 3
+    NormalTextWithIconAndRarity: 5
+    NormalTitleAndSubTitle: 2
+    Scenario: 6
+    ScenarioClickExpand: 8
+    Scoreboard: 14
+    SingleLineWithIcon: 13
+    WeeklyRewardUnlock: 9
+    WeeklyRewardUpgrade: 10
 EventToastEventType:
-  BattlePetLevelChanged: 8
-  BattlePetLevelUpAbility: 9
-  CriteriaUpdated: 19
-  FlightpointDiscovered: 25
-  HouseUpgradeAvailable: 26
-  LevelUp: 0
-  LevelUpDungeon: 2
-  LevelUpOther: 15
-  LevelUpPvP: 4
-  LevelUpRaid: 3
-  LevelUpSpell: 1
-  MythicPlusWeeklyRecord: 11
-  PetBattleCapture: 7
-  PetBattleFinalRound: 6
-  PetBattleNewAbility: 5
-  PlayerAuraAdded: 16
-  PlayerAuraRemoved: 17
-  PvPTierUpdate: 20
-  QuestBossEmote: 10
-  QuestTurnedIn: 12
-  Scenario: 14
-  SpellLearned: 21
-  SpellScript: 18
-  TreasureItem: 22
-  WeeklyRewardUnlock: 23
-  WeeklyRewardUpgrade: 24
-  WorldStateChange: 13
+  values:
+    BattlePetLevelChanged: 8
+    BattlePetLevelUpAbility: 9
+    CriteriaUpdated: 19
+    FlightpointDiscovered: 25
+    HouseUpgradeAvailable: 26
+    LevelUp: 0
+    LevelUpDungeon: 2
+    LevelUpOther: 15
+    LevelUpPvP: 4
+    LevelUpRaid: 3
+    LevelUpSpell: 1
+    MythicPlusWeeklyRecord: 11
+    PetBattleCapture: 7
+    PetBattleFinalRound: 6
+    PetBattleNewAbility: 5
+    PlayerAuraAdded: 16
+    PlayerAuraRemoved: 17
+    PvPTierUpdate: 20
+    QuestBossEmote: 10
+    QuestTurnedIn: 12
+    Scenario: 14
+    SpellLearned: 21
+    SpellScript: 18
+    TreasureItem: 22
+    WeeklyRewardUnlock: 23
+    WeeklyRewardUpgrade: 24
+    WorldStateChange: 13
 EventToastFlags:
-  DisableRightClickDismiss: 1
+  values:
+    DisableRightClickDismiss: 1
 ExcludedCensorSources:
-  All: 255
-  Friends: 1
-  Guild: 2
-  None: 0
-  Reserve1: 4
-  Reserve2: 8
-  Reserve3: 16
-  Reserve4: 32
-  Reserve5: 64
-  Reserve6: 128
+  values:
+    All: 255
+    Friends: 1
+    Guild: 2
+    None: 0
+    Reserve1: 4
+    Reserve2: 8
+    Reserve3: 16
+    Reserve4: 32
+    Reserve5: 64
+    Reserve6: 128
 ExpansionLandingPageType:
-  Midnight: 1
-  None: 0
+  values:
+    Midnight: 1
+    None: 0
 ExpansionLevel:
-  BattleForAzeroth: 7
-  BurningCrusade: 1
-  Cataclysm: 3
-  Draenor: 5
-  Dragonflight: 9
-  LastTitan: 12
-  Legion: 6
-  Midnight: 11
-  MistsOfPandaria: 4
-  None: 0
-  Northrend: 2
-  Shadowlands: 8
-  WarWithin: 10
+  values:
+    BattleForAzeroth: 7
+    BurningCrusade: 1
+    Cataclysm: 3
+    Draenor: 5
+    Dragonflight: 9
+    LastTitan: 12
+    Legion: 6
+    Midnight: 11
+    MistsOfPandaria: 4
+    None: 0
+    Northrend: 2
+    Shadowlands: 8
+    WarWithin: 10
 FlightPathFaction:
-  Alliance: 2
-  Horde: 1
-  Neutral: 0
+  values:
+    Alliance: 2
+    Horde: 1
+    Neutral: 0
 FlightPathState:
-  Current: 0
-  Reachable: 1
-  Unreachable: 2
+  values:
+    Current: 0
+    Reachable: 1
+    Unreachable: 2
 FollowerAbilityCastResult:
-  AlreadyAtMaxDurability: 13
-  CannotTargetLimitedUseFollower: 11
-  CannotTargetNonAutoMissionFollower: 14
-  Failure: 1
-  InvalidFollowerSpell: 4
-  InvalidFollowerType: 9
-  InvalidTarget: 3
-  MustBeUnique: 10
-  MustTargetFollower: 7
-  MustTargetLimitedUseFollower: 12
-  MustTargetTrait: 8
-  NoPendingCast: 2
-  RerollNotAllowed: 5
-  SingleMissionDuration: 6
-  Success: 0
+  values:
+    AlreadyAtMaxDurability: 13
+    CannotTargetLimitedUseFollower: 11
+    CannotTargetNonAutoMissionFollower: 14
+    Failure: 1
+    InvalidFollowerSpell: 4
+    InvalidFollowerType: 9
+    InvalidTarget: 3
+    MustBeUnique: 10
+    MustTargetFollower: 7
+    MustTargetLimitedUseFollower: 12
+    MustTargetTrait: 8
+    NoPendingCast: 2
+    RerollNotAllowed: 5
+    SingleMissionDuration: 6
+    Success: 0
 FontStringScaleAnimationMode:
-  FontSize: 0
-  Vertex: 1
+  values:
+    FontSize: 0
+    Vertex: 1
 ForbiddenAspect:
-  AlwaysPropagateInput: 32
-  ChangeAnimationTarget: 256
-  ChangeParent: 1024
-  EventRegistrations: 16
-  QueryFocus: 128
-  RemoveSecretAspects: 512
-  ScriptBindings: 2
-  ScriptedInput: 64
-  SetToDefaults: 1
-  UntrustedLayoutScriptExecution: 8
-  UntrustedScriptExecution: 4
+  values:
+    AlwaysPropagateInput: 32
+    ChangeAnimationTarget: 256
+    ChangeParent: 1024
+    EventRegistrations: 16
+    QueryFocus: 128
+    RemoveSecretAspects: 512
+    ScriptBindings: 2
+    ScriptedInput: 64
+    SetToDefaults: 1
+    UntrustedLayoutScriptExecution: 8
+    UntrustedScriptExecution: 4
 FragmentID:
-  Actor: 15
-  CgObject: 2
-  ClientObservablesData: 6
-  DeferredMessages: 9
-  EntityPosition: 1
-  FHousingDecor: 20
-  FHousingDecorActor: 28
-  FHousingDecorProxy: 26
-  FHousingFixture: 34
-  FHousingHouseDecorSet: 24
-  FHousingHouseFixtureSet: 35
-  FHousingHouseRoomSet: 25
-  FHousingPlayerHouse: 23
-  FHousingPlotAreaTrigger: 29
-  FHousingRoom: 21
-  FHousingRoomComponentMesh: 22
-  FHousingStorageMirrorData: 33
-  FJamHousingCornerstone: 27
-  FLootObjectList: 12
-  FMapObject: 43
-  FMeshObjectData: 19
-  FMirroredPositionData: 31
-  FNeighborhoodMirrorData: 30
-  FNeighborhoodStateData: 38
-  FPathingDoor: 41
-  FPathingDynamicLinks: 40
-  FPersistableJamServers: 10
-  FPhaseShiftData: 16
-  FPlayerHouseInfo: 32
-  FPlayerInitiativeInfo: 37
-  FPlayerJamServers: 11
-  FPlayerOwnershipLink: 13
-  FTransportLink: 5
-  FUnitAIGroupLink: 39
-  FUnitAreaTriggerLink: 14
-  FVendor: 17
-  FWorldStateListenerData: 42
-  HeartbeatData: 4
-  JamDispatcher: 3
-  MirroredObjectC: 18
-  MirrorState: 0
-  ReservedArchetypeSeparator: 255
-  TagActiveClientS: 216
-  TagActiveObjectC: 217
-  TagActivePlayer: 215
-  TagAIGroup: 212
-  TagAreaTrigger: 209
-  TagAzeriteEmpoweredItem: 202
-  TagAzeriteItem: 203
-  TagContainer: 201
-  TagConversation: 211
-  TagCorpse: 208
-  TagDynamicObject: 207
-  TagGameObject: 206
-  TagHouseExteriorPiece: 224
-  TagHouseExteriorRoot: 225
-  TagHousingDecorProxyGameObject: 226
-  TagHousingPoolObject: 223
-  TagHousingRoom: 220
-  TagHousingSubdivisionObject: 222
-  TagItem: 200
-  TagLootObject: 214
-  TagMeshObject: 221
-  TagPlayer: 205
-  TagScenario: 213
-  TagSceneObject: 210
-  TagUnit: 204
-  TagUnitVehicle: 219
-  TagVisibleObjectC: 218
-  TestFragment_1: 250
-  TestFragment_2: 251
-  TestFragment_3: 252
-  TestFragment_4: 253
-  TestFragment_5: 254
-  Timer: 36
-  TimerQueues: 7
-  TransferSuspensionData: 8
+  values:
+    Actor: 15
+    CgObject: 2
+    ClientObservablesData: 6
+    DeferredMessages: 9
+    EntityPosition: 1
+    FHousingDecor: 20
+    FHousingDecorActor: 28
+    FHousingDecorProxy: 26
+    FHousingFixture: 34
+    FHousingHouseDecorSet: 24
+    FHousingHouseFixtureSet: 35
+    FHousingHouseRoomSet: 25
+    FHousingPlayerHouse: 23
+    FHousingPlotAreaTrigger: 29
+    FHousingRoom: 21
+    FHousingRoomComponentMesh: 22
+    FHousingStorageMirrorData: 33
+    FJamHousingCornerstone: 27
+    FLootObjectList: 12
+    FMapObject: 43
+    FMeshObjectData: 19
+    FMirroredPositionData: 31
+    FNeighborhoodMirrorData: 30
+    FNeighborhoodStateData: 38
+    FPathingDoor: 41
+    FPathingDynamicLinks: 40
+    FPersistableJamServers: 10
+    FPhaseShiftData: 16
+    FPlayerHouseInfo: 32
+    FPlayerInitiativeInfo: 37
+    FPlayerJamServers: 11
+    FPlayerOwnershipLink: 13
+    FTransportLink: 5
+    FUnitAIGroupLink: 39
+    FUnitAreaTriggerLink: 14
+    FVendor: 17
+    FWorldStateListenerData: 42
+    HeartbeatData: 4
+    JamDispatcher: 3
+    MirroredObjectC: 18
+    MirrorState: 0
+    ReservedArchetypeSeparator: 255
+    TagActiveClientS: 216
+    TagActiveObjectC: 217
+    TagActivePlayer: 215
+    TagAIGroup: 212
+    TagAreaTrigger: 209
+    TagAzeriteEmpoweredItem: 202
+    TagAzeriteItem: 203
+    TagContainer: 201
+    TagConversation: 211
+    TagCorpse: 208
+    TagDynamicObject: 207
+    TagGameObject: 206
+    TagHouseExteriorPiece: 224
+    TagHouseExteriorRoot: 225
+    TagHousingDecorProxyGameObject: 226
+    TagHousingPoolObject: 223
+    TagHousingRoom: 220
+    TagHousingSubdivisionObject: 222
+    TagItem: 200
+    TagLootObject: 214
+    TagMeshObject: 221
+    TagPlayer: 205
+    TagScenario: 213
+    TagSceneObject: 210
+    TagUnit: 204
+    TagUnitVehicle: 219
+    TagVisibleObjectC: 218
+    TestFragment_1: 250
+    TestFragment_2: 251
+    TestFragment_3: 252
+    TestFragment_4: 253
+    TestFragment_5: 254
+    Timer: 36
+    TimerQueues: 7
+    TransferSuspensionData: 8
 FrameTutorialAccount:
-  AccountWideReputation: 9
-  AssistedCombatRotationActionButton: 22
-  AssistedCombatRotationDragSpell: 21
-  BindToAccountUntilEquip: 11
-  CompletedQuestsFilter: 12
-  CompletedQuestsFilterSeen: 13
-  ConcentrationCurrency: 14
-  EditModeManager: 3
-  EnconterJournalTutorialsTabSeen: 33
-  EventSchedulerTabSeen: 20
-  HeirloomJournalLevel: 7
-  HousingCleanupMode: 40
-  HousingDecorCleanup: 23
-  HousingDecorClippingGrid: 25
-  HousingDecorCustomization: 26
-  HousingDecorLayout: 27
-  HousingDecorPlace: 24
-  HousingEndeavorsTabSeen: 48
-  HousingExpertMode: 39
-  HousingHouseFinderMap: 28
-  HousingHouseFinderVisitHouse: 29
-  HousingInvalidCollision: 37
-  HousingItemAcquisition: 30
-  HousingMarketTab: 34
-  HousingModesUnlocked: 38
-  HousingNewPip: 31
-  HousingPetBeds: 50
-  HousingTeleportButton: 35
-  HudRevampBagChanges: 1
-  LFGList: 6
-  LocalStoriesFilterSeen: 19
-  MapLegendOpened: 15
-  MountCollectionDragonriding: 5
-  NpcCraftingOrderCreateButton: 17
-  NpcCraftingOrders: 16
-  NpcCraftingOrderTabNew: 18
-  PerksProgramActivitiesIntro: 2
-  PerksProgramActivitiesOpen: 32
-  RPETalentStarterBuild: 36
-  RunesOfPower: 49
-  TimerunnersAdvantage: 8
-  TransferableCurrencies: 10
-  TransmogCustomSets: 43
-  TransmogCustomSetsMigration: 47
-  TransmogOutfits: 41
-  TransmogSets: 42
-  TransmogSetsTab: 4
-  TransmogSituations: 44
-  TransmogTrialOfStyle: 46
-  TransmogWeaponOptions: 45
+  values:
+    AccountWideReputation: 9
+    AssistedCombatRotationActionButton: 22
+    AssistedCombatRotationDragSpell: 21
+    BindToAccountUntilEquip: 11
+    CompletedQuestsFilter: 12
+    CompletedQuestsFilterSeen: 13
+    ConcentrationCurrency: 14
+    EditModeManager: 3
+    EnconterJournalTutorialsTabSeen: 33
+    EventSchedulerTabSeen: 20
+    HeirloomJournalLevel: 7
+    HousingCleanupMode: 40
+    HousingDecorCleanup: 23
+    HousingDecorClippingGrid: 25
+    HousingDecorCustomization: 26
+    HousingDecorLayout: 27
+    HousingDecorPlace: 24
+    HousingEndeavorsTabSeen: 48
+    HousingExpertMode: 39
+    HousingHouseFinderMap: 28
+    HousingHouseFinderVisitHouse: 29
+    HousingInvalidCollision: 37
+    HousingItemAcquisition: 30
+    HousingMarketTab: 34
+    HousingModesUnlocked: 38
+    HousingNewPip: 31
+    HousingPetBeds: 50
+    HousingTeleportButton: 35
+    HudRevampBagChanges: 1
+    LFGList: 6
+    LocalStoriesFilterSeen: 19
+    MapLegendOpened: 15
+    MountCollectionDragonriding: 5
+    NpcCraftingOrderCreateButton: 17
+    NpcCraftingOrders: 16
+    NpcCraftingOrderTabNew: 18
+    PerksProgramActivitiesIntro: 2
+    PerksProgramActivitiesOpen: 32
+    RPETalentStarterBuild: 36
+    RunesOfPower: 49
+    TimerunnersAdvantage: 8
+    TransferableCurrencies: 10
+    TransmogCustomSets: 43
+    TransmogCustomSetsMigration: 47
+    TransmogOutfits: 41
+    TransmogSets: 42
+    TransmogSetsTab: 4
+    TransmogSituations: 44
+    TransmogTrialOfStyle: 46
+    TransmogWeaponOptions: 45
 GameMode:
-  Plunderstorm: 2
-  Standard: 1
-  WoWHack: 3
+  values:
+    Plunderstorm: 2
+    Standard: 1
+    WoWHack: 3
 GamePadPowerLevel:
-  Critical: 0
-  High: 3
-  Low: 1
-  Medium: 2
-  Unknown: 5
-  Wired: 4
+  values:
+    Critical: 0
+    High: 3
+    Low: 1
+    Medium: 2
+    Unknown: 5
+    Wired: 4
 GameRule:
-  AchievementsPanelDisabled: 40
-  ActionbarIconIntroDisabled: 60
-  ActionButtonTypeOverlayStrategy: 165
-  ActionCombatTargetLockEnabled: 87
-  AfterDeathSpectatingUI: 49
-  AllPlayersAreFastMovers: 53
-  AlwaysAllowAlliedRaces: 59
-  AutoAttacksDisabled: 103
-  BagSpaceOverride: 172
-  BagsUIDisabled: 64
-  BlockWhileSheathedAllowed: 88
-  CharacterCreateUseFixedBackgroundModel: 55
-  CharacterlessLogin: 14
-  CharacterPanelDisabled: 37
-  CharNameReservationEnabled: 2
-  CharReservationsPerRealmReopenThreshold: 8
-  ChatLinkLevelToastsDisabled: 63
-  ClearMailOnRealmTransfer: 92
-  CollectionsPanelDisabled: 36
-  CommunitiesPanelDisabled: 41
-  CompactRaidFrameManagerDisabled: 81
-  CustomActionbarOverlayHeightOffset: 33
-  DeleteItemConfirmationDisabled: 62
-  DisableCampsites: 114
-  DisableHonorDecay: 23
-  DisablePct: 9
-  DisableQuickJoin: 162
-  DisableRaidGroups: 163
-  DisableRealmSelection: 113
-  DisableVas: 119
-  DoesNotCountTowardAccountCharacterMax: 142
-  EditModeDisabled: 82
-  EjDungeonsDisabled: 149
-  EjItemSetsDisabled: 151
-  EjJourneysDisabled: 156
-  EjRaidsDisabled: 150
-  EjSuggestedContentDisabled: 148
-  EncounterJournalDisabled: 42
-  EtaRealmLaunchTime: 5
-  ExperienceBarDisabled: 159
-  FastAreaTriggerTick: 52
-  FinderPanelDisabled: 43
-  ForceAlteredFormsOn: 56
-  ForcedChatLanguage: 34
-  ForcedMultiActionBarSetting: 133
-  ForcedPartyFrameScale: 32
-  FrontEndChat: 50
-  FullCharacterCreateDisabled: 84
-  GameMode: 13
-  GdapiCharacterProfileDisabled: 153
-  GroupFinderCapabilities: 98
-  GuildsDisabled: 46
-  HardcoreRuleset: 10
-  HelpPanelDisabled: 45
-  HideAllMultiActionBars: 135
-  HideFaction: 116
-  HideTransmogZeroCost: 161
-  HideUnavailableTransmogSlots: 160
-  HousingDashboardDisabled: 102
-  HousingEnabled: 154
-  IgnoreChrclassDisabledFlag: 54
-  IngameCalendarDisabled: 75
-  IngameFriendsListDisabled: 79
-  IngameMailNotificationDisabled: 74
-  IngameTrackingDisabled: 76
-  IngameWhoListDisabled: 77
-  InstanceDifficultyBannerDisabled: 83
-  LandingPageFactionID: 35
-  LootMethodStyle: 157
-  MacrosDisabled: 80
-  MailGameRule: 132
-  MapPlunderstormCircle: 48
-  MaxAccountCharReservationsPerContentset: 4
-  MaxCharactersPerContentSet: 139
-  MaxCharReservationsPerRealm: 3
-  MaximizeWorldMapDisabled: 67
-  MaxLootDropLevel: 25
-  MaxNameplateDistance: 28
-  MaxUnitNameDistance: 27
-  MerchantFilterDisabled: 101
-  MicrobarScale: 26
-  MinimapDisabled: 146
-  MinUndeleteLevelRequired: 140
-  NameplateCastBarDisabled: 107
-  NoDebuffLimit: 1
-  NonPlayerNameplateScale: 31
-  ObjectiveTrackerDisabled: 104
-  PerksProgramActivityTrackingDisabled: 66
-  PersonalResourceDisplayDisabled: 129
-  PetBattlesDisabled: 65
-  PlayerCastBarDisabled: 105
-  PlayerFrameDisabled: 131
-  PlayerNameplateAlternateHealthColor: 58
-  PlayerNameplateDifficultyIcon: 57
-  PlunderstormAreaSelection: 94
-  PremadeGroupFinderStyle: 93
-  PvPInitialRatingOverride: 190
-  QuestLogMicrobuttonDisabled: 47
-  QuestLogPanelDisabled: 71
-  QuestLogSuperTrackingDisabled: 72
-  RaceAlteredFormsDisabled: 78
-  RecommendLeastPopulatedRealm: 169
-  ReleaseSpiritGhostDisabled: 61
-  RepairArmorDisabled: 147
-  ReplaceAbsentGmSeconds: 11
-  ReplaceGmRankLastOnlineSeconds: 12
-  RestrictedAchievementCategoryID: 155
-  Runecarving: 17
-  SelfFoundAllowed: 22
-  SpellbookPanelDisabled: 38
-  StoreDisabled: 44
-  SummoningStones: 108
-  TalentRespecCostMax: 19
-  TalentRespecCostMin: 18
-  TalentRespecCostStep: 20
-  TalentsPanelDisabled: 39
-  TargetCastBarDisabled: 106
-  TargetFrameBuffsDisabled: 85
-  TargetFrameDisabled: 130
-  TimerunningAllowed: 137
-  TransmogEnabled: 109
-  TrivialGroupXPPercent: 7
-  TutorialFrameDisabled: 73
-  UnflaggedPlayersCanAttackPvPFlaggedPlayers: 173
-  UnitFramePvPContextualDisabled: 86
-  UniversalNameplateOcclusion: 51
-  UseGameTableVariation: 164
-  UserAddonsDisabled: 29
-  UserScriptsDisabled: 30
-  UseSimpleCharacterSelectList: 115
-  VanillaAccountMailInstant: 91
-  VanillaNpcKnockback: 16
-  VanillaRageGenerationModifier: 21
-  WorldMapDisabled: 145
-  WorldMapFrameStrata: 100
-  WorldMapHelpPlateDisabled: 70
-  WorldMapLegendDisabled: 99
-  WorldMapTrackingOptionsDisabled: 68
-  WorldMapTrackingPinDisabled: 69
+  values:
+    AchievementsPanelDisabled: 40
+    ActionbarIconIntroDisabled: 60
+    ActionButtonTypeOverlayStrategy: 165
+    ActionCombatTargetLockEnabled: 87
+    AfterDeathSpectatingUI: 49
+    AllPlayersAreFastMovers: 53
+    AlwaysAllowAlliedRaces: 59
+    AutoAttacksDisabled: 103
+    BagSpaceOverride: 172
+    BagsUIDisabled: 64
+    BlockWhileSheathedAllowed: 88
+    CharacterCreateUseFixedBackgroundModel: 55
+    CharacterlessLogin: 14
+    CharacterPanelDisabled: 37
+    CharNameReservationEnabled: 2
+    CharReservationsPerRealmReopenThreshold: 8
+    ChatLinkLevelToastsDisabled: 63
+    ClearMailOnRealmTransfer: 92
+    CollectionsPanelDisabled: 36
+    CommunitiesPanelDisabled: 41
+    CompactRaidFrameManagerDisabled: 81
+    CustomActionbarOverlayHeightOffset: 33
+    DeleteItemConfirmationDisabled: 62
+    DisableCampsites: 114
+    DisableHonorDecay: 23
+    DisablePct: 9
+    DisableQuickJoin: 162
+    DisableRaidGroups: 163
+    DisableRealmSelection: 113
+    DisableVas: 119
+    DoesNotCountTowardAccountCharacterMax: 142
+    EditModeDisabled: 82
+    EjDungeonsDisabled: 149
+    EjItemSetsDisabled: 151
+    EjJourneysDisabled: 156
+    EjRaidsDisabled: 150
+    EjSuggestedContentDisabled: 148
+    EncounterJournalDisabled: 42
+    EtaRealmLaunchTime: 5
+    ExperienceBarDisabled: 159
+    FastAreaTriggerTick: 52
+    FinderPanelDisabled: 43
+    ForceAlteredFormsOn: 56
+    ForcedChatLanguage: 34
+    ForcedMultiActionBarSetting: 133
+    ForcedPartyFrameScale: 32
+    FrontEndChat: 50
+    FullCharacterCreateDisabled: 84
+    GameMode: 13
+    GdapiCharacterProfileDisabled: 153
+    GroupFinderCapabilities: 98
+    GuildsDisabled: 46
+    HardcoreRuleset: 10
+    HelpPanelDisabled: 45
+    HideAllMultiActionBars: 135
+    HideFaction: 116
+    HideTransmogZeroCost: 161
+    HideUnavailableTransmogSlots: 160
+    HousingDashboardDisabled: 102
+    HousingEnabled: 154
+    IgnoreChrclassDisabledFlag: 54
+    IngameCalendarDisabled: 75
+    IngameFriendsListDisabled: 79
+    IngameMailNotificationDisabled: 74
+    IngameTrackingDisabled: 76
+    IngameWhoListDisabled: 77
+    InstanceDifficultyBannerDisabled: 83
+    LandingPageFactionID: 35
+    LootMethodStyle: 157
+    MacrosDisabled: 80
+    MailGameRule: 132
+    MapPlunderstormCircle: 48
+    MaxAccountCharReservationsPerContentset: 4
+    MaxCharactersPerContentSet: 139
+    MaxCharReservationsPerRealm: 3
+    MaximizeWorldMapDisabled: 67
+    MaxLootDropLevel: 25
+    MaxNameplateDistance: 28
+    MaxUnitNameDistance: 27
+    MerchantFilterDisabled: 101
+    MicrobarScale: 26
+    MinimapDisabled: 146
+    MinUndeleteLevelRequired: 140
+    NameplateCastBarDisabled: 107
+    NoDebuffLimit: 1
+    NonPlayerNameplateScale: 31
+    ObjectiveTrackerDisabled: 104
+    PerksProgramActivityTrackingDisabled: 66
+    PersonalResourceDisplayDisabled: 129
+    PetBattlesDisabled: 65
+    PlayerCastBarDisabled: 105
+    PlayerFrameDisabled: 131
+    PlayerNameplateAlternateHealthColor: 58
+    PlayerNameplateDifficultyIcon: 57
+    PlunderstormAreaSelection: 94
+    PremadeGroupFinderStyle: 93
+    PvPInitialRatingOverride: 190
+    QuestLogMicrobuttonDisabled: 47
+    QuestLogPanelDisabled: 71
+    QuestLogSuperTrackingDisabled: 72
+    RaceAlteredFormsDisabled: 78
+    RecommendLeastPopulatedRealm: 169
+    ReleaseSpiritGhostDisabled: 61
+    RepairArmorDisabled: 147
+    ReplaceAbsentGmSeconds: 11
+    ReplaceGmRankLastOnlineSeconds: 12
+    RestrictedAchievementCategoryID: 155
+    Runecarving: 17
+    SelfFoundAllowed: 22
+    SpellbookPanelDisabled: 38
+    StoreDisabled: 44
+    SummoningStones: 108
+    TalentRespecCostMax: 19
+    TalentRespecCostMin: 18
+    TalentRespecCostStep: 20
+    TalentsPanelDisabled: 39
+    TargetCastBarDisabled: 106
+    TargetFrameBuffsDisabled: 85
+    TargetFrameDisabled: 130
+    TimerunningAllowed: 137
+    TransmogEnabled: 109
+    TrivialGroupXPPercent: 7
+    TutorialFrameDisabled: 73
+    UnflaggedPlayersCanAttackPvPFlaggedPlayers: 173
+    UnitFramePvPContextualDisabled: 86
+    UniversalNameplateOcclusion: 51
+    UseGameTableVariation: 164
+    UserAddonsDisabled: 29
+    UserScriptsDisabled: 30
+    UseSimpleCharacterSelectList: 115
+    VanillaAccountMailInstant: 91
+    VanillaNpcKnockback: 16
+    VanillaRageGenerationModifier: 21
+    WorldMapDisabled: 145
+    WorldMapFrameStrata: 100
+    WorldMapHelpPlateDisabled: 70
+    WorldMapLegendDisabled: 99
+    WorldMapTrackingOptionsDisabled: 68
+    WorldMapTrackingPinDisabled: 69
 GameRuleFlags:
-  AllowClient: 1
-  None: 0
-  RequiresDefault: 2
+  values:
+    AllowClient: 1
+    None: 0
+    RequiresDefault: 2
 GameRuleType:
-  Bool: 2
-  Float: 1
-  Int: 0
+  values:
+    Bool: 2
+    Float: 1
+    Int: 0
 GarrAutoBoardIndex:
-  AllyCenterFront: 3
-  AllyLeftBack: 0
-  AllyLeftFront: 2
-  AllyRightBack: 1
-  AllyRightFront: 4
-  EnemyCenterLeftBack: 10
-  EnemyCenterLeftFront: 6
-  EnemyCenterRightBack: 11
-  EnemyCenterRightFront: 7
-  EnemyLeftBack: 9
-  EnemyLeftFront: 5
-  EnemyRightBack: 12
-  EnemyRightFront: 8
-  None: -1
+  values:
+    AllyCenterFront: 3
+    AllyLeftBack: 0
+    AllyLeftFront: 2
+    AllyRightBack: 1
+    AllyRightFront: 4
+    EnemyCenterLeftBack: 10
+    EnemyCenterLeftFront: 6
+    EnemyCenterRightBack: 11
+    EnemyCenterRightFront: 7
+    EnemyLeftBack: 9
+    EnemyLeftFront: 5
+    EnemyRightBack: 12
+    EnemyRightFront: 8
+    None: -1
 GarrAutoCombatantRole:
-  HealSupport: 4
-  Melee: 1
-  None: 0
-  RangedMagic: 3
-  RangedPhysical: 2
-  Tank: 5
+  values:
+    HealSupport: 4
+    Melee: 1
+    None: 0
+    RangedMagic: 3
+    RangedPhysical: 2
+    Tank: 5
 GarrAutoCombatSpellTutorialFlag:
-  All: 4
-  Column: 2
-  None: 0
-  Row: 3
-  Single: 1
+  values:
+    All: 4
+    Column: 2
+    None: 0
+    Row: 3
+    Single: 1
 GarrAutoCombatTutorial:
-  AttackAll: 256
-  AttackColumn: 64
-  AttackRow: 128
-  AttackSingle: 32
-  BeneficialEffect: 16
-  EnvironmentalEffect: 1024
-  HealCompanion: 4
-  LevelHeal: 8
-  PlaceCompanion: 2
-  SelectMission: 1
-  TroopTutorial: 512
+  values:
+    AttackAll: 256
+    AttackColumn: 64
+    AttackRow: 128
+    AttackSingle: 32
+    BeneficialEffect: 16
+    EnvironmentalEffect: 1024
+    HealCompanion: 4
+    LevelHeal: 8
+    PlaceCompanion: 2
+    SelectMission: 1
+    TroopTutorial: 512
 GarrAutoEventFlags:
-  AutoAttack: 1
-  Environment: 4
-  None: 0
-  Passive: 2
+  values:
+    AutoAttack: 1
+    Environment: 4
+    None: 0
+    Passive: 2
 GarrAutoMissionEventType:
-  ApplyAura: 7
-  Died: 9
-  Heal: 4
-  MeleeDamage: 0
-  PeriodicDamage: 5
-  PeriodicHeal: 6
-  RangeDamage: 1
-  RemoveAura: 8
-  SpellMeleeDamage: 2
-  SpellRangeDamage: 3
+  values:
+    ApplyAura: 7
+    Died: 9
+    Heal: 4
+    MeleeDamage: 0
+    PeriodicDamage: 5
+    PeriodicHeal: 6
+    RangeDamage: 1
+    RemoveAura: 8
+    SpellMeleeDamage: 2
+    SpellRangeDamage: 3
 GarrAutoPreviewTargetType:
-  Buff: 4
-  Damage: 1
-  Debuff: 8
-  Heal: 2
-  None: 0
+  values:
+    Buff: 4
+    Damage: 1
+    Debuff: 8
+    Heal: 2
+    None: 0
 GarrFollowerMissionCompleteState:
-  Alive: 0
-  KilledByMissionFailure: 1
-  OutOfDurability: 3
-  SavedByPreventDeath: 2
+  values:
+    Alive: 0
+    KilledByMissionFailure: 1
+    OutOfDurability: 3
+    SavedByPreventDeath: 2
 GarrFollowerQuality:
-  Common: 1
-  Epic: 4
-  Legendary: 5
-  None: 0
-  Rare: 3
-  Title: 6
-  Uncommon: 2
+  values:
+    Common: 1
+    Epic: 4
+    Legendary: 5
+    None: 0
+    Rare: 3
+    Title: 6
+    Uncommon: 2
 GarrisonFollowerType:
-  FollowerType_6_0_Boat: 2
-  FollowerType_6_0_GarrisonFollower: 1
-  FollowerType_7_0_GarrisonFollower: 4
-  FollowerType_8_0_GarrisonFollower: 22
-  FollowerType_9_0_GarrisonFollower: 123
+  values:
+    FollowerType_6_0_Boat: 2
+    FollowerType_6_0_GarrisonFollower: 1
+    FollowerType_7_0_GarrisonFollower: 4
+    FollowerType_8_0_GarrisonFollower: 22
+    FollowerType_9_0_GarrisonFollower: 123
 GarrisonTalentAvailability:
-  Available: 0
-  Unavailable: 1
-  UnavailableAlreadyHave: 7
-  UnavailableAnotherIsResearching: 2
-  UnavailableNotEnoughGold: 4
-  UnavailableNotEnoughResources: 3
-  UnavailablePlayerCondition: 6
-  UnavailableRequiresPrerequisiteTalent: 8
-  UnavailableTierUnavailable: 5
+  values:
+    Available: 0
+    Unavailable: 1
+    UnavailableAlreadyHave: 7
+    UnavailableAnotherIsResearching: 2
+    UnavailableNotEnoughGold: 4
+    UnavailableNotEnoughResources: 3
+    UnavailablePlayerCondition: 6
+    UnavailableRequiresPrerequisiteTalent: 8
+    UnavailableTierUnavailable: 5
 GarrisonType:
-  Type_6_0_Garrison: 2
-  Type_7_0_Garrison: 3
-  Type_8_0_Garrison: 9
-  Type_9_0_Garrison: 111
+  values:
+    Type_6_0_Garrison: 2
+    Type_7_0_Garrison: 3
+    Type_8_0_Garrison: 9
+    Type_9_0_Garrison: 111
 GarrTalentCostType:
-  Initial: 0
-  MakePermanent: 2
-  Respec: 1
-  TreeReset: 3
+  values:
+    Initial: 0
+    MakePermanent: 2
+    Respec: 1
+    TreeReset: 3
 GarrTalentFeatureSubtype:
-  Ardenweald: 3
-  Bastion: 1
-  Generic: 0
-  Maldraxxus: 4
-  Revendreth: 2
+  values:
+    Ardenweald: 3
+    Bastion: 1
+    Generic: 0
+    Maldraxxus: 4
+    Revendreth: 2
 GarrTalentFeatureType:
-  Adventures: 3
-  AnimaDiversion: 1
-  AnimaDiversionMap: 7
-  Cyphers: 8
-  Generic: 0
-  ReservoirUpgrades: 4
-  SanctumUnique: 5
-  SoulBinds: 6
-  TravelPortals: 2
+  values:
+    Adventures: 3
+    AnimaDiversion: 1
+    AnimaDiversionMap: 7
+    Cyphers: 8
+    Generic: 0
+    ReservoirUpgrades: 4
+    SanctumUnique: 5
+    SoulBinds: 6
+    TravelPortals: 2
 GarrTalentResearchCostSource:
-  Talent: 0
-  Tree: 1
+  values:
+    Talent: 0
+    Tree: 1
 GarrTalentSocketType:
-  Conduit: 2
-  None: 0
-  Spell: 1
+  values:
+    Conduit: 2
+    None: 0
+    Spell: 1
 GarrTalentTreeType:
-  Classic: 1
-  Tiers: 0
+  values:
+    Classic: 1
+    Tiers: 0
 GarrTalentType:
-  Major: 2
-  Minor: 1
-  Socket: 3
-  Standard: 0
+  values:
+    Major: 2
+    Minor: 1
+    Socket: 3
+    Standard: 0
 GarrTalentUI:
-  AnimaDiversionMap: 3
-  CovenantSanctum: 1
-  Generic: 0
-  SoulBinds: 2
+  values:
+    AnimaDiversionMap: 3
+    CovenantSanctum: 1
+    Generic: 0
+    SoulBinds: 2
 GossipNpcOption:
-  AccountBanker: 57
-  AdventureMap: 31
-  ArtifactRespec: 21
-  Auctioneer: 10
-  AzeriteRespec: 35
-  Banker: 6
-  BarbersChoice: 52
-  Battlemaster: 9
-  Binder: 5
-  BlackMarketAuctionHouse: 46
-  CemeterySelect: 22
-  CharacterBanker: 56
-  ChromieTimeNpc: 40
-  ContributionCollector: 33
-  CovenantPreviewNpc: 41
-  CovenantRenownNpc: 45
-  DisableXPGain: 16
-  EnableXPGain: 17
-  ForgeMaster: 55
-  GarrisonArchitect: 26
-  GarrisonMissionNpc: 27
-  GarrisonRecruitment: 30
-  GarrisonTalent: 32
-  GarrisonTradeskillNpc: 29
-  GlyphMaster: 24
-  GuildBanker: 14
-  GuildRename: 62
-  GuildTabardVendor: 8
-  HouseFinder: 65
-  HousingCreateGuildNeighborhood: 60
-  HousingGetNeighborhoodCharter: 61
-  HousingOpenCharterConfirmation: 63
-  IslandsMissionNpc: 36
-  ItemUpgrade: 64
-  LFGDungeon: 20
-  Mailbox: 18
-  MajorFactionRenown: 53
-  NewPlayerGuide: 43
-  None: 0
-  PerksProgramVendor: 47
-  PersonalTabardVendor: 54
-  PetitionVendor: 7
-  PetSpecializationMaster: 13
-  ProfessionRespec: 58
-  ProfessionsCraftingOrder: 48
-  ProfessionsCustomerOrder: 50
-  ProfessionsOpen: 49
-  QueueScenario: 25
-  RenameNeighborhood: 59
-  RuneforgeLegendaryCrafting: 42
-  RuneforgeLegendaryUpgrade: 44
-  ShipmentCrafter: 28
-  Soulbind: 39
-  SpecializationMaster: 23
-  Spellclick: 15
-  SpiritHealer: 4
-  Stablemaster: 12
-  TalentMaster: 11
-  Taxinode: 2
-  TieredEntrance: 66
-  Trainer: 3
-  TraitSystem: 51
-  Transmogrify: 34
-  UIItemInteraction: 37
-  Vendor: 1
-  WorldMap: 38
-  WorldPvPQueue: 19
+  values:
+    AccountBanker: 57
+    AdventureMap: 31
+    ArtifactRespec: 21
+    Auctioneer: 10
+    AzeriteRespec: 35
+    Banker: 6
+    BarbersChoice: 52
+    Battlemaster: 9
+    Binder: 5
+    BlackMarketAuctionHouse: 46
+    CemeterySelect: 22
+    CharacterBanker: 56
+    ChromieTimeNpc: 40
+    ContributionCollector: 33
+    CovenantPreviewNpc: 41
+    CovenantRenownNpc: 45
+    DisableXPGain: 16
+    EnableXPGain: 17
+    ForgeMaster: 55
+    GarrisonArchitect: 26
+    GarrisonMissionNpc: 27
+    GarrisonRecruitment: 30
+    GarrisonTalent: 32
+    GarrisonTradeskillNpc: 29
+    GlyphMaster: 24
+    GuildBanker: 14
+    GuildRename: 62
+    GuildTabardVendor: 8
+    HouseFinder: 65
+    HousingCreateGuildNeighborhood: 60
+    HousingGetNeighborhoodCharter: 61
+    HousingOpenCharterConfirmation: 63
+    IslandsMissionNpc: 36
+    ItemUpgrade: 64
+    LFGDungeon: 20
+    Mailbox: 18
+    MajorFactionRenown: 53
+    NewPlayerGuide: 43
+    None: 0
+    PerksProgramVendor: 47
+    PersonalTabardVendor: 54
+    PetitionVendor: 7
+    PetSpecializationMaster: 13
+    ProfessionRespec: 58
+    ProfessionsCraftingOrder: 48
+    ProfessionsCustomerOrder: 50
+    ProfessionsOpen: 49
+    QueueScenario: 25
+    RenameNeighborhood: 59
+    RuneforgeLegendaryCrafting: 42
+    RuneforgeLegendaryUpgrade: 44
+    ShipmentCrafter: 28
+    Soulbind: 39
+    SpecializationMaster: 23
+    Spellclick: 15
+    SpiritHealer: 4
+    Stablemaster: 12
+    TalentMaster: 11
+    Taxinode: 2
+    TieredEntrance: 66
+    Trainer: 3
+    TraitSystem: 51
+    Transmogrify: 34
+    UIItemInteraction: 37
+    Vendor: 1
+    WorldMap: 38
+    WorldPvPQueue: 19
 GossipNpcOptionDisplayFlags:
-  ForceInteractionOnSingleChoice: 1
+  values:
+    ForceInteractionOnSingleChoice: 1
 GossipOptionRecFlags:
-  HideOptionIDFromClient: 2
-  PlayMovieLabelPrepend: 4
-  QuestLabelPrepend: 1
+  values:
+    HideOptionIDFromClient: 2
+    PlayMovieLabelPrepend: 4
+    QuestLabelPrepend: 1
 GossipOptionRewardType:
-  Currency: 1
-  Item: 0
+  values:
+    Currency: 1
+    Item: 0
 GossipOptionStatus:
-  AlreadyComplete: 3
-  Available: 0
-  Locked: 2
-  Unavailable: 1
+  values:
+    AlreadyComplete: 3
+    Available: 0
+    Locked: 2
+    Unavailable: 1
 GossipOptionUIWidgetSetTypes:
-  Background: 1
-  Modifiers: 0
+  values:
+    Background: 1
+    Modifiers: 0
 GraphicsValidationResult:
-  AmdGpuUnsupported: 36
-  AppleGpuUnsupported: 35
-  CompatMode: 41
-  CpuMem_2: 6
-  CpuMem_4: 7
-  CpuMem_8: 8
-  DualCore: 4
-  Dx11Unsupported: 30
-  Dx12Win7Unsupported: 31
-  GpuDriver: 40
-  Graphics: 3
-  Illegal: 1
-  IntelGpuUnsupported: 37
-  LegacyUnsupported: 29
-  MacOsUnsupported: 27
-  Needs_5_0: 9
-  Needs_6_0: 10
-  NeedsAmdGpu: 15
-  NeedsAppleGpu: 14
-  NeedsDx12: 12
-  NeedsDx12Vrs2: 13
-  NeedsIntelGpu: 16
-  NeedsMacOs_10_13: 19
-  NeedsMacOs_10_14: 20
-  NeedsMacOs_10_15: 21
-  NeedsMacOs_11_0: 22
-  NeedsMacOs_12_0: 23
-  NeedsMacOs_13_0: 24
-  NeedsNvidiaGpu: 17
-  NeedsQualcommGpu: 18
-  NeedsRt: 11
-  NeedsWindows_10: 25
-  NeedsWindows_11: 26
-  NvapiWineUnsupported: 34
-  NvidiaGpuUnsupported: 38
-  QuadCore: 5
-  QualcommGpuUnsupported: 39
-  RemoteDesktopUnsupported: 32
-  Supported: 0
-  Unknown: 42
-  Unsupported: 2
-  WindowsUnsupported: 28
-  WineUnsupported: 33
+  values:
+    AmdGpuUnsupported: 36
+    AppleGpuUnsupported: 35
+    CompatMode: 41
+    CpuMem_2: 6
+    CpuMem_4: 7
+    CpuMem_8: 8
+    DualCore: 4
+    Dx11Unsupported: 30
+    Dx12Win7Unsupported: 31
+    GpuDriver: 40
+    Graphics: 3
+    Illegal: 1
+    IntelGpuUnsupported: 37
+    LegacyUnsupported: 29
+    MacOsUnsupported: 27
+    Needs_5_0: 9
+    Needs_6_0: 10
+    NeedsAmdGpu: 15
+    NeedsAppleGpu: 14
+    NeedsDx12: 12
+    NeedsDx12Vrs2: 13
+    NeedsIntelGpu: 16
+    NeedsMacOs_10_13: 19
+    NeedsMacOs_10_14: 20
+    NeedsMacOs_10_15: 21
+    NeedsMacOs_11_0: 22
+    NeedsMacOs_12_0: 23
+    NeedsMacOs_13_0: 24
+    NeedsNvidiaGpu: 17
+    NeedsQualcommGpu: 18
+    NeedsRt: 11
+    NeedsWindows_10: 25
+    NeedsWindows_11: 26
+    NvapiWineUnsupported: 34
+    NvidiaGpuUnsupported: 38
+    QuadCore: 5
+    QualcommGpuUnsupported: 39
+    RemoteDesktopUnsupported: 32
+    Supported: 0
+    Unknown: 42
+    Unsupported: 2
+    WindowsUnsupported: 28
+    WineUnsupported: 33
 GroupBuffItemFlags:
-  HideByDefault: 1
+  values:
+    HideByDefault: 1
 GuildErrorType:
-  AlreadyInGuild: 2
-  BadItem: 29
-  BankNotFound: 43
-  BankTabFull: 28
-  BankTabLocked: 35
-  Busy: 20
-  CantInviteSelf: 41
-  DeleteNoAppropriateLeader: 47
-  GuildBankNotAvailable: 45
-  GuildRepTooLow: 40
-  HasRestriction: 42
-  HousingEvictError: 51
-  Ignored: 19
-  InCooldown: 49
-  InvalidBankTab: 24
-  InvitedToGuild: 4
-  LockedForMove: 39
-  NameAlreadyExists: 7
-  NameInvalid: 6
-  NewLeaderWrongFaction: 44
-  NewLeaderWrongRealm: 46
-  NoPermisson: 8
-  NotEnoughMoney: 26
-  NotInGuild: 9
-  PlayerNotFound: 11
-  RankInUse: 18
-  RankRequiresAuthenticator: 34
-  RanksLocked: 17
-  RealmMismatch: 48
-  ReservationExpired: 50
-  Success: 0
-  TargetAlreadyInGuild: 3
-  TargetInvitedToGuild: 5
-  TargetLevelTooHigh: 22
-  TargetLevelTooLow: 21
-  TargetNotInGuild: 10
-  TargetTooHigh: 13
-  TargetTooLow: 14
-  TeamNotFound: 27
-  TeamsLocked: 30
-  Throttled: 52
-  TooFewRanks: 16
-  TooManyCreate: 33
-  TooManyMembers: 23
-  TooManyRanks: 15
-  TooMuchMoney: 31
-  TrialAccount: 36
-  UndeletableDueToLevel: 38
-  UnknownError: 1
-  VeteranAccount: 37
-  WithdrawLimit: 25
-  WrongBankTab: 32
-  WrongFaction: 12
+  values:
+    AlreadyInGuild: 2
+    BadItem: 29
+    BankNotFound: 43
+    BankTabFull: 28
+    BankTabLocked: 35
+    Busy: 20
+    CantInviteSelf: 41
+    DeleteNoAppropriateLeader: 47
+    GuildBankNotAvailable: 45
+    GuildRepTooLow: 40
+    HasRestriction: 42
+    HousingEvictError: 51
+    Ignored: 19
+    InCooldown: 49
+    InvalidBankTab: 24
+    InvitedToGuild: 4
+    LockedForMove: 39
+    NameAlreadyExists: 7
+    NameInvalid: 6
+    NewLeaderWrongFaction: 44
+    NewLeaderWrongRealm: 46
+    NoPermisson: 8
+    NotEnoughMoney: 26
+    NotInGuild: 9
+    PlayerNotFound: 11
+    RankInUse: 18
+    RankRequiresAuthenticator: 34
+    RanksLocked: 17
+    RealmMismatch: 48
+    ReservationExpired: 50
+    Success: 0
+    TargetAlreadyInGuild: 3
+    TargetInvitedToGuild: 5
+    TargetLevelTooHigh: 22
+    TargetLevelTooLow: 21
+    TargetNotInGuild: 10
+    TargetTooHigh: 13
+    TargetTooLow: 14
+    TeamNotFound: 27
+    TeamsLocked: 30
+    Throttled: 52
+    TooFewRanks: 16
+    TooManyCreate: 33
+    TooManyMembers: 23
+    TooManyRanks: 15
+    TooMuchMoney: 31
+    TrialAccount: 36
+    UndeletableDueToLevel: 38
+    UnknownError: 1
+    VeteranAccount: 37
+    WithdrawLimit: 25
+    WrongBankTab: 32
+    WrongFaction: 12
 HolidayCalendarFlags:
-  Alliance: 1
-  Horde: 2
+  values:
+    Alliance: 1
+    Horde: 2
 HolidayFlags:
-  BeginEventOnlyOnStageChange: 64
-  DontDisplayBanner: 8
-  DontDisplayEnd: 4
-  DontShowInCalendar: 2
-  DurationUseMinutes: 32
-  IsRegionwide: 1
-  NotAvailableClientSide: 16
+  values:
+    BeginEventOnlyOnStageChange: 64
+    DontDisplayBanner: 8
+    DontDisplayEnd: 4
+    DontShowInCalendar: 2
+    DurationUseMinutes: 32
+    IsRegionwide: 1
+    NotAvailableClientSide: 16
 HouseEditingContext:
-  Decor: 1
-  Fixture: 3
-  None: 0
-  Room: 2
+  values:
+    Decor: 1
+    Fixture: 3
+    None: 0
+    Room: 2
 HouseEditorMode:
-  BasicDecor: 1
-  Cleanup: 5
-  Customize: 4
-  ExpertDecor: 2
-  ExteriorCustomization: 6
-  Layout: 3
-  None: 0
+  values:
+    BasicDecor: 1
+    Cleanup: 5
+    Customize: 4
+    ExpertDecor: 2
+    ExteriorCustomization: 6
+    Layout: 3
+    None: 0
 HouseEditorPlayerType:
-  None: 0
-  Owner: 1
-  Visitor: 2
+  values:
+    None: 0
+    Owner: 1
+    Visitor: 2
 HouseExteriorWMODataFlags:
-  AllowedInAllianceNeighborhoods: 4
-  AllowedInHordeNeighborhoods: 2
-  HiddenUnlessOwned: 8
-  None: 0
-  UnlockedByDefault: 1
+  values:
+    AllowedInAllianceNeighborhoods: 4
+    AllowedInHordeNeighborhoods: 2
+    HiddenUnlessOwned: 8
+    None: 0
+    UnlockedByDefault: 1
 HouseFinderSuggestionReason:
-  BNetFriends: 8
-  CharterInvite: 2
-  Guild: 4
-  HomeOwner: 64
-  None: 0
-  Owner: 1
-  PartySync: 16
-  Random: 32
-  Relinquished: 128
+  values:
+    BNetFriends: 8
+    CharterInvite: 2
+    Guild: 4
+    HomeOwner: 64
+    None: 0
+    Owner: 1
+    PartySync: 16
+    Random: 32
+    Relinquished: 128
 HouseLevelRewardType:
-  Object: 1
-  Value: 0
+  values:
+    Object: 1
+    Value: 0
 HouseLevelRewardValueType:
-  ExteriorDecor: 0
-  Fixtures: 3
-  InteriorDecor: 1
-  Rooms: 2
+  values:
+    ExteriorDecor: 0
+    Fixtures: 3
+    InteriorDecor: 1
+    Rooms: 2
 HouseOwnerError:
-  Faction: 1
-  GenericPermission: 3
-  Guild: 2
-  None: 0
+  values:
+    Faction: 1
+    GenericPermission: 3
+    Guild: 2
+    None: 0
 HouseSettingFlags:
-  BlueprintExportAnyone: 1024
-  BlueprintExportFriends: 8192
-  BlueprintExportGuild: 4096
-  BlueprintExportNeighbors: 2048
-  BlueprintExportParty: 16384
-  HouseAccessAnyone: 1
-  HouseAccessFriends: 8
-  HouseAccessGuild: 4
-  HouseAccessNeighbors: 2
-  HouseAccessParty: 16
-  None: 0
-  PlotAccessAnyone: 32
-  PlotAccessFriends: 256
-  PlotAccessGuild: 128
-  PlotAccessNeighbors: 64
-  PlotAccessParty: 512
+  values:
+    BlueprintExportAnyone: 1024
+    BlueprintExportFriends: 8192
+    BlueprintExportGuild: 4096
+    BlueprintExportNeighbors: 2048
+    BlueprintExportParty: 16384
+    HouseAccessAnyone: 1
+    HouseAccessFriends: 8
+    HouseAccessGuild: 4
+    HouseAccessNeighbors: 2
+    HouseAccessParty: 16
+    None: 0
+    PlotAccessAnyone: 32
+    PlotAccessFriends: 256
+    PlotAccessGuild: 128
+    PlotAccessNeighbors: 64
+    PlotAccessParty: 512
 HouseVisitType:
-  Friend: 1
-  Guild: 2
-  Party: 3
-  Unknown: 0
+  values:
+    Friend: 1
+    Guild: 2
+    Party: 3
+    Unknown: 0
 HousingBasicModeTargetType:
-  Decor: 1
-  House: 2
-  None: 0
+  values:
+    Decor: 1
+    House: 2
+    None: 0
 HousingBlueprintContentType:
-  Decor: 3
-  Dye: 4
-  Fixture: 5
-  HouseType: 1
-  None: 0
-  Other: 6
-  Room: 2
+  values:
+    Decor: 3
+    Dye: 4
+    Fixture: 5
+    HouseType: 1
+    None: 0
+    Other: 6
+    Room: 2
 HousingBlueprintFlag:
-  AutomaticBackup: 1
-  None: 0
+  values:
+    AutomaticBackup: 1
+    None: 0
 HousingBlueprintType:
-  Exterior: 4
-  House: 1
-  Interior: 3
-  None: 0
-  Room: 2
+  values:
+    Exterior: 4
+    House: 1
+    Interior: 3
+    None: 0
+    Room: 2
 HousingBlueprintUnmetRequirementFlags:
-  HouseSizeLocked: 128
-  HouseTypeLocked: 64
-  InsufficientBudget: 1
-  MismatchedExteriorFaction: 32
-  MissingDecor: 8
-  MissingDye: 16
-  MissingFixture: 4
-  MissingRoom: 2
+  values:
+    HouseSizeLocked: 128
+    HouseTypeLocked: 64
+    InsufficientBudget: 1
+    MismatchedExteriorFaction: 32
+    MissingDecor: 8
+    MissingDye: 16
+    MissingFixture: 4
+    MissingRoom: 2
 HousingBudgetType:
-  DecorPlacement: 1
-  PetDecor: 2
-  RoomPlacement: 0
+  values:
+    DecorPlacement: 1
+    PetDecor: 2
+    RoomPlacement: 0
 HousingCatalogEntryModelScenePresets:
-  DecorCeiling: 1338
-  DecorDefault: 1317
-  DecorFlat: 1318
-  DecorHorizontalSurface: 1452
-  DecorHuge: 1337
-  DecorLarge: 1336
-  DecorMedium: 1335
-  DecorSmall: 1334
-  DecorTiny: 1333
-  DecorWall: 1339
+  values:
+    DecorCeiling: 1338
+    DecorDefault: 1317
+    DecorFlat: 1318
+    DecorHorizontalSurface: 1452
+    DecorHuge: 1337
+    DecorLarge: 1336
+    DecorMedium: 1335
+    DecorSmall: 1334
+    DecorTiny: 1333
+    DecorWall: 1339
 HousingCatalogEntrySize:
-  Huge: 69
-  Large: 68
-  Medium: 67
-  None: 0
-  Small: 66
-  Tiny: 65
+  values:
+    Huge: 69
+    Large: 68
+    Medium: 67
+    None: 0
+    Small: 66
+    Tiny: 65
 HousingCatalogEntryType:
-  Decor: 1
-  Invalid: 0
-  Room: 2
+  values:
+    Decor: 1
+    Invalid: 0
+    Room: 2
 HousingCatalogSortType:
-  Alphabetical: 1
-  DateAdded: 0
+  values:
+    Alphabetical: 1
+    DateAdded: 0
 HousingCleanupModeTargetType:
-  Decor: 1
-  HouseExterior: 2
-  None: 0
+  values:
+    Decor: 1
+    HouseExterior: 2
+    None: 0
 HousingCustomizeModeTargetType:
-  Decor: 1
-  ExteriorHouse: 3
-  None: 0
-  RoomComponent: 2
+  values:
+    Decor: 1
+    ExteriorHouse: 3
+    None: 0
+    RoomComponent: 2
 HousingDecorActionFlags:
-  Add: 1
-  ClickTarget: 16
-  DragMove: 4
-  HoverTarget: 32
-  IncludeTargetChildren: 512
-  MaintainLastTarget: 256
-  None: 0
-  PrecisionMove: 8
-  PreviewDecor: 2048
-  Remove: 2
-  TargetHouseExterior: 128
-  TargetRoomComponents: 64
-  UsePlacedDecorList: 1024
+  values:
+    Add: 1
+    ClickTarget: 16
+    DragMove: 4
+    HoverTarget: 32
+    IncludeTargetChildren: 512
+    MaintainLastTarget: 256
+    None: 0
+    PrecisionMove: 8
+    PreviewDecor: 2048
+    Remove: 2
+    TargetHouseExterior: 128
+    TargetRoomComponents: 64
+    UsePlacedDecorList: 1024
 HousingDecorModelType:
-  M2: 1
-  M3: 3
-  None: 0
-  WMO: 2
+  values:
+    M2: 1
+    M3: 3
+    None: 0
+    WMO: 2
 HousingDecorPlacementRestriction:
-  ChildOutsideBounds: 8
-  InvalidCollision: 32
-  InvalidLightOverlap: 64
-  InvalidTarget: 16
-  OutsidePlotBounds: 4
-  OutsideRoomBounds: 2
-  TooFarAway: 1
+  values:
+    ChildOutsideBounds: 8
+    InvalidCollision: 32
+    InvalidLightOverlap: 64
+    InvalidTarget: 16
+    OutsidePlotBounds: 4
+    OutsideRoomBounds: 2
+    TooFarAway: 1
 HousingDecorTheme:
-  BloodElf: 5
-  Folk: 1
-  Generic: 3
-  NightElf: 4
-  None: 0
-  Rugged: 2
+  values:
+    BloodElf: 5
+    Folk: 1
+    Generic: 3
+    NightElf: 4
+    None: 0
+    Rugged: 2
 HousingDecorType:
-  Ceiling: 3
-  Floor: 1
-  Flooring: 4
-  None: 0
-  Wall: 2
+  values:
+    Ceiling: 3
+    Floor: 1
+    Flooring: 4
+    None: 0
+    Wall: 2
 HousingExpertModeTargetType:
-  Decor: 1
-  House: 2
-  None: 0
+  values:
+    Decor: 1
+    House: 2
+    None: 0
 HousingExpertSubmodeRestriction:
-  NoHouseExteriorScale: 2
-  None: 0
-  NotInExpertMode: 1
-  NoWMOScale: 3
+  values:
+    NoHouseExteriorScale: 2
+    None: 0
+    NotInExpertMode: 1
+    NoWMOScale: 3
 HousingFavorUpdateSource:
-  DecorCollection: 1
-  DeferredRewards: 2
-  InitiativeChest: 6
-  InitiativeTask: 5
-  NewHouseDecorFavor: 4
-  Quest: 7
-  RetroactiveDecor: 3
-  Unknown: 0
+  values:
+    DecorCollection: 1
+    DeferredRewards: 2
+    InitiativeChest: 6
+    InitiativeTask: 5
+    NewHouseDecorFavor: 4
+    Quest: 7
+    RetroactiveDecor: 3
+    Unknown: 0
 HousingFavorUpdateType:
-  Add: 0
-  InitiativeAdd: 1
-  Set: 2
+  values:
+    Add: 0
+    InitiativeAdd: 1
+    Set: 2
 HousingFixtureDecorAction:
-  Detach: 1
-  Store: 0
+  values:
+    Detach: 1
+    Store: 0
 HousingFixtureFlags:
-  IsDefaultFixture: 1
-  None: 0
-  UnlockedByDefault: 2
+  values:
+    IsDefaultFixture: 1
+    None: 0
+    UnlockedByDefault: 2
 HousingFixtureSize:
-  Any: 1
-  Large: 4
-  Medium: 3
-  None: 0
-  Small: 2
+  values:
+    Any: 1
+    Large: 4
+    Medium: 3
+    None: 0
+    Small: 2
 HousingFixtureType:
-  Base: 9
-  Chimney: 16
-  Door: 11
-  None: 0
-  Roof: 10
-  RoofDetail: 13
-  RoofWindow: 14
-  Tower: 15
-  Window: 12
+  values:
+    Base: 9
+    Chimney: 16
+    Door: 11
+    None: 0
+    Roof: 10
+    RoofDetail: 13
+    RoofWindow: 14
+    Tower: 15
+    Window: 12
 HousingHouseScope:
-  Exterior: 2
-  Interior: 1
-  None: 0
+  values:
+    Exterior: 2
+    Interior: 1
+    None: 0
 HousingIncrementType:
-  Back: 8
-  Down: 32
-  Forward: 4
-  Left: 1
-  Right: 2
-  RotateLeft: 64
-  RotateRight: 128
-  ScaleDown: 512
-  ScaleUp: 256
-  Up: 16
+  values:
+    Back: 8
+    Down: 32
+    Forward: 4
+    Left: 1
+    Right: 2
+    RotateLeft: 64
+    RotateRight: 128
+    ScaleDown: 512
+    ScaleUp: 256
+    Up: 16
 HousingItemToastType:
-  Customization: 2
-  Decor: 3
-  Fixture: 1
-  HouseType: 4
-  Room: 0
+  values:
+    Customization: 2
+    Decor: 3
+    Fixture: 1
+    HouseType: 4
+    Room: 0
 HousingLayoutCameraDirection:
-  Down: 2
-  Left: 4
-  None: 0
-  Right: 8
-  Up: 1
+  values:
+    Down: 2
+    Left: 4
+    None: 0
+    Right: 8
+    Up: 1
 HousingLayoutPinType:
-  Door: 0
-  Room: 1
+  values:
+    Door: 0
+    Room: 1
 HousingLayoutRestriction:
-  IsBaseRoom: 4
-  LastRoom: 7
-  None: 0
-  NotHouseOwner: 3
-  NotInsideHouse: 2
-  RoomNotFound: 1
-  RoomNotLeaf: 5
-  SingleDoor: 9
-  StairwellConnection: 6
-  UnreachableRoom: 8
+  values:
+    IsBaseRoom: 4
+    LastRoom: 7
+    None: 0
+    NotHouseOwner: 3
+    NotInsideHouse: 2
+    RoomNotFound: 1
+    RoomNotLeaf: 5
+    SingleDoor: 9
+    StairwellConnection: 6
+    UnreachableRoom: 8
 HousingLayoutStairDirection:
-  Down: 1
-  Up: 0
+  values:
+    Down: 1
+    Up: 0
 HousingPetBehaviorType:
-  Stationary: 0
-  Wander: 1
+  values:
+    Stationary: 0
+    Wander: 1
 HousingPlotOwnerType:
-  Friend: 2
-  None: 0
-  Self: 3
-  Stranger: 1
+  values:
+    Friend: 2
+    None: 0
+    Self: 3
+    Stranger: 1
 HousingPrecisionSubmode:
-  Rotate: 1
-  Scale: 2
-  Translate: 0
+  values:
+    Rotate: 1
+    Scale: 2
+    Translate: 0
 HousingResult:
-  AccountBanned: 1
-  ActionLockedByCombat: 2
-  BlueprintCodeInvalid: 3
-  BlueprintDyeFailed: 4
-  BlueprintGenericExportError: 5
-  BlueprintGenericImportError: 6
-  BlueprintLocationInvalid: 7
-  BlueprintNameInvalid: 8
-  BlueprintNotFound: 9
-  BlueprintRequirementsUnmet: 10
-  BlueprintRoomPlacementRequired: 11
-  BlueprintStorageLimit: 14
-  BlueprintTypeInvalid: 12
-  BlueprintTypeLocationInvalid: 13
-  BlueprintVersionInvalid: 15
-  BoundsFailureChildren: 16
-  BoundsFailurePlot: 17
-  BoundsFailureRoom: 18
-  BoundToStartingArea: 19
-  CannotAfford: 20
-  CharterComplete: 21
-  CollisionInvalid: 22
-  DbError: 23
-  DecorCannotBeRedeemed: 24
-  DecorItemNotDestroyable: 25
-  DecorNotFound: 26
-  DecorNotFoundInStorage: 27
-  DuplicateCharterSignature: 28
-  FilterRejected: 29
-  FixtureCantDeleteDoor: 30
-  FixtureHookEmpty: 31
-  FixtureHookOccupied: 32
-  FixtureHouseTypeMismatch: 33
-  FixtureNotFound: 34
-  FixtureSizeMismatch: 35
-  FixtureTypeMismatch: 36
-  GenericFailure: 37
-  GuildMoreAccountsNeeded: 38
-  GuildMoreActivePlayersNeeded: 39
-  GuildNotLoaded: 40
-  HookNotChildOfFixture: 49
-  HouseEditLockFailed: 41
-  HouseExteriorAlreadyThatSize: 42
-  HouseExteriorAlreadyThatType: 43
-  HouseExteriorRootNotFound: 44
-  HouseExteriorSizeNotAvailable: 48
-  HouseExteriorTypeNeighborhoodMismatch: 45
-  HouseExteriorTypeNotFound: 46
-  HouseExteriorTypeSizeMismatch: 47
-  HouseNotFound: 50
-  IncorrectFaction: 51
-  InsufficientRoomBudget: 64
-  InvalidDecorItem: 52
-  InvalidDistance: 53
-  InvalidExteriorDocument: 54
-  InvalidGuild: 55
-  InvalidHouse: 56
-  InvalidInstance: 57
-  InvalidInteraction: 58
-  InvalidInteriorDocument: 59
-  InvalidLightOverlap: 60
-  InvalidMap: 61
-  InvalidNeighborhoodName: 62
-  InvalidRoomLayout: 63
-  LockedByOtherPlayer: 65
-  LockOperationFailed: 66
-  MaxPetDecorReached: 68
-  MaxPlacedDecorReached: 67
-  MaxPreviewDecorReached: 69
-  MaxStorageDecorReached: 70
-  MissingCoreFixture: 71
-  MissingDye: 72
-  MissingExpansionAccess: 73
-  MissingFactionMap: 74
-  MissingPrivateNeighborhoodInvite: 75
-  MoreHouseSlotsNeeded: 76
-  MoreSignaturesNeeded: 77
-  NeighborhoodNotFound: 78
-  NoNeighborhoodOwnershipRequests: 79
-  NotInDecorEditMode: 80
-  NotInFixtureEditMode: 81
-  NotInLayoutEditMode: 82
-  NotInsideHouse: 83
-  NotOnOwnedPlot: 84
-  OperationAborted: 85
-  OwnerNotInGuild: 86
-  PermissionDenied: 87
-  PlacementTargetInvalid: 88
-  PlayerNotFound: 89
-  PlayerNotInInstance: 90
-  PlotNotFound: 91
-  PlotNotVacant: 92
-  PlotReservationCooldown: 93
-  PlotReserved: 94
-  RoomNotFound: 95
-  RoomPlacementOutOfBounds: 96
-  RoomUpdateFailed: 97
-  RpcFailure: 98
-  ServiceNotAvailable: 99
-  StaticDataNotFound: 100
-  Success: 0
-  TimeoutLimit: 101
-  TimerunningNotAllowed: 102
-  TokenRequired: 103
-  TooManyRequests: 104
-  TransactionFailure: 105
-  UncollectedExteriorFixture: 106
-  UncollectedHouseType: 107
-  UncollectedRoom: 108
-  UncollectedRoomMaterial: 109
-  UncollectedRoomTheme: 110
-  UnlockOperationFailed: 111
+  values:
+    AccountBanned: 1
+    ActionLockedByCombat: 2
+    BlueprintCodeInvalid: 3
+    BlueprintDyeFailed: 4
+    BlueprintGenericExportError: 5
+    BlueprintGenericImportError: 6
+    BlueprintLocationInvalid: 7
+    BlueprintNameInvalid: 8
+    BlueprintNotFound: 9
+    BlueprintRequirementsUnmet: 10
+    BlueprintRoomPlacementRequired: 11
+    BlueprintStorageLimit: 14
+    BlueprintTypeInvalid: 12
+    BlueprintTypeLocationInvalid: 13
+    BlueprintVersionInvalid: 15
+    BoundsFailureChildren: 16
+    BoundsFailurePlot: 17
+    BoundsFailureRoom: 18
+    BoundToStartingArea: 19
+    CannotAfford: 20
+    CharterComplete: 21
+    CollisionInvalid: 22
+    DbError: 23
+    DecorCannotBeRedeemed: 24
+    DecorItemNotDestroyable: 25
+    DecorNotFound: 26
+    DecorNotFoundInStorage: 27
+    DuplicateCharterSignature: 28
+    FilterRejected: 29
+    FixtureCantDeleteDoor: 30
+    FixtureHookEmpty: 31
+    FixtureHookOccupied: 32
+    FixtureHouseTypeMismatch: 33
+    FixtureNotFound: 34
+    FixtureSizeMismatch: 35
+    FixtureTypeMismatch: 36
+    GenericFailure: 37
+    GuildMoreAccountsNeeded: 38
+    GuildMoreActivePlayersNeeded: 39
+    GuildNotLoaded: 40
+    HookNotChildOfFixture: 49
+    HouseEditLockFailed: 41
+    HouseExteriorAlreadyThatSize: 42
+    HouseExteriorAlreadyThatType: 43
+    HouseExteriorRootNotFound: 44
+    HouseExteriorSizeNotAvailable: 48
+    HouseExteriorTypeNeighborhoodMismatch: 45
+    HouseExteriorTypeNotFound: 46
+    HouseExteriorTypeSizeMismatch: 47
+    HouseNotFound: 50
+    IncorrectFaction: 51
+    InsufficientRoomBudget: 64
+    InvalidDecorItem: 52
+    InvalidDistance: 53
+    InvalidExteriorDocument: 54
+    InvalidGuild: 55
+    InvalidHouse: 56
+    InvalidInstance: 57
+    InvalidInteraction: 58
+    InvalidInteriorDocument: 59
+    InvalidLightOverlap: 60
+    InvalidMap: 61
+    InvalidNeighborhoodName: 62
+    InvalidRoomLayout: 63
+    LockedByOtherPlayer: 65
+    LockOperationFailed: 66
+    MaxPetDecorReached: 68
+    MaxPlacedDecorReached: 67
+    MaxPreviewDecorReached: 69
+    MaxStorageDecorReached: 70
+    MissingCoreFixture: 71
+    MissingDye: 72
+    MissingExpansionAccess: 73
+    MissingFactionMap: 74
+    MissingPrivateNeighborhoodInvite: 75
+    MoreHouseSlotsNeeded: 76
+    MoreSignaturesNeeded: 77
+    NeighborhoodNotFound: 78
+    NoNeighborhoodOwnershipRequests: 79
+    NotInDecorEditMode: 80
+    NotInFixtureEditMode: 81
+    NotInLayoutEditMode: 82
+    NotInsideHouse: 83
+    NotOnOwnedPlot: 84
+    OperationAborted: 85
+    OwnerNotInGuild: 86
+    PermissionDenied: 87
+    PlacementTargetInvalid: 88
+    PlayerNotFound: 89
+    PlayerNotInInstance: 90
+    PlotNotFound: 91
+    PlotNotVacant: 92
+    PlotReservationCooldown: 93
+    PlotReserved: 94
+    RoomNotFound: 95
+    RoomPlacementOutOfBounds: 96
+    RoomUpdateFailed: 97
+    RpcFailure: 98
+    ServiceNotAvailable: 99
+    StaticDataNotFound: 100
+    Success: 0
+    TimeoutLimit: 101
+    TimerunningNotAllowed: 102
+    TokenRequired: 103
+    TooManyRequests: 104
+    TransactionFailure: 105
+    UncollectedExteriorFixture: 106
+    UncollectedHouseType: 107
+    UncollectedRoom: 108
+    UncollectedRoomMaterial: 109
+    UncollectedRoomTheme: 110
+    UnlockOperationFailed: 111
 HousingRoomComponentCeilingType:
-  Flat: 0
-  Vaulted: 1
+  values:
+    Flat: 0
+    Vaulted: 1
 HousingRoomComponentDoorType:
-  Doorway: 1
-  None: 0
-  Threshold: 2
+  values:
+    Doorway: 1
+    None: 0
+    Threshold: 2
 HousingRoomComponentFlags:
-  HiddenInLayoutMode: 1
-  None: 0
+  values:
+    HiddenInLayoutMode: 1
+    None: 0
 HousingRoomComponentFloorType:
-  Floor: 0
+  values:
+    Floor: 0
 HousingRoomComponentOptionFlags:
-  IsDefault: 1
-  None: 0
+  values:
+    IsDefault: 1
+    None: 0
 HousingRoomComponentOptionType:
-  Cosmetic: 0
-  Doorway: 2
-  DoorwayWall: 1
+  values:
+    Cosmetic: 0
+    Doorway: 2
+    DoorwayWall: 1
 HousingRoomComponentStairType:
-  MiddleToEnd: 4
-  MiddleToMiddle: 3
-  None: 0
-  StartToEnd: 1
-  StartToMiddle: 2
+  values:
+    MiddleToEnd: 4
+    MiddleToMiddle: 3
+    None: 0
+    StartToEnd: 1
+    StartToMiddle: 2
 HousingRoomComponentTextureFlags:
-  None: 0
-  UnlockedByDefault: 1
+  values:
+    None: 0
+    UnlockedByDefault: 1
 HousingRoomComponentType:
-  Ceiling: 3
-  Doorway: 7
-  DoorwayWall: 6
-  Floor: 2
-  None: 0
-  Pillar: 5
-  Stairs: 4
-  Wall: 1
+  values:
+    Ceiling: 3
+    Doorway: 7
+    DoorwayWall: 6
+    Floor: 2
+    None: 0
+    Pillar: 5
+    Stairs: 4
+    Wall: 1
 HousingRoomFlags:
-  BaseRoom: 1
-  HasCustomGeometry: 8
-  HasStairs: 2
-  None: 0
-  UnlockedByDefault: 4
+  values:
+    BaseRoom: 1
+    HasCustomGeometry: 8
+    HasStairs: 2
+    None: 0
+    UnlockedByDefault: 4
 HousingShowcaseType:
-  None: 0
-  PrivateVisitCode: 2
-  PublicSubmission: 1
+  values:
+    None: 0
+    PrivateVisitCode: 2
+    PublicSubmission: 1
 HousingTeleportReason:
-  Booted: 3
-  Cheat: 1
-  ExitingHouse: 9
-  Friend: 6
-  GuildMember: 7
-  Homestone: 4
-  None: 0
-  PartyMember: 8
-  Portal: 10
-  Tutorial: 11
-  UnspecifiedSpellcast: 2
-  Visit: 5
+  values:
+    Booted: 3
+    Cheat: 1
+    ExitingHouse: 9
+    Friend: 6
+    GuildMember: 7
+    Homestone: 4
+    None: 0
+    PartyMember: 8
+    Portal: 10
+    Tutorial: 11
+    UnspecifiedSpellcast: 2
+    Visit: 5
 HousingThemeFlags:
-  None: 0
-  ShowInStyleSelector: 2
-  UnlockedByDefault: 1
+  values:
+    None: 0
+    ShowInStyleSelector: 2
+    UnlockedByDefault: 1
 HousingThrottleType:
-  Decoration: 1
-  General: 0
+  values:
+    Decoration: 1
+    General: 0
 IconAndTextShiftTextType:
-  None: 0
-  ShiftText: 1
+  values:
+    None: 0
+    ShiftText: 1
 IconAndTextWidgetState:
-  Hidden: 0
-  Shown: 1
-  ShownWithDynamicIconFlashing: 2
-  ShownWithDynamicIconNotFlashing: 3
+  values:
+    Hidden: 0
+    Shown: 1
+    ShownWithDynamicIconFlashing: 2
+    ShownWithDynamicIconNotFlashing: 3
 IconState:
-  Hidden: 0
-  ShowState1: 1
-  ShowState2: 2
+  values:
+    Hidden: 0
+    ShowState1: 1
+    ShowState2: 2
 ImageSharingResult:
-  AccountDataRequestFailure: 6
-  EncryptionFailure: 11
-  EncryptionSecretNotSet: 14
-  FailedToCreateHeader: 10
-  Failure: 0
-  GetAccountDataRequestFailure: 7
-  InvalidOAuthExpiration: 12
-  InvalidRefreshExpiration: 13
-  MissingFieldApiError: 5
-  NotConfigured: 2
-  PlatformApiError: 4
-  RefreshTokenExpired: 9
-  RetrievedExisting: 3
-  SetAccountDataRequestFailure: 8
-  Success: 1
+  values:
+    AccountDataRequestFailure: 6
+    EncryptionFailure: 11
+    EncryptionSecretNotSet: 14
+    FailedToCreateHeader: 10
+    Failure: 0
+    GetAccountDataRequestFailure: 7
+    InvalidOAuthExpiration: 12
+    InvalidRefreshExpiration: 13
+    MissingFieldApiError: 5
+    NotConfigured: 2
+    PlatformApiError: 4
+    RefreshTokenExpired: 9
+    RetrievedExisting: 3
+    SetAccountDataRequestFailure: 8
+    Success: 1
 InitiativeMilestoneFlags:
-  FinalMilestone: 1
+  values:
+    FinalMilestone: 1
 InitiativeRewardFlags:
-  PermanentWorldState: 1
+  values:
+    PermanentWorldState: 1
 InputContext:
-  GamePad: 3
-  Keyboard: 1
-  Mouse: 2
-  None: 0
+  values:
+    GamePad: 3
+    Keyboard: 1
+    Mouse: 2
+    None: 0
 InvalidPlotScreenshotReason:
-  Facing: 2
-  NoActivePlayer: 4
-  None: 0
-  NoNeighborhoodFound: 3
-  OutOfBounds: 1
+  values:
+    Facing: 2
+    NoActivePlayer: 4
+    None: 0
+    NoNeighborhoodFound: 3
+    OutOfBounds: 1
 InventoryType:
-  Index2HweaponType: 17
-  IndexAmmoType: 24
-  IndexBagType: 18
-  IndexBodyType: 4
-  IndexChestType: 5
-  IndexCloakType: 16
-  IndexEquipablespellDefensiveType: 33
-  IndexEquipablespellOffensiveType: 31
-  IndexEquipablespellUtilityType: 32
-  IndexEquipablespellWeaponType: 34
-  IndexFeetType: 8
-  IndexFingerType: 11
-  IndexHandType: 10
-  IndexHeadType: 1
-  IndexHoldableType: 23
-  IndexLegsType: 7
-  IndexNeckType: 2
-  IndexNonEquipType: 0
-  IndexProfessionGearType: 30
-  IndexProfessionToolType: 29
-  IndexQuiverType: 27
-  IndexRangedrightType: 26
-  IndexRangedType: 15
-  IndexRelicType: 28
-  IndexRobeType: 20
-  IndexShieldType: 14
-  IndexShoulderType: 3
-  IndexTabardType: 19
-  IndexThrownType: 25
-  IndexTrinketType: 12
-  IndexWaistType: 6
-  IndexWeaponmainhandType: 21
-  IndexWeaponoffhandType: 22
-  IndexWeaponType: 13
-  IndexWristType: 9
+  values:
+    Index2HweaponType: 17
+    IndexAmmoType: 24
+    IndexBagType: 18
+    IndexBodyType: 4
+    IndexChestType: 5
+    IndexCloakType: 16
+    IndexEquipablespellDefensiveType: 33
+    IndexEquipablespellOffensiveType: 31
+    IndexEquipablespellUtilityType: 32
+    IndexEquipablespellWeaponType: 34
+    IndexFeetType: 8
+    IndexFingerType: 11
+    IndexHandType: 10
+    IndexHeadType: 1
+    IndexHoldableType: 23
+    IndexLegsType: 7
+    IndexNeckType: 2
+    IndexNonEquipType: 0
+    IndexProfessionGearType: 30
+    IndexProfessionToolType: 29
+    IndexQuiverType: 27
+    IndexRangedrightType: 26
+    IndexRangedType: 15
+    IndexRelicType: 28
+    IndexRobeType: 20
+    IndexShieldType: 14
+    IndexShoulderType: 3
+    IndexTabardType: 19
+    IndexThrownType: 25
+    IndexTrinketType: 12
+    IndexWaistType: 6
+    IndexWeaponmainhandType: 21
+    IndexWeaponoffhandType: 22
+    IndexWeaponType: 13
+    IndexWristType: 9
 ItemArmorSubclass:
-  Cloth: 1
-  Cosmetic: 5
-  Generic: 0
-  Idol: 8
-  Leather: 2
-  Libram: 7
-  Mail: 3
-  Plate: 4
-  Relic: 11
-  Shield: 6
-  Sigil: 10
-  Totem: 9
+  values:
+    Cloth: 1
+    Cosmetic: 5
+    Generic: 0
+    Idol: 8
+    Leather: 2
+    Libram: 7
+    Mail: 3
+    Plate: 4
+    Relic: 11
+    Shield: 6
+    Sigil: 10
+    Totem: 9
 ItemBind:
-  None: 0
-  OnAcquire: 1
-  OnEquip: 2
-  OnUse: 3
-  Quest: 4
-  ToBnetAccount: 8
-  ToBnetAccountUntilEquipped: 9
-  ToWoWAccount: 7
-  Unused1: 5
-  Unused2: 6
+  values:
+    None: 0
+    OnAcquire: 1
+    OnEquip: 2
+    OnUse: 3
+    Quest: 4
+    ToBnetAccount: 8
+    ToBnetAccountUntilEquipped: 9
+    ToWoWAccount: 7
+    Unused1: 5
+    Unused2: 6
 ItemClass:
-  Armor: 4
-  Battlepet: 17
-  Consumable: 0
-  Container: 1
-  CurrencyTokenObsolete: 10
-  Gem: 3
-  Glyph: 16
-  Housing: 20
-  ItemEnhancement: 8
-  Key: 13
-  Miscellaneous: 15
-  PermanentObsolete: 14
-  Profession: 19
-  Projectile: 6
-  Questitem: 12
-  Quiver: 11
-  Reagent: 5
-  Recipe: 9
-  Tradegoods: 7
-  Weapon: 2
-  WoWToken: 18
+  values:
+    Armor: 4
+    Battlepet: 17
+    Consumable: 0
+    Container: 1
+    CurrencyTokenObsolete: 10
+    Gem: 3
+    Glyph: 16
+    Housing: 20
+    ItemEnhancement: 8
+    Key: 13
+    Miscellaneous: 15
+    PermanentObsolete: 14
+    Profession: 19
+    Projectile: 6
+    Questitem: 12
+    Quiver: 11
+    Reagent: 5
+    Recipe: 9
+    Tradegoods: 7
+    Weapon: 2
+    WoWToken: 18
 Itemclassfilterflags:
-  Armor: 16
-  Battlepet: 131072
-  Consumable: 1
-  Container: 2
-  CurrencyTokenObsolete: 1024
-  Gem: 8
-  Glyph: 65536
-  ItemEnhancement: 256
-  Key: 8192
-  Miscellaneous: 32768
-  PermanentObsolete: 16384
-  Projectile: 64
-  Questitemclassfilterflags: 4096
-  Quiver: 2048
-  Reagent: 32
-  Recipe: 512
-  Tradegoods: 128
-  Weapon: 4
+  values:
+    Armor: 16
+    Battlepet: 131072
+    Consumable: 1
+    Container: 2
+    CurrencyTokenObsolete: 1024
+    Gem: 8
+    Glyph: 65536
+    ItemEnhancement: 256
+    Key: 8192
+    Miscellaneous: 32768
+    PermanentObsolete: 16384
+    Projectile: 64
+    Questitemclassfilterflags: 4096
+    Quiver: 2048
+    Reagent: 32
+    Recipe: 512
+    Tradegoods: 128
+    Weapon: 4
 ItemCollectionType:
-  ExteriorFixture: 9
-  Heirloom: 2
-  HouseType: 13
-  None: 0
-  Room: 8
-  RoomMaterial: 11
-  RoomTheme: 10
-  RuneforgeLegendaryAbility: 5
-  Toy: 1
-  Transmog: 3
-  TransmogIllusion: 6
-  TransmogOutfit: 12
-  TransmogSetFavorite: 4
-  WarbandScene: 7
+  values:
+    ExteriorFixture: 9
+    Heirloom: 2
+    HouseType: 13
+    None: 0
+    Room: 8
+    RoomMaterial: 11
+    RoomTheme: 10
+    RuneforgeLegendaryAbility: 5
+    Toy: 1
+    Transmog: 3
+    TransmogIllusion: 6
+    TransmogOutfit: 12
+    TransmogSetFavorite: 4
+    WarbandScene: 7
 ItemCommodityStatus:
-  Commodity: 2
-  Item: 1
-  Unknown: 0
+  values:
+    Commodity: 2
+    Item: 1
+    Unknown: 0
 ItemConsumableSubclass:
-  Bandage: 7
-  CombatCurio: 11
-  Elixir: 2
-  Flasksphials: 3
-  Fooddrink: 5
-  Generic: 0
-  Itemenhancement: 6
-  Other: 8
-  Potion: 1
-  Relic: 12
-  Scroll: 4
-  UtilityCurio: 10
-  VantusRune: 9
+  values:
+    Bandage: 7
+    CombatCurio: 11
+    Elixir: 2
+    Flasksphials: 3
+    Fooddrink: 5
+    Generic: 0
+    Itemenhancement: 6
+    Other: 8
+    Potion: 1
+    Relic: 12
+    Scroll: 4
+    UtilityCurio: 10
+    VantusRune: 9
 ItemConversionFlags:
-  UseInputItemStats: 1
+  values:
+    UseInputItemStats: 1
 ItemCreationContext:
-  BlackMarket: 15
-  BonusRoll_1: 187
-  BonusRoll_2: 188
-  BonusRoll_3: 189
-  BonusRoll_4: 190
-  BonusRoll_5: 191
-  ChallengeMode_1: 16
-  ChallengeMode_2: 33
-  ChallengeMode_3: 34
-  ChallengeMode_4: 87
-  ChallengeModeJackpot: 35
-  CharacterBoost_1: 61
-  CharacterBoost_2: 62
-  CharacterBoost_3: 86
-  CorpseRecovery: 80
-  Delves_1: 104
-  Delves_2: 106
-  Delves_3: 107
-  DelvesBonus_1: 129
-  DelvesBonus_10: 138
-  DelvesBonus_2: 130
-  DelvesBonus_3: 131
-  DelvesBonus_4: 132
-  DelvesBonus_5: 133
-  DelvesBonus_6: 134
-  DelvesBonus_7: 135
-  DelvesBonus_8: 136
-  DelvesBonus_9: 137
-  DelvesBounty_1: 117
-  DelvesBounty_2: 118
-  DelvesBounty_3: 119
-  DelvesBounty_4: 120
-  DelvesBounty_5: 121
-  DelvesBounty_6: 122
-  DelvesBounty_7: 123
-  DelvesBounty_8: 124
-  DelvesJackpot: 108
-  DelvesKey_1: 109
-  DelvesKey_2: 110
-  DelvesKey_3: 111
-  DelvesKey_4: 112
-  DelvesKey_5: 113
-  DelvesKey_6: 114
-  DelvesKey_7: 115
-  DelvesKey_8: 116
-  DelvesLevelUp_1: 125
-  DelvesLevelUp_2: 126
-  DelvesLevelUp_3: 127
-  DelvesLevelUp_4: 128
-  DungeonBonus_1: 139
-  DungeonBonus_10: 148
-  DungeonBonus_2: 140
-  DungeonBonus_3: 141
-  DungeonBonus_4: 142
-  DungeonBonus_5: 143
-  DungeonBonus_6: 144
-  DungeonBonus_7: 145
-  DungeonBonus_8: 146
-  DungeonBonus_9: 147
-  DungeonHardMode_1: 159
-  DungeonHardMode_2: 160
-  DungeonHardMode_3: 161
-  DungeonHeroic: 2
-  DungeonHeroicJackpot: 102
-  DungeonLevelUp_1: 17
-  DungeonLevelUp_2: 18
-  DungeonLevelUp_3: 19
-  DungeonLevelUp_4: 20
-  DungeonMythic: 23
-  DungeonMythicJackpot: 103
-  DungeonNormal: 1
-  DungeonNormalJackpot: 101
-  Endeavors: 185
-  ForceNone: 21
-  LegendaryCrafting_1: 63
-  LegendaryCrafting_2: 64
-  LegendaryCrafting_3: 65
-  LegendaryCrafting_4: 66
-  LegendaryCrafting_5: 67
-  LegendaryCrafting_6: 68
-  LegendaryCrafting_7: 69
-  LegendaryCrafting_8: 70
-  LegendaryCrafting_9: 71
-  LegendaryForge: 59
-  MissionReward_1: 31
-  MissionReward_2: 32
-  NewCharacter: 75
-  None: 0
-  PvPBrawl_1: 77
-  PvPBrawl_2: 78
-  PvPHonorReward: 24
-  PvPRanked_1: 8
-  PvPRanked_2: 38
-  PvPRanked_3: 39
-  PvPRanked_4: 40
-  PvPRanked_5: 44
-  PvPRanked_6: 45
-  PvPRanked_7: 46
-  PvPRanked_8: 52
-  PvPRanked_9: 88
-  PvPRankedJackpot: 56
-  PvPUnranked_1: 7
-  PvPUnranked_2: 41
-  PvPUnranked_3: 47
-  PvPUnranked_4: 48
-  PvPUnranked_5: 49
-  PvPUnranked_6: 50
-  PvPUnranked_7: 51
-  QuestBonusLoot: 60
-  QuestReward: 11
-  RaidBonus_1: 149
-  RaidBonus_10: 158
-  RaidBonus_2: 150
-  RaidBonus_3: 151
-  RaidBonus_4: 152
-  RaidBonus_5: 153
-  RaidBonus_6: 154
-  RaidBonus_7: 155
-  RaidBonus_8: 156
-  RaidBonus_9: 157
-  RaidFinder: 4
-  RaidFinderExtended: 83
-  RaidFinderExtended_2: 90
-  RaidFinderExtended_3: 94
-  RaidHeroic: 5
-  RaidHeroicExtended: 84
-  RaidHeroicExtended_2: 91
-  RaidHeroicExtended_3: 95
-  RaidMythic: 6
-  RaidMythicExtended: 85
-  RaidMythicExtended_2: 92
-  RaidMythicExtended_3: 96
-  RaidNormal: 3
-  RaidNormalExtended: 82
-  RaidNormalExtended_2: 89
-  RaidNormalExtended_3: 93
-  Relinquished: 58
-  ScenarioHeroic: 10
-  ScenarioNormal: 9
-  Store: 12
-  TemplateCharacter_1: 97
-  TemplateCharacter_2: 98
-  TemplateCharacter_3: 99
-  TemplateCharacter_4: 100
-  Timerunning: 105
-  TimewalkerLevelUp: 22
-  TimewalkerMaxLevel: 186
-  Torghast: 79
-  TournamentRealm_1: 57
-  TournamentRealm_2: 162
-  TournamentRealm_3: 163
-  TournamentRealm_4: 164
-  TradeSkill: 13
-  Vendor: 14
-  Warbound_1: 165
-  Warbound_10: 174
-  Warbound_11: 175
-  Warbound_12: 176
-  Warbound_13: 177
-  Warbound_14: 178
-  Warbound_15: 179
-  Warbound_16: 180
-  Warbound_17: 181
-  Warbound_18: 182
-  Warbound_19: 183
-  Warbound_2: 166
-  Warbound_20: 184
-  Warbound_3: 167
-  Warbound_4: 168
-  Warbound_5: 169
-  Warbound_6: 170
-  Warbound_7: 171
-  Warbound_8: 172
-  Warbound_9: 173
-  WarMode: 76
-  WeeklyRewardsAdditional: 72
-  WeeklyRewardsConcession: 73
-  WorldBoss: 81
-  WorldQuest_1: 25
-  WorldQuest_10: 43
-  WorldQuest_11: 53
-  WorldQuest_12: 54
-  WorldQuest_13: 55
-  WorldQuest_2: 26
-  WorldQuest_3: 27
-  WorldQuest_4: 28
-  WorldQuest_5: 29
-  WorldQuest_6: 30
-  WorldQuest_7: 36
-  WorldQuest_8: 37
-  WorldQuest_9: 42
-  WorldQuestJackpot: 74
+  values:
+    BlackMarket: 15
+    BonusRoll_1: 187
+    BonusRoll_2: 188
+    BonusRoll_3: 189
+    BonusRoll_4: 190
+    BonusRoll_5: 191
+    ChallengeMode_1: 16
+    ChallengeMode_2: 33
+    ChallengeMode_3: 34
+    ChallengeMode_4: 87
+    ChallengeModeJackpot: 35
+    CharacterBoost_1: 61
+    CharacterBoost_2: 62
+    CharacterBoost_3: 86
+    CorpseRecovery: 80
+    Delves_1: 104
+    Delves_2: 106
+    Delves_3: 107
+    DelvesBonus_1: 129
+    DelvesBonus_10: 138
+    DelvesBonus_2: 130
+    DelvesBonus_3: 131
+    DelvesBonus_4: 132
+    DelvesBonus_5: 133
+    DelvesBonus_6: 134
+    DelvesBonus_7: 135
+    DelvesBonus_8: 136
+    DelvesBonus_9: 137
+    DelvesBounty_1: 117
+    DelvesBounty_2: 118
+    DelvesBounty_3: 119
+    DelvesBounty_4: 120
+    DelvesBounty_5: 121
+    DelvesBounty_6: 122
+    DelvesBounty_7: 123
+    DelvesBounty_8: 124
+    DelvesJackpot: 108
+    DelvesKey_1: 109
+    DelvesKey_2: 110
+    DelvesKey_3: 111
+    DelvesKey_4: 112
+    DelvesKey_5: 113
+    DelvesKey_6: 114
+    DelvesKey_7: 115
+    DelvesKey_8: 116
+    DelvesLevelUp_1: 125
+    DelvesLevelUp_2: 126
+    DelvesLevelUp_3: 127
+    DelvesLevelUp_4: 128
+    DungeonBonus_1: 139
+    DungeonBonus_10: 148
+    DungeonBonus_2: 140
+    DungeonBonus_3: 141
+    DungeonBonus_4: 142
+    DungeonBonus_5: 143
+    DungeonBonus_6: 144
+    DungeonBonus_7: 145
+    DungeonBonus_8: 146
+    DungeonBonus_9: 147
+    DungeonHardMode_1: 159
+    DungeonHardMode_2: 160
+    DungeonHardMode_3: 161
+    DungeonHeroic: 2
+    DungeonHeroicJackpot: 102
+    DungeonLevelUp_1: 17
+    DungeonLevelUp_2: 18
+    DungeonLevelUp_3: 19
+    DungeonLevelUp_4: 20
+    DungeonMythic: 23
+    DungeonMythicJackpot: 103
+    DungeonNormal: 1
+    DungeonNormalJackpot: 101
+    Endeavors: 185
+    ForceNone: 21
+    LegendaryCrafting_1: 63
+    LegendaryCrafting_2: 64
+    LegendaryCrafting_3: 65
+    LegendaryCrafting_4: 66
+    LegendaryCrafting_5: 67
+    LegendaryCrafting_6: 68
+    LegendaryCrafting_7: 69
+    LegendaryCrafting_8: 70
+    LegendaryCrafting_9: 71
+    LegendaryForge: 59
+    MissionReward_1: 31
+    MissionReward_2: 32
+    NewCharacter: 75
+    None: 0
+    PvPBrawl_1: 77
+    PvPBrawl_2: 78
+    PvPHonorReward: 24
+    PvPRanked_1: 8
+    PvPRanked_2: 38
+    PvPRanked_3: 39
+    PvPRanked_4: 40
+    PvPRanked_5: 44
+    PvPRanked_6: 45
+    PvPRanked_7: 46
+    PvPRanked_8: 52
+    PvPRanked_9: 88
+    PvPRankedJackpot: 56
+    PvPUnranked_1: 7
+    PvPUnranked_2: 41
+    PvPUnranked_3: 47
+    PvPUnranked_4: 48
+    PvPUnranked_5: 49
+    PvPUnranked_6: 50
+    PvPUnranked_7: 51
+    QuestBonusLoot: 60
+    QuestReward: 11
+    RaidBonus_1: 149
+    RaidBonus_10: 158
+    RaidBonus_2: 150
+    RaidBonus_3: 151
+    RaidBonus_4: 152
+    RaidBonus_5: 153
+    RaidBonus_6: 154
+    RaidBonus_7: 155
+    RaidBonus_8: 156
+    RaidBonus_9: 157
+    RaidFinder: 4
+    RaidFinderExtended: 83
+    RaidFinderExtended_2: 90
+    RaidFinderExtended_3: 94
+    RaidHeroic: 5
+    RaidHeroicExtended: 84
+    RaidHeroicExtended_2: 91
+    RaidHeroicExtended_3: 95
+    RaidMythic: 6
+    RaidMythicExtended: 85
+    RaidMythicExtended_2: 92
+    RaidMythicExtended_3: 96
+    RaidNormal: 3
+    RaidNormalExtended: 82
+    RaidNormalExtended_2: 89
+    RaidNormalExtended_3: 93
+    Relinquished: 58
+    ScenarioHeroic: 10
+    ScenarioNormal: 9
+    Store: 12
+    TemplateCharacter_1: 97
+    TemplateCharacter_2: 98
+    TemplateCharacter_3: 99
+    TemplateCharacter_4: 100
+    Timerunning: 105
+    TimewalkerLevelUp: 22
+    TimewalkerMaxLevel: 186
+    Torghast: 79
+    TournamentRealm_1: 57
+    TournamentRealm_2: 162
+    TournamentRealm_3: 163
+    TournamentRealm_4: 164
+    TradeSkill: 13
+    Vendor: 14
+    Warbound_1: 165
+    Warbound_10: 174
+    Warbound_11: 175
+    Warbound_12: 176
+    Warbound_13: 177
+    Warbound_14: 178
+    Warbound_15: 179
+    Warbound_16: 180
+    Warbound_17: 181
+    Warbound_18: 182
+    Warbound_19: 183
+    Warbound_2: 166
+    Warbound_20: 184
+    Warbound_3: 167
+    Warbound_4: 168
+    Warbound_5: 169
+    Warbound_6: 170
+    Warbound_7: 171
+    Warbound_8: 172
+    Warbound_9: 173
+    WarMode: 76
+    WeeklyRewardsAdditional: 72
+    WeeklyRewardsConcession: 73
+    WorldBoss: 81
+    WorldQuest_1: 25
+    WorldQuest_10: 43
+    WorldQuest_11: 53
+    WorldQuest_12: 54
+    WorldQuest_13: 55
+    WorldQuest_2: 26
+    WorldQuest_3: 27
+    WorldQuest_4: 28
+    WorldQuest_5: 29
+    WorldQuest_6: 30
+    WorldQuest_7: 36
+    WorldQuest_8: 37
+    WorldQuest_9: 42
+    WorldQuestJackpot: 74
 ItemDisplayTextDisplayStyle:
-  ItemNameAndInfoText: 1
-  ItemNameOnlyCentered: 2
-  PlayerChoiceReward: 3
-  WorldQuestReward: 0
+  values:
+    ItemNameAndInfoText: 1
+    ItemNameOnlyCentered: 2
+    PlayerChoiceReward: 3
+    WorldQuestReward: 0
 ItemDisplayTooltipEnabledType:
-  Disabled: 1
-  Enabled: 0
+  values:
+    Disabled: 1
+    Enabled: 0
 ItemGemColor:
-  Arcane: 1024
-  Blood: 128
-  Blue: 8
-  Cogwheel: 32
-  Cypher: 8388608
-  DominationBlood: 1048576
-  DominationFrost: 2097152
-  DominationUnholy: 4194304
-  Fel: 512
-  Fiber: 1073741824
-  Fire: 4096
-  Fragrance: 67108864
-  Frost: 2048
-  Holy: 65536
-  Hydraulic: 16
-  Iron: 64
-  Life: 16384
-  Meta: 1
-  Primordial: 33554432
-  PunchcardBlue: 524288
-  PunchcardRed: 131072
-  PunchcardYellow: 262144
-  Red: 2
-  Shadow: 256
-  SingingSea: 268435456
-  SingingThunder: 134217728
-  SingingWind: 536870912
-  Tinker: 16777216
-  Water: 8192
-  Wind: 32768
-  Yellow: 4
+  values:
+    Arcane: 1024
+    Blood: 128
+    Blue: 8
+    Cogwheel: 32
+    Cypher: 8388608
+    DominationBlood: 1048576
+    DominationFrost: 2097152
+    DominationUnholy: 4194304
+    Fel: 512
+    Fiber: 1073741824
+    Fire: 4096
+    Fragrance: 67108864
+    Frost: 2048
+    Holy: 65536
+    Hydraulic: 16
+    Iron: 64
+    Life: 16384
+    Meta: 1
+    Primordial: 33554432
+    PunchcardBlue: 524288
+    PunchcardRed: 131072
+    PunchcardYellow: 262144
+    Red: 2
+    Shadow: 256
+    SingingSea: 268435456
+    SingingThunder: 134217728
+    SingingWind: 536870912
+    Tinker: 16777216
+    Water: 8192
+    Wind: 32768
+    Yellow: 4
 ItemGemSubclass:
-  Agility: 1
-  Artifactrelic: 11
-  Criticalstrike: 5
-  Haste: 7
-  Intellect: 0
-  Mastery: 6
-  Multiplestats: 10
-  Other: 9
-  Spirit: 4
-  Stamina: 3
-  Strength: 2
-  Versatility: 8
+  values:
+    Agility: 1
+    Artifactrelic: 11
+    Criticalstrike: 5
+    Haste: 7
+    Intellect: 0
+    Mastery: 6
+    Multiplestats: 10
+    Other: 9
+    Spirit: 4
+    Stamina: 3
+    Strength: 2
+    Versatility: 8
 ItemHousingSubclass:
-  Decor: 0
-  Dye: 1
-  ExteriorCustomization: 4
-  Room: 2
-  RoomCustomization: 3
-  ServiceItem: 5
+  values:
+    Decor: 0
+    Dye: 1
+    ExteriorCustomization: 4
+    Room: 2
+    RoomCustomization: 3
+    ServiceItem: 5
 ItemMiscellaneousSubclass:
-  CompanionPet: 2
-  Holiday: 3
-  Junk: 0
-  Mount: 5
-  MountEquipment: 6
-  Other: 4
-  Reagent: 1
+  values:
+    CompanionPet: 2
+    Holiday: 3
+    Junk: 0
+    Mount: 5
+    MountEquipment: 6
+    Other: 4
+    Reagent: 1
 ItemModification:
-  ArtifactAppearanceID: 8
-  ArtifactTier: 24
-  BattlePetBreed: 4
-  BattlePetCreaturedisplayid: 6
-  BattlePetLevel: 5
-  BattlePetSpecies: 3
-  ChangeModifiedCraftingStat_1: 29
-  ChangeModifiedCraftingStat_2: 30
-  ContentTuningID: 28
-  CraftingDataID: 40
-  CraftingQualityID: 38
-  CraftingReagentSlot_0: 43
-  CraftingReagentSlot_1: 44
-  CraftingReagentSlot_10: 53
-  CraftingReagentSlot_11: 54
-  CraftingReagentSlot_12: 55
-  CraftingReagentSlot_13: 56
-  CraftingReagentSlot_14: 57
-  CraftingReagentSlot_2: 45
-  CraftingReagentSlot_3: 46
-  CraftingReagentSlot_4: 47
-  CraftingReagentSlot_5: 48
-  CraftingReagentSlot_6: 49
-  CraftingReagentSlot_7: 50
-  CraftingReagentSlot_8: 51
-  CraftingReagentSlot_9: 52
-  CraftingSkillLineAbilityID: 39
-  CraftingSkillReagents: 41
-  CraftingSkillWatermark: 42
-  CurrencyWalletID: 61
-  CurrencyWalletQuantity: 62
-  CurrencyWalletVersion: 63
-  DbidHigh: 59
-  DbidLow: 60
-  IncrementLevelObsolete: 2
-  KeystoneAffix0: 19
-  KeystoneAffix01: 20
-  KeystoneAffix02: 21
-  KeystoneAffix03: 22
-  KeystoneMapChallengeModeID: 17
-  KeystonePowerLevel: 18
-  LegionArtifactKnowledgeObsolete: 23
-  PvPRating: 26
-  RedirectedBaseStats: 64
-  Reforge: 58
-  SoulbindConduitRank: 37
-  TimewalkerLevel: 9
-  TransmogrifyItemModifiedAppearanceIDSpec_0: 1
-  TransmogrifyItemModifiedAppearanceIDSpec_1: 11
-  TransmogrifyItemModifiedAppearanceIDSpec_2: 13
-  TransmogrifyItemModifiedAppearanceIDSpec_3: 15
-  TransmogrifyItemModifiedAppearanceIDSpec_4: 25
-  TransmogrifyItemModifiedAppearanceIDSpecAll: 0
-  TransmogrifyOverrideEnchantVisualIDSpec_0: 10
-  TransmogrifyOverrideEnchantVisualIDSpec_1: 12
-  TransmogrifyOverrideEnchantVisualIDSpec_2: 14
-  TransmogrifyOverrideEnchantVisualIDSpec_3: 16
-  TransmogrifyOverrideEnchantVisualIDSpec_4: 27
-  TransmogrifyOverrideEnchantVisualIDSpecAll: 7
-  TransmogrifySecondaryItemModifiedAppearanceIDSpec_0: 32
-  TransmogrifySecondaryItemModifiedAppearanceIDSpec_1: 33
-  TransmogrifySecondaryItemModifiedAppearanceIDSpec_2: 34
-  TransmogrifySecondaryItemModifiedAppearanceIDSpec_3: 35
-  TransmogrifySecondaryItemModifiedAppearanceIDSpec_4: 36
-  TransmogrifySecondaryItemModifiedAppearanceIDSpecAll: 31
+  values:
+    ArtifactAppearanceID: 8
+    ArtifactTier: 24
+    BattlePetBreed: 4
+    BattlePetCreaturedisplayid: 6
+    BattlePetLevel: 5
+    BattlePetSpecies: 3
+    ChangeModifiedCraftingStat_1: 29
+    ChangeModifiedCraftingStat_2: 30
+    ContentTuningID: 28
+    CraftingDataID: 40
+    CraftingQualityID: 38
+    CraftingReagentSlot_0: 43
+    CraftingReagentSlot_1: 44
+    CraftingReagentSlot_10: 53
+    CraftingReagentSlot_11: 54
+    CraftingReagentSlot_12: 55
+    CraftingReagentSlot_13: 56
+    CraftingReagentSlot_14: 57
+    CraftingReagentSlot_2: 45
+    CraftingReagentSlot_3: 46
+    CraftingReagentSlot_4: 47
+    CraftingReagentSlot_5: 48
+    CraftingReagentSlot_6: 49
+    CraftingReagentSlot_7: 50
+    CraftingReagentSlot_8: 51
+    CraftingReagentSlot_9: 52
+    CraftingSkillLineAbilityID: 39
+    CraftingSkillReagents: 41
+    CraftingSkillWatermark: 42
+    CurrencyWalletID: 61
+    CurrencyWalletQuantity: 62
+    CurrencyWalletVersion: 63
+    DbidHigh: 59
+    DbidLow: 60
+    IncrementLevelObsolete: 2
+    KeystoneAffix0: 19
+    KeystoneAffix01: 20
+    KeystoneAffix02: 21
+    KeystoneAffix03: 22
+    KeystoneMapChallengeModeID: 17
+    KeystonePowerLevel: 18
+    LegionArtifactKnowledgeObsolete: 23
+    PvPRating: 26
+    RedirectedBaseStats: 64
+    Reforge: 58
+    SoulbindConduitRank: 37
+    TimewalkerLevel: 9
+    TransmogrifyItemModifiedAppearanceIDSpec_0: 1
+    TransmogrifyItemModifiedAppearanceIDSpec_1: 11
+    TransmogrifyItemModifiedAppearanceIDSpec_2: 13
+    TransmogrifyItemModifiedAppearanceIDSpec_3: 15
+    TransmogrifyItemModifiedAppearanceIDSpec_4: 25
+    TransmogrifyItemModifiedAppearanceIDSpecAll: 0
+    TransmogrifyOverrideEnchantVisualIDSpec_0: 10
+    TransmogrifyOverrideEnchantVisualIDSpec_1: 12
+    TransmogrifyOverrideEnchantVisualIDSpec_2: 14
+    TransmogrifyOverrideEnchantVisualIDSpec_3: 16
+    TransmogrifyOverrideEnchantVisualIDSpec_4: 27
+    TransmogrifyOverrideEnchantVisualIDSpecAll: 7
+    TransmogrifySecondaryItemModifiedAppearanceIDSpec_0: 32
+    TransmogrifySecondaryItemModifiedAppearanceIDSpec_1: 33
+    TransmogrifySecondaryItemModifiedAppearanceIDSpec_2: 34
+    TransmogrifySecondaryItemModifiedAppearanceIDSpec_3: 35
+    TransmogrifySecondaryItemModifiedAppearanceIDSpec_4: 36
+    TransmogrifySecondaryItemModifiedAppearanceIDSpecAll: 31
 ItemProfessionSubclass:
-  Alchemy: 2
-  Archaeology: 13
-  Blacksmithing: 0
-  Cooking: 4
-  Enchanting: 8
-  Engineering: 7
-  Fishing: 9
-  Herbalism: 3
-  Inscription: 12
-  Jewelcrafting: 11
-  Leatherworking: 1
-  Mining: 5
-  Skinning: 10
-  Tailoring: 6
+  values:
+    Alchemy: 2
+    Archaeology: 13
+    Blacksmithing: 0
+    Cooking: 4
+    Enchanting: 8
+    Engineering: 7
+    Fishing: 9
+    Herbalism: 3
+    Inscription: 12
+    Jewelcrafting: 11
+    Leatherworking: 1
+    Mining: 5
+    Skinning: 10
+    Tailoring: 6
 ItemQuality:
-  Artifact: 6
-  Common: 1
-  Epic: 4
-  Heirloom: 7
-  Legendary: 5
-  Poor: 0
-  Rare: 3
-  Uncommon: 2
-  WoWToken: 8
+  values:
+    Artifact: 6
+    Common: 1
+    Epic: 4
+    Heirloom: 7
+    Legendary: 5
+    Poor: 0
+    Rare: 3
+    Uncommon: 2
+    WoWToken: 8
 ItemReagentSubclass:
-  ContextToken: 2
-  Keystone: 1
-  Reagent: 0
+  values:
+    ContextToken: 2
+    Keystone: 1
+    Reagent: 0
 ItemRecipeSubclass:
-  Alchemy: 6
-  Blacksmithing: 4
-  Book: 0
-  Cooking: 5
-  Enchanting: 8
-  Engineering: 3
-  FirstAid: 7
-  Fishing: 9
-  Inscription: 11
-  Jewelcrafting: 10
-  Leatherworking: 1
-  Tailoring: 2
+  values:
+    Alchemy: 6
+    Blacksmithing: 4
+    Book: 0
+    Cooking: 5
+    Enchanting: 8
+    Engineering: 3
+    FirstAid: 7
+    Fishing: 9
+    Inscription: 11
+    Jewelcrafting: 10
+    Leatherworking: 1
+    Tailoring: 2
 ItemRecraftFlags:
-  Invalid: 1
+  values:
+    Invalid: 1
 ItemRedundancySlot:
-  Chest: 3
-  Cloak: 11
-  Feet: 6
-  Finger: 9
-  Hand: 8
-  Head: 0
-  Legs: 5
-  MainhandWeapon: 13
-  Neck: 1
-  Offhand: 16
-  OnehandWeapon: 14
-  OnehandWeaponSecond: 15
-  Shoulder: 2
-  Trinket: 10
-  Twohand: 12
-  Waist: 4
-  Wrist: 7
+  values:
+    Chest: 3
+    Cloak: 11
+    Feet: 6
+    Finger: 9
+    Hand: 8
+    Head: 0
+    Legs: 5
+    MainhandWeapon: 13
+    Neck: 1
+    Offhand: 16
+    OnehandWeapon: 14
+    OnehandWeaponSecond: 15
+    Shoulder: 2
+    Trinket: 10
+    Twohand: 12
+    Waist: 4
+    Wrist: 7
 Itemsetflags:
-  Legacy: 1
-  RequiresPvPTalentsActive: 4
-  UseItemHistorySetSlots: 2
+  values:
+    Legacy: 1
+    RequiresPvPTalentsActive: 4
+    UseItemHistorySetSlots: 2
 ItemSlotFilterType:
-  Chest: 4
-  Cloak: 3
-  Feet: 9
-  Finger: 12
-  Hand: 6
-  Head: 0
-  Legs: 8
-  MainHand: 10
-  Neck: 1
-  NoFilter: 15
-  OffHand: 11
-  Other: 14
-  Shoulder: 2
-  Trinket: 13
-  Waist: 7
-  Wrist: 5
+  values:
+    Chest: 4
+    Cloak: 3
+    Feet: 9
+    Finger: 12
+    Hand: 6
+    Head: 0
+    Legs: 8
+    MainHand: 10
+    Neck: 1
+    NoFilter: 15
+    OffHand: 11
+    Other: 14
+    Shoulder: 2
+    Trinket: 13
+    Waist: 7
+    Wrist: 5
 ItemSocketInfoUIType:
-  Default: 0
+  values:
+    Default: 0
 ItemSocketType:
-  Arcane: 12
-  Blood: 9
-  Blue: 4
-  Cogwheel: 6
-  Cypher: 23
-  Domination: 22
-  Fel: 11
-  Fiber: 30
-  Fire: 14
-  Fragrance: 26
-  Frost: 13
-  Holy: 18
-  Hydraulic: 5
-  Iron: 8
-  Life: 16
-  Meta: 1
-  None: 0
-  Primordial: 25
-  Prismatic: 7
-  PunchcardBlue: 21
-  PunchcardRed: 19
-  PunchcardYellow: 20
-  Red: 2
-  Shadow: 10
-  SingingSea: 28
-  SingingThunder: 27
-  SingingWind: 29
-  Tinker: 24
-  Water: 15
-  Wind: 17
-  Yellow: 3
+  values:
+    Arcane: 12
+    Blood: 9
+    Blue: 4
+    Cogwheel: 6
+    Cypher: 23
+    Domination: 22
+    Fel: 11
+    Fiber: 30
+    Fire: 14
+    Fragrance: 26
+    Frost: 13
+    Holy: 18
+    Hydraulic: 5
+    Iron: 8
+    Life: 16
+    Meta: 1
+    None: 0
+    Primordial: 25
+    Prismatic: 7
+    PunchcardBlue: 21
+    PunchcardRed: 19
+    PunchcardYellow: 20
+    Red: 2
+    Shadow: 10
+    SingingSea: 28
+    SingingThunder: 27
+    SingingWind: 29
+    Tinker: 24
+    Water: 15
+    Wind: 17
+    Yellow: 3
 ItemSoundType:
-  Close: 3
-  Drop: 1
-  Pickup: 0
-  Use: 2
+  values:
+    Close: 3
+    Drop: 1
+    Pickup: 0
+    Use: 2
 ItemSubclassDisplay:
-  HideSubclassInAuction: 2
-  HideSubclassInTooltips: 1
-  ShowItemCount: 4
+  values:
+    HideSubclassInAuction: 2
+    HideSubclassInTooltips: 1
+    ShowItemCount: 4
 ItemSubclassFlag:
-  ArmorsubclassLfgscalingarmor: 1024
-  ItemsubclassQuivernotrequired: 64
-  ItemsubclassUsesInvtype: 512
-  WeaponsubclassCanparry: 1
-  WeaponsubclassDeprecatedReuseMe: 256
-  WeaponsubclassIsrifle: 8
-  WeaponsubclassIsthrown: 16
-  WeaponsubclassIsunarmed: 4
-  WeaponsubclassRanged: 128
-  WeaponsubclassRighthandRanged: 32
-  WeaponsubclassSetfingerseq: 2
+  values:
+    ArmorsubclassLfgscalingarmor: 1024
+    ItemsubclassQuivernotrequired: 64
+    ItemsubclassUsesInvtype: 512
+    WeaponsubclassCanparry: 1
+    WeaponsubclassDeprecatedReuseMe: 256
+    WeaponsubclassIsrifle: 8
+    WeaponsubclassIsthrown: 16
+    WeaponsubclassIsunarmed: 4
+    WeaponsubclassRanged: 128
+    WeaponsubclassRighthandRanged: 32
+    WeaponsubclassSetfingerseq: 2
 ItemTryOnReason:
-  DataPending: 3
-  NotEquippable: 2
-  Success: 0
-  WrongRace: 1
+  values:
+    DataPending: 3
+    NotEquippable: 2
+    Success: 0
+    WrongRace: 1
 ItemWeaponSubclass:
-  Axe1H: 0
-  Axe2H: 1
-  Bearclaw: 11
-  Bows: 2
-  Catclaw: 12
-  Crossbow: 18
-  Dagger: 15
-  Fishingpole: 20
-  Generic: 14
-  Guns: 3
-  Mace1H: 4
-  Mace2H: 5
-  Obsolete3: 17
-  Polearm: 6
-  Staff: 10
-  Sword1H: 7
-  Sword2H: 8
-  Thrown: 16
-  Unarmed: 13
-  Wand: 19
-  Warglaive: 9
+  values:
+    Axe1H: 0
+    Axe2H: 1
+    Bearclaw: 11
+    Bows: 2
+    Catclaw: 12
+    Crossbow: 18
+    Dagger: 15
+    Fishingpole: 20
+    Generic: 14
+    Guns: 3
+    Mace1H: 4
+    Mace2H: 5
+    Obsolete3: 17
+    Polearm: 6
+    Staff: 10
+    Sword1H: 7
+    Sword2H: 8
+    Thrown: 16
+    Unarmed: 13
+    Wand: 19
+    Warglaive: 9
 JailersTowerType:
-  AdamantVaults: 11
-  ArkobanHall: 7
-  BossRush: 14
-  Coldheart: 4
-  ForgottenCatacombs: 12
-  FractureChambers: 2
-  Mortregar: 5
-  Ossuary: 13
-  SkoldusHalls: 1
-  Soulforges: 3
-  TormentChamberAnduin: 10
-  TormentChamberJaina: 8
-  TormentChamberThrall: 9
-  TwistingCorridors: 0
-  UpperReaches: 6
+  values:
+    AdamantVaults: 11
+    ArkobanHall: 7
+    BossRush: 14
+    Coldheart: 4
+    ForgottenCatacombs: 12
+    FractureChambers: 2
+    Mortregar: 5
+    Ossuary: 13
+    SkoldusHalls: 1
+    Soulforges: 3
+    TormentChamberAnduin: 10
+    TormentChamberJaina: 8
+    TormentChamberThrall: 9
+    TwistingCorridors: 0
+    UpperReaches: 6
 JournalEncounterFlags:
-  AllianceOnly: 4
-  DoNotDisplayEncounter: 64
-  HordeOnly: 8
-  InternalOnly: 32
-  LimitDifficulties: 2
-  NoMap: 16
-  Obsolete: 1
+  values:
+    AllianceOnly: 4
+    DoNotDisplayEncounter: 64
+    HordeOnly: 8
+    InternalOnly: 32
+    LimitDifficulties: 2
+    NoMap: 16
+    Obsolete: 1
 JournalEncounterIconFlags:
-  Bleed: 8192
-  Curse: 256
-  Deadly: 16
-  Disease: 1024
-  Dps: 2
-  Enrage: 2048
-  Healer: 4
-  Heroic: 8
-  Important: 32
-  Interruptible: 64
-  Magic: 128
-  Mythic: 4096
-  Poison: 512
-  Tank: 1
+  values:
+    Bleed: 8192
+    Curse: 256
+    Deadly: 16
+    Disease: 1024
+    Dps: 2
+    Enrage: 2048
+    Healer: 4
+    Heroic: 8
+    Important: 32
+    Interruptible: 64
+    Magic: 128
+    Mythic: 4096
+    Poison: 512
+    Tank: 1
 JournalEncounterItemFlags:
-  DisplayAsExtremelyRare: 16
-  DisplayAsPerPlayerLoot: 4
-  DisplayAsVeryRare: 8
-  LimitDifficulties: 2
-  Obsolete: 1
+  values:
+    DisplayAsExtremelyRare: 16
+    DisplayAsPerPlayerLoot: 4
+    DisplayAsVeryRare: 8
+    LimitDifficulties: 2
+    Obsolete: 1
 JournalEncounterLocFlags:
-  Primary: 1
+  values:
+    Primary: 1
 JournalEncounterSectionFlags:
-  LimitDifficulties: 2
-  StartExpanded: 1
+  values:
+    LimitDifficulties: 2
+    StartExpanded: 1
 JournalEncounterSecTypes:
-  Ability: 2
-  Creature: 1
-  Generic: 0
-  Overview: 3
+  values:
+    Ability: 2
+    Creature: 1
+    Generic: 0
+    Overview: 3
 JournalInstanceFlags:
-  DoNotDisplayInstance: 4
-  HideUserSelectableDifficulty: 2
-  Timewalker: 1
+  values:
+    DoNotDisplayInstance: 4
+    HideUserSelectableDifficulty: 2
+    Timewalker: 1
 JournalLinkTypes:
-  Encounter: 1
-  Instance: 0
-  Section: 2
-  Tier: 3
+  values:
+    Encounter: 1
+    Instance: 0
+    Section: 2
+    Tier: 3
 LanguageFlag:
-  HiddenFromPlayer: 2
-  HideLanguageNameInChat: 4
-  IsExotic: 1
+  values:
+    HiddenFromPlayer: 2
+    HideLanguageNameInChat: 4
+    IsExotic: 1
 LeavePartyConfirmReason:
-  QuestSync: 0
-  RestrictedChallengeMode: 1
+  values:
+    QuestSync: 0
+    RestrictedChallengeMode: 1
 LFGEntryGeneralPlaystyle:
-  Expert: 4
-  FunRelaxed: 2
-  FunSerious: 3
-  Learning: 1
-  None: 0
+  values:
+    Expert: 4
+    FunRelaxed: 2
+    FunSerious: 3
+    Learning: 1
+    None: 0
 LFGEntryPlaystyle:
-  Casual: 2
-  Hardcore: 3
-  None: 0
-  Standard: 1
+  values:
+    Casual: 2
+    Hardcore: 3
+    None: 0
+    Standard: 1
 LFGListDisplayType:
-  ClassEnumerate: 2
-  Comment: 5
-  HideAll: 3
-  PlayerCount: 4
-  RoleCount: 0
-  RoleEnumerate: 1
+  values:
+    ClassEnumerate: 2
+    Comment: 5
+    HideAll: 3
+    PlayerCount: 4
+    RoleCount: 0
+    RoleEnumerate: 1
 LFGListFilter:
-  CurrentExpansion: 32
-  CurrentSeason: 64
-  NotCurrentSeason: 128
-  NotRecommended: 2
-  PvE: 4
-  PvP: 8
-  Recommended: 1
-  Timerunning: 16
+  values:
+    CurrentExpansion: 32
+    CurrentSeason: 64
+    NotCurrentSeason: 128
+    NotRecommended: 2
+    PvE: 4
+    PvP: 8
+    Recommended: 1
+    Timerunning: 16
 LFGRole:
-  Damage: 2
-  Healer: 1
-  Tank: 0
+  values:
+    Damage: 2
+    Healer: 1
+    Tank: 0
 LFGSlotInvalidReason:
-  AreaNotExplored: 9
-  CannotRunAnyChildDungeon: 14
-  ChromieTime: 16
-  EngagedInPvP: 12
-  ExpansionTooLow: 1
-  GearTooHigh: 5
-  GearTooLow: 4
-  LevelTargetTooHigh: 8
-  LevelTargetTooLow: 7
-  LevelTooHigh: 3
-  LevelTooLow: 2
-  None: 0
-  NoSpec: 13
-  NoValidRoles: 11
-  Npe: 17
-  PlayerConditionFailed: 19
-  RaidLocked: 6
-  Restricted: 15
-  Timerunning: 18
-  WrongFaction: 10
+  values:
+    AreaNotExplored: 9
+    CannotRunAnyChildDungeon: 14
+    ChromieTime: 16
+    EngagedInPvP: 12
+    ExpansionTooLow: 1
+    GearTooHigh: 5
+    GearTooLow: 4
+    LevelTargetTooHigh: 8
+    LevelTargetTooLow: 7
+    LevelTooHigh: 3
+    LevelTooLow: 2
+    None: 0
+    NoSpec: 13
+    NoValidRoles: 11
+    Npe: 17
+    PlayerConditionFailed: 19
+    RaidLocked: 6
+    Restricted: 15
+    Timerunning: 18
+    WrongFaction: 10
 LgVendorPurchaseSettlementState:
-  NotSettled: 1
-  Settled: 0
+  values:
+    NotSettled: 1
+    Settled: 0
 LgVendorPurchaseSqlResults:
-  AlreadyOwned: 102
-  Failed: 0
-  InsufficientFunds: 101
-  InsufficientSpent: 103
-  InvalidState: 107
-  NoRecord: 106
-  NotOwned: 104
-  RefundExpired: 105
-  Success: 100
+  values:
+    AlreadyOwned: 102
+    Failed: 0
+    InsufficientFunds: 101
+    InsufficientSpent: 103
+    InvalidState: 107
+    NoRecord: 106
+    NotOwned: 104
+    RefundExpired: 105
+    Success: 100
 LgVendorPurchaseState:
-  NotOwned: 0
-  Owned: 1
+  values:
+    NotOwned: 0
+    Owned: 1
 LightRadiusIndicatorType:
-  Always: 0
-  Never: 2
-  Overlap: 1
+  values:
+    Always: 0
+    Never: 2
+    Overlap: 1
 LimitedInputType:
-  MouseDown: 1
-  MouseMove: 0
-  MouseUp: 2
-  MouseWheel: 3
+  values:
+    MouseDown: 1
+    MouseMove: 0
+    MouseUp: 2
+    MouseWheel: 3
 LinkedCurrencyFlags:
-  AddIgnoresMax: 8
-  IgnoreAdd: 1
-  IgnoreSubtract: 2
-  SuppressChatLog: 4
+  values:
+    AddIgnoresMax: 8
+    IgnoreAdd: 1
+    IgnoreSubtract: 2
+    SuppressChatLog: 4
 LoadConfigResult:
-  Error: 0
-  LoadInProgress: 2
-  NoChangesNecessary: 1
-  Ready: 3
+  values:
+    Error: 0
+    LoadInProgress: 2
+    NoChangesNecessary: 1
+    Ready: 3
 LogicLogicop:
-  And: 1
-  None: 0
-  Or: 2
-  Xor: 3
+  values:
+    And: 1
+    None: 0
+    Or: 2
+    Xor: 3
 LogicMathop:
-  Div: 4
-  Minus: 2
-  Mod: 5
-  None: 0
-  Plus: 1
-  Times: 3
+  values:
+    Div: 4
+    Minus: 2
+    Mod: 5
+    None: 0
+    Plus: 1
+    Times: 3
 LogicRelop:
-  Equal: 1
-  Gt: 5
-  Gteq: 6
-  Lt: 3
-  Lteq: 4
-  None: 0
-  Notequal: 2
+  values:
+    Equal: 1
+    Gt: 5
+    Gteq: 6
+    Lt: 3
+    Lteq: 4
+    None: 0
+    Notequal: 2
 LoginTicketLicenses:
-  GmLicense: 11486
+  values:
+    GmLicense: 11486
 LogPriority:
-  Debug: 30
-  Error: 2
-  Fatal: 1
-  Normal: 10
-  Spam: 40
-  Warning: 3
+  values:
+    Debug: 30
+    Error: 2
+    Fatal: 1
+    Normal: 10
+    Spam: 40
+    Warning: 3
 LootMethod:
-  Freeforall: 0
-  Group: 3
-  Masterlooter: 2
-  Needbeforegreed: 4
-  Personal: 5
-  Roundrobin: 1
+  values:
+    Freeforall: 0
+    Group: 3
+    Masterlooter: 2
+    Needbeforegreed: 4
+    Personal: 5
+    Roundrobin: 1
 LootMethodStyles:
-  Mainline: 0
-  Vanilla: 1
+  values:
+    Mainline: 0
+    Vanilla: 1
 LootSlotType:
-  Currency: 3
-  Item: 1
-  Money: 2
-  None: 0
+  values:
+    Currency: 3
+    Item: 1
+    Money: 2
+    None: 0
 LuaCurveType:
-  Cosine: 2
-  Cubic: 3
-  Linear: 0
-  Step: 1
+  values:
+    Cosine: 2
+    Cubic: 3
+    Linear: 0
+    Step: 1
 MajorFactionFeatureAbility:
-  Fishing: 1
-  Generic: 0
-  Hunts: 2
+  values:
+    Fishing: 1
+    Generic: 0
+    Hunts: 2
 MajorFactionType:
-  DragonscaleExpedition: 1
-  IskaaraTuskarr: 3
-  MaruukCentaur: 2
-  None: 0
-  ValdrakkenAccord: 4
+  values:
+    DragonscaleExpedition: 1
+    IskaaraTuskarr: 3
+    MaruukCentaur: 2
+    None: 0
+    ValdrakkenAccord: 4
 ManipulatorEventType:
-  Complete: 2
-  Delete: 3
-  Move: 1
-  Start: 0
+  values:
+    Complete: 2
+    Delete: 3
+    Move: 1
+    Start: 0
 MapCanvasPosition:
-  BottomLeft: 1
-  BottomRight: 2
-  None: 0
-  TopLeft: 3
-  TopRight: 4
+  values:
+    BottomLeft: 1
+    BottomRight: 2
+    None: 0
+    TopLeft: 3
+    TopRight: 4
 MapIconUIWidgetSetType:
-  AdventureMapDetails: 2
-  BehindIcon: 1
-  Tooltip: 0
+  values:
+    AdventureMapDetails: 2
+    BehindIcon: 1
+    Tooltip: 0
 MapobjEventTypes:
-  PlayAnim: 0
-  SetAnimSpeed: 1
+  values:
+    PlayAnim: 0
+    SetAnimSpeed: 1
 MapOverlayDisplayLocation:
-  BottomLeft: 1
-  BottomRight: 3
-  Default: 0
-  Hidden: 5
-  TopLeft: 2
-  TopRight: 4
+  values:
+    BottomLeft: 1
+    BottomRight: 3
+    Default: 0
+    Hidden: 5
+    TopLeft: 2
+    TopRight: 4
 MapPinAnimationType:
-  None: 0
-  Pulse: 1
+  values:
+    None: 0
+    Pulse: 1
 MatchDetailType:
-  Kills: 1
-  Placement: 0
-  PlunderAcquired: 2
+  values:
+    Kills: 1
+    Placement: 0
+    PlunderAcquired: 2
 MicroMenuOrder:
-  Default: 0
-  Reverse: 1
+  values:
+    Default: 0
+    Reverse: 1
 MicroMenuOrientation:
-  Horizontal: 0
-  Vertical: 1
+  values:
+    Horizontal: 0
+    Vertical: 1
 MinimapTrackingFilter:
-  AccountBanker: 4194304
-  AccountCompletedQuests: 2097152
-  Auctioneer: 1
-  Banker: 2
-  Barber: 262144
-  Battlemaster: 4
-  Digsites: 131072
-  Focus: 32768
-  Innkeeper: 32
-  ItemUpgrade: 524288
-  Mailbox: 64
-  POI: 8192
-  QuestPOIs: 65536
-  Repair: 512
-  Stablemaster: 2048
-  Target: 16384
-  TaxiNode: 8
-  TrainerProfession: 128
-  Transmogrifier: 4096
-  TrivialQuests: 1024
-  Unfiltered: 0
-  VenderFood: 16
-  VendorPoison: 1048576
-  VendorReagent: 256
+  values:
+    AccountBanker: 4194304
+    AccountCompletedQuests: 2097152
+    Auctioneer: 1
+    Banker: 2
+    Barber: 262144
+    Battlemaster: 4
+    Digsites: 131072
+    Focus: 32768
+    Innkeeper: 32
+    ItemUpgrade: 524288
+    Mailbox: 64
+    POI: 8192
+    QuestPOIs: 65536
+    Repair: 512
+    Stablemaster: 2048
+    Target: 16384
+    TaxiNode: 8
+    TrainerProfession: 128
+    Transmogrifier: 4096
+    TrivialQuests: 1024
+    Unfiltered: 0
+    VenderFood: 16
+    VendorPoison: 1048576
+    VendorReagent: 256
 ModelBlendOperation:
-  Anim: 1
-  None: 0
+  values:
+    Anim: 1
+    None: 0
 ModelLightType:
-  Directional: 0
-  Point: 1
+  values:
+    Directional: 0
+    Point: 1
 ModelSceneSetting:
-  AlignLightToOrbitDelta: 1
+  values:
+    AlignLightToOrbitDelta: 1
 ModelSceneType:
-  ArtifactRelicTalentEffect: 9
-  ArtifactTier2: 5
-  ArtifactTier2ForgingScene: 6
-  ArtifactTier2SlamEffect: 7
-  AzeriteItemLevelUpToast: 13
-  AzeritePowers: 14
-  AzeriteRewardGlow: 15
-  CommentatorVictoryFanfare: 8
-  EncounterJournal: 3
-  HeartOfAzeroth: 16
-  JailersTowerAnimaGlow: 19
-  MountJournal: 0
-  PartyPose: 12
-  PetJournalCard: 1
-  PetJournalLoadout: 4
-  PvPWarModeFire: 11
-  PvPWarModeOrb: 10
-  ShopCard: 2
-  Soulbinds: 18
-  WorldMapThreat: 17
+  values:
+    ArtifactRelicTalentEffect: 9
+    ArtifactTier2: 5
+    ArtifactTier2ForgingScene: 6
+    ArtifactTier2SlamEffect: 7
+    AzeriteItemLevelUpToast: 13
+    AzeritePowers: 14
+    AzeriteRewardGlow: 15
+    CommentatorVictoryFanfare: 8
+    EncounterJournal: 3
+    HeartOfAzeroth: 16
+    JailersTowerAnimaGlow: 19
+    MountJournal: 0
+    PartyPose: 12
+    PetJournalCard: 1
+    PetJournalLoadout: 4
+    PvPWarModeFire: 11
+    PvPWarModeOrb: 10
+    ShopCard: 2
+    Soulbinds: 18
+    WorldMapThreat: 17
 ModelSoundOverrideType:
-  Mute: 2
-  UseOverride: 1
-  UseParent: 0
+  values:
+    Mute: 2
+    UseOverride: 1
+    UseParent: 0
 ModelSoundTagType:
-  Looping: 2
-  Oneshot: 1
+  values:
+    Looping: 2
+    Oneshot: 1
 MountType:
-  Aquatic: 2
-  Dragonriding: 3
-  Flying: 1
-  Ground: 0
-  RideAlong: 4
+  values:
+    Aquatic: 2
+    Dragonriding: 3
+    Flying: 1
+    Ground: 0
+    RideAlong: 4
 MountTypeFlag:
-  IsAquaticMount: 2
-  IsDragonRidingMount: 4
-  IsFlyingMount: 1
-  IsRideAlongMount: 8
+  values:
+    IsAquaticMount: 2
+    IsDragonRidingMount: 4
+    IsFlyingMount: 1
+    IsRideAlongMount: 8
 NamePlateCastBarDisplay:
-  HighlightImportantCasts: 4
-  HighlightWhenCastTarget: 5
-  None: 0
-  SpellIcon: 2
-  SpellName: 1
-  SpellTarget: 3
+  values:
+    HighlightImportantCasts: 4
+    HighlightWhenCastTarget: 5
+    None: 0
+    SpellIcon: 2
+    SpellName: 1
+    SpellTarget: 3
 NamePlateEnemyNpcAuraDisplay:
-  Buffs: 1
-  CrowdControl: 3
-  Debuffs: 2
-  None: 0
+  values:
+    Buffs: 1
+    CrowdControl: 3
+    Debuffs: 2
+    None: 0
 NamePlateEnemyPlayerAuraDisplay:
-  Buffs: 1
-  Debuffs: 2
-  LossOfControl: 3
-  None: 0
+  values:
+    Buffs: 1
+    Debuffs: 2
+    LossOfControl: 3
+    None: 0
 NamePlateFriendlyPlayerAuraDisplay:
-  Buffs: 1
-  Debuffs: 2
-  LossOfControl: 3
-  None: 0
+  values:
+    Buffs: 1
+    Debuffs: 2
+    LossOfControl: 3
+    None: 0
 NamePlateInfoDisplay:
-  CurrentHealthPercent: 1
-  CurrentHealthValue: 2
-  None: 0
-  RarityIcon: 3
+  values:
+    CurrentHealthPercent: 1
+    CurrentHealthValue: 2
+    None: 0
+    RarityIcon: 3
 NamePlateSimplifiedType:
-  FriendlyNpc: 4
-  FriendlyPlayer: 3
-  Minion: 1
-  MinusMob: 2
-  None: 0
+  values:
+    FriendlyNpc: 4
+    FriendlyPlayer: 3
+    Minion: 1
+    MinusMob: 2
+    None: 0
 NamePlateSize:
-  ExtraLarge: 4
-  Huge: 5
-  Large: 3
-  Medium: 2
-  Small: 1
+  values:
+    ExtraLarge: 4
+    Huge: 5
+    Large: 3
+    Medium: 2
+    Small: 1
 NamePlateStackType:
-  Enemy: 1
-  Friendly: 2
-  None: 0
+  values:
+    Enemy: 1
+    Friendly: 2
+    None: 0
 NamePlateStyle:
-  Block: 2
-  CastFocus: 4
-  Classic: 6
-  HealthFocus: 3
-  Legacy: 5
-  Modern: 0
-  Thin: 1
+  values:
+    Block: 2
+    CastFocus: 4
+    Classic: 6
+    HealthFocus: 3
+    Legacy: 5
+    Modern: 0
+    Thin: 1
 NamePlateThreatDisplay:
-  Flash: 2
-  HealthBarColor: 3
-  None: 0
-  Progressive: 1
+  values:
+    Flash: 2
+    HealthBarColor: 3
+    None: 0
+    Progressive: 1
 NamePlateType:
-  Enemy: 1
-  Friendly: 0
+  values:
+    Enemy: 1
+    Friendly: 0
 NavigationState:
-  Disabled: 3
-  InRange: 2
-  Invalid: 0
-  Occluded: 1
+  values:
+    Disabled: 3
+    InRange: 2
+    Invalid: 0
+    Occluded: 1
 NeighborhoodFlags:
-  None: 0
-  OpenToPublic: 2
-  PoolParent: 1
+  values:
+    None: 0
+    OpenToPublic: 2
+    PoolParent: 1
 NeighborhoodInitiativeChestResult:
-  NiNoHouseFound: 2
-  NiNoRewards: 3
-  NiServiceDisabled: 5
-  NiSuccess: 0
-  NiThrottled: 4
-  NiUnspecifiedFailure: 1
+  values:
+    NiNoHouseFound: 2
+    NiNoRewards: 3
+    NiServiceDisabled: 5
+    NiSuccess: 0
+    NiThrottled: 4
+    NiUnspecifiedFailure: 1
 NeighborhoodInitiativeFlags:
-  Disabled: 1
-  NoAbandon: 2
-  NoRepeat: 4
+  values:
+    Disabled: 1
+    NoAbandon: 2
+    NoRepeat: 4
 NeighborhoodInitiativeNeighborhoodTypes:
-  NiNeighborhoodTypePool: 1
-  NiNeighborhoodTypeSingleton: 0
+  values:
+    NiNeighborhoodTypePool: 1
+    NiNeighborhoodTypeSingleton: 0
 NeighborhoodInitiativesCompletionStates:
-  NiCompletionStateNotCompleted: 0
-  NiCompletionStatePlayerCompleted: 1
-  NiCompletionStateSystemAbandoned: 2
+  values:
+    NiCompletionStateNotCompleted: 0
+    NiCompletionStatePlayerCompleted: 1
+    NiCompletionStateSystemAbandoned: 2
 NeighborhoodInitiativeTaskType:
-  RepeatableFinite: 1
-  RepeatableInfinite: 2
-  Single: 0
+  values:
+    RepeatableFinite: 1
+    RepeatableInfinite: 2
+    Single: 0
 NeighborhoodInitiativeUpdateStatus:
-  Completed: 2
-  Failed: 3
-  MilestoneCompleted: 1
-  Started: 0
+  values:
+    Completed: 2
+    Failed: 3
+    MilestoneCompleted: 1
+    Started: 0
 NeighborhoodInviteResult:
-  AlreadyInNeighborhood: 11
-  DbError: 1
-  Faction: 5
-  GenericFailure: 3
-  InviteLimit: 7
-  NotEnoughPlots: 8
-  NotFound: 9
-  PendingInvitation: 6
-  Permission: 4
-  RpcFailure: 2
-  Success: 0
-  TooManyRequests: 10
+  values:
+    AlreadyInNeighborhood: 11
+    DbError: 1
+    Faction: 5
+    GenericFailure: 3
+    InviteLimit: 7
+    NotEnoughPlots: 8
+    NotFound: 9
+    PendingInvitation: 6
+    Permission: 4
+    RpcFailure: 2
+    Success: 0
+    TooManyRequests: 10
 NeighborhoodMapFlags:
-  AlliancePurchasable: 1
-  CanSystemGenerate: 4
-  HordePurchasable: 2
-  None: 0
+  values:
+    AlliancePurchasable: 1
+    CanSystemGenerate: 4
+    HordePurchasable: 2
+    None: 0
 NeighborhoodOwnerType:
-  Charter: 2
-  Guild: 1
-  None: 0
+  values:
+    Charter: 2
+    Guild: 1
+    None: 0
 NeighborhoodType:
-  Open: 0
-  Private: 1
-  Public: 2
+  values:
+    Open: 0
+    Private: 1
+    Public: 2
 NewCharGear:
-  Preview: 1
-  Start: 0
+  values:
+    Preview: 1
+    Start: 0
 NodeOpFailureReason:
-  AccountDataNoMatch: 25
-  DataError: 13
-  EntryNotFound: 19
-  HasMutuallyExclusiveEdge: 4
-  LevelTooLow: 22
-  MaxRank: 12
-  MissingAchievement: 8
-  MissingEdgeConnection: 1
-  MissingQuest: 9
-  MissingRequiredEdge: 3
-  NodeNeverPurchasable: 24
-  NodeNotFound: 18
-  None: 0
-  NotEnoughCurrency: 15
-  NotEnoughCurrencySpent: 6
-  NotEnoughGold: 16
-  NotEnoughGoldSpent: 7
-  NotEnoughRanksInEntry: 26
-  NotEnoughSourcedCurrency: 14
-  NotEnoughSourcedCurrencySpent: 5
-  RequiredForCondition: 20
-  RequiredForEdge: 2
-  SameSelection: 17
-  TreeFlaggedNoRefund: 23
-  WrongSelection: 11
-  WrongSpec: 10
-  WrongTreeID: 21
+  values:
+    AccountDataNoMatch: 25
+    DataError: 13
+    EntryNotFound: 19
+    HasMutuallyExclusiveEdge: 4
+    LevelTooLow: 22
+    MaxRank: 12
+    MissingAchievement: 8
+    MissingEdgeConnection: 1
+    MissingQuest: 9
+    MissingRequiredEdge: 3
+    NodeNeverPurchasable: 24
+    NodeNotFound: 18
+    None: 0
+    NotEnoughCurrency: 15
+    NotEnoughCurrencySpent: 6
+    NotEnoughGold: 16
+    NotEnoughGoldSpent: 7
+    NotEnoughRanksInEntry: 26
+    NotEnoughSourcedCurrency: 14
+    NotEnoughSourcedCurrencySpent: 5
+    RequiredForCondition: 20
+    RequiredForEdge: 2
+    SameSelection: 17
+    TreeFlaggedNoRefund: 23
+    WrongSelection: 11
+    WrongSpec: 10
+    WrongTreeID: 21
 NoRPEReason:
-  BNetToken: 8
-  FactionOrRaceChange: 7
-  HasRPE: 0
-  IneligibleMap: 3
-  LowLevel: 1
-  PlayerLocked: 9
-  RecentlyActive: 4
-  RecentlyBoosted: 5
-  Timerunner: 2
-  UpgradeInProgress: 6
+  values:
+    BNetToken: 8
+    FactionOrRaceChange: 7
+    HasRPE: 0
+    IneligibleMap: 3
+    LowLevel: 1
+    PlayerLocked: 9
+    RecentlyActive: 4
+    RecentlyBoosted: 5
+    Timerunner: 2
+    UpgradeInProgress: 6
 NpcCraftingOrderSetFlags:
-  AllowDuplicate: 2
-  AllowMultiple: 1
+  values:
+    AllowDuplicate: 2
+    AllowMultiple: 1
 NumericRuleFormatRounding:
-  Down: 2
-  Nearest: 0
-  Up: 1
+  values:
+    Down: 2
+    Nearest: 0
+    Up: 1
 OnUpdateMode:
-  Disabled: 0
-  RunAlways: 4
-  RunOnce: 3
-  RunWhenVisible: 1
-  RunWhenVisibleOnce: 2
+  values:
+    Disabled: 0
+    RunAlways: 4
+    RunOnce: 3
+    RunWhenVisible: 1
+    RunWhenVisibleOnce: 2
 PartyPlaylistEntry:
-  DuoGameMode: 1
-  SoloGameMode: 0
-  TrainingGameMode: 3
-  TrioGameMode: 2
+  values:
+    DuoGameMode: 1
+    SoloGameMode: 0
+    TrainingGameMode: 3
+    TrioGameMode: 2
 PartyPoseFlags:
-  HideLeaveInstanceButton: 1
+  values:
+    HideLeaveInstanceButton: 1
 PartyRequestJoinRelation:
-  Club: 3
-  Friend: 1
-  Guild: 2
-  None: 0
-  RecentAllies: 4
+  values:
+    Club: 3
+    Friend: 1
+    Guild: 2
+    None: 0
+    RecentAllies: 4
 PerksVendorCategoryType:
-  Achievement: 23
-  Activity: 21
-  GmAdjustment: 22
-  Illusion: 7
-  Mount: 2
-  Pet: 3
-  RefundUnused: 24
-  Stipend: 20
-  Toy: 5
-  Transmog: 1
-  Transmogset: 8
-  WarbandScene: 9
+  values:
+    Achievement: 23
+    Activity: 21
+    GmAdjustment: 22
+    Illusion: 7
+    Mount: 2
+    Pet: 3
+    RefundUnused: 24
+    Stipend: 20
+    Toy: 5
+    Transmog: 1
+    Transmogset: 8
+    WarbandScene: 9
 PermanentChatChannelType:
-  Communities: 2
-  Custom: 3
-  None: 0
-  Zone: 1
+  values:
+    Communities: 2
+    Custom: 3
+    None: 0
+    Zone: 1
 PersonalResourceDisplayVisibleSetting:
-  Always: 0
-  Hidden: 2
-  InCombat: 1
+  values:
+    Always: 0
+    Hidden: 2
+    InCombat: 1
 PetActionbuttonType:
-  Max: 18
-  Mode: 6
-  None: 0
-  Orders: 7
-  Slot1: 8
-  Slot10: 17
-  Slot1Obsolete: 2
-  Slot2: 9
-  Slot2Obsolete: 3
-  Slot3: 10
-  Slot3Obsolete: 4
-  Slot4: 11
-  Slot4Obsolete: 5
-  Slot5: 12
-  Slot6: 13
-  Slot7: 14
-  Slot8: 15
-  Slot9: 16
-  Spell: 1
-  VehicleAction: 19
+  values:
+    Max: 18
+    Mode: 6
+    None: 0
+    Orders: 7
+    Slot1: 8
+    Slot10: 17
+    Slot1Obsolete: 2
+    Slot2: 9
+    Slot2Obsolete: 3
+    Slot3: 10
+    Slot3Obsolete: 4
+    Slot4: 11
+    Slot4Obsolete: 5
+    Slot5: 12
+    Slot6: 13
+    Slot7: 14
+    Slot8: 15
+    Slot9: 16
+    Spell: 1
+    VehicleAction: 19
 PetActionFeedback:
-  Dead: 1
-  FriendlyTarget: 3
-  InvalidTarget: 2
-  NoPath: 4
-  Success: 0
+  values:
+    Dead: 1
+    FriendlyTarget: 3
+    InvalidTarget: 2
+    NoPath: 4
+    Success: 0
 PetBattleQueueStatus:
-  AlreadyQueued: 3
-  InBattle: 20
-  JoinFailed: 4
-  JoinFailedJournalLock: 6
-  JoinFailedNeutral: 7
-  JoinFailedSlots: 5
-  LostConnection: 16
-  MatchAccepted: 8
-  MatchDeclined: 9
-  Matchmaking: 15
-  MatchOpponentDeclined: 10
-  NoBattlingHere: 21
-  None: 0
-  ProposalTimedOut: 11
-  Queued: 1
-  QueuedUpdate: 2
-  Removed: 12
-  RequeuedAfterInternalError: 13
-  RequeuedAfterOpponentRemoved: 14
-  Shutdown: 17
-  Suspended: 18
-  Unsuspended: 19
+  values:
+    AlreadyQueued: 3
+    InBattle: 20
+    JoinFailed: 4
+    JoinFailedJournalLock: 6
+    JoinFailedNeutral: 7
+    JoinFailedSlots: 5
+    LostConnection: 16
+    MatchAccepted: 8
+    MatchDeclined: 9
+    Matchmaking: 15
+    MatchOpponentDeclined: 10
+    NoBattlingHere: 21
+    None: 0
+    ProposalTimedOut: 11
+    Queued: 1
+    QueuedUpdate: 2
+    Removed: 12
+    RequeuedAfterInternalError: 13
+    RequeuedAfterOpponentRemoved: 14
+    Shutdown: 17
+    Suspended: 18
+    Unsuspended: 19
 PetbattleSlot:
-  Slot_0: 0
-  Slot_1: 1
-  Slot_2: 2
+  values:
+    Slot_0: 0
+    Slot_1: 1
+    Slot_2: 2
 PetbattleState:
-  Created: 0
-  CreatedFailed: 4
-  FinalRound: 5
-  Finished: 6
-  RoundInProgress: 2
-  WaitingForFrontPets: 3
-  WaitingPreBattle: 1
+  values:
+    Created: 0
+    CreatedFailed: 4
+    FinalRound: 5
+    Finished: 6
+    RoundInProgress: 2
+    WaitingForFrontPets: 3
+    WaitingPreBattle: 1
 PetJournalError:
-  InvalidFaction: 3
-  JournalIsLocked: 2
-  NoFavoritesToSummon: 4
-  None: 0
-  NoValidRandomSummon: 5
-  PetIsDead: 1
+  values:
+    InvalidFaction: 3
+    JournalIsLocked: 2
+    NoFavoritesToSummon: 4
+    None: 0
+    NoValidRandomSummon: 5
+    PetIsDead: 1
 PetMode:
-  Aggressive: 2
-  Assist: 3
-  Defensive: 1
-  Passive: 0
+  values:
+    Aggressive: 2
+    Assist: 3
+    Defensive: 1
+    Passive: 0
 PetOrders:
-  Attack: 2
-  Dismiss: 3
-  Follow: 1
-  MoveTo: 4
-  Wait: 0
+  values:
+    Attack: 2
+    Dismiss: 3
+    Follow: 1
+    MoveTo: 4
+    Wait: 0
 PetOverride:
-  AICombatControl: 1
-  AICombatPassive: 2
-  None: 0
-  OwnerMounted: 4
+  values:
+    AICombatControl: 1
+    AICombatPassive: 2
+    None: 0
+    OwnerMounted: 4
 Pettameresult:
-  Anothersummonactive: 5
-  Cantcontrolexotic: 12
-  Creaturealreadyowned: 3
-  Dead: 10
-  EliteToohighlevel: 14
-  Internalerror: 8
-  Invalidcreature: 1
-  Invalidslot: 13
-  Nopetavailable: 7
-  Notdead: 11
-  Nottameable: 4
-  Numresults: 15
-  Ok: 0
-  Toohighlevel: 9
-  Toomany: 2
-  Unitscanttame: 6
+  values:
+    Anothersummonactive: 5
+    Cantcontrolexotic: 12
+    Creaturealreadyowned: 3
+    Dead: 10
+    EliteToohighlevel: 14
+    Internalerror: 8
+    Invalidcreature: 1
+    Invalidslot: 13
+    Nopetavailable: 7
+    Notdead: 11
+    Nottameable: 4
+    Numresults: 15
+    Ok: 0
+    Toohighlevel: 9
+    Toomany: 2
+    Unitscanttame: 6
 PhaseReason:
-  ChromieTime: 3
-  Phasing: 0
-  Sharding: 1
-  TimerunningHwt: 4
-  WarMode: 2
+  values:
+    ChromieTime: 3
+    Phasing: 0
+    Sharding: 1
+    TimerunningHwt: 4
+    WarMode: 2
 PhotoSharingStatus:
-  AADCRestricted: 6
-  Configured: 2
-  Disabled: 0
-  Error: 7
-  Expired: 3
-  FailedToClear: 8
-  NotConfigured: 1
-  ParentalControl: 4
-  TrialOrVeteran: 5
+  values:
+    AADCRestricted: 6
+    Configured: 2
+    Disabled: 0
+    Error: 7
+    Expired: 3
+    FailedToClear: 8
+    NotConfigured: 1
+    ParentalControl: 4
+    TrialOrVeteran: 5
 PhotoSharingUploadStatus:
-  CreatePageApiCallFailed: 13
-  CreatePageBadRequest: 14
-  CreatePageForbidden: 16
-  CreatePageGenericFailure: 19
-  CreatePageNoBoardIDFound: 20
-  CreatePageNotFound: 17
-  CreatePageTooManyRequests: 18
-  CreatePageUnauthorized: 15
-  CreatePostApiCallFailed: 21
-  CreatePostBadRequest: 22
-  CreatePostForbidden: 24
-  CreatePostGenericFailure: 27
-  CreatePostNoIDFound: 28
-  CreatePostNotFound: 25
-  CreatePostThrottled: 29
-  CreatePostTooManyRequests: 26
-  CreatePostUnauthorized: 23
-  Disabled: 0
-  Failed: 1
-  ListPagesApiCallFailed: 4
-  ListPagesBadRequest: 5
-  ListPagesEmptyBoardID: 11
-  ListPagesForbidden: 7
-  ListPagesGenericFailure: 10
-  ListPagesInvalidBookmark: 12
-  ListPagesNotFound: 8
-  ListPagesTooManyRequests: 9
-  ListPagesUnauthorized: 6
-  Locked: 3
-  Success: 2
+  values:
+    CreatePageApiCallFailed: 13
+    CreatePageBadRequest: 14
+    CreatePageForbidden: 16
+    CreatePageGenericFailure: 19
+    CreatePageNoBoardIDFound: 20
+    CreatePageNotFound: 17
+    CreatePageTooManyRequests: 18
+    CreatePageUnauthorized: 15
+    CreatePostApiCallFailed: 21
+    CreatePostBadRequest: 22
+    CreatePostForbidden: 24
+    CreatePostGenericFailure: 27
+    CreatePostNoIDFound: 28
+    CreatePostNotFound: 25
+    CreatePostThrottled: 29
+    CreatePostTooManyRequests: 26
+    CreatePostUnauthorized: 23
+    Disabled: 0
+    Failed: 1
+    ListPagesApiCallFailed: 4
+    ListPagesBadRequest: 5
+    ListPagesEmptyBoardID: 11
+    ListPagesForbidden: 7
+    ListPagesGenericFailure: 10
+    ListPagesInvalidBookmark: 12
+    ListPagesNotFound: 8
+    ListPagesTooManyRequests: 9
+    ListPagesUnauthorized: 6
+    Locked: 3
+    Success: 2
 PingMode:
-  ClickDrag: 1
-  KeyDown: 0
+  values:
+    ClickDrag: 1
+    KeyDown: 0
 PingResult:
-  FailedDisabledByLeader: 3
-  FailedDisabledBySettings: 4
-  FailedGeneric: 1
-  FailedOutOfPingArea: 5
-  FailedSilent: 8
-  FailedSpamming: 2
-  FailedSquelched: 6
-  FailedUnspecified: 7
-  Success: 0
+  values:
+    FailedDisabledByLeader: 3
+    FailedDisabledBySettings: 4
+    FailedGeneric: 1
+    FailedOutOfPingArea: 5
+    FailedSilent: 8
+    FailedSpamming: 2
+    FailedSquelched: 6
+    FailedUnspecified: 7
+    Success: 0
 PingSetTargetState:
-  Failed: 1
-  FailedSilent: 2
-  Ok: 0
+  values:
+    Failed: 1
+    FailedSilent: 2
+    Ok: 0
 PingSubjectType:
-  ActionNotReady: 9
-  ActionOnCooldown: 7
-  ActionReady: 6
-  ActionUnavailable: 8
-  AlertNotThreat: 5
-  AlertThreat: 4
-  Assist: 2
-  Attack: 0
-  OnMyWay: 3
-  Warning: 1
+  values:
+    ActionNotReady: 9
+    ActionOnCooldown: 7
+    ActionReady: 6
+    ActionUnavailable: 8
+    AlertNotThreat: 5
+    AlertThreat: 4
+    Assist: 2
+    Attack: 0
+    OnMyWay: 3
+    Warning: 1
 PingTargetOption:
-  All: 0
-  Environment: 1
-  Units: 2
+  values:
+    All: 0
+    Environment: 1
+    Units: 2
 PingTargetType:
-  Action: 2
-  Point: 1
-  Unit: 0
+  values:
+    Action: 2
+    Point: 1
+    Unit: 0
 PingTextureType:
-  Center: 0
-  Expand: 1
-  Rotation: 2
+  values:
+    Center: 0
+    Expand: 1
+    Rotation: 2
 PingTypeFlags:
-  DefaultPing: 1
+  values:
+    DefaultPing: 1
 PlayerChoiceFlags:
-  DoNotRefresh: 8
-  HideAnswerArt: 128
-  HideWarboardHeader: 2
-  InfiniteRange: 1
-  KeepOpenAfterChoice: 4
-  RequiresSelection: 32
-  ShowChoicesAsColumns: 256
-  ShowChoicesAsGrid: 64
-  ShowChoicesAsList: 16
+  values:
+    DoNotRefresh: 8
+    HideAnswerArt: 128
+    HideWarboardHeader: 2
+    InfiniteRange: 1
+    KeepOpenAfterChoice: 4
+    RequiresSelection: 32
+    ShowChoicesAsColumns: 256
+    ShowChoicesAsGrid: 64
+    ShowChoicesAsList: 16
 PlayerChoiceLayout:
-  Columns: 3
-  Default: 0
-  Grid: 1
-  List: 2
+  values:
+    Columns: 3
+    Default: 0
+    Grid: 1
+    List: 2
 PlayerChoiceRarity:
-  Common: 0
-  Epic: 3
-  Rare: 2
-  Uncommon: 1
+  values:
+    Common: 0
+    Epic: 3
+    Rare: 2
+    Uncommon: 1
 PlayerChoiceResponseFlags:
-  CheckmarkOnlyButton: 64
-  ConsolidateWidgets: 32
-  HideButton: 128
-  InvertCondition: 8
-  None: 0
-  ShowAnswerDisabled: 1
-  ShowAnswerDisabledWhenConditionFails: 16
-  ShowAnswerSelected: 256
-  ShowArtDesaturated: 2
-  ShowOptionDisabled: 4
+  values:
+    CheckmarkOnlyButton: 64
+    ConsolidateWidgets: 32
+    HideButton: 128
+    InvertCondition: 8
+    None: 0
+    ShowAnswerDisabled: 1
+    ShowAnswerDisabledWhenConditionFails: 16
+    ShowAnswerSelected: 256
+    ShowArtDesaturated: 2
+    ShowOptionDisabled: 4
 PlayerClubRequestStatus:
-  Approved: 4
-  AutoApproved: 2
-  Canceled: 7
-  Declined: 3
-  Joined: 5
-  JoinedAnother: 6
-  None: 0
-  Pending: 1
+  values:
+    Approved: 4
+    AutoApproved: 2
+    Canceled: 7
+    Declined: 3
+    Joined: 5
+    JoinedAnother: 6
+    None: 0
+    Pending: 1
 PlayerCompanionInfoFlags:
-  IgnoreSeasonInScenarios: 1
+  values:
+    IgnoreSeasonInScenarios: 1
 PlayerCurrencyFlags:
-  Incremented: 1
-  Loading: 2
+  values:
+    Incremented: 1
+    Loading: 2
 PlayerCurrencyFlagsDbFlags:
-  IgnoreMaxQtyOnload: 1
-  InBackpack: 4
-  Reuse1: 2
-  Reuse2: 16
-  UnusedInUI: 8
+  values:
+    IgnoreMaxQtyOnload: 1
+    InBackpack: 4
+    Reuse1: 2
+    Reuse2: 16
+    UnusedInUI: 8
 PlayerDataElementType:
-  Float: 1
-  Int: 0
+  values:
+    Float: 1
+    Int: 0
 PlayerInteractionType:
-  AccountBanker: 68
-  AdventureJournal: 54
-  AdventureMap: 28
-  AlliedRaceDetailsGiver: 9
-  AnimaDiversion: 47
-  AreaSpiritHealer: 19
-  ArtifactForge: 38
-  Auctioneer: 21
-  AzeriteForge: 56
-  AzeriteRespec: 42
-  Banker: 8
-  BarbersChoice: 62
-  BattleMaster: 23
-  Binder: 20
-  BlackMarketAuctioneer: 27
-  CharacterBanker: 67
-  ChromieTime: 45
-  ContributionCollector: 41
-  CornerstoneInteraction: 70
-  CovenantPreview: 46
-  CovenantSanctum: 51
-  CreateGuildNeighborhood: 74
-  ForgeMaster: 66
-  GarrArchitect: 30
-  GarrMission: 32
-  GarrRecruitment: 34
-  GarrTalent: 35
-  GarrTradeskill: 31
-  Gossip: 3
-  GuildBanker: 10
-  GuildRename: 76
-  GuildTabardVendor: 14
-  HousingBulletinBoard: 72
-  HousingPedestal: 73
-  IslandQueue: 43
-  Item: 2
-  ItemInteraction: 44
-  ItemUpgrade: 53
-  JailersTowerBuffs: 63
-  LegendaryCrafting: 48
-  LFGDungeon: 25
-  MailInfo: 17
-  MajorFactionRenown: 64
-  Merchant: 5
-  NeighborhoodCharter: 75
-  NewPlayerGuide: 52
-  None: 0
-  ObliterumForge: 39
-  OpenHouseFinder: 78
-  OpenNeighborhoodCharterConfirmation: 77
-  PerksProgramVendor: 57
-  PersonalTabardVendor: 65
-  PetitionVendor: 13
-  PlayerChoice: 37
-  ProfessionRespec: 69
-  Professions: 59
-  ProfessionsCraftingOrder: 58
-  ProfessionsCustomerOrder: 60
-  QuestGiver: 4
-  Registrar: 11
-  RenameNeighborhood: 71
-  Renown: 55
-  ScrappingMachine: 40
-  ShipmentCrafter: 33
-  Soulbind: 50
-  SpecializationMaster: 16
-  SpiritHealer: 18
-  StableMaster: 22
-  TalentMaster: 15
-  TaxiNode: 6
-  TieredEntrance: 79
-  TradePartner: 1
-  Trainer: 7
-  TraitSystem: 61
-  Transmogrifier: 24
-  Trophy: 36
-  Vendor: 12
-  VoidStorageBanker: 26
-  WeeklyRewards: 49
-  WorldMap: 29
+  values:
+    AccountBanker: 68
+    AdventureJournal: 54
+    AdventureMap: 28
+    AlliedRaceDetailsGiver: 9
+    AnimaDiversion: 47
+    AreaSpiritHealer: 19
+    ArtifactForge: 38
+    Auctioneer: 21
+    AzeriteForge: 56
+    AzeriteRespec: 42
+    Banker: 8
+    BarbersChoice: 62
+    BattleMaster: 23
+    Binder: 20
+    BlackMarketAuctioneer: 27
+    CharacterBanker: 67
+    ChromieTime: 45
+    ContributionCollector: 41
+    CornerstoneInteraction: 70
+    CovenantPreview: 46
+    CovenantSanctum: 51
+    CreateGuildNeighborhood: 74
+    ForgeMaster: 66
+    GarrArchitect: 30
+    GarrMission: 32
+    GarrRecruitment: 34
+    GarrTalent: 35
+    GarrTradeskill: 31
+    Gossip: 3
+    GuildBanker: 10
+    GuildRename: 76
+    GuildTabardVendor: 14
+    HousingBulletinBoard: 72
+    HousingPedestal: 73
+    IslandQueue: 43
+    Item: 2
+    ItemInteraction: 44
+    ItemUpgrade: 53
+    JailersTowerBuffs: 63
+    LegendaryCrafting: 48
+    LFGDungeon: 25
+    MailInfo: 17
+    MajorFactionRenown: 64
+    Merchant: 5
+    NeighborhoodCharter: 75
+    NewPlayerGuide: 52
+    None: 0
+    ObliterumForge: 39
+    OpenHouseFinder: 78
+    OpenNeighborhoodCharterConfirmation: 77
+    PerksProgramVendor: 57
+    PersonalTabardVendor: 65
+    PetitionVendor: 13
+    PlayerChoice: 37
+    ProfessionRespec: 69
+    Professions: 59
+    ProfessionsCraftingOrder: 58
+    ProfessionsCustomerOrder: 60
+    QuestGiver: 4
+    Registrar: 11
+    RenameNeighborhood: 71
+    Renown: 55
+    ScrappingMachine: 40
+    ShipmentCrafter: 33
+    Soulbind: 50
+    SpecializationMaster: 16
+    SpiritHealer: 18
+    StableMaster: 22
+    TalentMaster: 15
+    TaxiNode: 6
+    TieredEntrance: 79
+    TradePartner: 1
+    Trainer: 7
+    TraitSystem: 61
+    Transmogrifier: 24
+    Trophy: 36
+    Vendor: 12
+    VoidStorageBanker: 26
+    WeeklyRewards: 49
+    WorldMap: 29
 PlayerMentorshipApplicationResult:
-  AlreadyMentor: 1
-  Ineligible: 2
-  Success: 0
+  values:
+    AlreadyMentor: 1
+    Ineligible: 2
+    Success: 0
 PlayerMentorshipStatus:
-  Mentor: 2
-  Newcomer: 1
-  None: 0
+  values:
+    Mentor: 2
+    Newcomer: 1
+    None: 0
 PlunderstormQueueState:
-  None: 0
-  Proposed: 2
-  Queued: 1
-  Suspended: 3
+  values:
+    None: 0
+    Proposed: 2
+    Queued: 1
+    Suspended: 3
 PowerType:
-  Alternate: 10
-  AlternateEncounter: 24
-  AlternateMount: 25
-  AlternateQuest: 23
-  ArcaneCharges: 16
-  Balance: 26
-  BurningEmbers: 14
-  Chi: 12
-  ComboPoints: 4
-  DemonicFury: 15
-  Energy: 3
-  Essence: 19
-  Focus: 2
-  Fury: 17
-  Happiness: 27
-  HolyPower: 9
-  Insanity: 13
-  LunarPower: 8
-  Maelstrom: 11
-  Mana: 0
-  Pain: 18
-  Rage: 1
-  RuneBlood: 20
-  RuneChromatic: 29
-  RuneFrost: 21
-  Runes: 5
-  RuneUnholy: 22
-  RunicPower: 6
-  ShadowOrbs: 28
-  SoulShards: 7
+  values:
+    Alternate: 10
+    AlternateEncounter: 24
+    AlternateMount: 25
+    AlternateQuest: 23
+    ArcaneCharges: 16
+    Balance: 26
+    BurningEmbers: 14
+    Chi: 12
+    ComboPoints: 4
+    DemonicFury: 15
+    Energy: 3
+    Essence: 19
+    Focus: 2
+    Fury: 17
+    Happiness: 27
+    HolyPower: 9
+    Insanity: 13
+    LunarPower: 8
+    Maelstrom: 11
+    Mana: 0
+    Pain: 18
+    Rage: 1
+    RuneBlood: 20
+    RuneChromatic: 29
+    RuneFrost: 21
+    Runes: 5
+    RuneUnholy: 22
+    RunicPower: 6
+    ShadowOrbs: 28
+    SoulShards: 7
 PowerTypeSign:
-  Negative: 1
-  None: -1
-  Positive: 0
+  values:
+    Negative: 1
+    None: -1
+    Positive: 0
 PowerTypeSlot:
-  Slot_0: 0
-  Slot_1: 1
-  Slot_2: 2
-  Slot_3: 3
-  Slot_4: 4
-  Slot_5: 5
-  Slot_6: 6
-  Slot_7: 7
-  Slot_8: 8
-  Slot_9: 9
+  values:
+    Slot_0: 0
+    Slot_1: 1
+    Slot_2: 2
+    Slot_3: 3
+    Slot_4: 4
+    Slot_5: 5
+    Slot_6: 6
+    Slot_7: 7
+    Slot_8: 8
+    Slot_9: 9
 PremadeGroupFinderStyle:
-  Disabled: 0
-  Mainline: 1
-  Vanilla: 2
+  values:
+    Disabled: 0
+    Mainline: 1
+    Vanilla: 2
 PreyHuntProgressState:
-  Cold: 0
-  Final: 3
-  Hot: 2
-  Warm: 1
+  values:
+    Cold: 0
+    Final: 3
+    Hot: 2
+    Warm: 1
 ProceduralSpawnInteractionMode:
-  Manipulate: 2
-  None: 0
-  Paint: 1
+  values:
+    Manipulate: 2
+    None: 0
+    Paint: 1
 ProceduralSpawnVolumeChunkFlags:
-  AllSubChunksSet: 1
-  None: 0
+  values:
+    AllSubChunksSet: 1
+    None: 0
 Profession:
-  Alchemy: 3
-  Archaeology: 14
-  Blacksmithing: 1
-  Cooking: 5
-  Enchanting: 9
-  Engineering: 8
-  FirstAid: 0
-  Fishing: 10
-  Herbalism: 4
-  Inscription: 13
-  Jewelcrafting: 12
-  Leatherworking: 2
-  Mining: 6
-  Skinning: 11
-  Tailoring: 7
+  values:
+    Alchemy: 3
+    Archaeology: 14
+    Blacksmithing: 1
+    Cooking: 5
+    Enchanting: 9
+    Engineering: 8
+    FirstAid: 0
+    Fishing: 10
+    Herbalism: 4
+    Inscription: 13
+    Jewelcrafting: 12
+    Leatherworking: 2
+    Mining: 6
+    Skinning: 11
+    Tailoring: 7
 ProfessionActionType:
-  Craft: 0
-  Gather: 1
+  values:
+    Craft: 0
+    Gather: 1
 ProfessionEffect:
-  AccumulateRanksByLabel: 25
-  ConcentrationRefund: 30
-  DecreaseDifficulty: 22
-  IncreaseDifficulty: 23
-  ModConcentration: 27
-  ModCraftCritSize: 20
-  ModCraftExtraQuantity: 18
-  ModCraftingSpeed: 14
-  ModCraftReductionQuantity: 21
-  ModDeftness: 12
-  ModFinesse: 11
-  ModGatherExtraQuantity: 19
-  ModIngenuity: 29
-  ModInspiration: 9
-  ModMulticraft: 15
-  ModPerception: 13
-  ModResourcefulness: 10
-  ModSkillGain: 24
-  ModUnused_1: 16
-  ModUnused_2: 17
-  Skill: 0
-  StatCraftingSpeed: 6
-  StatDeftness: 4
-  StatFinesse: 3
-  StatIngenuity: 26
-  StatInspiration: 1
-  StatMulticraft: 7
-  StatPerception: 5
-  StatResourcefulness: 2
-  Tokenizer: 28
-  UnlockReagentSlot: 8
+  values:
+    AccumulateRanksByLabel: 25
+    ConcentrationRefund: 30
+    DecreaseDifficulty: 22
+    IncreaseDifficulty: 23
+    ModConcentration: 27
+    ModCraftCritSize: 20
+    ModCraftExtraQuantity: 18
+    ModCraftingSpeed: 14
+    ModCraftReductionQuantity: 21
+    ModDeftness: 12
+    ModFinesse: 11
+    ModGatherExtraQuantity: 19
+    ModIngenuity: 29
+    ModInspiration: 9
+    ModMulticraft: 15
+    ModPerception: 13
+    ModResourcefulness: 10
+    ModSkillGain: 24
+    ModUnused_1: 16
+    ModUnused_2: 17
+    Skill: 0
+    StatCraftingSpeed: 6
+    StatDeftness: 4
+    StatFinesse: 3
+    StatIngenuity: 26
+    StatInspiration: 1
+    StatMulticraft: 7
+    StatPerception: 5
+    StatResourcefulness: 2
+    Tokenizer: 28
+    UnlockReagentSlot: 8
 ProfessionRating:
-  CraftingSpeed: 5
-  Deftness: 3
-  Finesse: 2
-  Ingenuity: 7
-  Inspiration: 0
-  Multicraft: 6
-  Perception: 4
-  Resourcefulness: 1
-  Unused_2: 8
+  values:
+    CraftingSpeed: 5
+    Deftness: 3
+    Finesse: 2
+    Ingenuity: 7
+    Inspiration: 0
+    Multicraft: 6
+    Perception: 4
+    Resourcefulness: 1
+    Unused_2: 8
 ProfessionRatingType:
-  Craft: 0
-  Gather: 1
+  values:
+    Craft: 0
+    Gather: 1
 ProfessionsSpecPathState:
-  Completed: 2
-  Locked: 0
-  Progressing: 1
+  values:
+    Completed: 2
+    Locked: 0
+    Progressing: 1
 ProfessionsSpecPerkState:
-  Earned: 2
-  Pending: 1
-  Unearned: 0
+  values:
+    Earned: 2
+    Pending: 1
+    Unearned: 0
 ProfessionsSpecTabState:
-  Locked: 0
-  Unlockable: 2
-  Unlocked: 1
+  values:
+    Locked: 0
+    Unlockable: 2
+    Unlocked: 1
 ProfTraitPerkNodeFlags:
-  IsMajorBonus: 2
-  UnlocksSubpath: 1
+  values:
+    IsMajorBonus: 2
+    UnlocksSubpath: 1
 PurchaseEligibility:
-  ExpansionTooHigh: 4
-  ExpansionTooLow: 3
-  MissingRequiredDeliverable: 5
-  Ok: 0
-  Owned: 2
-  PartiallyOwned: 1
+  values:
+    ExpansionTooHigh: 4
+    ExpansionTooLow: 3
+    MissingRequiredDeliverable: 5
+    Ok: 0
+    Owned: 2
+    PartiallyOwned: 1
 PurchaseHouseDisabledReason:
-  CharterLockout: 7
-  GuildLockout: 6
-  MaxHouses: 8
-  NoExpansion: 4
-  NoGameTimeRemaining: 9
-  None: 0
-  NotInvited: 3
-  Reserved: 5
-  WrongFaction: 1
-  WrongGuild: 2
+  values:
+    CharterLockout: 7
+    GuildLockout: 6
+    MaxHouses: 8
+    NoExpansion: 4
+    NoGameTimeRemaining: 9
+    None: 0
+    NotInvited: 3
+    Reserved: 5
+    WrongFaction: 1
+    WrongGuild: 2
 PurchaseResult:
-  ErrorAuthorizingPayment: 37
-  ErrorBattlepayDisabled: 14
-  ErrorBattlepayTemporarilyUnavailable: 13
-  ErrorBattlepayTimeoutMopAndRisk: 11
-  ErrorBattlepayTimeoutValidatePurchase: 56
-  ErrorBattlepayTimeoutValidationHash: 62
-  ErrorBlockedByParentalControls: 33
-  ErrorBuyingProductNotAllowedInGlueScreen: 27
-  ErrorBuyingProductNotAllowedInWorld: 32
-  ErrorCharacterUpgradeOperationInProgress: 51
-  ErrorClientCheckoutCanceledOrFailed: 63
-  ErrorClientCheckoutTimeout: 60
-  ErrorClientDeclined: 4
-  ErrorClientDeclinedChallenge: 41
-  ErrorClientGone: 9
-  ErrorClientRestricted: 66
-  ErrorClientTimeout: 3
-  ErrorClientTimeoutChallenge: 40
-  ErrorCommerceServerDisabled: 48
-  ErrorCouldNotGetValidationHash: 64
-  ErrorCurrencyInvalidInRegion: 12
-  ErrorDistributionObjectAlreadyAssigned: 20
-  ErrorDistributionObjectExpansionBlocked: 45
-  ErrorDistributionObjectInvalidChoice: 35
-  ErrorDistributionObjectInvalidTarget: 42
-  ErrorDistributionObjectNotFound: 19
-  ErrorDistributionObjectTrialBlocked: 44
-  ErrorDistributionObjectWrongGameAccount: 65
-  ErrorFailedOldPurchaseFlow: 59
-  ErrorFailedToCreatePurchaseRecord: 5
-  ErrorFailedToGetPurchaseID: 6
-  ErrorFailedToSaveClientCheckoutStatus: 58
-  ErrorFailedToSaveMopAndRiskResponse: 8
-  ErrorFailedToSaveMopAndRiskStatus: 7
-  ErrorFailedToSavePlaceOrderStatus: 10
-  ErrorFailedToSaveRedeemTokenStatus: 67
-  ErrorFailedToSaveValidatePurchaseResponse: 55
-  ErrorFailedToSaveValidatePurchaseStatus: 54
-  ErrorFailedToSaveValidationHashStatus: 61
-  ErrorFailedToWriteVasLicenseID: 50
-  ErrorFailedToWriteVasPurchaseID: 49
-  ErrorFixedLicenseProductAlreadyExists: 43
-  ErrorInManualReview: 71
-  ErrorInvalidCreditCardExpiryDate: 36
-  ErrorInvalidDeviceID: 53
-  ErrorInvalidPlatform: 52
-  ErrorInvalidProduct: 16
-  ErrorInvalidPurchaseID: 68
-  ErrorInvalidRegionGroupMask: 17
-  ErrorMopAndRiskAmqpRpcFailed: 22
-  ErrorMopAndRiskNotEnoughBalance: 28
-  ErrorMopAndRiskNoValidPaymentMethods: 25
-  ErrorMopAndRiskRpcErrorFromBattlepay: 23
-  ErrorMopAndRiskUnexpectedResponseFromBattlepay: 24
-  ErrorNoStorePurchaseFlagIsSet: 34
-  ErrorOrderCanceledPriceChange: 26
-  ErrorOrderFailed: 2
-  ErrorOverSpendingLimit: 39
-  ErrorOwnsConsumableToken: 46
-  ErrorPaymentProviderDeniedPayment: 38
-  ErrorPlaceOrderNotEnoughBalance: 29
-  ErrorProductInvalidInRegion: 18
-  ErrorProductNotPurchasable: 57
-  ErrorProgrammerManualFail: 30
-  ErrorRiskDenied: 1
-  ErrorRiskResponseMissingScore: 21
-  ErrorServerRestarted: 15
-  ErrorThrottledByUserServer: 31
-  ErrorTokenRedemptionOrderFailed: 69
-  ErrorTooManyTokens: 47
-  ErrorVasTransactionCreateFailed: 70
-  Ok: 0
+  values:
+    ErrorAuthorizingPayment: 37
+    ErrorBattlepayDisabled: 14
+    ErrorBattlepayTemporarilyUnavailable: 13
+    ErrorBattlepayTimeoutMopAndRisk: 11
+    ErrorBattlepayTimeoutValidatePurchase: 56
+    ErrorBattlepayTimeoutValidationHash: 62
+    ErrorBlockedByParentalControls: 33
+    ErrorBuyingProductNotAllowedInGlueScreen: 27
+    ErrorBuyingProductNotAllowedInWorld: 32
+    ErrorCharacterUpgradeOperationInProgress: 51
+    ErrorClientCheckoutCanceledOrFailed: 63
+    ErrorClientCheckoutTimeout: 60
+    ErrorClientDeclined: 4
+    ErrorClientDeclinedChallenge: 41
+    ErrorClientGone: 9
+    ErrorClientRestricted: 66
+    ErrorClientTimeout: 3
+    ErrorClientTimeoutChallenge: 40
+    ErrorCommerceServerDisabled: 48
+    ErrorCouldNotGetValidationHash: 64
+    ErrorCurrencyInvalidInRegion: 12
+    ErrorDistributionObjectAlreadyAssigned: 20
+    ErrorDistributionObjectExpansionBlocked: 45
+    ErrorDistributionObjectInvalidChoice: 35
+    ErrorDistributionObjectInvalidTarget: 42
+    ErrorDistributionObjectNotFound: 19
+    ErrorDistributionObjectTrialBlocked: 44
+    ErrorDistributionObjectWrongGameAccount: 65
+    ErrorFailedOldPurchaseFlow: 59
+    ErrorFailedToCreatePurchaseRecord: 5
+    ErrorFailedToGetPurchaseID: 6
+    ErrorFailedToSaveClientCheckoutStatus: 58
+    ErrorFailedToSaveMopAndRiskResponse: 8
+    ErrorFailedToSaveMopAndRiskStatus: 7
+    ErrorFailedToSavePlaceOrderStatus: 10
+    ErrorFailedToSaveRedeemTokenStatus: 67
+    ErrorFailedToSaveValidatePurchaseResponse: 55
+    ErrorFailedToSaveValidatePurchaseStatus: 54
+    ErrorFailedToSaveValidationHashStatus: 61
+    ErrorFailedToWriteVasLicenseID: 50
+    ErrorFailedToWriteVasPurchaseID: 49
+    ErrorFixedLicenseProductAlreadyExists: 43
+    ErrorInManualReview: 71
+    ErrorInvalidCreditCardExpiryDate: 36
+    ErrorInvalidDeviceID: 53
+    ErrorInvalidPlatform: 52
+    ErrorInvalidProduct: 16
+    ErrorInvalidPurchaseID: 68
+    ErrorInvalidRegionGroupMask: 17
+    ErrorMopAndRiskAmqpRpcFailed: 22
+    ErrorMopAndRiskNotEnoughBalance: 28
+    ErrorMopAndRiskNoValidPaymentMethods: 25
+    ErrorMopAndRiskRpcErrorFromBattlepay: 23
+    ErrorMopAndRiskUnexpectedResponseFromBattlepay: 24
+    ErrorNoStorePurchaseFlagIsSet: 34
+    ErrorOrderCanceledPriceChange: 26
+    ErrorOrderFailed: 2
+    ErrorOverSpendingLimit: 39
+    ErrorOwnsConsumableToken: 46
+    ErrorPaymentProviderDeniedPayment: 38
+    ErrorPlaceOrderNotEnoughBalance: 29
+    ErrorProductInvalidInRegion: 18
+    ErrorProductNotPurchasable: 57
+    ErrorProgrammerManualFail: 30
+    ErrorRiskDenied: 1
+    ErrorRiskResponseMissingScore: 21
+    ErrorServerRestarted: 15
+    ErrorThrottledByUserServer: 31
+    ErrorTokenRedemptionOrderFailed: 69
+    ErrorTooManyTokens: 47
+    ErrorVasTransactionCreateFailed: 70
+    Ok: 0
 PvPFaction:
-  Alliance: 1
-  Horde: 0
+  values:
+    Alliance: 1
+    Horde: 0
 PvPMatchmakingType:
-  Arena: 1
-  Battleground: 0
+  values:
+    Arena: 1
+    Battleground: 0
 PvPMatchState:
-  Complete: 5
-  Engaged: 3
-  Inactive: 0
-  PostRound: 4
-  StartUp: 2
-  Waiting: 1
+  values:
+    Complete: 5
+    Engaged: 3
+    Inactive: 0
+    PostRound: 4
+    StartUp: 2
+    Waiting: 1
 PvPRanks:
-  Rank_1: 5
-  Rank_10: 14
-  Rank_11: 15
-  Rank_12: 16
-  Rank_13: 17
-  Rank_14: 18
-  Rank_2: 6
-  Rank_3: 7
-  Rank_4: 8
-  Rank_5: 9
-  Rank_6: 10
-  Rank_7: 11
-  Rank_8: 12
-  Rank_9: 13
-  RankDishonored: 4
-  RankExiled: 3
-  RankNone: 0
-  RankOutlaw: 2
-  RankPariah: 1
+  values:
+    Rank_1: 5
+    Rank_10: 14
+    Rank_11: 15
+    Rank_12: 16
+    Rank_13: 17
+    Rank_14: 18
+    Rank_2: 6
+    Rank_3: 7
+    Rank_4: 8
+    Rank_5: 9
+    Rank_6: 10
+    Rank_7: 11
+    Rank_8: 12
+    Rank_9: 13
+    RankDishonored: 4
+    RankExiled: 3
+    RankNone: 0
+    RankOutlaw: 2
+    RankPariah: 1
 PvPUnitClassification:
-  AssassinAlliance: 6
-  AssassinHorde: 5
-  CartRunnerAlliance: 4
-  CartRunnerHorde: 3
-  FlagCarrierAlliance: 1
-  FlagCarrierHorde: 0
-  FlagCarrierNeutral: 2
-  OrbCarrierBlue: 7
-  OrbCarrierGreen: 8
-  OrbCarrierOrange: 9
-  OrbCarrierPurple: 10
+  values:
+    AssassinAlliance: 6
+    AssassinHorde: 5
+    CartRunnerAlliance: 4
+    CartRunnerHorde: 3
+    FlagCarrierAlliance: 1
+    FlagCarrierHorde: 0
+    FlagCarrierNeutral: 2
+    OrbCarrierBlue: 7
+    OrbCarrierGreen: 8
+    OrbCarrierOrange: 9
+    OrbCarrierPurple: 10
 QuestClassification:
-  BonusObjective: 8
-  Calling: 3
-  Campaign: 2
-  Important: 0
-  Legendary: 1
-  Meta: 4
-  Normal: 7
-  Questline: 6
-  Recurring: 5
-  Threat: 9
-  WorldQuest: 10
+  values:
+    BonusObjective: 8
+    Calling: 3
+    Campaign: 2
+    Important: 0
+    Legendary: 1
+    Meta: 4
+    Normal: 7
+    Questline: 6
+    Recurring: 5
+    Threat: 9
+    WorldQuest: 10
 QuestCompleteSpellType:
-  Ability: 3
-  Aura: 4
-  Companion: 7
-  Follower: 1
-  LegacyBehavior: 0
-  PossibleReward: 11
-  QuestlineReward: 9
-  QuestlineUnlock: 8
-  QuestlineUnlockPart: 10
-  Spell: 5
-  Tradeskill: 2
-  Unlock: 6
+  values:
+    Ability: 3
+    Aura: 4
+    Companion: 7
+    Follower: 1
+    LegacyBehavior: 0
+    PossibleReward: 11
+    QuestlineReward: 9
+    QuestlineUnlock: 8
+    QuestlineUnlockPart: 10
+    Spell: 5
+    Tradeskill: 2
+    Unlock: 6
 QuestFrequency:
-  Daily: 1
-  Default: 0
-  ResetByScheduler: 3
-  Weekly: 2
+  values:
+    Daily: 1
+    Default: 0
+    ResetByScheduler: 3
+    Weekly: 2
 QuestLineFloorLocation:
-  Above: 0
-  Below: 1
-  Same: 2
+  values:
+    Above: 0
+    Below: 1
+    Same: 2
 QuestRepeatability:
-  Daily: 1
-  None: 0
-  Turnin: 3
-  Weekly: 2
-  World: 4
+  values:
+    Daily: 1
+    None: 0
+    Turnin: 3
+    Weekly: 2
+    World: 4
 QuestRewardContextFlags:
-  FirstCompletionBonus: 1
-  None: 0
-  RepeatCompletionBonus: 2
+  values:
+    FirstCompletionBonus: 1
+    None: 0
+    RepeatCompletionBonus: 2
 QuestSessionCommand:
-  None: 0
-  SessionActiveNoCommand: 3
-  Start: 1
-  Stop: 2
+  values:
+    None: 0
+    SessionActiveNoCommand: 3
+    Start: 1
+    Stop: 2
 QuestSessionResult:
-  AlreadyActive: 3
-  AlreadyJoined: 20
-  AlreadyMember: 17
-  AlreadyOwner: 19
-  Busy: 22
-  Disabled: 8
-  Empty: 25
-  InCombat: 32
-  InPetBattle: 29
-  InRaid: 5
-  InvalidOwner: 2
-  InvalidPublicParty: 30
-  Joined: 11
-  JoinRejected: 23
-  Left: 12
-  Logout: 24
-  MemberInCombat: 33
-  MemberTimeout: 16
-  NotActive: 4
-  NotInParty: 1
-  NotMember: 21
-  NotOwner: 18
-  Ok: 0
-  OwnerLeft: 13
-  OwnerRefused: 6
-  PartyDestroyed: 15
-  QuestNotCompleted: 26
-  ReadyCheckFailed: 14
-  Restricted: 28
-  RestrictedCrossFaction: 34
-  Resync: 27
-  Started: 9
-  Stopped: 10
-  Timeout: 7
-  Unknown: 31
+  values:
+    AlreadyActive: 3
+    AlreadyJoined: 20
+    AlreadyMember: 17
+    AlreadyOwner: 19
+    Busy: 22
+    Disabled: 8
+    Empty: 25
+    InCombat: 32
+    InPetBattle: 29
+    InRaid: 5
+    InvalidOwner: 2
+    InvalidPublicParty: 30
+    Joined: 11
+    JoinRejected: 23
+    Left: 12
+    Logout: 24
+    MemberInCombat: 33
+    MemberTimeout: 16
+    NotActive: 4
+    NotInParty: 1
+    NotMember: 21
+    NotOwner: 18
+    Ok: 0
+    OwnerLeft: 13
+    OwnerRefused: 6
+    PartyDestroyed: 15
+    QuestNotCompleted: 26
+    ReadyCheckFailed: 14
+    Restricted: 28
+    RestrictedCrossFaction: 34
+    Resync: 27
+    Started: 9
+    Stopped: 10
+    Timeout: 7
+    Unknown: 31
 QuestTag:
-  Account: 102
-  CombatAlly: 266
-  Delve: 288
-  Dungeon: 81
-  Group: 1
-  Heroic: 85
-  Legendary: 83
-  PvP: 41
-  Raid: 62
-  Raid10: 88
-  Raid25: 89
-  Scenario: 98
+  values:
+    Account: 102
+    CombatAlly: 266
+    Delve: 288
+    Dungeon: 81
+    Group: 1
+    Heroic: 85
+    Legendary: 83
+    PvP: 41
+    Raid: 62
+    Raid10: 88
+    Raid25: 89
+    Scenario: 98
 QuestTagType:
-  Bounty: 5
-  Capstone: 17
-  Contribution: 9
-  CovenantCalling: 15
-  DragonRiderRacing: 16
-  Dungeon: 6
-  FactionAssault: 12
-  Invasion: 7
-  InvasionWrapper: 11
-  Islands: 13
-  Normal: 2
-  PetBattle: 4
-  Prey: 19
-  Profession: 1
-  PvP: 3
-  Raid: 8
-  RatedReward: 10
-  Tag: 0
-  Threat: 14
-  WorldBoss: 18
+  values:
+    Bounty: 5
+    Capstone: 17
+    Contribution: 9
+    CovenantCalling: 15
+    DragonRiderRacing: 16
+    Dungeon: 6
+    FactionAssault: 12
+    Invasion: 7
+    InvasionWrapper: 11
+    Islands: 13
+    Normal: 2
+    PetBattle: 4
+    Prey: 19
+    Profession: 1
+    PvP: 3
+    Raid: 8
+    RatedReward: 10
+    Tag: 0
+    Threat: 14
+    WorldBoss: 18
 QuestTreasurePickerType:
-  Hidden: 1
-  Select: 2
-  Visible: 0
+  values:
+    Hidden: 1
+    Select: 2
+    Visible: 0
 QuestWatchType:
-  Automatic: 0
-  Manual: 1
+  values:
+    Automatic: 0
+    Manual: 1
 RafLinkType:
-  Both: 3
-  Friend: 2
-  None: 0
-  Recruit: 1
+  values:
+    Both: 3
+    Friend: 2
+    None: 0
+    Recruit: 1
 RafRecruitActivityState:
-  Complete: 1
-  Incomplete: 0
-  RewardClaimed: 2
+  values:
+    Complete: 1
+    Incomplete: 0
+    RewardClaimed: 2
 RafRecruitSubStatus:
-  Active: 1
-  Inactive: 2
-  Trial: 0
+  values:
+    Active: 1
+    Inactive: 2
+    Trial: 0
 RafRewardType:
-  Appearance: 2
-  AppearanceSet: 5
-  GameTime: 4
-  Illusion: 6
-  Invalid: 7
-  Mount: 1
-  Pet: 0
-  Title: 3
+  values:
+    Appearance: 2
+    AppearanceSet: 5
+    GameTime: 4
+    Illusion: 6
+    Invalid: 7
+    Mount: 1
+    Pet: 0
+    Title: 3
 RaidAuraOrganizationType:
-  BuffsRightDebuffsLeft: 2
-  BuffsTopDebuffsBottom: 1
-  Legacy: 0
+  values:
+    BuffsRightDebuffsLeft: 2
+    BuffsTopDebuffsBottom: 1
+    Legacy: 0
 RaidDispelDisplayType:
-  Disabled: 0
-  DispellableByMe: 1
-  DisplayAll: 2
+  values:
+    Disabled: 0
+    DispellableByMe: 1
+    DisplayAll: 2
 RaidDispelOverlayType:
-  Disabled: 0
-  UseBlack: 2
-  UseDebuffColor: 1
+  values:
+    Disabled: 0
+    UseBlack: 2
+    UseDebuffColor: 1
 RaidGroupDisplayType:
-  CombineGroupsHorizontal: 3
-  CombineGroupsVertical: 2
-  SeparateGroupsHorizontal: 1
-  SeparateGroupsVertical: 0
+  values:
+    CombineGroupsHorizontal: 3
+    CombineGroupsVertical: 2
+    SeparateGroupsHorizontal: 1
+    SeparateGroupsVertical: 0
 RcoCloseReason:
-  Cancel: 2
-  CrafterFulfill: 5
-  Expire: 1
-  Fulfill: 0
-  GmCancel: 4
-  Invalid: 6
-  Reject: 3
+  values:
+    Cancel: 2
+    CrafterFulfill: 5
+    Expire: 1
+    Fulfill: 0
+    GmCancel: 4
+    Invalid: 6
+    Reject: 3
 RecentAlliesFriendTag:
-  Delves: 4
-  Dungeons: 3
-  Professions: 0
-  PvP: 1
-  Questing: 5
-  Raiding: 2
+  values:
+    Delves: 4
+    Dungeons: 3
+    Professions: 0
+    PvP: 1
+    Questing: 5
+    Raiding: 2
 RecentAllyPinResult:
-  ServerError: 1
-  Success: 0
+  values:
+    ServerError: 1
+    Success: 0
 RecipeRequirementType:
-  Area: 2
-  SpellFocus: 0
-  Totem: 1
+  values:
+    Area: 2
+    SpellFocus: 0
+    Totem: 1
 RecruitAFriendFailure:
-  InsufExpanLvl: 7
-  MapIncomingTransferNotAllowed: 9
-  NoTarget: 3
-  NotInClassic: 10
-  NotInParty: 4
-  NotLinked: 1
-  NotNow: 2
-  Offline: 8
-  Success: 0
-  SummonCooldown: 6
-  SummonLevelMax: 5
+  values:
+    InsufExpanLvl: 7
+    MapIncomingTransferNotAllowed: 9
+    NoTarget: 3
+    NotInClassic: 10
+    NotInParty: 4
+    NotLinked: 1
+    NotNow: 2
+    Offline: 8
+    Success: 0
+    SummonCooldown: 6
+    SummonLevelMax: 5
 RecruitAFriendRewardsVersion:
-  InvalidVersion: 0
-  UnusedVersionOne: 1
-  VersionThree: 3
-  VersionTwo: 2
+  values:
+    InvalidVersion: 0
+    UnusedVersionOne: 1
+    VersionThree: 3
+    VersionTwo: 2
 RegisterAddonMessagePrefixResult:
-  DuplicatePrefix: 1
-  InvalidPrefix: 2
-  MaxPrefixes: 3
-  Success: 0
+  values:
+    DuplicatePrefix: 1
+    InvalidPrefix: 2
+    MaxPrefixes: 3
+    Success: 0
 RelativeContentDifficulty:
-  Difficult: 3
-  Easy: 1
-  Fair: 2
-  Impossible: 4
-  Trivial: 0
+  values:
+    Difficult: 3
+    Easy: 1
+    Fair: 2
+    Impossible: 4
+    Trivial: 0
 ReleaseType:
-  Classic: 2
-  Original: 1
+  values:
+    Classic: 2
+    Original: 1
 RenownRewardDisplayType:
-  Currency: 9
-  GarrFollower: 8
-  Item: 1
-  Mount: 3
-  None: 0
-  Spell: 2
-  Title: 7
-  Transmog: 4
-  TransmogIllusion: 6
-  TransmogSet: 5
+  values:
+    Currency: 9
+    GarrFollower: 8
+    Item: 1
+    Mount: 3
+    None: 0
+    Spell: 2
+    Title: 7
+    Transmog: 4
+    TransmogIllusion: 6
+    TransmogSet: 5
 RenownRewardsFlags:
-  AccountUnlock: 8
-  Capstone: 2
-  Hidden: 4
-  Milestone: 1
+  values:
+    AccountUnlock: 8
+    Capstone: 2
+    Hidden: 4
+    Milestone: 1
 ReportEvidenceType:
-  HouseLayoutJson: 2
-  HouseScreenshot: 1
-  Invalid: 0
+  values:
+    HouseLayoutJson: 2
+    HouseScreenshot: 1
+    Invalid: 0
 ReportMajorCategory:
-  Cheating: 2
-  GameplaySabotage: 1
-  InappropriateBlueprint: 5
-  InappropriateCommunication: 0
-  InappropriateDecor: 4
-  InappropriateName: 3
+  values:
+    Cheating: 2
+    GameplaySabotage: 1
+    InappropriateBlueprint: 5
+    InappropriateCommunication: 0
+    InappropriateDecor: 4
+    InappropriateName: 3
 ReportMinorCategory:
-  Advertisement: 256
-  Afk: 8
-  BlockingProgress: 32
-  Boosting: 2
-  Botting: 128
-  BTag: 512
-  CharacterName: 2048
-  ChildSexualExploitationAndAbuse: 262144
-  Description: 8192
-  Disruption: 65536
-  GroupName: 1024
-  GuildName: 4096
-  Hacking: 64
-  HarmfulToMinors: 32768
-  HousingBlueprint: 1048576
-  IntentionallyFeeding: 16
-  Name: 16384
-  NeighborhoodName: 524288
-  Spam: 4
-  TerroristAndViolentExtremistContent: 131072
-  TextChat: 1
+  values:
+    Advertisement: 256
+    Afk: 8
+    BlockingProgress: 32
+    Boosting: 2
+    Botting: 128
+    BTag: 512
+    CharacterName: 2048
+    ChildSexualExploitationAndAbuse: 262144
+    Description: 8192
+    Disruption: 65536
+    GroupName: 1024
+    GuildName: 4096
+    Hacking: 64
+    HarmfulToMinors: 32768
+    HousingBlueprint: 1048576
+    IntentionallyFeeding: 16
+    Name: 16384
+    NeighborhoodName: 524288
+    Spam: 4
+    TerroristAndViolentExtremistContent: 131072
+    TextChat: 1
 ReportSubComplaintTypes:
-  Advertising: 1
-  Inappropriate: 0
+  values:
+    Advertising: 1
+    Inappropriate: 0
 ReportThrottleType:
-  Expensive: 2
-  General: 1
-  Invalid: 0
+  values:
+    Expensive: 2
+    General: 1
+    Invalid: 0
 ReportType:
-  BattlePet: 10
-  Calendar: 11
-  Chat: 0
-  ClubFinderApplicant: 3
-  ClubFinderPosting: 2
-  ClubMember: 6
-  CraftingOrder: 16
-  Friend: 8
-  GroupFinderApplicant: 5
-  GroupFinderPosting: 4
-  GroupMember: 7
-  HousingBlueprint: 21
-  HousingDecor: 18
-  InWorld: 1
-  Mail: 12
-  Neighborhood: 19
-  NeighborhoodRoster: 20
-  Pet: 9
-  PvP: 13
-  PvPGroupMember: 15
-  PvPScoreboard: 14
-  RecentAlly: 17
+  values:
+    BattlePet: 10
+    Calendar: 11
+    Chat: 0
+    ClubFinderApplicant: 3
+    ClubFinderPosting: 2
+    ClubMember: 6
+    CraftingOrder: 16
+    Friend: 8
+    GroupFinderApplicant: 5
+    GroupFinderPosting: 4
+    GroupMember: 7
+    HousingBlueprint: 21
+    HousingDecor: 18
+    InWorld: 1
+    Mail: 12
+    Neighborhood: 19
+    NeighborhoodRoster: 20
+    Pet: 9
+    PvP: 13
+    PvPGroupMember: 15
+    PvPScoreboard: 14
+    RecentAlly: 17
 ReputationSortType:
-  Account: 1
-  Character: 2
-  None: 0
+  values:
+    Account: 1
+    Character: 2
+    None: 0
 ReservationFlags:
-  Canceled: 2
-  None: 0
-  Plotless: 4
-  Relinquish: 1
+  values:
+    Canceled: 2
+    None: 0
+    Plotless: 4
+    Relinquish: 1
 ResidentType:
-  Manager: 1
-  Owner: 2
-  Resident: 0
+  values:
+    Manager: 1
+    Owner: 2
+    Resident: 0
 RestrictPingsTo:
-  Assist: 2
-  Lead: 1
-  None: 0
-  TankHealer: 3
+  values:
+    Assist: 2
+    Lead: 1
+    None: 0
+    TankHealer: 3
 RetroactiveDecorRewardFlags:
-  AllCriteriaRequired: 1
-  None: 0
+  values:
+    AllCriteriaRequired: 1
+    None: 0
 RolodexContactMigrationResult:
-  ContactAdded: 0
-  ContactUpdated: 1
+  values:
+    ContactAdded: 0
+    ContactUpdated: 1
 RolodexContextLevelType:
-  DelveTier: 3
-  Difficulty: 1
-  KeystoneLevel: 2
-  None: 0
+  values:
+    DelveTier: 3
+    Difficulty: 1
+    KeystoneLevel: 2
+    None: 0
 RolodexDbFlags:
-  None: 0
-  PromotedFromContact: 1
+  values:
+    None: 0
+    PromotedFromContact: 1
 RolodexType:
-  CompleteArena: 16
-  CompleteBg: 17
-  CompleteDelve: 15
-  CompleteDungeon: 12
-  CreatureKill: 11
-  Duel: 18
-  GuildOrderFilledByOther: 9
-  GuildOrderFilledByYou: 10
-  KillLfrBoss: 14
-  KillRaidBoss: 13
-  LegacyFriend: 23
-  None: 0
-  PartyMember: 1
-  PersonalOrderFilledByOther: 7
-  PersonalOrderFilledByYou: 8
-  PetBattle: 19
-  PublicOrderFilledByOther: 5
-  PublicOrderFilledByYou: 6
-  PvPKill: 20
-  RaidMember: 2
-  Trade: 3
-  Whisper: 4
+  values:
+    CompleteArena: 16
+    CompleteBg: 17
+    CompleteDelve: 15
+    CompleteDungeon: 12
+    CreatureKill: 11
+    Duel: 18
+    GuildOrderFilledByOther: 9
+    GuildOrderFilledByYou: 10
+    KillLfrBoss: 14
+    KillRaidBoss: 13
+    LegacyFriend: 23
+    None: 0
+    PartyMember: 1
+    PersonalOrderFilledByOther: 7
+    PersonalOrderFilledByYou: 8
+    PetBattle: 19
+    PublicOrderFilledByOther: 5
+    PublicOrderFilledByYou: 6
+    PvPKill: 20
+    RaidMember: 2
+    Trade: 3
+    Whisper: 4
 RolodexTypeFlags:
-  HiddenFromHistory: 1
-  None: 0
+  values:
+    HiddenFromHistory: 1
+    None: 0
 RoomConnectionType:
-  All: 1
-  None: 0
+  values:
+    All: 1
+    None: 0
 RuneforgePowerFilter:
-  All: 0
-  Available: 2
-  Relevant: 1
-  Unavailable: 3
+  values:
+    All: 0
+    Available: 2
+    Relevant: 1
+    Unavailable: 3
 RuneforgePowerState:
-  Available: 0
-  Invalid: 2
-  Unavailable: 1
+  values:
+    Available: 0
+    Invalid: 2
+    Unavailable: 1
 ScreenLocationType:
-  Bottom: 4
-  Center: 0
-  Left: 1
-  LeftOutside: 7
-  LeftRight: 9
-  LeftRightOutside: 11
-  Right: 2
-  RightOutside: 8
-  Top: 3
-  TopBottom: 10
-  TopLeft: 5
-  TopRight: 6
+  values:
+    Bottom: 4
+    Center: 0
+    Left: 1
+    LeftOutside: 7
+    LeftRight: 9
+    LeftRightOutside: 11
+    Right: 2
+    RightOutside: 8
+    Top: 3
+    TopBottom: 10
+    TopLeft: 5
+    TopRight: 6
 ScreenshotSource:
-  Automatic: 0
-  Cheat: 2
-  PlayerReport: 1
+  values:
+    Automatic: 0
+    Cheat: 2
+    PlayerReport: 1
 ScriptBindingType:
-  Extrinsic: 1
-  Postcall: 2
-  Precall: 0
+  values:
+    Extrinsic: 1
+    Postcall: 2
+    Precall: 0
 ScriptedAnimationBehavior:
-  None: 0
-  SourceCollideWithTarget: 4
-  SourceRecoil: 3
-  TargetKnockBack: 2
-  TargetShake: 1
-  UIParentShake: 5
+  values:
+    None: 0
+    SourceCollideWithTarget: 4
+    SourceRecoil: 3
+    TargetKnockBack: 2
+    TargetShake: 1
+    UIParentShake: 5
 ScriptedAnimationFlags:
-  UseTargetAsSource: 1
+  values:
+    UseTargetAsSource: 1
 ScriptedAnimationTrajectory:
-  AtSource: 0
-  AtTarget: 1
-  CurveLeft: 3
-  CurveRandom: 5
-  CurveRight: 4
-  HalfwayBetween: 6
-  Straight: 2
+  values:
+    AtSource: 0
+    AtTarget: 1
+    CurveLeft: 3
+    CurveRandom: 5
+    CurveRight: 4
+    HalfwayBetween: 6
+    Straight: 2
 ScriptObjectAccessRestriction:
-  DenyTaintedAccessWhenAurasAreSecret: 1
+  values:
+    DenyTaintedAccessWhenAurasAreSecret: 1
 ScriptObjectMetatable:
-  Forbidden: 1
-  Public: 0
+  values:
+    Forbidden: 1
+    Public: 0
 ScriptObjectPartition:
-  Forbidden: 1
-  Public: 0
+  values:
+    Forbidden: 1
+    Public: 0
 ScriptObjectPropagationPath:
-  Hierarchy: 0
-  Layout: 1
+  values:
+    Hierarchy: 0
+    Layout: 1
 ScrubStringFlags:
-  AllowBarCodes: 2
-  None: 0
-  StripControlCodes: 4
-  TruncateNewLines: 1
+  values:
+    AllowBarCodes: 2
+    None: 0
+    StripControlCodes: 4
+    TruncateNewLines: 1
 SeasonID:
-  Fresh: 11
-  FreshHardcore: 12
-  Hardcore: 3
-  NoSeason: 0
-  SeasonOfDiscovery: 2
-  SeasonOfMastery: 1
+  values:
+    Fresh: 11
+    FreshHardcore: 12
+    Hardcore: 3
+    NoSeason: 0
+    SeasonOfDiscovery: 2
+    SeasonOfMastery: 1
 SecondsFormatterAbbreviation:
-  None: 0
-  OneLetter: 2
-  Truncate: 1
+  values:
+    None: 0
+    OneLetter: 2
+    Truncate: 1
 SecondsFormatterInterval:
-  Days: 3
-  Hours: 2
-  Minutes: 1
-  Seconds: 0
+  values:
+    Days: 3
+    Hours: 2
+    Minutes: 1
+    Seconds: 0
 SecondsFormatterIntervalWhitespace:
-  Preserve: 0
-  Strip: 1
-  StripIgnoreLocale: 2
+  values:
+    Preserve: 0
+    Strip: 1
+    StripIgnoreLocale: 2
 SecrecyLevel:
-  AlwaysSecret: 1
-  ContextuallySecret: 2
-  NeverSecret: 0
+  values:
+    AlwaysSecret: 1
+    ContextuallySecret: 2
+    NeverSecret: 0
 SecretAspect:
-  Alpha: 128
-  Attributes: 1
-  BarValue: 16384
-  ButtonState: 2097152
-  Cooldown: 32768
-  CooldownStyle: 524288
-  Cursor: 1024
-  Desaturation: 4096
-  FrameLevel: 256
-  Hierarchy: 1
-  ID: 2
-  MinimumWidth: 131072
-  ObjectDebug: 1
-  ObjectName: 1
-  ObjectSecrets: 1
-  ObjectSecurity: 1
-  ObjectType: 1
-  Padding: 262144
-  RadialProgress: 8388608
-  Rotation: 65536
-  Scale: 64
-  ScrollOffset: 4194304
-  ScrollRange: 512
-  SecureText: 16
-  Shown: 32
-  TexCoords: 8192
-  Text: 8
-  TooltipTexture: 1048576
-  Toplevel: 4
-  VertexColor: 2048
+  values:
+    Alpha: 128
+    Attributes: 1
+    BarValue: 16384
+    ButtonState: 2097152
+    Cooldown: 32768
+    CooldownStyle: 524288
+    Cursor: 1024
+    Desaturation: 4096
+    FrameLevel: 256
+    Hierarchy: 1
+    ID: 2
+    MinimumWidth: 131072
+    ObjectDebug: 1
+    ObjectName: 1
+    ObjectSecrets: 1
+    ObjectSecurity: 1
+    ObjectType: 1
+    Padding: 262144
+    RadialProgress: 8388608
+    Rotation: 65536
+    Scale: 64
+    ScrollOffset: 4194304
+    ScrollRange: 512
+    SecureText: 16
+    Shown: 32
+    TexCoords: 8192
+    Text: 8
+    TooltipTexture: 1048576
+    Toplevel: 4
+    VertexColor: 2048
 SelfResurrectOptionType:
-  Item: 1
-  Spell: 0
+  values:
+    Item: 1
+    Spell: 0
 SendAddonMessageResult:
-  AddOnMessageLockdown: 11
-  AddonMessageThrottle: 3
-  ChannelThrottle: 8
-  GeneralError: 9
-  InvalidChannel: 7
-  InvalidChatType: 4
-  InvalidMessage: 2
-  InvalidPrefix: 1
-  NotInGroup: 5
-  NotInGuild: 10
-  Success: 0
-  TargetOffline: 12
-  TargetRequired: 6
+  values:
+    AddOnMessageLockdown: 11
+    AddonMessageThrottle: 3
+    ChannelThrottle: 8
+    GeneralError: 9
+    InvalidChannel: 7
+    InvalidChatType: 4
+    InvalidMessage: 2
+    InvalidPrefix: 1
+    NotInGroup: 5
+    NotInGuild: 10
+    Success: 0
+    TargetOffline: 12
+    TargetRequired: 6
 SendReportResult:
-  GeneralError: 1
-  RequiresChatLine: 3
-  RequiresChatLineOrVoice: 4
-  RequiresScreenshot: 5
-  Success: 0
-  TooManyReports: 2
+  values:
+    GeneralError: 1
+    RequiresChatLine: 3
+    RequiresChatLineOrVoice: 4
+    RequiresScreenshot: 5
+    Success: 0
+    TooManyReports: 2
 SharedStringFlag:
-  InternalOnly: 1
+  values:
+    InternalOnly: 1
 ShutdownSessionReason:
-  AccountLoginCommand: 4
-  Error: 6
-  ForceLogoutCommand: 2
-  LuaScript: 5
-  RealmSelectCommand: 3
-  RestartSessionCommand: 1
-  SessionEnded: 0
+  values:
+    AccountLoginCommand: 4
+    Error: 6
+    ForceLogoutCommand: 2
+    LuaScript: 5
+    RealmSelectCommand: 3
+    RestartSessionCommand: 1
+    SessionEnded: 0
 Siflag:
-  Affectedbyaltitude: 16
-  Affectedbysanity: 2048
-  AutocreatedByBroadcastText: 4
-  CasterOwnsTargetSound: 128
-  Disablepositionallpf: 1
-  Dontplayindoors: 256
-  Dontplayunderwater: 1024
-  Dontstopondeath: 4096
-  Ignoresuppressors: 64
-  Ignorevopriority: 16384
-  Looping: 512
-  Noduplicates: 32
-  None: 0
-  Onlyplayindoors: 32768
-  Onlyplayunderwater: 65536
-  Playonlyforowner: 8192
-  Playsequential: 8
-  UseModCastSpeed: 2
+  values:
+    Affectedbyaltitude: 16
+    Affectedbysanity: 2048
+    AutocreatedByBroadcastText: 4
+    CasterOwnsTargetSound: 128
+    Disablepositionallpf: 1
+    Dontplayindoors: 256
+    Dontplayunderwater: 1024
+    Dontstopondeath: 4096
+    Ignoresuppressors: 64
+    Ignorevopriority: 16384
+    Looping: 512
+    Noduplicates: 32
+    None: 0
+    Onlyplayindoors: 32768
+    Onlyplayunderwater: 65536
+    Playonlyforowner: 8192
+    Playsequential: 8
+    UseModCastSpeed: 2
 SimpleOrderStatus:
-  Creating: 1
-  Failed: 4
-  InProgress: 2
-  Invalid: 0
-  Success: 3
+  values:
+    Creating: 1
+    Failed: 4
+    InProgress: 2
+    Invalid: 0
+    Success: 3
 SkinningState:
-  Looting: 3
-  None: 0
-  Reserved: 1
-  Skinned: 4
-  Skinning: 2
+  values:
+    Looting: 3
+    None: 0
+    Reserved: 1
+    Skinned: 4
+    Skinning: 2
 SleevesGeoRange:
-  Default: 1
-  Flared: 2
-  None: 0
-  PandaCollar: 4
-  Puffy: 3
+  values:
+    Default: 1
+    Flared: 2
+    None: 0
+    PandaCollar: 4
+    Puffy: 3
 SlotRegion:
-  AccountBank: 5
-  CharacterBank: 4
-  Invalid: 0
-  PlayerBags: 2
-  PlayerEquip: 1
-  PlayerInv: 3
+  values:
+    AccountBank: 5
+    CharacterBank: 4
+    Invalid: 0
+    PlayerBags: 2
+    PlayerEquip: 1
+    PlayerInv: 3
 SlotRegionMask:
-  AccountBank: 64
-  CharacterBank: 16
-  Invalid: 1
-  PlayerBags: 4
-  PlayerEquip: 2
-  PlayerInv: 8
+  values:
+    AccountBank: 64
+    CharacterBank: 16
+    Invalid: 1
+    PlayerBags: 4
+    PlayerEquip: 2
+    PlayerInv: 8
 SocialSystemType:
-  Friends: 0
-  QuickJoin: 1
-  RaidList: 2
-  RecentAllies: 4
-  RecruitAFriend: 3
+  values:
+    Friends: 0
+    QuickJoin: 1
+    RaidList: 2
+    RecentAllies: 4
+    RecruitAFriend: 3
 SocialUIBlockType:
-  BattleNetInviteBlock: 2
-  Ignore: 1
-  None: 0
+  values:
+    BattleNetInviteBlock: 2
+    Ignore: 1
+    None: 0
 SocialUIPresenceType:
-  AppearOffline: 5
-  Away: 3
-  Busy: 4
-  Offline: 2
-  Online: 1
-  Unknown: 0
+  values:
+    AppearOffline: 5
+    Away: 3
+    Busy: 4
+    Offline: 2
+    Online: 1
+    Unknown: 0
 SocialWhoOrigin:
-  Chat: 2
-  Item: 3
-  Social: 1
-  Unknown: 0
+  values:
+    Chat: 2
+    Item: 3
+    Social: 1
+    Unknown: 0
 SoftTargetEnableFlags:
-  Any: 3
-  Gamepad: 1
-  Kbm: 2
-  None: 0
+  values:
+    Any: 3
+    Gamepad: 1
+    Kbm: 2
+    None: 0
 SortPlayersBy:
-  Alphabetical: 2
-  Group: 1
-  Role: 0
+  values:
+    Alphabetical: 2
+    Group: 1
+    Role: 0
 SoulbindConduitFlags:
-  VisibleToGetallsoulbindconduitScript: 1
+  values:
+    VisibleToGetallsoulbindconduitScript: 1
 SoulbindConduitInstallResult:
-  DuplicateConduit: 4
-  ForgeNotInProximity: 5
-  InvalidConduit: 2
-  InvalidItem: 1
-  InvalidTalent: 3
-  SocketNotEmpty: 6
-  Success: 0
+  values:
+    DuplicateConduit: 4
+    ForgeNotInProximity: 5
+    InvalidConduit: 2
+    InvalidItem: 1
+    InvalidTalent: 3
+    SocketNotEmpty: 6
+    Success: 0
 SoulbindConduitTransactionType:
-  Install: 0
-  Uninstall: 1
+  values:
+    Install: 0
+    Uninstall: 1
 SoulbindConduitType:
-  Endurance: 2
-  Finesse: 0
-  Flex: 3
-  Potency: 1
+  values:
+    Endurance: 2
+    Finesse: 0
+    Flex: 3
+    Potency: 1
 SoulbindNodeState:
-  Selectable: 2
-  Selected: 3
-  Unavailable: 0
-  Unselected: 1
+  values:
+    Selectable: 2
+    Selected: 3
+    Unavailable: 0
+    Unselected: 1
 SoundBusFlag:
-  Disablepositionallpf: 1
+  values:
+    Disablepositionallpf: 1
 SpecializationSystem:
-  ChrSpecialization: 1
-  TalentTab: 0
+  values:
+    ChrSpecialization: 1
+    TalentTab: 0
 SpellAuraVisibilityType:
-  EnemyTarget: 2
-  RaidInCombat: 0
-  RaidOutOfCombat: 1
+  values:
+    EnemyTarget: 2
+    RaidInCombat: 0
+    RaidOutOfCombat: 1
 SpellBookItemType:
-  Flyout: 4
-  FutureSpell: 2
-  None: 0
-  PetAction: 3
-  Spell: 1
+  values:
+    Flyout: 4
+    FutureSpell: 2
+    None: 0
+    PetAction: 3
+    Spell: 1
 SpellBookSkillLineIndex:
-  Class: 2
-  General: 1
-  MainSpec: 3
-  OffSpecStart: 4
+  values:
+    Class: 2
+    General: 1
+    MainSpec: 3
+    OffSpecStart: 4
 SpellBookSpellBank:
-  Pet: 1
-  Player: 0
+  values:
+    Pet: 1
+    Player: 0
 SpellDiminishCategory:
-  AoEKnockback: 3
-  Disarm: 7
-  Disorient: 5
-  Incapacitate: 4
-  Root: 0
-  Silence: 6
-  Stun: 2
-  Taunt: 1
+  values:
+    AoEKnockback: 3
+    Disarm: 7
+    Disorient: 5
+    Incapacitate: 4
+    Root: 0
+    Silence: 6
+    Stun: 2
+    Taunt: 1
 SpellDiminishRuleset:
-  None: 0
-  PvE: 1
-  PvP: 2
+  values:
+    None: 0
+    PvE: 1
+    PvP: 2
 SpellDisplayBorderColor:
-  Black: 1
-  Blue: 8
-  Green: 7
-  None: 0
-  Orange: 5
-  Purple: 6
-  Red: 3
-  White: 2
-  Yellow: 4
+  values:
+    Black: 1
+    Blue: 8
+    Green: 7
+    None: 0
+    Orange: 5
+    Purple: 6
+    Red: 3
+    White: 2
+    Yellow: 4
 SpellDisplayIconDisplayType:
-  Buff: 0
-  Circular: 2
-  Debuff: 1
-  NoBorder: 3
+  values:
+    Buff: 0
+    Circular: 2
+    Debuff: 1
+    NoBorder: 3
 SpellDisplayTextShownStateType:
-  Hidden: 1
-  Shown: 0
+  values:
+    Hidden: 1
+    Shown: 0
 SpellDisplayTint:
-  None: 0
-  Red: 1
+  values:
+    None: 0
+    Red: 1
 SplashScreenType:
-  SeasonRollOver: 1
-  WhatsNew: 0
+  values:
+    SeasonRollOver: 1
+    WhatsNew: 0
 StableResult:
-  AlreadyStabled: 5
-  AlreadySummoned: 6
-  BuySlotSuccess: 14
-  CantControlExotic: 11
-  CheckForLuaHack: 13
-  FavoriteToggle: 15
-  InsufficientFunds: 1
-  InternalError: 12
-  InvalidSlot: 3
-  MaxSlots: 0
-  NoPet: 4
-  NotFound: 7
-  NotStableMaster: 2
-  PetRenamed: 16
-  ReviveSuccess: 10
-  StableSuccess: 8
-  UnstableSuccess: 9
+  values:
+    AlreadyStabled: 5
+    AlreadySummoned: 6
+    BuySlotSuccess: 14
+    CantControlExotic: 11
+    CheckForLuaHack: 13
+    FavoriteToggle: 15
+    InsufficientFunds: 1
+    InternalError: 12
+    InvalidSlot: 3
+    MaxSlots: 0
+    NoPet: 4
+    NotFound: 7
+    NotStableMaster: 2
+    PetRenamed: 16
+    ReviveSuccess: 10
+    StableSuccess: 8
+    UnstableSuccess: 9
 StartTimerType:
-  ChallengeModeCountdown: 1
-  PlayerCountdown: 2
-  PlunderstormCountdown: 3
-  PvPBeginTimer: 0
+  values:
+    ChallengeModeCountdown: 1
+    PlayerCountdown: 2
+    PlunderstormCountdown: 3
+    PvPBeginTimer: 0
 StatusBarColorTintValue:
-  Black: 1
-  Blue: 8
-  Green: 7
-  None: 0
-  Orange: 5
-  Purple: 6
-  Red: 3
-  White: 2
-  Yellow: 4
+  values:
+    Black: 1
+    Blue: 8
+    Green: 7
+    None: 0
+    Orange: 5
+    Purple: 6
+    Red: 3
+    White: 2
+    Yellow: 4
 StatusBarFillStyle:
-  Center: 2
-  Reverse: 3
-  Standard: 0
-  StandardNoRangeFill: 1
+  values:
+    Center: 2
+    Reverse: 3
+    Standard: 0
+    StandardNoRangeFill: 1
 StatusBarInterpolation:
-  ExponentialEaseOut: 1
-  Immediate: 0
+  values:
+    ExponentialEaseOut: 1
+    Immediate: 0
 StatusBarOverrideBarTextShownType:
-  Always: 1
-  Never: 0
-  OnlyNotOnMouseover: 3
-  OnlyOnMouseover: 2
+  values:
+    Always: 1
+    Never: 0
+    OnlyNotOnMouseover: 3
+    OnlyOnMouseover: 2
 StatusBarRenderMode:
-  Linear: 0
-  Radial: 1
+  values:
+    Linear: 0
+    Radial: 1
 StatusBarTimerDirection:
-  ElapsedTime: 0
-  RemainingTime: 1
+  values:
+    ElapsedTime: 0
+    RemainingTime: 1
 StatusBarValueTextType:
-  Hidden: 0
-  Percentage: 1
-  Time: 3
-  TimeShowOneLevelOnly: 4
-  Value: 2
-  ValueOverMax: 5
-  ValueOverMaxNormalized: 6
+  values:
+    Hidden: 0
+    Percentage: 1
+    Time: 3
+    TimeShowOneLevelOnly: 4
+    Value: 2
+    ValueOverMax: 5
+    ValueOverMaxNormalized: 6
 StoreError:
-  AlreadyOwned: 7
-  BattlepayDisabled: 4
-  ClientRestricted: 13
-  ConsumableTokenOwned: 10
-  InsufficientBalance: 5
-  InvalidPaymentMethod: 1
-  ItemUnavailable: 12
-  Other: 6
-  ParentalControlsNoPurchase: 8
-  PaymentFailed: 2
-  PurchaseDenied: 9
-  Success: 0
-  TooManyTokens: 11
-  WrongCurrency: 3
+  values:
+    AlreadyOwned: 7
+    BattlepayDisabled: 4
+    ClientRestricted: 13
+    ConsumableTokenOwned: 10
+    InsufficientBalance: 5
+    InvalidPaymentMethod: 1
+    ItemUnavailable: 12
+    Other: 6
+    ParentalControlsNoPurchase: 8
+    PaymentFailed: 2
+    PurchaseDenied: 9
+    Success: 0
+    TooManyTokens: 11
+    WrongCurrency: 3
 SubcontainerType:
-  AccountBankTabs: 36
-  Auction: 5
-  Bag: 0
-  Bankbag: 3
-  Bankgeneric: 2
-  BuybackSlots: 26
-  CachedReward: 27
-  CharacterBankTabs: 38
-  Childequipmentstorage: 23
-  CraftingOrder: 34
-  CraftingOrderReagents: 35
-  CreatedImmediately: 25
-  CurrencytokenOboslete: 15
-  CurrencyTransfer: 37
-  Equipablespells: 14
-  Equipped: 1
-  EquippedBags: 28
-  EquippedCooking: 31
-  EquippedFishing: 32
-  EquippedProfession1: 29
-  EquippedProfession2: 30
-  EquippedReagentbag: 33
-  GuildBank0: 7
-  GuildBank1: 8
-  GuildBank10: 20
-  GuildBank11: 21
-  GuildBank2: 9
-  GuildBank3: 10
-  GuildBank4: 11
-  GuildBank5: 12
-  GuildBank6: 16
-  GuildBank7: 17
-  GuildBank8: 18
-  GuildBank9: 19
-  GuildOverflow: 13
-  HousingDecorConversion: 39
-  Keyring: 6
-  Mail: 4
-  Quarantine: 24
-  Reagentbank: 22
-  Reserved: 40
+  values:
+    AccountBankTabs: 36
+    Auction: 5
+    Bag: 0
+    Bankbag: 3
+    Bankgeneric: 2
+    BuybackSlots: 26
+    CachedReward: 27
+    CharacterBankTabs: 38
+    Childequipmentstorage: 23
+    CraftingOrder: 34
+    CraftingOrderReagents: 35
+    CreatedImmediately: 25
+    CurrencytokenOboslete: 15
+    CurrencyTransfer: 37
+    Equipablespells: 14
+    Equipped: 1
+    EquippedBags: 28
+    EquippedCooking: 31
+    EquippedFishing: 32
+    EquippedProfession1: 29
+    EquippedProfession2: 30
+    EquippedReagentbag: 33
+    GuildBank0: 7
+    GuildBank1: 8
+    GuildBank10: 20
+    GuildBank11: 21
+    GuildBank2: 9
+    GuildBank3: 10
+    GuildBank4: 11
+    GuildBank5: 12
+    GuildBank6: 16
+    GuildBank7: 17
+    GuildBank8: 18
+    GuildBank9: 19
+    GuildOverflow: 13
+    HousingDecorConversion: 39
+    Keyring: 6
+    Mail: 4
+    Quarantine: 24
+    Reagentbank: 22
+    Reserved: 40
 SubscriptionInterstitialResponseType:
-  Clicked: 0
-  Closed: 1
-  WebRedirect: 2
+  values:
+    Clicked: 0
+    Closed: 1
+    WebRedirect: 2
 SubscriptionInterstitialType:
-  LeftNpeArea: 1
-  MaxLevel: 2
-  Standard: 0
+  values:
+    LeftNpeArea: 1
+    MaxLevel: 2
+    Standard: 0
 SummonReason:
-  Scenario: 1
-  Spell: 0
+  values:
+    Scenario: 1
+    Spell: 0
 SummonStatus:
-  Accepted: 2
-  Declined: 3
-  None: 0
-  Pending: 1
+  values:
+    Accepted: 2
+    Declined: 3
+    None: 0
+    Pending: 1
 SuperTrackingMapPinType:
-  AreaPOI: 0
-  DigSite: 3
-  HousingPlot: 4
-  QuestOffer: 1
-  TaxiNode: 2
+  values:
+    AreaPOI: 0
+    DigSite: 3
+    HousingPlot: 4
+    QuestOffer: 1
+    TaxiNode: 2
 SuperTrackingType:
-  Content: 4
-  Corpse: 2
-  MapPin: 6
-  PartyMember: 5
-  Quest: 0
-  Scenario: 3
-  UserWaypoint: 1
-  Vignette: 7
+  values:
+    Content: 4
+    Corpse: 2
+    MapPin: 6
+    PartyMember: 5
+    Quest: 0
+    Scenario: 3
+    UserWaypoint: 1
+    Vignette: 7
 SurveyDeliveryFlags:
-  EncounterSucccessOnly: 1
-  None: 0
+  values:
+    EncounterSucccessOnly: 1
+    None: 0
 SurveyDeliveryMoment:
-  ChestLooted: 3
-  EncounterEnd: 5
-  Login: 0
-  MythicPlusCompleted: 4
-  ProfessionTable: 1
-  QuestTurnIn: 2
+  values:
+    ChestLooted: 3
+    EncounterEnd: 5
+    Login: 0
+    MythicPlusCompleted: 4
+    ProfessionTable: 1
+    QuestTurnIn: 2
 TableSecurityOption:
-  DisallowSecretKeys: 1
-  DisallowTaintedAccess: 0
-  SecretWrapContents: 2
+  values:
+    DisallowSecretKeys: 1
+    DisallowTaintedAccess: 0
+    SecretWrapContents: 2
 TieredEntranceRewardType:
-  Currency: 1
-  Item: 0
+  values:
+    Currency: 1
+    Item: 0
 TieredEntranceTierFlag:
-  IsLFG: 1
+  values:
+    IsLFG: 1
 TieredEntranceType:
-  Delve: 1
-  Invalid: 0
-  Lairs: 4
-  Sites: 2
-  WorldTier: 3
+  values:
+    Delve: 1
+    Invalid: 0
+    Lairs: 4
+    Sites: 2
+    WorldTier: 3
 TimeEventFlag:
-  GlobalLaunch: 4
-  GlueScreenShortcut: 1
-  WeeklyReset: 2
+  values:
+    GlobalLaunch: 4
+    GlueScreenShortcut: 1
+    WeeklyReset: 2
 TitleIconVersion:
-  Large: 2
-  Medium: 1
-  Small: 0
+  values:
+    Large: 2
+    Medium: 1
+    Small: 0
 TooltipComparisonMethod:
-  Single: 0
-  WithBagMainHandItem: 2
-  WithBagOffHandItem: 3
-  WithBothHands: 1
+  values:
+    Single: 0
+    WithBagMainHandItem: 2
+    WithBagOffHandItem: 3
+    WithBothHands: 1
 TooltipDataItemBinding:
-  Account: 1
-  AccountUntilEquipped: 9
-  BindOnEquip: 7
-  BindOnPickup: 6
-  BindOnUse: 8
-  BindToAccount: 4
-  BindToAccountUntilEquipped: 10
-  BindToBnetAccount: 5
-  BnetAccount: 2
-  Quest: 0
-  Soulbound: 3
+  values:
+    Account: 1
+    AccountUntilEquipped: 9
+    BindOnEquip: 7
+    BindOnPickup: 6
+    BindOnUse: 8
+    BindToAccount: 4
+    BindToAccountUntilEquipped: 10
+    BindToBnetAccount: 5
+    BnetAccount: 2
+    Quest: 0
+    Soulbound: 3
 TooltipDataLineType:
-  AzeriteEssencePower: 5
-  AzeriteEssenceSlot: 4
-  AzeriteItemPowerDescription: 9
-  Blank: 1
-  CurrencyTotal: 14
-  DisabledLine: 42
-  EquipSlot: 21
-  ErrorLine: 41
-  FlavorText: 37
-  GemSocket: 3
-  GemSocketEnchantment: 30
-  ItemBinding: 20
-  ItemEnchantmentPermanent: 15
-  ItemLevel: 31
-  ItemName: 22
-  ItemQuality: 35
-  ItemSpellTriggerLearn: 38
-  ItemSpellTriggerOnEquip: 45
-  ItemSpellTriggerOnProc: 46
-  ItemSpellTriggerOnUse: 44
-  ItemUpgradeLevel: 32
-  LearnableSpell: 6
-  LearnTransmogIllusion: 40
-  LearnTransmogSet: 39
-  NestedBlock: 19
-  None: 0
-  ProfessionCraftingQuality: 12
-  QuestObjective: 8
-  QuestPlayer: 18
-  QuestTitle: 17
-  RuneforgeLegendaryPowerDescription: 10
-  SellPrice: 11
-  Separator: 23
-  SpellDescription: 34
-  SpellName: 13
-  SpellPassive: 33
-  ToyDescription: 28
-  ToyDuration: 27
-  ToyEffect: 26
-  ToyName: 24
-  ToySource: 29
-  ToyText: 25
-  TradeTimeRemaining: 36
-  UnitDead: 49
-  UnitLevel: 47
-  UnitName: 2
-  UnitOwner: 16
-  UnitThreat: 7
-  UnitType: 48
-  UsageRequirement: 43
+  values:
+    AzeriteEssencePower: 5
+    AzeriteEssenceSlot: 4
+    AzeriteItemPowerDescription: 9
+    Blank: 1
+    CurrencyTotal: 14
+    DisabledLine: 42
+    EquipSlot: 21
+    ErrorLine: 41
+    FlavorText: 37
+    GemSocket: 3
+    GemSocketEnchantment: 30
+    ItemBinding: 20
+    ItemEnchantmentPermanent: 15
+    ItemLevel: 31
+    ItemName: 22
+    ItemQuality: 35
+    ItemSpellTriggerLearn: 38
+    ItemSpellTriggerOnEquip: 45
+    ItemSpellTriggerOnProc: 46
+    ItemSpellTriggerOnUse: 44
+    ItemUpgradeLevel: 32
+    LearnableSpell: 6
+    LearnTransmogIllusion: 40
+    LearnTransmogSet: 39
+    NestedBlock: 19
+    None: 0
+    ProfessionCraftingQuality: 12
+    QuestObjective: 8
+    QuestPlayer: 18
+    QuestTitle: 17
+    RuneforgeLegendaryPowerDescription: 10
+    SellPrice: 11
+    Separator: 23
+    SpellDescription: 34
+    SpellName: 13
+    SpellPassive: 33
+    ToyDescription: 28
+    ToyDuration: 27
+    ToyEffect: 26
+    ToyName: 24
+    ToySource: 29
+    ToyText: 25
+    TradeTimeRemaining: 36
+    UnitDead: 49
+    UnitLevel: 47
+    UnitName: 2
+    UnitOwner: 16
+    UnitThreat: 7
+    UnitType: 48
+    UsageRequirement: 43
 TooltipDataType:
-  Achievement: 12
-  AzeriteEssence: 8
-  BattlePet: 6
-  CompanionPet: 9
-  Corpse: 3
-  CorruptionCleanser: 20
-  Currency: 5
-  Debug: 26
-  EnhancedConduit: 13
-  EquipmentSet: 14
-  Flyout: 22
-  InstanceLock: 15
-  Item: 0
-  Macro: 25
-  MinimapMouseover: 21
-  Mount: 10
-  Object: 4
-  Outfit: 27
-  PetAction: 11
-  PvPBrawl: 16
-  Quest: 23
-  QuestPartyProgress: 24
-  RecipeRankInfo: 17
-  Spell: 1
-  Totem: 18
-  Toy: 19
-  Unit: 2
-  UnitAura: 7
+  values:
+    Achievement: 12
+    AzeriteEssence: 8
+    BattlePet: 6
+    CompanionPet: 9
+    Corpse: 3
+    CorruptionCleanser: 20
+    Currency: 5
+    Debug: 26
+    EnhancedConduit: 13
+    EquipmentSet: 14
+    Flyout: 22
+    InstanceLock: 15
+    Item: 0
+    Macro: 25
+    MinimapMouseover: 21
+    Mount: 10
+    Object: 4
+    Outfit: 27
+    PetAction: 11
+    PvPBrawl: 16
+    Quest: 23
+    QuestPartyProgress: 24
+    RecipeRankInfo: 17
+    Spell: 1
+    Totem: 18
+    Toy: 19
+    Unit: 2
+    UnitAura: 7
 TooltipDataUsageRequirementType:
-  Achievement: 7
-  ArenaRating: 11
-  EarnCurrency: 12
-  EquippedItem: 9
-  Faction: 1
-  Guild: 6
-  Level: 5
-  NotAlreadyKnown: 14
-  NotInArena: 15
-  NotInRatedBg: 16
-  PvPMedal: 3
-  PvPRank: 8
-  RaceClass: 0
-  Reputation: 4
-  ShapeshiftForm: 10
-  Skill: 2
-  Specialization: 13
+  values:
+    Achievement: 7
+    ArenaRating: 11
+    EarnCurrency: 12
+    EquippedItem: 9
+    Faction: 1
+    Guild: 6
+    Level: 5
+    NotAlreadyKnown: 14
+    NotInArena: 15
+    NotInRatedBg: 16
+    PvPMedal: 3
+    PvPRank: 8
+    RaceClass: 0
+    Reputation: 4
+    ShapeshiftForm: 10
+    Skill: 2
+    Specialization: 13
 TooltipSide:
-  Bottom: 3
-  Left: 0
-  Right: 1
-  Top: 2
+  values:
+    Bottom: 3
+    Left: 0
+    Right: 1
+    Top: 2
 TooltipTextureAnchor:
-  All: 6
-  LeftBottom: 2
-  LeftCenter: 1
-  LeftTop: 0
-  RightBottom: 5
-  RightCenter: 4
-  RightTop: 3
+  values:
+    All: 6
+    LeftBottom: 2
+    LeftCenter: 1
+    LeftTop: 0
+    RightBottom: 5
+    RightCenter: 4
+    RightTop: 3
 TooltipTextureRelativeRegion:
-  LeftLine: 0
-  RightLine: 1
+  values:
+    LeftLine: 0
+    RightLine: 1
 TrackedSpellCategory:
-  Debuff: 3
-  Defensive: 2
-  None: 0
-  Offensive: 1
-  RacialAbility: 4
+  values:
+    Debuff: 3
+    Defensive: 2
+    None: 0
+    Offensive: 1
+    RacialAbility: 4
 TrackedSpellsResult:
-  MismatchedCooldownInfo: 3
-  NoCooldownInfo: 2
-  PlayerNotFound: 1
-  Success: 0
+  values:
+    MismatchedCooldownInfo: 3
+    NoCooldownInfo: 2
+    PlayerNotFound: 1
+    Success: 0
 TradeskillOrderDuration:
-  Long: 3
-  Medium: 2
-  Short: 1
+  values:
+    Long: 3
+    Medium: 2
+    Short: 1
 TradeskillOrderRecipient:
-  Guild: 2
-  Private: 3
-  Public: 1
+  values:
+    Guild: 2
+    Private: 3
+    Public: 1
 TradeskillOrderStatus:
-  Completed: 3
-  Expired: 4
-  Started: 2
-  Unclaimed: 1
+  values:
+    Completed: 3
+    Expired: 4
+    Started: 2
+    Unclaimed: 1
 TradeskillRecipeType:
-  Enchant: 3
-  Gathering: 4
-  Item: 1
-  Salvage: 2
+  values:
+    Enchant: 3
+    Gathering: 4
+    Item: 1
+    Salvage: 2
 TradeskillRelativeDifficulty:
-  Easy: 2
-  Medium: 1
-  Optimal: 0
-  Trivial: 3
+  values:
+    Easy: 2
+    Medium: 1
+    Optimal: 0
+    Trivial: 3
 TradeskillSlotDataType:
-  Currency: 3
-  ModifiedReagent: 2
-  Reagent: 1
+  values:
+    Currency: 3
+    ModifiedReagent: 2
+    Reagent: 1
 TraitCombatConfigFlags:
-  ActiveForSpec: 1
-  SharedActionBars: 4
-  StarterBuild: 2
+  values:
+    ActiveForSpec: 1
+    SharedActionBars: 4
+    StarterBuild: 2
 TraitCondFlag:
-  IsAlwaysMet: 2
-  IsGate: 1
-  IsSufficient: 4
+  values:
+    IsAlwaysMet: 2
+    IsGate: 1
+    IsSufficient: 4
 TraitConditionType:
-  Available: 0
-  DisplayError: 4
-  Granted: 2
-  Increased: 3
-  RanksAllowed: 5
-  Visible: 1
+  values:
+    Available: 0
+    DisplayError: 4
+    Granted: 2
+    Increased: 3
+    RanksAllowed: 5
+    Visible: 1
 TraitConfigDbState:
-  Created: 1
-  Deleted: 3
-  Ready: 0
-  Removed: 2
+  values:
+    Created: 1
+    Deleted: 3
+    Ready: 0
+    Removed: 2
 TraitConfigType:
-  Combat: 1
-  Generic: 3
-  Invalid: 0
-  Profession: 2
+  values:
+    Combat: 1
+    Generic: 3
+    Invalid: 0
+    Profession: 2
 TraitCurrencyFlag:
-  ShowQuantityAsSpent: 1
-  TraitSourcedShowMax: 2
-  UseClassIcon: 4
-  UseSpecIcon: 8
+  values:
+    ShowQuantityAsSpent: 1
+    TraitSourcedShowMax: 2
+    UseClassIcon: 4
+    UseSpecIcon: 8
 TraitCurrencyType:
-  CurrencyTypesBased: 1
-  Gold: 0
-  TraitSourced: 2
-  TraitSourcedPlayerDataElement: 3
+  values:
+    CurrencyTypesBased: 1
+    Gold: 0
+    TraitSourced: 2
+    TraitSourcedPlayerDataElement: 3
 TraitDefinitionSubType:
-  DragonflightBlack: 4
-  DragonflightBlue: 1
-  DragonflightBronze: 3
-  DragonflightGreen: 2
-  DragonflightRed: 0
+  values:
+    DragonflightBlack: 4
+    DragonflightBlue: 1
+    DragonflightBronze: 3
+    DragonflightGreen: 2
+    DragonflightRed: 0
 TraitEdgeType:
-  DeprecatedRankConnection: 1
-  DeprecatedSelectionOption: 5
-  MutuallyExclusive: 4
-  RequiredForAvailability: 3
-  SufficientForAvailability: 2
-  VisualOnly: 0
+  values:
+    DeprecatedRankConnection: 1
+    DeprecatedSelectionOption: 5
+    MutuallyExclusive: 4
+    RequiredForAvailability: 3
+    SufficientForAvailability: 2
+    VisualOnly: 0
 TraitEdgeVisualStyle:
-  None: 0
-  Straight: 1
+  values:
+    None: 0
+    Straight: 1
 TraitNodeEntryType:
-  ArmorSet: 11
-  DeprecatedSelect: 4
-  DragAndDrop: 5
-  ProfPath: 7
-  ProfPathUnlock: 9
-  ProfPerk: 8
-  RedButton: 10
-  SpendCapstoneCircle: 13
-  SpendCapstoneSquare: 14
-  SpendCircle: 2
-  SpendDiamond: 6
-  SpendHex: 0
-  SpendInfinite: 12
-  SpendSmallCircle: 3
-  SpendSquare: 1
+  values:
+    ArmorSet: 11
+    DeprecatedSelect: 4
+    DragAndDrop: 5
+    ProfPath: 7
+    ProfPathUnlock: 9
+    ProfPerk: 8
+    RedButton: 10
+    SpendCapstoneCircle: 13
+    SpendCapstoneSquare: 14
+    SpendCircle: 2
+    SpendDiamond: 6
+    SpendHex: 0
+    SpendInfinite: 12
+    SpendSmallCircle: 3
+    SpendSquare: 1
 TraitNodeFlag:
-  ActiveAtFirstRank: 16
-  HideMaxRank: 64
-  HighestChosenRank: 128
-  NeverPurchasable: 2
-  ShowExpandedSelection: 32
-  ShowMultipleIcons: 1
-  ShowTierTrack: 256
-  TestGridPositioned: 8
-  TestPositionLocked: 4
+  values:
+    ActiveAtFirstRank: 16
+    HideMaxRank: 64
+    HighestChosenRank: 128
+    NeverPurchasable: 2
+    ShowExpandedSelection: 32
+    ShowMultipleIcons: 1
+    ShowTierTrack: 256
+    TestGridPositioned: 8
+    TestPositionLocked: 4
 TraitNodeGroupFlag:
-  AvailableByDefault: 1
+  values:
+    AvailableByDefault: 1
 TraitNodeType:
-  Selection: 2
-  Single: 0
-  SubTreeSelection: 3
-  Tiered: 1
+  values:
+    Selection: 2
+    Single: 0
+    SubTreeSelection: 3
+    Tiered: 1
 TraitPointsOperationType:
-  Multiply: 1
-  None: -1
-  Set: 0
+  values:
+    Multiply: 1
+    None: -1
+    Set: 0
 TraitSystemFlag:
-  AllowEditInChallengeMode: 8
-  AllowEditInCombat: 4
-  AllowMultipleLoadoutsPerTree: 1
-  ShowSpendConfirmation: 2
+  values:
+    AllowEditInChallengeMode: 8
+    AllowEditInCombat: 4
+    AllowMultipleLoadoutsPerTree: 1
+    ShowSpendConfirmation: 2
 TraitSystemVariationType:
-  None: 0
-  Spec: 1
+  values:
+    None: 0
+    Spec: 1
 TraitTreeFlag:
-  CannotRefund: 1
-  HideSingleRankNumbers: 2
+  values:
+    CannotRefund: 1
+    HideSingleRankNumbers: 2
 TransformManipulatorAxis:
-  X: 1
-  Y: 2
-  Z: 4
+  values:
+    X: 1
+    Y: 2
+    Z: 4
 TransformManipulatorControlState:
-  Default: 0
-  Dimmed: 2
-  ExternallyHighlighted: 3
-  Hidden: 1
-  Hovered: 4
-  Moving: 6
-  Selected: 5
+  values:
+    Default: 0
+    Dimmed: 2
+    ExternallyHighlighted: 3
+    Hidden: 1
+    Hovered: 4
+    Moving: 6
+    Selected: 5
 TransformManipulatorDirection:
-  Negative: 1
-  Positive: 0
+  values:
+    Negative: 1
+    Positive: 0
 TransformManipulatorEvent:
-  Cancel: 3
-  Change: 1
-  Complete: 2
-  Hover: 4
-  MouseDown: 5
-  MouseUp: 6
-  Start: 0
+  values:
+    Cancel: 3
+    Change: 1
+    Complete: 2
+    Hover: 4
+    MouseDown: 5
+    MouseUp: 6
+    Start: 0
 TransformManipulatorMode:
-  Rotate: 1
-  Scale: 2
-  Translate: 0
+  values:
+    Rotate: 1
+    Scale: 2
+    Translate: 0
 TransmogCameraVariation:
-  CloakBackpack: 1
-  None: 0
-  RightShoulder: 1
+  values:
+    CloakBackpack: 1
+    None: 0
+    RightShoulder: 1
 TransmogCollectionType:
-  Back: 3
-  Bow: 25
-  Chest: 4
-  Crossbow: 27
-  Dagger: 16
-  Feet: 11
-  Fist: 17
-  Gun: 26
-  Hands: 8
-  Head: 1
-  Holdable: 19
-  Legs: 10
-  None: 0
-  OneHAxe: 13
-  OneHMace: 15
-  OneHSword: 14
-  Paired: 29
-  Polearm: 24
-  Shield: 18
-  Shirt: 5
-  Shoulder: 2
-  Staff: 23
-  Tabard: 6
-  TwoHAxe: 20
-  TwoHMace: 22
-  TwoHSword: 21
-  Waist: 9
-  Wand: 12
-  Warglaives: 28
-  Wrist: 7
+  values:
+    Back: 3
+    Bow: 25
+    Chest: 4
+    Crossbow: 27
+    Dagger: 16
+    Feet: 11
+    Fist: 17
+    Gun: 26
+    Hands: 8
+    Head: 1
+    Holdable: 19
+    Legs: 10
+    None: 0
+    OneHAxe: 13
+    OneHMace: 15
+    OneHSword: 14
+    Paired: 29
+    Polearm: 24
+    Shield: 18
+    Shirt: 5
+    Shoulder: 2
+    Staff: 23
+    Tabard: 6
+    TwoHAxe: 20
+    TwoHMace: 22
+    TwoHSword: 21
+    Waist: 9
+    Wand: 12
+    Warglaives: 28
+    Wrist: 7
 TransmogIllusionFlags:
-  AllowedRangedShieldsHoldables: 4
-  HideUntilCollected: 1
-  PlayerConditionGrantsOnLogin: 2
+  values:
+    AllowedRangedShieldsHoldables: 4
+    HideUntilCollected: 1
+    PlayerConditionGrantsOnLogin: 2
 TransmogModification:
-  Main: 0
-  Secondary: 1
+  values:
+    Main: 0
+    Secondary: 1
 TransmogOutfitCostModifiersApplied:
-  AuraDiscountApplied: 8
-  DebugOnlyFreeDiscountApplied: 1
-  OutfitCostModifierApplied: 4
-  VoidRacialDiscountApplied: 2
+  values:
+    AuraDiscountApplied: 8
+    DebugOnlyFreeDiscountApplied: 1
+    OutfitCostModifierApplied: 4
+    VoidRacialDiscountApplied: 2
 TransmogOutfitDataFlags:
-  IsCachedLocally: 1
+  values:
+    IsCachedLocally: 1
 TransmogOutfitDisplayType:
-  Assigned: 1
-  Disabled: 4
-  Equipped: 2
-  Hidden: 3
-  Unassigned: 0
+  values:
+    Assigned: 1
+    Disabled: 4
+    Equipped: 2
+    Hidden: 3
+    Unassigned: 0
 TransmogOutfitEntryFlags:
-  AutomaticallyAwardedOnLogin: 1
-  IsDefaultEquipped: 32
-  OnlyAvailableDuringEvent: 4
-  SortedToTopOfList: 8
-  UseOverrideCostModifier: 16
-  UseOverrideName: 2
+  values:
+    AutomaticallyAwardedOnLogin: 1
+    IsDefaultEquipped: 32
+    OnlyAvailableDuringEvent: 4
+    SortedToTopOfList: 8
+    UseOverrideCostModifier: 16
+    UseOverrideName: 2
 TransmogOutfitEntrySource:
-  AutomaticallyAwarded: 1
-  PlayerPurchased: 2
-  StampedSource: 0
+  values:
+    AutomaticallyAwarded: 1
+    PlayerPurchased: 2
+    StampedSource: 0
 TransmogOutfitEquipAction:
-  Equip: 0
-  EquipAndLock: 1
-  Lock: 5
-  Remove: 2
-  RemoveAndLock: 3
-  Unlock: 4
+  values:
+    Equip: 0
+    EquipAndLock: 1
+    Lock: 5
+    Remove: 2
+    RemoveAndLock: 3
+    Unlock: 4
 TransmogOutfitSetType:
-  CustomSet: 2
-  Equipped: 0
-  Outfit: 1
+  values:
+    CustomSet: 2
+    Equipped: 0
+    Outfit: 1
 TransmogOutfitSlot:
-  Back: 3
-  Body: 6
-  Chest: 4
-  Feet: 11
-  Hand: 8
-  Head: 0
-  Legs: 10
-  ShoulderLeft: 2
-  ShoulderRight: 1
-  Tabard: 5
-  Waist: 9
-  WeaponMainHand: 12
-  WeaponOffHand: 13
-  WeaponRanged: 14
-  Wrist: 7
+  values:
+    Back: 3
+    Body: 6
+    Chest: 4
+    Feet: 11
+    Hand: 8
+    Head: 0
+    Legs: 10
+    ShoulderLeft: 2
+    ShoulderRight: 1
+    Tabard: 5
+    Waist: 9
+    WeaponMainHand: 12
+    WeaponOffHand: 13
+    WeaponRanged: 14
+    Wrist: 7
 TransmogOutfitSlotError:
-  CannotUseItem: 10
-  IncompatibleWithMainHand: 14
-  InvalidDestination: 5
-  InvalidItemType: 4
-  InvalidSlotForForm: 13
-  InvalidSlotForRace: 11
-  InvalidSource: 8
-  InvalidSourceQuality: 9
-  Legendary: 3
-  Mismatch: 6
-  NoIllusion: 12
-  NoItem: 1
-  NotSoulbound: 2
-  Ok: 0
-  SameItem: 7
+  values:
+    CannotUseItem: 10
+    IncompatibleWithMainHand: 14
+    InvalidDestination: 5
+    InvalidItemType: 4
+    InvalidSlotForForm: 13
+    InvalidSlotForRace: 11
+    InvalidSource: 8
+    InvalidSourceQuality: 9
+    Legendary: 3
+    Mismatch: 6
+    NoIllusion: 12
+    NoItem: 1
+    NotSoulbound: 2
+    Ok: 0
+    SameItem: 7
 TransmogOutfitSlotFlags:
-  CanHaveIllusions: 2
-  CannotBeHidden: 1
-  IsSecondarySlot: 4
+  values:
+    CanHaveIllusions: 2
+    CannotBeHidden: 1
+    IsSecondarySlot: 4
 TransmogOutfitSlotOption:
-  ArtifactSpecFour: 11
-  ArtifactSpecOne: 8
-  ArtifactSpecThree: 10
-  ArtifactSpecTwo: 9
-  DeprecatedReuseMe: 6
-  FuryTwoHandedWeapon: 7
-  None: 0
-  OffHand: 4
-  OneHandedWeapon: 1
-  RangedWeapon: 3
-  Shield: 5
-  TwoHandedWeapon: 2
+  values:
+    ArtifactSpecFour: 11
+    ArtifactSpecOne: 8
+    ArtifactSpecThree: 10
+    ArtifactSpecTwo: 9
+    DeprecatedReuseMe: 6
+    FuryTwoHandedWeapon: 7
+    None: 0
+    OffHand: 4
+    OneHandedWeapon: 1
+    RangedWeapon: 3
+    Shield: 5
+    TwoHandedWeapon: 2
 TransmogOutfitSlotOptionFlags:
-  DisablesOffhandSlot: 4
-  DynamicOptionName: 2
-  IllusionNotAllowed: 1
+  values:
+    DisablesOffhandSlot: 4
+    DynamicOptionName: 2
+    IllusionNotAllowed: 1
 TransmogOutfitSlotOptionSheatheCategory:
-  Back: 1
-  Default: 0
-  Hide: 3
-  Side: 2
+  values:
+    Back: 1
+    Default: 0
+    Hide: 3
+    Side: 2
 TransmogOutfitSlotPosition:
-  Bottom: 2
-  Left: 0
-  Right: 1
+  values:
+    Bottom: 2
+    Left: 0
+    Right: 1
 TransmogOutfitSlotSaveFlags:
-  AppearanceIsNotValid: 1
+  values:
+    AppearanceIsNotValid: 1
 TransmogOutfitSlotWarning:
-  InvalidEquippedDestinationItem: 1
-  NothingEquipped: 5
-  Ok: 0
-  PendingWeaponChanges: 3
-  WeaponDoesNotSupportIllusions: 4
-  WrongWeaponCategoryEquipped: 2
+  values:
+    InvalidEquippedDestinationItem: 1
+    NothingEquipped: 5
+    Ok: 0
+    PendingWeaponChanges: 3
+    WeaponDoesNotSupportIllusions: 4
+    WrongWeaponCategoryEquipped: 2
 TransmogOutfitTransactionFlags:
-  AddNewOutfitMask: 20
-  AddOutfitAndUpdateSlots: 28
-  CreateAndUpdateOutfitInfoMask: 6
-  CreateOutfitInfo: 4
-  FullOutfitUpdateMask: 27
-  UpdateMetadata: 1
-  UpdateOutfitInfo: 2
-  UpdateSituations: 16
-  UpdateSituationsMask: 18
-  UpdateSlots: 8
+  values:
+    AddNewOutfitMask: 20
+    AddOutfitAndUpdateSlots: 28
+    CreateAndUpdateOutfitInfoMask: 6
+    CreateOutfitInfo: 4
+    FullOutfitUpdateMask: 27
+    UpdateMetadata: 1
+    UpdateOutfitInfo: 2
+    UpdateSituations: 16
+    UpdateSituationsMask: 18
+    UpdateSlots: 8
 TransmogOutfitTransactionType:
-  CreateOutfitInfo: 2
-  UpdateMetadata: 0
-  UpdateOutfitInfo: 1
-  UpdateSituations: 4
-  UpdateSlots: 3
+  values:
+    CreateOutfitInfo: 2
+    UpdateMetadata: 0
+    UpdateOutfitInfo: 1
+    UpdateSituations: 4
+    UpdateSlots: 3
 TransmogPendingType:
-  Apply: 0
-  Revert: 1
-  ToggleOff: 3
-  ToggleOn: 2
+  values:
+    Apply: 0
+    Revert: 1
+    ToggleOff: 3
+    ToggleOn: 2
 TransmogSearchType:
-  BaseSets: 2
-  Items: 1
-  UsableSets: 3
+  values:
+    BaseSets: 2
+    Items: 1
+    UsableSets: 3
 TransmogSituation:
-  AllEquipmentSets: 17
-  AllLocations: 2
-  AllMovement: 12
-  AllRacialForms: 19
-  AllSpecs: 0
-  AllTime: 27
-  AllWeather: 22
-  EquipmentSets: 18
-  FormNative: 20
-  FormNonNative: 21
-  LocationArenas: 10
-  LocationBattlegrounds: 11
-  LocationCharacterSelect: 5
-  LocationDelves: 7
-  LocationDungeons: 8
-  LocationHouse: 4
-  LocationRaids: 9
-  LocationRested: 3
-  LocationWorld: 6
-  MovementFlyingMount: 16
-  MovementGroundMount: 15
-  MovementSwimming: 14
-  MovementUnmounted: 13
-  Spec: 1
-  TimeDay: 29
-  TimeEvening: 30
-  TimeMorning: 28
-  TimeNight: 31
-  WeatherClear: 23
-  WeatherRain: 24
-  WeatherSand: 26
-  WeatherSnow: 25
+  values:
+    AllEquipmentSets: 17
+    AllLocations: 2
+    AllMovement: 12
+    AllRacialForms: 19
+    AllSpecs: 0
+    AllTime: 27
+    AllWeather: 22
+    EquipmentSets: 18
+    FormNative: 20
+    FormNonNative: 21
+    LocationArenas: 10
+    LocationBattlegrounds: 11
+    LocationCharacterSelect: 5
+    LocationDelves: 7
+    LocationDungeons: 8
+    LocationHouse: 4
+    LocationRaids: 9
+    LocationRested: 3
+    LocationWorld: 6
+    MovementFlyingMount: 16
+    MovementGroundMount: 15
+    MovementSwimming: 14
+    MovementUnmounted: 13
+    Spec: 1
+    TimeDay: 29
+    TimeEvening: 30
+    TimeMorning: 28
+    TimeNight: 31
+    WeatherClear: 23
+    WeatherRain: 24
+    WeatherSand: 26
+    WeatherSnow: 25
 TransmogSituationFlags:
-  AllSituation: 4
-  DefaultsToOn: 8
-  DisabledSituation: 64
-  DynamicallyNamed: 16
-  IsPlayerFacing: 1
-  NoneSituation: 32
-  SpecUseTalentLoadout: 2
+  values:
+    AllSituation: 4
+    DefaultsToOn: 8
+    DisabledSituation: 64
+    DynamicallyNamed: 16
+    IsPlayerFacing: 1
+    NoneSituation: 32
+    SpecUseTalentLoadout: 2
 TransmogSituationGroupFlags:
-  DynamicallyCreatesGroups: 1
+  values:
+    DynamicallyCreatesGroups: 1
 TransmogSituationTrigger:
-  EquipmentSet: 6
-  EventOutfit: 8
-  Forms: 7
-  Location: 3
-  Manual: 1
-  Movement: 4
-  None: 0
-  Specialization: 5
-  TimeOfDay: 10
-  TransmogUpdate: 2
-  Weather: 9
+  values:
+    EquipmentSet: 6
+    EventOutfit: 8
+    Forms: 7
+    Location: 3
+    Manual: 1
+    Movement: 4
+    None: 0
+    Specialization: 5
+    TimeOfDay: 10
+    TransmogUpdate: 2
+    Weather: 9
 TransmogSituationTriggerFlags:
-  CanChangeLockedOutfit: 2
-  CanLockOutfit: 1
-  DisabledTrigger: 16
-  IsPlayerFacing: 4
-  SituationsAreExclusive: 8
+  values:
+    CanChangeLockedOutfit: 2
+    CanLockOutfit: 1
+    DisabledTrigger: 16
+    IsPlayerFacing: 4
+    SituationsAreExclusive: 8
 TransmogSituationTriggerType:
-  Automatic: 2
-  Manual: 1
-  None: 0
-  TransmogUpdate: 3
+  values:
+    Automatic: 2
+    Manual: 1
+    None: 0
+    TransmogUpdate: 3
 TransmogSlot:
-  Back: 2
-  Body: 4
-  Chest: 3
-  Feet: 10
-  Hand: 7
-  Head: 0
-  Legs: 9
-  Mainhand: 11
-  Offhand: 12
-  Shoulder: 1
-  Tabard: 5
-  Waist: 8
-  Wrist: 6
+  values:
+    Back: 2
+    Body: 4
+    Chest: 3
+    Feet: 10
+    Hand: 7
+    Head: 0
+    Legs: 9
+    Mainhand: 11
+    Offhand: 12
+    Shoulder: 1
+    Tabard: 5
+    Waist: 8
+    Wrist: 6
 TransmogSource:
-  Achievement: 7
-  CantCollect: 6
-  HiddenUntilCollected: 5
-  JournalEncounter: 1
-  None: 0
-  NotValidForTransmog: 9
-  Profession: 8
-  Quest: 2
-  TradingPost: 10
-  Vendor: 3
-  WorldDrop: 4
+  values:
+    Achievement: 7
+    CantCollect: 6
+    HiddenUntilCollected: 5
+    JournalEncounter: 1
+    None: 0
+    NotValidForTransmog: 9
+    Profession: 8
+    Quest: 2
+    TradingPost: 10
+    Vendor: 3
+    WorldDrop: 4
 TransmogTimeOfDayCategory:
-  Evening: 2
-  Midday: 1
-  Morning: 0
-  Night: 3
+  values:
+    Evening: 2
+    Midday: 1
+    Morning: 0
+    Night: 3
 TransmogType:
-  Appearance: 0
-  Illusion: 1
+  values:
+    Appearance: 0
+    Illusion: 1
 TransmogUseErrorType:
-  Ability: 3
-  Class: 7
-  Faction: 9
-  Holiday: 5
-  HotRecheckFailed: 6
-  ItemProficiency: 10
-  None: 0
-  PlayerCondition: 1
-  Race: 8
-  Reputation: 4
-  Skill: 2
+  values:
+    Ability: 3
+    Class: 7
+    Faction: 9
+    Holiday: 5
+    HotRecheckFailed: 6
+    ItemProficiency: 10
+    None: 0
+    PlayerCondition: 1
+    Race: 8
+    Reputation: 4
+    Skill: 2
 TtsBoolSetting:
-  AddCharacterNameToSpeech: 1
-  AlternateSystemVoice: 3
-  NarrateMyMessages: 4
-  PlayActivitySoundWhenNotFocused: 2
-  PlaySoundSeparatingChatLineBreaks: 0
+  values:
+    AddCharacterNameToSpeech: 1
+    AlternateSystemVoice: 3
+    NarrateMyMessages: 4
+    PlayActivitySoundWhenNotFocused: 2
+    PlaySoundSeparatingChatLineBreaks: 0
 TtsVoiceType:
-  Alternate: 1
-  Standard: 0
+  values:
+    Alternate: 1
+    Standard: 0
 TugOfWarMarkerArrowShownState:
-  Always: 1
-  FlashOnMove: 2
-  Never: 0
+  values:
+    Always: 1
+    FlashOnMove: 2
+    Never: 0
 TugOfWarStyleValue:
-  ArchaeologyBrown: 1
-  DefaultYellow: 0
+  values:
+    ArchaeologyBrown: 1
+    DefaultYellow: 0
 TurnStrafeStyle:
-  Custom: 2
-  Legacy: 1
-  Modern: 0
+  values:
+    Custom: 2
+    Legacy: 1
+    Modern: 0
 UIActionType:
-  DefaultAction: 0
-  UpdateMapSystem: 1
+  values:
+    DefaultAction: 0
+    UpdateMapSystem: 1
 UICovenantDisplayInfoFlags:
-  DisplayCovenantAsJourney: 1
-  UseJourneyRewardTrack: 2
-  UseJourneyUnlockToastText: 3
+  values:
+    DisplayCovenantAsJourney: 1
+    UseJourneyRewardTrack: 2
+    UseJourneyUnlockToastText: 3
 UICursorType:
-  ActionBar: 6
-  AmmoObsolete: 8
-  BattlePet: 16
-  ConduitCollectionItem: 19
-  Currency: 13
-  Default: 0
-  EquipmentSet: 12
-  Flyout: 14
-  GuildBank: 10
-  GuildBankMoney: 11
-  Item: 1
-  Macro: 7
-  Merchant: 5
-  Money: 2
-  Mount: 17
-  Outfit: 21
-  PerksProgramVendorItem: 20
-  Pet: 9
-  PetAction: 4
-  Spell: 3
-  Toy: 18
-  VoidItem: 15
+  values:
+    ActionBar: 6
+    AmmoObsolete: 8
+    BattlePet: 16
+    ConduitCollectionItem: 19
+    Currency: 13
+    Default: 0
+    EquipmentSet: 12
+    Flyout: 14
+    GuildBank: 10
+    GuildBankMoney: 11
+    Item: 1
+    Macro: 7
+    Merchant: 5
+    Money: 2
+    Mount: 17
+    Outfit: 21
+    PerksProgramVendorItem: 20
+    Pet: 9
+    PetAction: 4
+    Spell: 3
+    Toy: 18
+    VoidItem: 15
 UIFrameType:
-  InterruptTutorial: 1
-  JailersTowerBuffs: 0
+  values:
+    InterruptTutorial: 1
+    JailersTowerBuffs: 0
 UIItemInteractionFlags:
-  AddCurrency: 16
-  ClickShowsFlyout: 8
-  ConfirmationHasDelay: 2
-  ConversionMode: 4
-  DisplayWithInset: 1
-  UsesCharges: 32
+  values:
+    AddCurrency: 16
+    ClickShowsFlyout: 8
+    ConfirmationHasDelay: 2
+    ConversionMode: 4
+    DisplayWithInset: 1
+    UsesCharges: 32
 UIItemInteractionType:
-  CastSpell: 1
-  CleanseCorruption: 2
-  ItemConversion: 4
-  None: 0
-  RunecarverScrapping: 3
+  values:
+    CastSpell: 1
+    CleanseCorruption: 2
+    ItemConversion: 4
+    None: 0
+    RunecarverScrapping: 3
 UIMapFlag:
-  AlwaysAllowTaxiPathing: 131072
-  AlwaysAllowUserWaypoints: 65536
-  DoNotShowOnNavbar: 524288
-  DoNotTranslateBranches: 512
-  FallbackToParentMap: 16
-  FlightMapAutoZoom: 16384
-  FlightMapShowZoomOut: 8192
-  ForceAllOverlayExplored: 4096
-  ForceAllowMapLinks: 262144
-  ForceOnNavbar: 32768
-  GarrisonMap: 8
-  HideArchaeologyDigs: 256
-  HideIcons: 1024
-  HideVignettes: 2048
-  IgnoreInTranslationsToParent: 2097152
-  IsCityMap: 1048576
-  NoHighlight: 1
-  NoHighlightTexture: 32
-  NoWorldPositions: 128
-  ShowOverlays: 2
-  ShowTaskObjectives: 64
-  ShowTaxiNodes: 4
+  values:
+    AlwaysAllowTaxiPathing: 131072
+    AlwaysAllowUserWaypoints: 65536
+    DoNotShowOnNavbar: 524288
+    DoNotTranslateBranches: 512
+    FallbackToParentMap: 16
+    FlightMapAutoZoom: 16384
+    FlightMapShowZoomOut: 8192
+    ForceAllOverlayExplored: 4096
+    ForceAllowMapLinks: 262144
+    ForceOnNavbar: 32768
+    GarrisonMap: 8
+    HideArchaeologyDigs: 256
+    HideIcons: 1024
+    HideVignettes: 2048
+    IgnoreInTranslationsToParent: 2097152
+    IsCityMap: 1048576
+    NoHighlight: 1
+    NoHighlightTexture: 32
+    NoWorldPositions: 128
+    ShowOverlays: 2
+    ShowTaskObjectives: 64
+    ShowTaxiNodes: 4
 UIMapGroupFlag:
-  ShowIconsAcrossFloors: 1
+  values:
+    ShowIconsAcrossFloors: 1
 UIMapSystem:
-  Adventure: 2
-  Minimap: 3
-  Taxi: 1
-  World: 0
+  values:
+    Adventure: 2
+    Minimap: 3
+    Taxi: 1
+    World: 0
 UIMapType:
-  Continent: 2
-  Cosmic: 0
-  Dungeon: 4
-  Micro: 5
-  Orphan: 6
-  World: 1
-  Zone: 3
+  values:
+    Continent: 2
+    Cosmic: 0
+    Dungeon: 4
+    Micro: 5
+    Orphan: 6
+    World: 1
+    Zone: 3
 UIModelSceneActorFlag:
-  Deprecated1: 1
-  UseCenterForOriginX: 2
-  UseCenterForOriginY: 4
-  UseCenterForOriginZ: 8
+  values:
+    Deprecated1: 1
+    UseCenterForOriginX: 2
+    UseCenterForOriginY: 4
+    UseCenterForOriginZ: 8
 UIModelSceneContext:
-  None: -1
-  PerksProgram: 0
+  values:
+    None: -1
+    PerksProgram: 0
 UIModelSceneFlags:
-  Autodress: 4
-  HideWeapon: 2
-  NoCameraSpin: 8
-  SheatheWeapon: 1
+  values:
+    Autodress: 4
+    HideWeapon: 2
+    NoCameraSpin: 8
+    SheatheWeapon: 1
 UISystemType:
-  InGameNavigation: 0
+  values:
+    InGameNavigation: 0
 UITextureSliceMode:
-  Stretched: 0
-  Tiled: 1
+  values:
+    Stretched: 0
+    Tiled: 1
 UIWidgetBlendModeType:
-  Additive: 1
-  Opaque: 0
+  values:
+    Additive: 1
+    Opaque: 0
 UIWidgetButtonEnabledState:
-  Disabled: 0
-  Enabled: 1
+  values:
+    Disabled: 0
+    Enabled: 1
 UIWidgetButtonIconType:
-  Checkmark: 3
-  Exit: 0
-  RedX: 4
-  Speak: 1
-  Undo: 2
+  values:
+    Checkmark: 3
+    Exit: 0
+    RedX: 4
+    Speak: 1
+    Undo: 2
 UIWidgetFlag:
-  UniversalWidget: 1
+  values:
+    UniversalWidget: 1
 UIWidgetFontType:
-  Normal: 0
-  Outline: 2
-  Shadow: 1
+  values:
+    Normal: 0
+    Outline: 2
+    Shadow: 1
 UIWidgetHorizontalDirection:
-  LeftToRight: 0
-  RightToLeft: 1
+  values:
+    LeftToRight: 0
+    RightToLeft: 1
 UIWidgetLayoutDirection:
-  Default: 0
-  Horizontal: 2
-  HorizontalForceNewRow: 4
-  Overlap: 3
-  Vertical: 1
+  values:
+    Default: 0
+    Horizontal: 2
+    HorizontalForceNewRow: 4
+    Overlap: 3
+    Vertical: 1
 UIWidgetModelSceneLayer:
-  Back: 2
-  Front: 1
-  None: 0
+  values:
+    Back: 2
+    Front: 1
+    None: 0
 UIWidgetMotionType:
-  Instant: 0
-  Smooth: 1
+  values:
+    Instant: 0
+    Smooth: 1
 UIWidgetOverrideState:
-  Active: 1
-  Inactive: 0
+  values:
+    Active: 1
+    Inactive: 0
 UIWidgetRewardShownState:
-  Hidden: 0
-  ShownEarned: 1
-  ShownUnearned: 2
+  values:
+    Hidden: 0
+    ShownEarned: 1
+    ShownUnearned: 2
 UIWidgetScale:
-  Eighty: 2
-  Fifty: 5
-  Ninty: 1
-  OneHundred: 0
-  OneHundredEighty: 13
-  OneHundredFifty: 10
-  OneHundredForty: 9
-  OneHundredNinety: 14
-  OneHundredSeventy: 12
-  OneHundredSixty: 11
-  OneHundredTen: 6
-  OneHundredThirty: 8
-  OneHundredTwenty: 7
-  Seventy: 3
-  Sixty: 4
-  TwoHundred: 15
+  values:
+    Eighty: 2
+    Fifty: 5
+    Ninty: 1
+    OneHundred: 0
+    OneHundredEighty: 13
+    OneHundredFifty: 10
+    OneHundredForty: 9
+    OneHundredNinety: 14
+    OneHundredSeventy: 12
+    OneHundredSixty: 11
+    OneHundredTen: 6
+    OneHundredThirty: 8
+    OneHundredTwenty: 7
+    Seventy: 3
+    Sixty: 4
+    TwoHundred: 15
 UIWidgetSetLayoutDirection:
-  Horizontal: 1
-  Overlap: 2
-  Vertical: 0
+  values:
+    Horizontal: 1
+    Overlap: 2
+    Vertical: 0
 UIWidgetSpellButtonCooldownType:
-  HideCooldown: 0
-  ShowCooldown: 1
-  ShowCooldownAndDisableOnCooldown: 2
+  values:
+    HideCooldown: 0
+    ShowCooldown: 1
+    ShowCooldownAndDisableOnCooldown: 2
 UIWidgetTextFormatType:
-  LeadingZeroesWithSixDigits: 3
-  None: 0
-  TimeOneLevel: 1
-  TimeTwoLevel: 2
+  values:
+    LeadingZeroesWithSixDigits: 3
+    None: 0
+    TimeOneLevel: 1
+    TimeTwoLevel: 2
 UIWidgetTextSizeType:
-  Huge27Pt: 3
-  Large20Pt: 8
-  Large24Pt: 2
-  Medium16Pt: 1
-  Medium18Pt: 7
-  Small10Pt: 5
-  Small11Pt: 6
-  Small12Pt: 0
-  Standard14Pt: 4
+  values:
+    Huge27Pt: 3
+    Large20Pt: 8
+    Large24Pt: 2
+    Medium16Pt: 1
+    Medium18Pt: 7
+    Small10Pt: 5
+    Small11Pt: 6
+    Small12Pt: 0
+    Standard14Pt: 4
 UIWidgetTextureAndTextSizeType:
-  Huge: 3
-  Large: 2
-  Medium: 1
-  Medium2: 5
-  Small: 0
-  Standard: 4
+  values:
+    Huge: 3
+    Large: 2
+    Medium: 1
+    Medium2: 5
+    Small: 0
+    Standard: 4
 UIWidgetTooltipLocation:
-  Bottom: 8
-  BottomLeft: 1
-  BottomRight: 7
-  Default: 0
-  Left: 2
-  Right: 6
-  Top: 4
-  TopLeft: 3
-  TopRight: 5
+  values:
+    Bottom: 8
+    BottomLeft: 1
+    BottomRight: 7
+    Default: 0
+    Left: 2
+    Right: 6
+    Top: 4
+    TopLeft: 3
+    TopRight: 5
 UIWidgetUpdateAnimType:
-  Flash: 1
-  FlashAndAnimateNumber: 2
-  None: 0
+  values:
+    Flash: 1
+    FlashAndAnimateNumber: 2
+    None: 0
 UIWidgetVisualizationType:
-  BulletTextList: 10
-  ButtonHeader: 30
-  CaptureBar: 1
-  CaptureZone: 17
-  DiscreteProgressSteps: 19
-  DoubleIconAndText: 5
-  DoubleStateIconRow: 14
-  DoubleStatusBar: 3
-  FillUpFrames: 24
-  HorizontalCurrencies: 9
-  IconAndText: 0
-  IconTextAndBackground: 4
-  IconTextAndCurrencies: 7
-  ItemDisplay: 27
-  MapPinAnimation: 26
-  PreyHuntProgress: 31
-  ScenarioHeaderCurrenciesAndBackground: 11
-  ScenarioHeaderDelves: 29
-  ScenarioHeaderTimer: 20
-  Spacer: 22
-  SpellDisplay: 13
-  StackedResourceTracker: 6
-  StatusBar: 2
-  TextColumnRow: 21
-  TextureAndText: 12
-  TextureAndTextRow: 15
-  TextureWithAnimation: 18
-  TextWithState: 8
-  TextWithSubtext: 25
-  TugOfWar: 28
-  UnitPowerBar: 23
-  ZoneControl: 16
+  values:
+    BulletTextList: 10
+    ButtonHeader: 30
+    CaptureBar: 1
+    CaptureZone: 17
+    DiscreteProgressSteps: 19
+    DoubleIconAndText: 5
+    DoubleStateIconRow: 14
+    DoubleStatusBar: 3
+    FillUpFrames: 24
+    HorizontalCurrencies: 9
+    IconAndText: 0
+    IconTextAndBackground: 4
+    IconTextAndCurrencies: 7
+    ItemDisplay: 27
+    MapPinAnimation: 26
+    PreyHuntProgress: 31
+    ScenarioHeaderCurrenciesAndBackground: 11
+    ScenarioHeaderDelves: 29
+    ScenarioHeaderTimer: 20
+    Spacer: 22
+    SpellDisplay: 13
+    StackedResourceTracker: 6
+    StatusBar: 2
+    TextColumnRow: 21
+    TextureAndText: 12
+    TextureAndTextRow: 15
+    TextureWithAnimation: 18
+    TextWithState: 8
+    TextWithSubtext: 25
+    TugOfWar: 28
+    UnitPowerBar: 23
+    ZoneControl: 16
 UnitAuraSortDirection:
-  Normal: 0
-  Reverse: 1
+  values:
+    Normal: 0
+    Reverse: 1
 UnitAuraSortRule:
-  BigDefensive: 2
-  Default: 1
-  Expiration: 3
-  ExpirationOnly: 4
-  Name: 5
-  NameOnly: 6
-  Unsorted: 0
+  values:
+    BigDefensive: 2
+    Default: 1
+    Expiration: 3
+    ExpirationOnly: 4
+    Name: 5
+    NameOnly: 6
+    Unsorted: 0
 UnitAuraSoundTrigger:
-  Added: 0
-  ApplicationsIncreased: 1
-  Removed: 2
+  values:
+    Added: 0
+    ApplicationsIncreased: 1
+    Removed: 2
 UnitDamageAbsorbClampMode:
-  MaximumHealth: 2
-  MissingHealth: 0
-  MissingHealthWithoutIncomingHeals: 1
+  values:
+    MaximumHealth: 2
+    MissingHealth: 0
+    MissingHealthWithoutIncomingHeals: 1
 UnitHealAbsorbClampMode:
-  CurrentHealth: 0
-  MaximumHealth: 1
+  values:
+    CurrentHealth: 0
+    MaximumHealth: 1
 UnitHealAbsorbMode:
-  ReducedByIncomingHeals: 0
-  Total: 1
+  values:
+    ReducedByIncomingHeals: 0
+    Total: 1
 UnitIncomingHealClampMode:
-  MaximumHealth: 1
-  MissingHealth: 0
+  values:
+    MaximumHealth: 1
+    MissingHealth: 0
 UnitMaximumHealthMode:
-  Default: 0
-  WithAbsorbs: 1
+  values:
+    Default: 0
+    WithAbsorbs: 1
 UnitMirrorPetFlags:
-  Dismissable: 2
-  ExtraPet: 16
-  RecentlyTamed: 4
-  Renameable: 1
-  Stampede: 8
+  values:
+    Dismissable: 2
+    ExtraPet: 16
+    RecentlyTamed: 4
+    Renameable: 1
+    Stampede: 8
 UnitSex:
-  Both: 3
-  Female: 1
-  Male: 0
-  Neutral: 4
-  None: 2
+  values:
+    Both: 3
+    Female: 1
+    Male: 0
+    Neutral: 4
+    None: 2
 UrlTextureResult:
-  Found: 1
-  NotAllowed: 4
-  NotFound: 2
-  Requested: 3
+  values:
+    Found: 1
+    NotAllowed: 4
+    NotFound: 2
+    Requested: 3
 ValidateNameResult:
-  ConsecutiveSpaces: 13
-  DeclensionDoesntMatchBaseName: 16
-  Failure: 1
-  InvalidApostrophe: 9
-  InvalidCharacter: 5
-  InvalidSpace: 12
-  MixedLanguages: 6
-  MultipleApostrophes: 10
-  NoName: 2
-  Profane: 7
-  Reserved: 8
-  RussianConsecutiveSilentCharacters: 14
-  RussianSilentCharacterAtBeginningOrEnd: 15
-  SpacesDisallowed: 17
-  Success: 0
-  ThreeConsecutive: 11
-  TooLong: 4
-  TooShort: 3
+  values:
+    ConsecutiveSpaces: 13
+    DeclensionDoesntMatchBaseName: 16
+    Failure: 1
+    InvalidApostrophe: 9
+    InvalidCharacter: 5
+    InvalidSpace: 12
+    MixedLanguages: 6
+    MultipleApostrophes: 10
+    NoName: 2
+    Profane: 7
+    Reserved: 8
+    RussianConsecutiveSilentCharacters: 14
+    RussianSilentCharacterAtBeginningOrEnd: 15
+    SpacesDisallowed: 17
+    Success: 0
+    ThreeConsecutive: 11
+    TooLong: 4
+    TooShort: 3
 VasPurchaseProgress:
-  ApplyingLicense: 3
-  Complete: 7
-  Invalid: 0
-  PaymentPending: 2
-  PrePurchase: 1
-  ProcessingFactionChange: 6
-  Ready: 5
-  WaitingOnQueue: 4
+  values:
+    ApplyingLicense: 3
+    Complete: 7
+    Invalid: 0
+    PaymentPending: 2
+    PrePurchase: 1
+    ProcessingFactionChange: 6
+    Ready: 5
+    WaitingOnQueue: 4
 VasServiceType:
-  AppearanceChange: 2
-  CharacterTransfer: 4
-  FactionChange: 1
-  FactionTransfer: 5
-  GuildFactionChange: 7
-  GuildFactionTransfer: 9
-  GuildNameChange: 6
-  GuildTransfer: 8
-  NameChange: 0
-  RaceChange: 3
+  values:
+    AppearanceChange: 2
+    CharacterTransfer: 4
+    FactionChange: 1
+    FactionTransfer: 5
+    GuildFactionChange: 7
+    GuildFactionTransfer: 9
+    GuildNameChange: 6
+    GuildTransfer: 8
+    NameChange: 0
+    RaceChange: 3
 VasTransactionPurchaseResult:
-  BeginDbErrors: 20010
-  BeginProxyErrors: 17
-  DbAccountDoesNotOwnCharacter: 20017
-  DbAllianceNotEligible: 20027
-  DbAlreadyRenameFlagged: 20055
-  DbAuthenticatorInsufficient: 20073
-  DbBatchProcessingDisabled: 20028
-  DbBatchStateInvalid: 20067
-  DbBnetAccountNotProvided: 20077
-  DbBoostProcessingDisabled: 20095
-  DbBpayDeliveryPending: 20078
-  DbCagedPetInInventory: 20084
-  DbCannotMoveArenaCaptn: 20064
-  DbCannotMoveGuildmaster: 20012
-  DbCharacterDoesNotExist: 20019
-  DbCharacterWithoutGuild: 20070
-  DbCharLocked: 20026
-  DbCharNotLocked: 20025
-  DbCouldNotObtainCharLock: 20041
-  DbCustomizeAlreadyRequested: 20057
-  DbDeletedGuild: 20071
-  DbDuplicateCharacterName: 20015
-  DbDuplicateSupportRequest: 20063
-  DbEventNotActive: 20068
-  DbEventRealmClosed: 20038
-  DbFactionChangeTooSoon: 20061
-  DbGmSenorityInsufficient: 20072
-  DbGuildLevelInsufficient: 20074
-  DbGuildRankInsufficient: 20069
-  DbHasAuctions: 20033
-  DbHasBpayToken: 20079
-  DbHasCraftingOrders: 20092
-  DbHasHeirloomItem: 20080
-  DbHasMail: 20016
-  DbHasNewPlayerExperienceRestriction: 20091
-  DbHasUnclaimedCacheRewards: 20089
-  DbHouseOwnerRestriction: 20096
-  DbIneligibleMapID: 20076
-  DbIneligibleTargetRealm: 20022
-  DbInvalidName: 20094
-  DbInventoryCorrupt: 20040
-  DbLastCustomizeTooSoon: 20058
-  DbLastRenameTooRecent: 20052
-  DbLastRequestTooSoon: 20054
-  DbLastSaveTooDistant: 20083
-  DbLastSaveTooRecent: 20034
-  DbLockAlreadyRequested: 20044
-  DbLockNotAcknowledged: 20043
-  DbMaxCharactersOnServer: 20013
-  DbMoveInProgress: 20018
-  DbMultipleTransferCn: 20056
-  DbNameChangeSkipped: 20093
-  DbNameNotAvailable: 20051
-  DbNeedsEraChoice: 20090
-  DbNeedsLevelSquish: 20088
-  DbNewLeaderInvalid: 20086
-  DbNewNameTooLong: 20024
-  DbNoCopiesAvailable: 20020
-  DbNoCsiFound: 20065
-  DbNoMixedAlliance: 20014
-  DbNoneBatchQueueID: 20029
-  DbNoneLockID: 20042
-  DbNoneRealmForEvent: 20037
-  DbNoneSupportActionID: 20046
-  DbNoneSupportQueueID: 20045
-  DbNoneTemplateForEvent: 20039
-  DbNotMovebackable: 20048
-  DbNotRollbackable: 20047
-  DbOnBoostCooldown: 20085
-  DbPendingItemAudit: 20066
-  DbPvEPvPTransferNotAllowed: 20087
-  DbRaceClassComboIneligible: 20062
-  DbRealmNotEligible: 20011
-  DbRegionalDbNotFound: 20075
-  DbRenameAlreadyRequested: 20049
-  DbReservationDoesNotMatch: 20053
-  DbReservationExpired: 20050
-  DbResultAccountRestricted: 20082
-  DbResultSourceAccountBanned: 20081
-  DbTooMuchMoneyForLevel: 20032
-  DbTransferDateTooSoon: 20023
-  DbTransferNotCancellable: 20031
-  DbTransferNotFinalized: 20030
-  DbTransferNotLockable: 20035
-  DbTransferNotUnlockable: 20036
-  DbUnableToCustomize: 20060
-  DbUnderMinLevelReq: 20021
-  DbWaitingForPayment: 20059
-  DisallowedDestinationAccount: 9
-  DisallowedSourceAccount: 8
-  EndDbErrors: 20097
-  EndProxyErrors: 56
-  EndServerErrors: 16
-  InvalidBpayDeliverableID: 14
-  InvalidBpayProductID: 13
-  InvalidBpayProductType: 15
-  InvalidDestinationAccount: 6
-  InvalidDestinationRealm: 5
-  InvalidDistribution: 12
-  InvalidSourceAccount: 7
-  LowerBoxLevel: 11
-  None: 0
-  NoneCharacter: 2
-  NoneProduct: 3
-  OnlyOneVasAtATime: 4
-  ProxyAccountDataTooBig: 55
-  ProxyBadDbType: 35
-  ProxyBadObjType: 18
-  ProxyBadRequestContained: 33
-  ProxyBindFailed: 51
-  ProxyCannotDeleteArenaCaptain: 31
-  ProxyCannotDeleteGuildLeader: 30
-  ProxyCannotInsertNull: 45
-  ProxyCannotUndeleteTrialBoostCharacter: 46
-  ProxyCharacterHasWoWToken: 53
-  ProxyCharacterLevelTooHigh: 38
-  ProxyCharacterTransferred: 39
-  ProxyCharacterTransferredNoBoostInProgress: 40
-  ProxyDataInvalid: 22
-  ProxyDbError: 21
-  ProxyDeleteNotSupported: 28
-  ProxyExternalUpdateDetected: 37
-  ProxyGenericError: 44
-  ProxyInsertRequestContainedNoData: 49
-  ProxyInvalidKey: 50
-  ProxyIsReadonly: 34
-  ProxyLockedForToken: 42
-  ProxyLockedForTransfer: 26
-  ProxyLockedForUpgrade: 41
-  ProxyLockedForVas: 43
-  ProxyLocksFailed: 24
-  ProxyLostProxyConnection: 23
-  ProxyMissingResultsPtr: 25
-  ProxyMoneyLimitExceeded: 32
-  ProxyNoReturnValue: 27
-  ProxyObjDropped: 29
-  ProxyObjNotInDb: 19
-  ProxyOperationAlreadyInProgress: 36
-  ProxyPredicateFailed: 47
-  ProxyTooBusyBackOff: 54
-  ProxyTooManyRows: 52
-  ProxyUniqueKey: 20
-  ProxyWeeklyRewardNotFound: 48
-  UnknownError: 10
-  VasPurchaseDisabled: 1
+  values:
+    BeginDbErrors: 20010
+    BeginProxyErrors: 17
+    DbAccountDoesNotOwnCharacter: 20017
+    DbAllianceNotEligible: 20027
+    DbAlreadyRenameFlagged: 20055
+    DbAuthenticatorInsufficient: 20073
+    DbBatchProcessingDisabled: 20028
+    DbBatchStateInvalid: 20067
+    DbBnetAccountNotProvided: 20077
+    DbBoostProcessingDisabled: 20095
+    DbBpayDeliveryPending: 20078
+    DbCagedPetInInventory: 20084
+    DbCannotMoveArenaCaptn: 20064
+    DbCannotMoveGuildmaster: 20012
+    DbCharacterDoesNotExist: 20019
+    DbCharacterWithoutGuild: 20070
+    DbCharLocked: 20026
+    DbCharNotLocked: 20025
+    DbCouldNotObtainCharLock: 20041
+    DbCustomizeAlreadyRequested: 20057
+    DbDeletedGuild: 20071
+    DbDuplicateCharacterName: 20015
+    DbDuplicateSupportRequest: 20063
+    DbEventNotActive: 20068
+    DbEventRealmClosed: 20038
+    DbFactionChangeTooSoon: 20061
+    DbGmSenorityInsufficient: 20072
+    DbGuildLevelInsufficient: 20074
+    DbGuildRankInsufficient: 20069
+    DbHasAuctions: 20033
+    DbHasBpayToken: 20079
+    DbHasCraftingOrders: 20092
+    DbHasHeirloomItem: 20080
+    DbHasMail: 20016
+    DbHasNewPlayerExperienceRestriction: 20091
+    DbHasUnclaimedCacheRewards: 20089
+    DbHouseOwnerRestriction: 20096
+    DbIneligibleMapID: 20076
+    DbIneligibleTargetRealm: 20022
+    DbInvalidName: 20094
+    DbInventoryCorrupt: 20040
+    DbLastCustomizeTooSoon: 20058
+    DbLastRenameTooRecent: 20052
+    DbLastRequestTooSoon: 20054
+    DbLastSaveTooDistant: 20083
+    DbLastSaveTooRecent: 20034
+    DbLockAlreadyRequested: 20044
+    DbLockNotAcknowledged: 20043
+    DbMaxCharactersOnServer: 20013
+    DbMoveInProgress: 20018
+    DbMultipleTransferCn: 20056
+    DbNameChangeSkipped: 20093
+    DbNameNotAvailable: 20051
+    DbNeedsEraChoice: 20090
+    DbNeedsLevelSquish: 20088
+    DbNewLeaderInvalid: 20086
+    DbNewNameTooLong: 20024
+    DbNoCopiesAvailable: 20020
+    DbNoCsiFound: 20065
+    DbNoMixedAlliance: 20014
+    DbNoneBatchQueueID: 20029
+    DbNoneLockID: 20042
+    DbNoneRealmForEvent: 20037
+    DbNoneSupportActionID: 20046
+    DbNoneSupportQueueID: 20045
+    DbNoneTemplateForEvent: 20039
+    DbNotMovebackable: 20048
+    DbNotRollbackable: 20047
+    DbOnBoostCooldown: 20085
+    DbPendingItemAudit: 20066
+    DbPvEPvPTransferNotAllowed: 20087
+    DbRaceClassComboIneligible: 20062
+    DbRealmNotEligible: 20011
+    DbRegionalDbNotFound: 20075
+    DbRenameAlreadyRequested: 20049
+    DbReservationDoesNotMatch: 20053
+    DbReservationExpired: 20050
+    DbResultAccountRestricted: 20082
+    DbResultSourceAccountBanned: 20081
+    DbTooMuchMoneyForLevel: 20032
+    DbTransferDateTooSoon: 20023
+    DbTransferNotCancellable: 20031
+    DbTransferNotFinalized: 20030
+    DbTransferNotLockable: 20035
+    DbTransferNotUnlockable: 20036
+    DbUnableToCustomize: 20060
+    DbUnderMinLevelReq: 20021
+    DbWaitingForPayment: 20059
+    DisallowedDestinationAccount: 9
+    DisallowedSourceAccount: 8
+    EndDbErrors: 20097
+    EndProxyErrors: 56
+    EndServerErrors: 16
+    InvalidBpayDeliverableID: 14
+    InvalidBpayProductID: 13
+    InvalidBpayProductType: 15
+    InvalidDestinationAccount: 6
+    InvalidDestinationRealm: 5
+    InvalidDistribution: 12
+    InvalidSourceAccount: 7
+    LowerBoxLevel: 11
+    None: 0
+    NoneCharacter: 2
+    NoneProduct: 3
+    OnlyOneVasAtATime: 4
+    ProxyAccountDataTooBig: 55
+    ProxyBadDbType: 35
+    ProxyBadObjType: 18
+    ProxyBadRequestContained: 33
+    ProxyBindFailed: 51
+    ProxyCannotDeleteArenaCaptain: 31
+    ProxyCannotDeleteGuildLeader: 30
+    ProxyCannotInsertNull: 45
+    ProxyCannotUndeleteTrialBoostCharacter: 46
+    ProxyCharacterHasWoWToken: 53
+    ProxyCharacterLevelTooHigh: 38
+    ProxyCharacterTransferred: 39
+    ProxyCharacterTransferredNoBoostInProgress: 40
+    ProxyDataInvalid: 22
+    ProxyDbError: 21
+    ProxyDeleteNotSupported: 28
+    ProxyExternalUpdateDetected: 37
+    ProxyGenericError: 44
+    ProxyInsertRequestContainedNoData: 49
+    ProxyInvalidKey: 50
+    ProxyIsReadonly: 34
+    ProxyLockedForToken: 42
+    ProxyLockedForTransfer: 26
+    ProxyLockedForUpgrade: 41
+    ProxyLockedForVas: 43
+    ProxyLocksFailed: 24
+    ProxyLostProxyConnection: 23
+    ProxyMissingResultsPtr: 25
+    ProxyMoneyLimitExceeded: 32
+    ProxyNoReturnValue: 27
+    ProxyObjDropped: 29
+    ProxyObjNotInDb: 19
+    ProxyOperationAlreadyInProgress: 36
+    ProxyPredicateFailed: 47
+    ProxyTooBusyBackOff: 54
+    ProxyTooManyRows: 52
+    ProxyUniqueKey: 20
+    ProxyWeeklyRewardNotFound: 48
+    UnknownError: 10
+    VasPurchaseDisabled: 1
 ViewArenaSize:
-  Three: 1
-  Two: 0
+  values:
+    Three: 1
+    Two: 0
 ViewRaidSize:
-  Forty: 2
-  Ten: 0
-  TwentyFive: 1
+  values:
+    Forty: 2
+    Ten: 0
+    TwentyFive: 1
 VignetteObjectiveType:
-  Defeat: 1
-  DefeatShowRemainingHealth: 2
-  None: 0
+  values:
+    Defeat: 1
+    DefeatShowRemainingHealth: 2
+    None: 0
 VignetteType:
-  FyrakkFlight: 4
-  Normal: 0
-  PvPBounty: 1
-  Torghast: 2
-  Treasure: 3
+  values:
+    FyrakkFlight: 4
+    Normal: 0
+    PvPBounty: 1
+    Torghast: 2
+    Treasure: 3
 VisualAlertType:
-  Flash: 6
-  FlashBlue: 10
-  FlashCyan: 7
-  FlashGreen: 9
-  FlashRed: 8
-  MarchingAnts: 1
-  MarchingAntsBlue: 5
-  MarchingAntsCyan: 2
-  MarchingAntsGreen: 4
-  MarchingAntsRed: 3
+  values:
+    Flash: 6
+    FlashBlue: 10
+    FlashCyan: 7
+    FlashGreen: 9
+    FlashRed: 8
+    MarchingAnts: 1
+    MarchingAntsBlue: 5
+    MarchingAntsCyan: 2
+    MarchingAntsGreen: 4
+    MarchingAntsRed: 3
 Vocalerrorsounds:
-  Abilitycooling: 50
-  Alreadyingroup: 20
-  Alreadyinguild: 21
-  Ammoonlyinbag: 28
-  Bagfull: 29
-  BoundNodrop: 4
-  Cantaffordbankslot: 22
-  CantattackNotarget: 38
-  CantattackNotstandingObsolete: 37
-  Cantattackrongdirection: 36
-  CantcastOutofrange: 46
-  Cantcreate: 18
-  Cantdrinkmore: 6
-  Canteatmore: 7
-  CanteatMoving: 24
-  Cantequip2Hequipped: 42
-  Cantequip2HNoskill: 43
-  Cantequip2HSkill: 41
-  Cantflyhere: 60
-  Cantinvite: 8
-  CantlearnLevel: 13
-  Cantloot: 17
-  CantlootDidntkill: 31
-  CantlootLocked: 33
-  CantlootNotstandingObsolete: 34
-  CantlootToofar: 35
-  CantlootWrongfacing: 32
-  Cantputbag: 26
-  Cantswap: 58
-  CanttaxiNomoney: 54
-  CanttradeSoulbound: 59
-  Cantuseitem: 51
-  Cantuselocked: 55
-  Cantusetoofar: 57
-  Chestinuse: 52
-  Declinegroup: 19
-  ExhaustedObsolete: 67
-  FoodcoolingObsolete: 53
-  Genericnotarget: 45
-  Guildpermissions: 62
-  Invaliditemtarget: 66
-  Invalidtarget: 11
-  Inventoryfull: 0
-  Inviteebusy: 9
-  Itemcooling: 5
-  Itemlocked: 61
-  Itemmaxcount: 30
-  Locked: 14
-  Mustequippitem: 49
-  Noenergy: 64
-  NoequipEver: 3
-  NoequipLevel: 2
-  Noequipslotavailable: 56
-  Noessence: 65
-  Nomana: 15
-  Norage: 63
-  Notabag: 25
-  Notenoughgold: 39
-  Notenoughmoney: 40
-  Notequippable: 44
-  Notwhiledead: 16
-  Outofammo: 1
-  Potioncooling: 47
-  Proficiencyneeded: 48
-  Spellcooling: 12
-  Targettoofar: 10
-  Toomanybankslots: 23
-  Wrongslot: 27
+  values:
+    Abilitycooling: 50
+    Alreadyingroup: 20
+    Alreadyinguild: 21
+    Ammoonlyinbag: 28
+    Bagfull: 29
+    BoundNodrop: 4
+    Cantaffordbankslot: 22
+    CantattackNotarget: 38
+    CantattackNotstandingObsolete: 37
+    Cantattackrongdirection: 36
+    CantcastOutofrange: 46
+    Cantcreate: 18
+    Cantdrinkmore: 6
+    Canteatmore: 7
+    CanteatMoving: 24
+    Cantequip2Hequipped: 42
+    Cantequip2HNoskill: 43
+    Cantequip2HSkill: 41
+    Cantflyhere: 60
+    Cantinvite: 8
+    CantlearnLevel: 13
+    Cantloot: 17
+    CantlootDidntkill: 31
+    CantlootLocked: 33
+    CantlootNotstandingObsolete: 34
+    CantlootToofar: 35
+    CantlootWrongfacing: 32
+    Cantputbag: 26
+    Cantswap: 58
+    CanttaxiNomoney: 54
+    CanttradeSoulbound: 59
+    Cantuseitem: 51
+    Cantuselocked: 55
+    Cantusetoofar: 57
+    Chestinuse: 52
+    Declinegroup: 19
+    ExhaustedObsolete: 67
+    FoodcoolingObsolete: 53
+    Genericnotarget: 45
+    Guildpermissions: 62
+    Invaliditemtarget: 66
+    Invalidtarget: 11
+    Inventoryfull: 0
+    Inviteebusy: 9
+    Itemcooling: 5
+    Itemlocked: 61
+    Itemmaxcount: 30
+    Locked: 14
+    Mustequippitem: 49
+    Noenergy: 64
+    NoequipEver: 3
+    NoequipLevel: 2
+    Noequipslotavailable: 56
+    Noessence: 65
+    Nomana: 15
+    Norage: 63
+    Notabag: 25
+    Notenoughgold: 39
+    Notenoughmoney: 40
+    Notequippable: 44
+    Notwhiledead: 16
+    Outofammo: 1
+    Potioncooling: 47
+    Proficiencyneeded: 48
+    Spellcooling: 12
+    Targettoofar: 10
+    Toomanybankslots: 23
+    Wrongslot: 27
 VoiceChannelErrorReason:
-  IsBattleNetChannel: 1
-  Unknown: 0
+  values:
+    IsBattleNetChannel: 1
+    Unknown: 0
 VoiceChatStatusCode:
-  AlreadyInChannel: 10
-  ChannelAlreadyExists: 9
-  ChannelNameTooLong: 8
-  ChannelNameTooShort: 7
-  ClientAlreadyLoggedIn: 6
-  ClientNotInitialized: 4
-  ClientNotLoggedIn: 5
-  Disabled: 18
-  Failure: 12
-  InvalidCommunityStream: 20
-  InvalidInputDevice: 23
-  InvalidOutputDevice: 24
-  LoginProhibited: 3
-  OperationPending: 1
-  PlayerSilenced: 21
-  PlayerVoiceChatParentalDisabled: 22
-  ProxyConnectionTimeOut: 15
-  ProxyConnectionUnableToConnect: 16
-  ProxyConnectionUnexpectedDisconnect: 17
-  ServiceLost: 13
-  Success: 0
-  TargetNotFound: 11
-  TooManyRequests: 2
-  UnableToLaunchProxy: 14
-  UnsupportedChatChannelType: 19
+  values:
+    AlreadyInChannel: 10
+    ChannelAlreadyExists: 9
+    ChannelNameTooLong: 8
+    ChannelNameTooShort: 7
+    ClientAlreadyLoggedIn: 6
+    ClientNotInitialized: 4
+    ClientNotLoggedIn: 5
+    Disabled: 18
+    Failure: 12
+    InvalidCommunityStream: 20
+    InvalidInputDevice: 23
+    InvalidOutputDevice: 24
+    LoginProhibited: 3
+    OperationPending: 1
+    PlayerSilenced: 21
+    PlayerVoiceChatParentalDisabled: 22
+    ProxyConnectionTimeOut: 15
+    ProxyConnectionUnableToConnect: 16
+    ProxyConnectionUnexpectedDisconnect: 17
+    ServiceLost: 13
+    Success: 0
+    TargetNotFound: 11
+    TooManyRequests: 2
+    UnableToLaunchProxy: 14
+    UnsupportedChatChannelType: 19
 VoiceTtsStatusCode:
-  DestinationQueueFull: 8
-  EngineAllocationFailed: 2
-  EnqueueNotNecessary: 9
-  InputTextEnqueued: 6
-  InternalError: 13
-  InvalidArgument: 12
-  InvalidEngineType: 1
-  ManagerNotFound: 11
-  MaxCharactersExceeded: 4
-  NotSupported: 3
-  SdkNotInitialized: 7
-  Success: 0
-  UtteranceBelowMinimumDuration: 5
-  UtteranceNotFound: 10
+  values:
+    DestinationQueueFull: 8
+    EngineAllocationFailed: 2
+    EnqueueNotNecessary: 9
+    InputTextEnqueued: 6
+    InternalError: 13
+    InvalidArgument: 12
+    InvalidEngineType: 1
+    ManagerNotFound: 11
+    MaxCharactersExceeded: 4
+    NotSupported: 3
+    SdkNotInitialized: 7
+    Success: 0
+    UtteranceBelowMinimumDuration: 5
+    UtteranceNotFound: 10
 WarbandSceneFlags:
-  AwardedAutomatically: 8
-  CannotBeSaved: 4
-  DoNotInclude: 1
-  HiddenUntilCollected: 2
-  IsDefault: 16
+  values:
+    AwardedAutomatically: 8
+    CannotBeSaved: 4
+    DoNotInclude: 1
+    HiddenUntilCollected: 2
+    IsDefault: 16
 WeaponSlot:
-  MainHand: 0
-  OffHand: 1
+  values:
+    MainHand: 0
+    OffHand: 1
 WeeklyRewardChestActivityType:
-  LFGDungeons: 1
-  Scenario: 0
-  World: 2
+  values:
+    LFGDungeons: 1
+    Scenario: 0
+    World: 2
 WeeklyRewardChestClaimRewardResult:
-  CountExceeded: 7
-  DbError: 5
-  InvalidSlot: 3
-  InvalidThreshold: 1
-  LockFailure: 6
-  PlayerNotFound: 2
-  Success: 0
-  TooManyItems: 4
+  values:
+    CountExceeded: 7
+    DbError: 5
+    InvalidSlot: 3
+    InvalidThreshold: 1
+    LockFailure: 6
+    PlayerNotFound: 2
+    Success: 0
+    TooManyItems: 4
 WeeklyRewardChestThresholdType:
-  Activities: 1
-  AlsoReceive: 4
-  Concession: 5
-  None: 0
-  Raid: 3
-  RankedPvP: 2
-  World: 6
+  values:
+    Activities: 1
+    AlsoReceive: 4
+    Concession: 5
+    None: 0
+    Raid: 3
+    RankedPvP: 2
+    World: 6
 WeeklyRewardProgressResult:
-  DbError: 3
-  NoPlayer: 4
-  NoSeason: 1
-  Success: 0
-  TimedOut: 2
+  values:
+    DbError: 3
+    NoPlayer: 4
+    NoSeason: 1
+    Success: 0
+    TimedOut: 2
 WidgetAnimationType:
-  Fade: 1
-  None: 0
+  values:
+    Fade: 1
+    None: 0
 WidgetCurrencyClass:
-  Currency: 0
-  Item: 1
+  values:
+    Currency: 0
+    Item: 1
 WidgetEnabledState:
-  Artifact: 5
-  Black: 6
-  BrightBlue: 7
-  Disabled: 0
-  Green: 4
-  Red: 2
-  White: 3
-  Yellow: 1
+  values:
+    Artifact: 5
+    Black: 6
+    BrightBlue: 7
+    Disabled: 0
+    Green: 4
+    Red: 2
+    White: 3
+    Yellow: 1
 WidgetGlowAnimType:
-  None: 0
-  Pulse: 1
+  values:
+    None: 0
+    Pulse: 1
 WidgetIconSizeType:
-  Large: 2
-  Medium: 1
-  Small: 0
-  Standard: 3
+  values:
+    Large: 2
+    Medium: 1
+    Small: 0
+    Standard: 3
 WidgetIconSourceType:
-  Item: 1
-  Spell: 0
+  values:
+    Item: 1
+    Spell: 0
 WidgetOpacityType:
-  Eighty: 2
-  Fifty: 5
-  Forty: 6
-  Ninety: 1
-  OneHundred: 0
-  Seventy: 3
-  Sixty: 4
-  Ten: 9
-  Thirty: 7
-  Twenty: 8
-  Zero: 10
+  values:
+    Eighty: 2
+    Fifty: 5
+    Forty: 6
+    Ninety: 1
+    OneHundred: 0
+    Seventy: 3
+    Sixty: 4
+    Ten: 9
+    Thirty: 7
+    Twenty: 8
+    Zero: 10
 WidgetShowGlowState:
-  HideGlow: 0
-  ShowGlow: 1
+  values:
+    HideGlow: 0
+    ShowGlow: 1
 WidgetShownState:
-  Hidden: 0
-  Shown: 1
+  values:
+    Hidden: 0
+    Shown: 1
 WidgetTextHorizontalAlignmentType:
-  Center: 1
-  Left: 0
-  Right: 2
+  values:
+    Center: 1
+    Left: 0
+    Right: 2
 WidgetUnitPowerBarFlashMomentType:
-  FlashWhenMax: 0
-  FlashWhenMin: 1
-  NeverFlash: 2
+  values:
+    FlashWhenMax: 0
+    FlashWhenMin: 1
+    NeverFlash: 2
 WorldCursorAnchorType:
-  Cursor: 2
-  Default: 1
-  Nameplate: 3
-  None: 0
+  values:
+    Cursor: 2
+    Default: 1
+    Nameplate: 3
+    None: 0
 WorldElapsedTimerTypes:
-  ChallengeMode: 1
-  None: 0
-  ProvingGround: 2
+  values:
+    ChallengeMode: 1
+    None: 0
+    ProvingGround: 2
 WorldQuestQuality:
-  Common: 0
-  Epic: 2
-  Rare: 1
+  values:
+    Common: 0
+    Epic: 2
+    Rare: 1
 WorldTierDifficulty:
-  Heroic: 2
-  Mythic: 3
-  Normal: 1
+  values:
+    Heroic: 2
+    Mythic: 3
+    Normal: 1
 WoWClientCursorSize:
-  ExtraLarge: 3
-  Large: 2
-  Massive: 4
-  Medium: 1
-  Standard: 0
+  values:
+    ExtraLarge: 3
+    Large: 2
+    Massive: 4
+    Medium: 1
+    Standard: 0
 WoWEntitlementType:
-  Appearance: 4
-  AppearanceSet: 5
-  Battlepet: 2
-  GameTime: 6
-  Illusion: 8
-  Invalid: 9
-  Item: 0
-  Mount: 1
-  Title: 7
-  Toy: 3
+  values:
+    Appearance: 4
+    AppearanceSet: 5
+    Battlepet: 2
+    GameTime: 6
+    Illusion: 8
+    Invalid: 9
+    Item: 0
+    Mount: 1
+    Title: 7
+    Toy: 3
 WoWLabsAreaType:
-  PlunderstormDropDense: 2
-  PlunderstormDropMedium: 1
-  PlunderstormDropSparse: 0
+  values:
+    PlunderstormDropDense: 2
+    PlunderstormDropMedium: 1
+    PlunderstormDropSparse: 0
 ZoneControlActiveState:
-  Active: 1
-  Inactive: 0
+  values:
+    Active: 1
+    Inactive: 0
 ZoneControlDangerFlashType:
-  ShowOnBadStates: 1
-  ShowOnBoth: 2
-  ShowOnGoodStates: 0
-  ShowOnNeither: 3
+  values:
+    ShowOnBadStates: 1
+    ShowOnBoth: 2
+    ShowOnGoodStates: 0
+    ShowOnNeither: 3
 ZoneControlFillType:
-  DoubleFillClockwise: 2
-  DoubleFillCounterClockwise: 3
-  SingleFillClockwise: 0
-  SingleFillCounterClockwise: 1
+  values:
+    DoubleFillClockwise: 2
+    DoubleFillCounterClockwise: 3
+    SingleFillClockwise: 0
+    SingleFillCounterClockwise: 1
 ZoneControlLeadingEdgeType:
-  NoLeadingEdge: 0
-  UseLeadingEdge: 1
+  values:
+    NoLeadingEdge: 0
+    UseLeadingEdge: 1
 ZoneControlMode:
-  BothStatesAreGood: 0
-  NeitherStateIsGood: 3
-  State1IsGood: 1
-  State2IsGood: 2
+  values:
+    BothStatesAreGood: 0
+    NeitherStateIsGood: 3
+    State1IsGood: 1
+    State2IsGood: 2
 ZoneControlState:
-  State1: 0
-  State2: 1
+  values:
+    State1: 0
+    State2: 1

--- a/data/products/wowxptr/enums.yaml
+++ b/data/products/wowxptr/enums.yaml
@@ -1,7521 +1,8370 @@
 AbbreviationDataError:
-  InvalidBreakpoint: 1
-  InvalidFractionDivisor: 4
-  InvalidSignificandDivisor: 2
-  NotMultipleOfTen: 8
+  values:
+    InvalidBreakpoint: 1
+    InvalidFractionDivisor: 4
+    InvalidSignificandDivisor: 2
+    NotMultipleOfTen: 8
 AccountCurrencyTransferResult:
-  CannotUseCurrency: 8
-  CharacterLoggedIn: 2
-  CurrencyTransferDisabled: 10
-  InsufficientCurrency: 3
-  InvalidCharacter: 1
-  InvalidCurrency: 5
-  MaxQuantity: 4
-  NoValidSourceCharacter: 6
-  ServerError: 7
-  Success: 0
-  TransactionInProgress: 9
+  values:
+    CannotUseCurrency: 8
+    CharacterLoggedIn: 2
+    CurrencyTransferDisabled: 10
+    InsufficientCurrency: 3
+    InvalidCharacter: 1
+    InvalidCurrency: 5
+    MaxQuantity: 4
+    NoValidSourceCharacter: 6
+    ServerError: 7
+    Success: 0
+    TransactionInProgress: 9
 AccountData:
-  Bindings: 2
-  Bindings2: 3
-  CharacterListOrder: 16
-  ChatSettings: 7
-  ClickBindings: 12
-  Config: 0
-  Config2: 1
-  CooldownManager: 17
-  CooldownManager2: 18
-  FlaggedIDs: 10
-  FlaggedIDs2: 11
-  FrontendChatSettings: 15
-  Macros: 4
-  Macros2: 5
-  Shop2PendingOrders: 19
-  TtsSettings: 8
-  TtsSettings2: 9
-  UIEditModeAccount: 13
-  UIEditModeChar: 14
-  UILayout: 6
+  values:
+    Bindings: 2
+    Bindings2: 3
+    CharacterListOrder: 16
+    ChatSettings: 7
+    ClickBindings: 12
+    Config: 0
+    Config2: 1
+    CooldownManager: 17
+    CooldownManager2: 18
+    FlaggedIDs: 10
+    FlaggedIDs2: 11
+    FrontendChatSettings: 15
+    Macros: 4
+    Macros2: 5
+    Shop2PendingOrders: 19
+    TtsSettings: 8
+    TtsSettings2: 9
+    UIEditModeAccount: 13
+    UIEditModeChar: 14
+    UILayout: 6
 AccountDataUpdateStatus:
-  Corrupt: 2
-  Failed: 1
-  Success: 0
-  Toobig: 3
+  values:
+    Corrupt: 2
+    Failed: 1
+    Success: 0
+    Toobig: 3
 AccountExportResult:
-  AlreadyInProgress: 11
-  Cancelled: 2
-  FailedToGenerateFile: 13
-  FailedToLockAccount: 12
-  FileInvalid: 8
-  FileWriteFailed: 9
-  NoAccountFound: 5
-  RequestedInvalidCharacter: 6
-  RpcError: 7
-  ShuttingDown: 3
-  Success: 0
-  TimedOut: 4
-  Unavailable: 10
-  UnknownError: 1
+  values:
+    AlreadyInProgress: 11
+    Cancelled: 2
+    FailedToGenerateFile: 13
+    FailedToLockAccount: 12
+    FileInvalid: 8
+    FileWriteFailed: 9
+    NoAccountFound: 5
+    RequestedInvalidCharacter: 6
+    RpcError: 7
+    ShuttingDown: 3
+    Success: 0
+    TimedOut: 4
+    Unavailable: 10
+    UnknownError: 1
 AccountSequenceCacheType:
-  HouseDecor: 2
-  Invalid: 0
-  Local: 1
+  values:
+    HouseDecor: 2
+    Invalid: 0
+    Local: 1
 AccountStateFlags:
-  AccountUpgradeComplete: 4
-  InPetCombat: 2
-  LoadFailed: 1
-  None: 0
-  TokenEligCheckComplete: 8
+  values:
+    AccountUpgradeComplete: 4
+    InPetCombat: 2
+    LoadFailed: 1
+    None: 0
+    TokenEligCheckComplete: 8
 AccountStateLoadedFlags:
-  AccountCurrenciesLoaded: '0x0000000000200000'
-  AccountFactionsLoaded: '0x0000000200000000'
-  AccountItemsLoaded: '0x0000000400000000'
-  AccountMappingLoaded: '0x0000008000000000'
-  AccountNotificationsLoaded: '0x0000000008000000'
-  AccountWowlabsLoaded: '0x0000000020000000'
-  AchievementsLoaded: '0x0000000000000001'
-  ArchivedPurchasesLoaded: '0x0000000000000200'
-  AuctionableTokensLoaded: '0x0000000000002000'
-  BanktabSettingsLoaded: '0x0000004000000000'
-  BattleNetAccountLoaded: '0x0000000000100000'
-  BitVectorsLoaded: '0x0000000100000000'
-  BpayAddLicenseObjectsLoaded: '0x0000000000000800'
-  BpayDistributionObjectsLoaded: '0x0000000000000100'
-  BpayProductitemObjectsLoaded: '0x0000000000020000'
-  CharacterItemsLoaded: '0x0000010000000000'
-  CharactersLoaded: '0x0000000000000040'
-  CombinedQuestLogLoaded: '0x0000000800000000'
-  ConsumableTokensLoaded: '0x0000000000004000'
-  CriteriaLoaded: '0x0000000000000002'
-  CurrencyCapsLoaded: '0x0000000000000010'
-  CurrencyTransferLogLoaded: '0x0000020000000000'
-  DataElementsLoaded: '0x0000001000000000'
-  DynamicCriteriaLoaded: '0x0000000001000000'
-  EventRecordsLoaded: '0x0000200000000000'
-  HousingDataLoaded: '0x0000080000000000'
-  ItemCollectionsLoaded: '0x0000000000001000'
-  LgVendorPurchaseLoaded: '0x0000040000000000'
-  LoadedNone: '0x0000000000000000'
-  MountsLoaded: '0x0000000000000004'
-  PerksHeldItemLoaded: '0x0000000040000000'
-  PerksPastRewardsLoaded: '0x0000000000008000'
-  PerksPendingPurchaseLoaded: '0x0000000010000000'
-  PerksPendingRewardsLoaded: '0x0000000080000000'
-  PetjournalInitialized: '0x0000000000000008'
-  PurchasesLoaded: '0x0000000000000080'
-  QuestCriteriaLoaded: '0x0000000000080000'
-  QuestLogLoaded: '0x0000000000000020'
-  RafActivityLoaded: '0x0000000002000000'
-  RafBalanceLoaded: '0x0000000000400000'
-  RafRewardsLoaded: '0x0000000000800000'
-  RevokedRafRewardsLoaded: '0x0000000004000000'
-  SettingsLoaded: '0x0000000000000400'
-  TransmogOutfitsLoaded: '0x0000400000000000'
-  TrialBoostHistoryLoaded: '0x0000000000040000'
-  VasTransactionsLoaded: '0x0000000000010000'
-  WarbandScenesLoaded: '0x0000100000000000'
-  WarbandsLoaded: '0x0000002000000000'
+  values:
+    AccountCurrenciesLoaded: '0x0000000000200000'
+    AccountFactionsLoaded: '0x0000000200000000'
+    AccountItemsLoaded: '0x0000000400000000'
+    AccountMappingLoaded: '0x0000008000000000'
+    AccountNotificationsLoaded: '0x0000000008000000'
+    AccountWowlabsLoaded: '0x0000000020000000'
+    AchievementsLoaded: '0x0000000000000001'
+    ArchivedPurchasesLoaded: '0x0000000000000200'
+    AuctionableTokensLoaded: '0x0000000000002000'
+    BanktabSettingsLoaded: '0x0000004000000000'
+    BattleNetAccountLoaded: '0x0000000000100000'
+    BitVectorsLoaded: '0x0000000100000000'
+    BpayAddLicenseObjectsLoaded: '0x0000000000000800'
+    BpayDistributionObjectsLoaded: '0x0000000000000100'
+    BpayProductitemObjectsLoaded: '0x0000000000020000'
+    CharacterItemsLoaded: '0x0000010000000000'
+    CharactersLoaded: '0x0000000000000040'
+    CombinedQuestLogLoaded: '0x0000000800000000'
+    ConsumableTokensLoaded: '0x0000000000004000'
+    CriteriaLoaded: '0x0000000000000002'
+    CurrencyCapsLoaded: '0x0000000000000010'
+    CurrencyTransferLogLoaded: '0x0000020000000000'
+    DataElementsLoaded: '0x0000001000000000'
+    DynamicCriteriaLoaded: '0x0000000001000000'
+    EventRecordsLoaded: '0x0000200000000000'
+    HousingDataLoaded: '0x0000080000000000'
+    ItemCollectionsLoaded: '0x0000000000001000'
+    LgVendorPurchaseLoaded: '0x0000040000000000'
+    LoadedNone: '0x0000000000000000'
+    MountsLoaded: '0x0000000000000004'
+    PerksHeldItemLoaded: '0x0000000040000000'
+    PerksPastRewardsLoaded: '0x0000000000008000'
+    PerksPendingPurchaseLoaded: '0x0000000010000000'
+    PerksPendingRewardsLoaded: '0x0000000080000000'
+    PetjournalInitialized: '0x0000000000000008'
+    PurchasesLoaded: '0x0000000000000080'
+    QuestCriteriaLoaded: '0x0000000000080000'
+    QuestLogLoaded: '0x0000000000000020'
+    RafActivityLoaded: '0x0000000002000000'
+    RafBalanceLoaded: '0x0000000000400000'
+    RafRewardsLoaded: '0x0000000000800000'
+    RevokedRafRewardsLoaded: '0x0000000004000000'
+    SettingsLoaded: '0x0000000000000400'
+    TransmogOutfitsLoaded: '0x0000400000000000'
+    TrialBoostHistoryLoaded: '0x0000000000040000'
+    VasTransactionsLoaded: '0x0000000000010000'
+    WarbandScenesLoaded: '0x0000100000000000'
+    WarbandsLoaded: '0x0000002000000000'
 AccountStoreCategoryType:
-  Creature: 1
-  Icon: 4
-  Mount: 3
-  TransmogSet: 2
+  values:
+    Creature: 1
+    Icon: 4
+    Mount: 3
+    TransmogSet: 2
 AccountStoreFrontFlag:
-  Enabled: 1
-  PurchaseEnabled: 2
-  RefundEnabled: 4
+  values:
+    Enabled: 1
+    PurchaseEnabled: 2
+    RefundEnabled: 4
 AccountStoreItemFlag:
-  DisplayAsNew: 4
-  DisplayDefaultArmor: 1
-  DisplayOnly: 8
-  NotInGameReward: 2
+  values:
+    DisplayAsNew: 4
+    DisplayDefaultArmor: 1
+    DisplayOnly: 8
+    NotInGameReward: 2
 AccountStoreItemMode:
-  Hidden: 2
-  Locked: 3
-  Normal: 1
+  values:
+    Hidden: 2
+    Locked: 3
+    Normal: 1
 AccountStoreItemRewardType:
-  Illusion: 7
-  Misc: 10
-  Mount: 2
-  Pet: 3
-  Tender: 9
-  Toy: 5
-  Transmog: 1
-  TransmogSet: 8
-  WarbandScene: 11
+  values:
+    Illusion: 7
+    Misc: 10
+    Mount: 2
+    Pet: 3
+    Tender: 9
+    Toy: 5
+    Transmog: 1
+    TransmogSet: 8
+    WarbandScene: 11
 AccountStoreItemStatus:
-  Owned: 3
-  Refundable: 2
-  Unowned: 1
+  values:
+    Owned: 3
+    Refundable: 2
+    Unowned: 1
 AccountStoreSettlementAction:
-  Give: 1
-  NotSet: 0
-  Remove: 2
+  values:
+    Give: 1
+    NotSet: 0
+    Remove: 2
 AccountStoreState:
-  Available: 0
-  Unavailable: 2
-  Unknown: 1
+  values:
+    Available: 0
+    Unavailable: 2
+    Unknown: 1
 AccountStoreTransactionResult:
-  Incomplete: 1
-  InsufficientFunds: 4
-  InvalidCurrencyType: 8
-  ItemAlreadyOwned: 6
-  ItemNotOwned: 7
-  ItemUnknown: 5
-  NotSupported: 10
-  OwnedButRefundTimeExpired: 9
-  ProxyError: 12
-  Success: 0
-  TransactionInProgress: 3
-  Unavailable: 11
-  UnknownError: 2
+  values:
+    Incomplete: 1
+    InsufficientFunds: 4
+    InvalidCurrencyType: 8
+    ItemAlreadyOwned: 6
+    ItemNotOwned: 7
+    ItemUnknown: 5
+    NotSupported: 10
+    OwnedButRefundTimeExpired: 9
+    ProxyError: 12
+    Success: 0
+    TransactionInProgress: 3
+    Unavailable: 11
+    UnknownError: 2
 AccountStoreTransactionType:
-  DebugRemoveItem: 4
-  DebugResetHistory: 3
-  Purchase: 1
-  Refund: 2
-  Undefined: 0
+  values:
+    DebugRemoveItem: 4
+    DebugResetHistory: 3
+    Purchase: 1
+    Refund: 2
+    Undefined: 0
 AccountTransType:
-  AccountCurrencies: 26
-  AccountNotifications: 38
-  AccountStore: 54
-  Achievements: 4
-  AddLicense: 16
-  ArchivedPurchases: 9
-  AuctionableToken: 18
-  BankTab: 48
-  BattlenetAccount: 25
-  Battlepet: 3
-  BitVectors: 50
-  CharacterDataMerge: 53
-  CharacterItems: 57
-  Characters: 7
-  CombinedQuestLog: 51
-  ConsumableToken: 19
-  CreateOrderInfo: 32
-  Criteria: 5
-  CriteriaNotif: 13
-  CurrencyCaps: 11
-  CurrencyTransferLog: 58
-  Distribution: 2
-  Distributions: 10
-  DynamicCriteria: 30
-  EventRecords: 63
-  Factions: 49
-  FixedLicense: 15
-  GetOrderStatusByPurchaseID: 46
-  HouseInitiativeFavor: 66
-  HousingItem: 64
-  ItemCollections: 17
-  Items: 47
-  LgVendorPurchase: 59
-  LoadWowlabs: 44
-  Mapping: 56
-  Mounts: 6
-  OutstandingRpc: 43
-  PerkItemHold: 39
-  PerkPastRewards: 41
-  PerkPendingRewards: 40
-  PerkTransaction: 42
-  PlayerDataElements: 52
-  Productitem: 21
-  Profile: 61
-  ProxyCreateAccountHonor: 34
-  ProxyForwarder: 0
-  ProxyGenerateBpayID: 37
-  ProxyGmSetHonor: 36
-  ProxyHonorInitialConversion: 33
-  ProxyValidateAccountHonor: 35
-  Purchase: 1
-  Purchases: 8
-  QuestCriteria: 24
-  QuestLog: 12
-  RafActivity: 31
-  RafFriendMonth: 28
-  RafRecruiterAcceptances: 27
-  RafReward: 29
-  SaveWarbandGroups: 60
-  Settings: 14
-  TransmogOutfitCollection: 65
-  TrialBoostHistories: 23
-  TrialBoostHistory: 22
-  UpgradeAccount: 45
-  VasTransaction: 20
-  WarbandGroups: 55
-  WarbandSceneCollection: 62
+  values:
+    AccountCurrencies: 26
+    AccountNotifications: 38
+    AccountStore: 54
+    Achievements: 4
+    AddLicense: 16
+    ArchivedPurchases: 9
+    AuctionableToken: 18
+    BankTab: 48
+    BattlenetAccount: 25
+    Battlepet: 3
+    BitVectors: 50
+    CharacterDataMerge: 53
+    CharacterItems: 57
+    Characters: 7
+    CombinedQuestLog: 51
+    ConsumableToken: 19
+    CreateOrderInfo: 32
+    Criteria: 5
+    CriteriaNotif: 13
+    CurrencyCaps: 11
+    CurrencyTransferLog: 58
+    Distribution: 2
+    Distributions: 10
+    DynamicCriteria: 30
+    EventRecords: 63
+    Factions: 49
+    FixedLicense: 15
+    GetOrderStatusByPurchaseID: 46
+    HouseInitiativeFavor: 66
+    HousingItem: 64
+    ItemCollections: 17
+    Items: 47
+    LgVendorPurchase: 59
+    LoadWowlabs: 44
+    Mapping: 56
+    Mounts: 6
+    OutstandingRpc: 43
+    PerkItemHold: 39
+    PerkPastRewards: 41
+    PerkPendingRewards: 40
+    PerkTransaction: 42
+    PlayerDataElements: 52
+    Productitem: 21
+    Profile: 61
+    ProxyCreateAccountHonor: 34
+    ProxyForwarder: 0
+    ProxyGenerateBpayID: 37
+    ProxyGmSetHonor: 36
+    ProxyHonorInitialConversion: 33
+    ProxyValidateAccountHonor: 35
+    Purchase: 1
+    Purchases: 8
+    QuestCriteria: 24
+    QuestLog: 12
+    RafActivity: 31
+    RafFriendMonth: 28
+    RafRecruiterAcceptances: 27
+    RafReward: 29
+    SaveWarbandGroups: 60
+    Settings: 14
+    TransmogOutfitCollection: 65
+    TrialBoostHistories: 23
+    TrialBoostHistory: 22
+    UpgradeAccount: 45
+    VasTransaction: 20
+    WarbandGroups: 55
+    WarbandSceneCollection: 62
 ActionBarOrientation:
-  Horizontal: 0
-  Vertical: 1
+  values:
+    Horizontal: 0
+    Vertical: 1
 ActionBarVisibleSetting:
-  Always: 0
-  Hidden: 3
-  InCombat: 1
-  OutOfCombat: 2
+  values:
+    Always: 0
+    Hidden: 3
+    InCombat: 1
+    OutOfCombat: 2
 AddOnEnableState:
-  All: 2
-  None: 0
-  Some: 1
+  values:
+    All: 2
+    None: 0
+    Some: 1
 AddOnPerformanceMessageType:
-  OverallAddOnErrorDialog: 2
-  SpecificAddOnChatWarning: 0
-  SpecificAddOnErrorDialog: 1
+  values:
+    OverallAddOnErrorDialog: 2
+    SpecificAddOnChatWarning: 0
+    SpecificAddOnErrorDialog: 1
 AddOnProfilerMetric:
-  CountTimeOver1000Ms: 11
-  CountTimeOver100Ms: 9
-  CountTimeOver10Ms: 7
-  CountTimeOver1Ms: 5
-  CountTimeOver500Ms: 10
-  CountTimeOver50Ms: 8
-  CountTimeOver5Ms: 6
-  EncounterAverageTime: 2
-  LastTime: 3
-  PeakTime: 4
-  RecentAverageTime: 1
-  SessionAverageTime: 0
+  values:
+    CountTimeOver1000Ms: 11
+    CountTimeOver100Ms: 9
+    CountTimeOver10Ms: 7
+    CountTimeOver1Ms: 5
+    CountTimeOver500Ms: 10
+    CountTimeOver50Ms: 8
+    CountTimeOver5Ms: 6
+    EncounterAverageTime: 2
+    LastTime: 3
+    PeakTime: 4
+    RecentAverageTime: 1
+    SessionAverageTime: 0
 AddOnRestrictionState:
-  Activating: 1
-  Active: 2
-  Inactive: 0
+  values:
+    Activating: 1
+    Active: 2
+    Inactive: 0
 AddOnRestrictionType:
-  ChallengeMode: 2
-  Chat: 5
-  Combat: 0
-  Encounter: 1
-  Map: 4
-  PvPMatch: 3
+  values:
+    ChallengeMode: 2
+    Chat: 5
+    Combat: 0
+    Encounter: 1
+    Map: 4
+    PvPMatch: 3
 AddOnSecurityStatus:
-  Banned: 2
-  Insecure: 1
-  NotAvailable: 3
-  Secure: 0
+  values:
+    Banned: 2
+    Insecure: 1
+    NotAvailable: 3
+    Secure: 0
 AddSoulbindConduitReason:
-  Cheat: 1
-  None: 0
-  SpellEffect: 2
-  Upgrade: 3
+  values:
+    Cheat: 1
+    None: 0
+    SpellEffect: 2
+    Upgrade: 3
 AnimaDiversionNodeState:
-  Available: 1
-  Cooldown: 4
-  SelectedPermanent: 3
-  SelectedTemporary: 2
-  Unavailable: 0
+  values:
+    Available: 1
+    Cooldown: 4
+    SelectedPermanent: 3
+    SelectedTemporary: 2
+    Unavailable: 0
 ArrowCalloutDirection:
-  Down: 1
-  Left: 2
-  Right: 3
-  Up: 0
+  values:
+    Down: 1
+    Left: 2
+    Right: 3
+    Up: 0
 ArrowCalloutType:
-  Generic: 1
-  None: 0
-  Tutorial: 3
-  WidgetContainerNoBorder: 4
-  WorldLootObject: 2
+  values:
+    Generic: 1
+    None: 0
+    Tutorial: 3
+    WidgetContainerNoBorder: 4
+    WorldLootObject: 2
 AssistActionType:
-  CapturedBuff: 6
-  GraveMarker: 2
-  LoungingPlayer: 1
-  None: 0
-  PlacedVo: 3
-  PlayerGuardian: 4
-  PlayerSlayer: 5
+  values:
+    CapturedBuff: 6
+    GraveMarker: 2
+    LoungingPlayer: 1
+    None: 0
+    PlacedVo: 3
+    PlayerGuardian: 4
+    PlayerSlayer: 5
 AuctionHouseCommoditySortOrder:
-  Quantity: 1
-  UnitPrice: 0
+  values:
+    Quantity: 1
+    UnitPrice: 0
 AuctionHouseError:
-  BidIncrement: 2
-  BidOwn: 3
-  BoundItem: 16
-  ConjuredItem: 17
-  DatabaseError: 10
-  DoubleBid: 23
-  EquippedBag: 20
-  FavoritesMaxed: 24
-  HasRestriction: 6
-  HigherBid: 1
-  IsBag: 19
-  IsBusy: 7
-  ItemBoundToAccountUntilEquip: 26
-  ItemHasQuote: 9
-  ItemNotAvailable: 25
-  ItemNotFound: 4
-  LimitedDurationItem: 18
-  LootItem: 22
-  MinBid: 11
-  NotEnoughItems: 12
-  NotEnoughMoney: 0
-  QuestItem: 15
-  RepairItem: 13
-  RestrictedAccountTrial: 5
-  Unavailable: 8
-  UsedCharges: 14
-  WrappedItem: 21
+  values:
+    BidIncrement: 2
+    BidOwn: 3
+    BoundItem: 16
+    ConjuredItem: 17
+    DatabaseError: 10
+    DoubleBid: 23
+    EquippedBag: 20
+    FavoritesMaxed: 24
+    HasRestriction: 6
+    HigherBid: 1
+    IsBag: 19
+    IsBusy: 7
+    ItemBoundToAccountUntilEquip: 26
+    ItemHasQuote: 9
+    ItemNotAvailable: 25
+    ItemNotFound: 4
+    LimitedDurationItem: 18
+    LootItem: 22
+    MinBid: 11
+    NotEnoughItems: 12
+    NotEnoughMoney: 0
+    QuestItem: 15
+    RepairItem: 13
+    RestrictedAccountTrial: 5
+    Unavailable: 8
+    UsedCharges: 14
+    WrappedItem: 21
 AuctionHouseExtraColumn:
-  Ilvl: 1
-  Level: 3
-  None: 0
-  Skill: 4
-  Slots: 2
+  values:
+    Ilvl: 1
+    Level: 3
+    None: 0
+    Skill: 4
+    Slots: 2
 AuctionHouseFilter:
-  ArtifactQuality: 12
-  CommonQuality: 7
-  CurrentExpansionOnly: 3
-  EpicQuality: 10
-  ExactMatch: 5
-  LegendaryCraftedItemOnly: 13
-  LegendaryQuality: 11
-  None: 0
-  PoorQuality: 6
-  RareQuality: 9
-  UncollectedOnly: 1
-  UncommonQuality: 8
-  UpgradesOnly: 4
-  UsableOnly: 2
+  values:
+    ArtifactQuality: 12
+    CommonQuality: 7
+    CurrentExpansionOnly: 3
+    EpicQuality: 10
+    ExactMatch: 5
+    LegendaryCraftedItemOnly: 13
+    LegendaryQuality: 11
+    None: 0
+    PoorQuality: 6
+    RareQuality: 9
+    UncollectedOnly: 1
+    UncommonQuality: 8
+    UpgradesOnly: 4
+    UsableOnly: 2
 AuctionHouseFilterCategory:
-  Equipment: 1
-  Rarity: 2
-  Uncategorized: 0
+  values:
+    Equipment: 1
+    Rarity: 2
+    Uncategorized: 0
 AuctionHouseItemSortOrder:
-  Bid: 0
-  Buyout: 1
+  values:
+    Bid: 0
+    Buyout: 1
 AuctionHouseNotification:
-  AuctionExpired: 5
-  AuctionOutbid: 3
-  AuctionRemoved: 1
-  AuctionSold: 4
-  AuctionWon: 2
-  BidPlaced: 0
+  values:
+    AuctionExpired: 5
+    AuctionOutbid: 3
+    AuctionRemoved: 1
+    AuctionSold: 4
+    AuctionWon: 2
+    BidPlaced: 0
 AuctionHouseSortOrder:
-  Bid: 3
-  Buyout: 4
-  Level: 2
-  Name: 1
-  Price: 0
-  TimeRemaining: 5
+  values:
+    Bid: 3
+    Buyout: 4
+    Level: 2
+    Name: 1
+    Price: 0
+    TimeRemaining: 5
 AuctionHouseTimeLeftBand:
-  Long: 2
-  Medium: 1
-  Short: 0
-  VeryLong: 3
+  values:
+    Long: 2
+    Medium: 1
+    Short: 0
+    VeryLong: 3
 AuctionStatus:
-  Active: 0
-  Sold: 1
+  values:
+    Active: 0
+    Sold: 1
 AuraFrameIconDirection:
-  Down: 0
-  Left: 0
-  Right: 1
-  Up: 1
+  values:
+    Down: 0
+    Left: 0
+    Right: 1
+    Up: 1
 AuraFrameIconWrap:
-  Down: 0
-  Left: 0
-  Right: 1
-  Up: 1
+  values:
+    Down: 0
+    Left: 0
+    Right: 1
+    Up: 1
 AuraFrameOrientation:
-  Horizontal: 0
-  Vertical: 1
+  values:
+    Horizontal: 0
+    Vertical: 1
 AuraFrameVisibleSetting:
-  Always: 0
-  Hidden: 2
-  InCombat: 1
+  values:
+    Always: 0
+    Hidden: 2
+    InCombat: 1
 AutoCompleteEntryFlag:
-  AccountCharacter: 128
-  Bnet: 8
-  Friend: 4
-  InAOI: 64
-  InGroup: 1
-  InGuild: 2
-  InteractedWith: 16
-  Online: 32
-  RecentPlayer: 256
+  values:
+    AccountCharacter: 128
+    Bnet: 8
+    Friend: 4
+    InAOI: 64
+    InGroup: 1
+    InGuild: 2
+    InteractedWith: 16
+    Online: 32
+    RecentPlayer: 256
 AutoCompletePriority:
-  AccountCharacter: 5
-  AccountCharacterSameRealm: 6
-  Friend: 4
-  Guild: 3
-  InGroup: 2
-  Interacted: 1
-  Other: 0
+  values:
+    AccountCharacter: 5
+    AccountCharacterSameRealm: 6
+    Friend: 4
+    Guild: 3
+    InGroup: 2
+    Interacted: 1
+    Other: 0
 AvgItemLevelCategories:
-  Base: 0
-  EquippedBase: 1
-  EquippedEffective: 2
-  EquippedEffectiveWeighted: 5
-  PvP: 3
-  PvPWeighted: 4
+  values:
+    Base: 0
+    EquippedBase: 1
+    EquippedEffective: 2
+    EquippedEffectiveWeighted: 5
+    PvP: 3
+    PvPWeighted: 4
 AzeriteEssenceSlot:
-  MainSlot: 0
-  PassiveOneSlot: 1
-  PassiveThreeSlot: 3
-  PassiveTwoSlot: 2
+  values:
+    MainSlot: 0
+    PassiveOneSlot: 1
+    PassiveThreeSlot: 3
+    PassiveTwoSlot: 2
 AzeritePowerLevel:
-  Base: 0
-  Downgraded: 2
-  Upgraded: 1
+  values:
+    Base: 0
+    Downgraded: 2
+    Upgraded: 1
 BagFlag:
-  AllowBagsInNonBagSlots: 1024
-  AllowBuyback: 65536
-  AllowPartialStack: 16384
-  AllowSoulboundItemInAccountBank: 134217728
-  AlreadyBound: 4
-  AlreadyOwner: 2
-  AsymmetricSwap: 1048576
-  BagIsEmpty: 16
-  DontFindStack: 1
-  HasRefund: 33554432
-  IgnoreBankcheck: 512
-  IgnoreBoundItemCheck: 64
-  IgnoreExisting: 8192
-  IgnorePetBankcheck: 131072
-  IgnoreReagentBags: 8388608
-  IgnoreSoulbound: 4194304
-  LookInAccountBankOnly: 16777216
-  LookInCharacterBankOnly: 32768
-  LookInInventory: 32
-  PreferNeutralPriorityBags: 524288
-  PreferPriorityBags: 262144
-  PreferQuivers: 2048
-  PreferReagentBags: 2097152
-  RecurseQuivers: 256
-  SkipValidCountCheck: 67108864
-  StackOnly: 128
-  Swap: 8
-  SwapBags: 4096
+  values:
+    AllowBagsInNonBagSlots: 1024
+    AllowBuyback: 65536
+    AllowPartialStack: 16384
+    AllowSoulboundItemInAccountBank: 134217728
+    AlreadyBound: 4
+    AlreadyOwner: 2
+    AsymmetricSwap: 1048576
+    BagIsEmpty: 16
+    DontFindStack: 1
+    HasRefund: 33554432
+    IgnoreBankcheck: 512
+    IgnoreBoundItemCheck: 64
+    IgnoreExisting: 8192
+    IgnorePetBankcheck: 131072
+    IgnoreReagentBags: 8388608
+    IgnoreSoulbound: 4194304
+    LookInAccountBankOnly: 16777216
+    LookInCharacterBankOnly: 32768
+    LookInInventory: 32
+    PreferNeutralPriorityBags: 524288
+    PreferPriorityBags: 262144
+    PreferQuivers: 2048
+    PreferReagentBags: 2097152
+    RecurseQuivers: 256
+    SkipValidCountCheck: 67108864
+    StackOnly: 128
+    Swap: 8
+    SwapBags: 4096
 BagIndex:
-  Accountbanktab: -3
-  AccountBankTab_1: 12
-  AccountBankTab_2: 13
-  AccountBankTab_3: 14
-  AccountBankTab_4: 15
-  AccountBankTab_5: 16
-  Backpack: 0
-  Bag_1: 1
-  Bag_2: 2
-  Bag_3: 3
-  Bag_4: 4
-  Characterbanktab: -2
-  CharacterBankTab_1: 6
-  CharacterBankTab_2: 7
-  CharacterBankTab_3: 8
-  CharacterBankTab_4: 9
-  CharacterBankTab_5: 10
-  CharacterBankTab_6: 11
-  Keyring: -1
-  ReagentBag: 5
+  values:
+    Accountbanktab: -3
+    AccountBankTab_1: 12
+    AccountBankTab_2: 13
+    AccountBankTab_3: 14
+    AccountBankTab_4: 15
+    AccountBankTab_5: 16
+    Backpack: 0
+    Bag_1: 1
+    Bag_2: 2
+    Bag_3: 3
+    Bag_4: 4
+    Characterbanktab: -2
+    CharacterBankTab_1: 6
+    CharacterBankTab_2: 7
+    CharacterBankTab_3: 8
+    CharacterBankTab_4: 9
+    CharacterBankTab_5: 10
+    CharacterBankTab_6: 11
+    Keyring: -1
+    ReagentBag: 5
 BagsDirection:
-  Down: 1
-  Left: 0
-  Right: 1
-  Up: 0
+  values:
+    Down: 1
+    Left: 0
+    Right: 1
+    Up: 0
 BagSlotFlags:
-  ClassConsumables: 4
-  ClassEquipment: 2
-  ClassJunk: 16
-  ClassProfessionGoods: 8
-  ClassQuestItems: 32
-  ClassReagents: 128
-  DisableAutoSort: 1
-  ExcludeJunkSell: 64
-  ExpansionCurrent: 256
-  ExpansionLegacy: 512
+  values:
+    ClassConsumables: 4
+    ClassEquipment: 2
+    ClassJunk: 16
+    ClassProfessionGoods: 8
+    ClassQuestItems: 32
+    ClassReagents: 128
+    DisableAutoSort: 1
+    ExcludeJunkSell: 64
+    ExpansionCurrent: 256
+    ExpansionLegacy: 512
 BagsOrientation:
-  Horizontal: 0
-  Vertical: 1
+  values:
+    Horizontal: 0
+    Vertical: 1
 BalanceType:
-  Eclipse: 0
-  None: -1
+  values:
+    Eclipse: 0
+    None: -1
 BankLockedReason:
-  BankConversionFailed: 3
-  BankDisabled: 2
-  NoAccountInventoryLock: 1
-  None: 0
+  values:
+    BankConversionFailed: 3
+    BankDisabled: 2
+    NoAccountInventoryLock: 1
+    None: 0
 BankType:
-  Account: 2
-  Character: 0
-  Guild: 1
+  values:
+    Account: 2
+    Character: 0
+    Guild: 1
 Base64Variant:
-  Standard: 0
-  StandardUrlSafe: 1
+  values:
+    Standard: 0
+    StandardUrlSafe: 1
 BattlepayBannerType:
-  Discount: 1
-  Featured: 2
-  New: 3
-  None: 0
+  values:
+    Discount: 1
+    Featured: 2
+    New: 3
+    None: 0
 BattlepayCardType:
-  FullCardWithBuyButton: 4
-  FullCardWithNydusLinkButton: 8
-  LargeHorizontalCard: 2
-  LargeHorizontalCardWithBuyButton: 6
-  LargeVeritcalCard: 3
-  LargeVeritcalCardWithBuyButton: 7
-  LargeVeritcalPageableCardWithBuyButton: 9
-  MediumCard: 1
-  MediumCardWithBuyButton: 5
-  SmallCard: 0
+  values:
+    FullCardWithBuyButton: 4
+    FullCardWithNydusLinkButton: 8
+    LargeHorizontalCard: 2
+    LargeHorizontalCardWithBuyButton: 6
+    LargeVeritcalCard: 3
+    LargeVeritcalCardWithBuyButton: 7
+    LargeVeritcalPageableCardWithBuyButton: 9
+    MediumCard: 1
+    MediumCardWithBuyButton: 5
+    SmallCard: 0
 BattlepayDisplayFlags:
-  CardAlwaysShowsTexture: 4
-  CardDoesNotShowModel: 2
-  Deprecated1: 32
-  Deprecated2: 64
-  Expansion: 1
-  HiddenPrice: 8
-  HideWhenOwned: 256
-  RafReward: 512
-  ShowFancyToast: 1024
-  UseHorizontalLayoutForFullCard: 16
-  UseIconBorderWithOverrideTexture: 2048
-  UseSquareIconBorder: 128
+  values:
+    CardAlwaysShowsTexture: 4
+    CardDoesNotShowModel: 2
+    Deprecated1: 32
+    Deprecated2: 64
+    Expansion: 1
+    HiddenPrice: 8
+    HideWhenOwned: 256
+    RafReward: 512
+    ShowFancyToast: 1024
+    UseHorizontalLayoutForFullCard: 16
+    UseIconBorderWithOverrideTexture: 2048
+    UseSquareIconBorder: 128
 BattlepayGroupDisplayType:
-  ActiveTimeOnly: 2
-  Everyone: 0
-  TrialAndVeteranOnly: 1
+  values:
+    ActiveTimeOnly: 2
+    Everyone: 0
+    TrialAndVeteranOnly: 1
 BattlepayLicenseSynthesisFlags:
-  ForceToGameAccount: 1
+  values:
+    ForceToGameAccount: 1
 BattlepayProductChoiceType:
-  ChoiceNone: 0
-  ChoiceOne: 1
-  SpecAndFaction: 2
-  VasCharacter: 3
-  VasCharacterAndName: 4
+  values:
+    ChoiceNone: 0
+    ChoiceOne: 1
+    SpecAndFaction: 2
+    VasCharacter: 3
+    VasCharacterAndName: 4
 BattlepayProductDecorator:
-  Boost: 0
-  Expansion: 1
-  VasService: 3
-  WoWToken: 2
+  values:
+    Boost: 0
+    Expansion: 1
+    VasService: 3
+    WoWToken: 2
 BattlepayProductGroupFlags:
-  DisableOwnedProducts: 4
-  EnabledForTrial: 2
-  EnabledForVeteran: 8
-  HideOwnedProducts: 1
-  None: 0
+  values:
+    DisableOwnedProducts: 4
+    EnabledForTrial: 2
+    EnabledForVeteran: 8
+    HideOwnedProducts: 1
+    None: 0
 BattlepayShopEntryBannerType:
-  Discount: 1
-  Featured: 0
-  New: 2
+  values:
+    Discount: 1
+    Featured: 0
+    New: 2
 BattlepayShopEntryFlags:
-  None: 0
+  values:
+    None: 0
 BattlePetAction:
-  Ability: 1
-  None: 0
-  Skip: 4
-  SwitchPet: 2
-  Trap: 3
+  values:
+    Ability: 1
+    None: 0
+    Skip: 4
+    SwitchPet: 2
+    Trap: 3
 BattlePetBreedQuality:
-  Common: 1
-  Epic: 4
-  Legendary: 5
-  Poor: 0
-  Rare: 3
-  Uncommon: 2
+  values:
+    Common: 1
+    Epic: 4
+    Legendary: 5
+    Poor: 0
+    Rare: 3
+    Uncommon: 2
 BattlePetOwner:
-  Ally: 1
-  Enemy: 2
-  Weather: 0
+  values:
+    Ally: 1
+    Enemy: 2
+    Weather: 0
 BattlePetSources:
-  Achievement: 5
-  Discovery: 10
-  Drop: 0
-  PetStore: 9
-  Profession: 3
-  Promotion: 7
-  Quest: 1
-  Tcg: 8
-  TradingPost: 11
-  Vendor: 2
-  WildPet: 4
-  WorldEvent: 6
+  values:
+    Achievement: 5
+    Discovery: 10
+    Drop: 0
+    PetStore: 9
+    Profession: 3
+    Promotion: 7
+    Quest: 1
+    Tcg: 8
+    TradingPost: 11
+    Vendor: 2
+    WildPet: 4
+    WorldEvent: 6
 BindingContext:
-  HousingEditor: 1
-  HousingEditorBasicAndExpertDecorMode: 7
-  HousingEditorBasicDecorMode: 2
-  HousingEditorCleanupMode: 5
-  HousingEditorCustomizeMode: 4
-  HousingEditorExpertDecorMode: 3
-  HousingEditorExteriorCustomizationMode: 8
-  HousingEditorLayoutMode: 6
-  None: 0
-  ReservedFutureFeatureBinding01: 9
+  values:
+    HousingEditor: 1
+    HousingEditorBasicAndExpertDecorMode: 7
+    HousingEditorBasicDecorMode: 2
+    HousingEditorCleanupMode: 5
+    HousingEditorCustomizeMode: 4
+    HousingEditorExpertDecorMode: 3
+    HousingEditorExteriorCustomizationMode: 8
+    HousingEditorLayoutMode: 6
+    None: 0
+    ReservedFutureFeatureBinding01: 9
 BindingSet:
-  Account: 1
-  Character: 2
-  Current: 3
-  Default: 0
+  values:
+    Account: 1
+    Character: 2
+    Current: 3
+    Default: 0
 BnetAccountFlag:
-  AccountQuestBitFixUp: 64
-  AchievementsToBi: 128
-  BattlePetTrainer: 1
-  CanBuyAhGameTimeTokens: 32768
-  CataLegendaryMountChecked: 262144
-  CataLegendaryMountObtained: 524288
-  DarkRealmLightCopy: 2048
-  Employee: 16
-  EmployeeFlagIsManual: 32
-  GdprErased: 1024
-  InvalidTransmogsFixUp: 256
-  InvalidTransmogsFixUp2: 512
-  IsLegacy: 131072
-  LockedForExport: 16384
-  MopQuestLogFlagsFixUp: 1048576
-  None: 0
-  PetAchievementFixUp: 65536
-  QuestLogFlagsFixUp: 4096
-  RafVeteranNotified: 2
-  TwitterHasTempSecret: 8
-  TwitterLinked: 4
-  WasSecured: 8192
+  values:
+    AccountQuestBitFixUp: 64
+    AchievementsToBi: 128
+    BattlePetTrainer: 1
+    CanBuyAhGameTimeTokens: 32768
+    CataLegendaryMountChecked: 262144
+    CataLegendaryMountObtained: 524288
+    DarkRealmLightCopy: 2048
+    Employee: 16
+    EmployeeFlagIsManual: 32
+    GdprErased: 1024
+    InvalidTransmogsFixUp: 256
+    InvalidTransmogsFixUp2: 512
+    IsLegacy: 131072
+    LockedForExport: 16384
+    MopQuestLogFlagsFixUp: 1048576
+    None: 0
+    PetAchievementFixUp: 65536
+    QuestLogFlagsFixUp: 4096
+    RafVeteranNotified: 2
+    TwitterHasTempSecret: 8
+    TwitterLinked: 4
+    WasSecured: 8192
 BonusStatIndex:
-  Agility: 3
-  AgilityOrIntellect: 73
-  AgilityOrStrength: 72
-  AgilityOrStrengthOrIntellect: 71
-  ArcaneResistance: 56
-  AttackPower: 38
-  BlockRating: 15
-  BlockValueObsolete: 48
-  CombatRatingAvoidance: 63
-  CombatRatingLifesteal: 62
-  CombatRatingSpeed: 61
-  CombatRatingSturdiness: 64
-  CombatRatingUnused_0: 58
-  CombatRatingUnused_10: 68
-  CombatRatingUnused_11: 69
-  CombatRatingUnused_12: 70
-  CombatRatingUnused_2: 59
-  CombatRatingUnused_27: 66
-  CombatRatingUnused_3: 60
-  CombatRatingUnused_7: 65
-  CombatRatingUnused_9: 67
-  Corruption: 22
-  CorruptionResistance: 23
-  CritMeleeRating: 19
-  CritRangedRating: 20
-  CritRating: 32
-  CritSpellRating: 21
-  CritTakenRangedRatingObsolete: 26
-  CritTakenRatingObsolete: 34
-  CritTakenSpellRatingObsolete: 27
-  DefenseSkillRating: 12
-  DodgeRating: 13
-  Endurance: 2
-  Energy: 8
-  ExpertiseRating: 37
-  ExtraArmor: 50
-  FireResistance: 51
-  Focus: 10
-  FrostResistance: 52
-  HasteMeleeRatingObsolete: 28
-  HasteRangedRatingObsolete: 29
-  HasteRating: 36
-  HasteSpellRatingObsolete: 30
-  Health: 1
-  HealthRegen: 46
-  HitMeleeRating: 16
-  HitRangedRating: 17
-  HitRating: 31
-  HitSpellRating: 18
-  HitTakenRatingObsolete: 33
-  HolyResistance: 53
-  Intellect: 5
-  Mana: 0
-  ManaRegenerationObsolete: 43
-  MasteryRating: 49
-  ModifiedCraftingStat_1: 24
-  ModifiedCraftingStat_2: 25
-  NatureResistance: 55
-  ParryRating: 14
-  ProfessionCraftingSpeed: 80
-  ProfessionDeftness: 78
-  ProfessionFinesse: 77
-  ProfessionIngenuity: 82
-  ProfessionInspiration: 75
-  ProfessionMulticraft: 81
-  ProfessionPerception: 79
-  ProfessionResourcefulness: 76
-  PvPPower: 57
-  Rage: 9
-  RangedAttackPower: 39
-  ResilienceRating: 35
-  ShadowResistance: 54
-  SpellDamageDone: 42
-  SpellHealingDone: 41
-  SpellPenetration: 47
-  SpellPower: 45
-  Spirit: 6
-  Stamina: 7
-  Strength: 4
-  StrengthOrIntellect: 74
-  Unused: 44
-  Versatility: 40
-  WeaponSkillRatingObsolete: 11
+  values:
+    Agility: 3
+    AgilityOrIntellect: 73
+    AgilityOrStrength: 72
+    AgilityOrStrengthOrIntellect: 71
+    ArcaneResistance: 56
+    AttackPower: 38
+    BlockRating: 15
+    BlockValueObsolete: 48
+    CombatRatingAvoidance: 63
+    CombatRatingLifesteal: 62
+    CombatRatingSpeed: 61
+    CombatRatingSturdiness: 64
+    CombatRatingUnused_0: 58
+    CombatRatingUnused_10: 68
+    CombatRatingUnused_11: 69
+    CombatRatingUnused_12: 70
+    CombatRatingUnused_2: 59
+    CombatRatingUnused_27: 66
+    CombatRatingUnused_3: 60
+    CombatRatingUnused_7: 65
+    CombatRatingUnused_9: 67
+    Corruption: 22
+    CorruptionResistance: 23
+    CritMeleeRating: 19
+    CritRangedRating: 20
+    CritRating: 32
+    CritSpellRating: 21
+    CritTakenRangedRatingObsolete: 26
+    CritTakenRatingObsolete: 34
+    CritTakenSpellRatingObsolete: 27
+    DefenseSkillRating: 12
+    DodgeRating: 13
+    Endurance: 2
+    Energy: 8
+    ExpertiseRating: 37
+    ExtraArmor: 50
+    FireResistance: 51
+    Focus: 10
+    FrostResistance: 52
+    HasteMeleeRatingObsolete: 28
+    HasteRangedRatingObsolete: 29
+    HasteRating: 36
+    HasteSpellRatingObsolete: 30
+    Health: 1
+    HealthRegen: 46
+    HitMeleeRating: 16
+    HitRangedRating: 17
+    HitRating: 31
+    HitSpellRating: 18
+    HitTakenRatingObsolete: 33
+    HolyResistance: 53
+    Intellect: 5
+    Mana: 0
+    ManaRegenerationObsolete: 43
+    MasteryRating: 49
+    ModifiedCraftingStat_1: 24
+    ModifiedCraftingStat_2: 25
+    NatureResistance: 55
+    ParryRating: 14
+    ProfessionCraftingSpeed: 80
+    ProfessionDeftness: 78
+    ProfessionFinesse: 77
+    ProfessionIngenuity: 82
+    ProfessionInspiration: 75
+    ProfessionMulticraft: 81
+    ProfessionPerception: 79
+    ProfessionResourcefulness: 76
+    PvPPower: 57
+    Rage: 9
+    RangedAttackPower: 39
+    ResilienceRating: 35
+    ShadowResistance: 54
+    SpellDamageDone: 42
+    SpellHealingDone: 41
+    SpellPenetration: 47
+    SpellPower: 45
+    Spirit: 6
+    Stamina: 7
+    Strength: 4
+    StrengthOrIntellect: 74
+    Unused: 44
+    Versatility: 40
+    WeaponSkillRatingObsolete: 11
 BrawlType:
-  Arena: 2
-  Battleground: 1
-  LFG: 3
-  None: 0
-  SoloRbg: 5
-  SoloShuffle: 4
+  values:
+    Arena: 2
+    Battleground: 1
+    LFG: 3
+    None: 0
+    SoloRbg: 5
+    SoloShuffle: 4
 BulkPurchaseResult:
-  ResultFailed: 3
-  ResultInProgress: 1
-  ResultInsufficientFunds: 6
-  ResultOk: 0
-  ResultPartialSuccess: 2
-  ResultPurchaseTimeout: 7
-  ResultSystemDisabled: 5
-  ResultTooManyProducts: 4
+  values:
+    ResultFailed: 3
+    ResultInProgress: 1
+    ResultInsufficientFunds: 6
+    ResultOk: 0
+    ResultPartialSuccess: 2
+    ResultPurchaseTimeout: 7
+    ResultSystemDisabled: 5
+    ResultTooManyProducts: 4
 BulkPurchaseStatus:
-  Done: 3
-  Failed: 4
-  FetchEntitlements: 2
-  PlacingOrders: 0
-  PurchasesPending: 1
+  values:
+    Done: 3
+    Failed: 4
+    FetchEntitlements: 2
+    PlacingOrders: 0
+    PurchasesPending: 1
 BulkRefundResult:
-  ResultFailed: 1
-  ResultInvalidRequest: 2
-  ResultOk: 0
-  ResultRefundWindowExpired: 3
-  ResultSystemDisabled: 4
-  ResultTimeout: 5
+  values:
+    ResultFailed: 1
+    ResultInvalidRequest: 2
+    ResultOk: 0
+    ResultRefundWindowExpired: 3
+    ResultSystemDisabled: 4
+    ResultTimeout: 5
 CachedRewardType:
-  Currency: 2
-  Item: 1
-  None: 0
-  Quest: 3
+  values:
+    Currency: 2
+    Item: 1
+    None: 0
+    Quest: 3
 CalendarCommandType:
-  Complain: 10
-  Create: 0
-  GetCalendar: 7
-  GetEvent: 8
-  Invite: 1
-  ModeratorStatus: 6
-  Notes: 11
-  RemoveEvent: 4
-  RemoveInvite: 3
-  Rsvp: 2
-  Status: 5
-  UpdateEvent: 9
+  values:
+    Complain: 10
+    Create: 0
+    GetCalendar: 7
+    GetEvent: 8
+    Invite: 1
+    ModeratorStatus: 6
+    Notes: 11
+    RemoveEvent: 4
+    RemoveInvite: 3
+    Rsvp: 2
+    Status: 5
+    UpdateEvent: 9
 CalendarErrorType:
-  ArenaEventsExceeded: 27
-  CalendarDisabled: 25
-  CommunityEventsExceeded: 1
-  ComplaintAdded: 50
-  ComplaintDisabled: 31
-  ComplaintGm: 34
-  ComplaintLimit: 35
-  ComplaintNotFound: 36
-  ComplaintSameGuild: 33
-  ComplaintSelf: 32
-  CreatorNotFound: 46
-  DataAlreadySet: 24
-  DeleteCreatorFailed: 23
-  EventInvalid: 6
-  EventLocked: 22
-  EventPassed: 21
-  EventsExceeded: 2
-  EventThrottled: 47
-  EventWrongServer: 37
-  Ignored: 14
-  Internal: 49
-  InvalidClub: 45
-  InvalidDate: 17
-  InvalidDescription: 44
-  InvalidMaxSize: 16
-  InvalidNotes: 42
-  InvalidSignup: 39
-  InvalidTime: 18
-  InvalidTitle: 43
-  InvitesExceeded: 15
-  InviteThrottled: 48
-  ModeratorRestricted: 41
-  NameNotFound: 12
-  NeedsTitle: 20
-  NoCommunityInvites: 38
-  NoInvite: 30
-  NoInvites: 19
-  NoModerator: 40
-  NoPermission: 5
-  NotInCommunity: 10
-  NotInGuild: 9
-  NotInvited: 7
-  OtherInvitesExceeded: 4
-  RestrictedAccount: 26
-  RestrictedLevel: 28
-  SelfInvitesExceeded: 3
-  Squelched: 29
-  Success: 0
-  TargetAlreadyInvited: 11
-  UnknownError: 8
-  WrongFaction: 13
+  values:
+    ArenaEventsExceeded: 27
+    CalendarDisabled: 25
+    CommunityEventsExceeded: 1
+    ComplaintAdded: 50
+    ComplaintDisabled: 31
+    ComplaintGm: 34
+    ComplaintLimit: 35
+    ComplaintNotFound: 36
+    ComplaintSameGuild: 33
+    ComplaintSelf: 32
+    CreatorNotFound: 46
+    DataAlreadySet: 24
+    DeleteCreatorFailed: 23
+    EventInvalid: 6
+    EventLocked: 22
+    EventPassed: 21
+    EventsExceeded: 2
+    EventThrottled: 47
+    EventWrongServer: 37
+    Ignored: 14
+    Internal: 49
+    InvalidClub: 45
+    InvalidDate: 17
+    InvalidDescription: 44
+    InvalidMaxSize: 16
+    InvalidNotes: 42
+    InvalidSignup: 39
+    InvalidTime: 18
+    InvalidTitle: 43
+    InvitesExceeded: 15
+    InviteThrottled: 48
+    ModeratorRestricted: 41
+    NameNotFound: 12
+    NeedsTitle: 20
+    NoCommunityInvites: 38
+    NoInvite: 30
+    NoInvites: 19
+    NoModerator: 40
+    NoPermission: 5
+    NotInCommunity: 10
+    NotInGuild: 9
+    NotInvited: 7
+    OtherInvitesExceeded: 4
+    RestrictedAccount: 26
+    RestrictedLevel: 28
+    SelfInvitesExceeded: 3
+    Squelched: 29
+    Success: 0
+    TargetAlreadyInvited: 11
+    UnknownError: 8
+    WrongFaction: 13
 CalendarEventBits:
-  ArenaDeprecated: 256
-  AutoApprove: 32
-  CantComplain: 3788
-  CommunityAnnouncement: 64
-  CommunitySignup: 1024
-  CommunityWide: 3136
-  GuildDeprecated: 2
-  GuildSignup: 2048
-  Holiday: 8
-  Locked: 16
-  Player: 1
-  PlayerCreated: 3395
-  RaidLockout: 128
-  RaidResetDeprecated: 512
-  System: 4
+  values:
+    ArenaDeprecated: 256
+    AutoApprove: 32
+    CantComplain: 3788
+    CommunityAnnouncement: 64
+    CommunitySignup: 1024
+    CommunityWide: 3136
+    GuildDeprecated: 2
+    GuildSignup: 2048
+    Holiday: 8
+    Locked: 16
+    Player: 1
+    PlayerCreated: 3395
+    RaidLockout: 128
+    RaidResetDeprecated: 512
+    System: 4
 CalendarEventRepeatOptions:
-  Biweekly: 2
-  Monthly: 3
-  Never: 0
-  Weekly: 1
+  values:
+    Biweekly: 2
+    Monthly: 3
+    Never: 0
+    Weekly: 1
 CalendarEventType:
-  Dungeon: 1
-  HeroicDeprecated: 5
-  Meeting: 3
-  Other: 4
-  PvP: 2
-  Raid: 0
+  values:
+    Dungeon: 1
+    HeroicDeprecated: 5
+    Meeting: 3
+    Other: 4
+    PvP: 2
+    Raid: 0
 CalendarFilterFlags:
-  Battleground: 4
-  Darkmoon: 2
-  RaidLockout: 8
-  RaidReset: 16
-  WeeklyHoliday: 1
+  values:
+    Battleground: 4
+    Darkmoon: 2
+    RaidLockout: 8
+    RaidReset: 16
+    WeeklyHoliday: 1
 CalendarGetEventType:
-  Add: 1
-  Copy: 2
-  Get: 0
+  values:
+    Add: 1
+    Copy: 2
+    Get: 0
 CalendarHolidayFilterType:
-  Battleground: 2
-  Darkmoon: 1
-  Weekly: 0
+  values:
+    Battleground: 2
+    Darkmoon: 1
+    Weekly: 0
 CalendarInviteBits:
-  Creator: 4
-  Moderator: 2
-  None: 0
-  PendingInvite: 1
-  Signup: 8
+  values:
+    Creator: 4
+    Moderator: 2
+    None: 0
+    PendingInvite: 1
+    Signup: 8
 CalendarInviteSortType:
-  Class: 2
-  Level: 1
-  Name: 0
-  Notes: 5
-  Party: 4
-  Status: 3
+  values:
+    Class: 2
+    Level: 1
+    Name: 0
+    Notes: 5
+    Party: 4
+    Status: 3
 CalendarInviteType:
-  Normal: 0
-  Signup: 1
+  values:
+    Normal: 0
+    Signup: 1
 CalendarModeratorStatus:
-  Creator: 2
-  Moderator: 1
-  None: 0
+  values:
+    Creator: 2
+    Moderator: 1
+    None: 0
 CalendarStatus:
-  Available: 1
-  Confirmed: 3
-  Declined: 2
-  Invited: 0
-  NotSignedup: 7
-  Out: 4
-  Signedup: 6
-  Standby: 5
-  Tentative: 8
+  values:
+    Available: 1
+    Confirmed: 3
+    Declined: 2
+    Invited: 0
+    NotSignedup: 7
+    Out: 4
+    Signedup: 6
+    Standby: 5
+    Tentative: 8
 CalendarTexturesType:
-  Dungeons: 0
-  Raid: 1
+  values:
+    Dungeons: 0
+    Raid: 1
 CalendarType:
-  Community: 1
-  Holiday: 4
-  HolidayBattleground: 7
-  HolidayDarkmoon: 6
-  HolidayWeekly: 5
-  Player: 0
-  RaidLockout: 2
-  RaidResetDeprecated: 3
+  values:
+    Community: 1
+    Holiday: 4
+    HolidayBattleground: 7
+    HolidayDarkmoon: 6
+    HolidayWeekly: 5
+    Player: 0
+    RaidLockout: 2
+    RaidResetDeprecated: 3
 CalendarWebActionType:
-  Accept: 0
-  Decline: 1
-  Remove: 2
-  ReportSpam: 3
-  Signup: 4
-  Tentative: 5
-  TentativeSignup: 6
+  values:
+    Accept: 0
+    Decline: 1
+    Remove: 2
+    ReportSpam: 3
+    Signup: 4
+    Tentative: 5
+    TentativeSignup: 6
 CallingStates:
-  QuestActive: 1
-  QuestCompleted: 2
-  QuestOffer: 0
+  values:
+    QuestActive: 1
+    QuestCompleted: 2
+    QuestOffer: 0
 CameraModeAspectRatio:
-  Cinemascope_2_Dot_4_X_1: 3
-  Default: 0
-  HighDefinition_16_X_9: 2
-  LegacyLetterbox: 1
+  values:
+    Cinemascope_2_Dot_4_X_1: 3
+    Default: 0
+    HighDefinition_16_X_9: 2
+    LegacyLetterbox: 1
 CampaignState:
-  Complete: 1
-  InProgress: 2
-  Invalid: 0
-  Stalled: 3
+  values:
+    Complete: 1
+    InProgress: 2
+    Invalid: 0
+    Stalled: 3
 CanRedeemTokenForBalanceResult:
-  FailureCap: 1
-  Ok: 0
+  values:
+    FailureCap: 1
+    Ok: 0
 CaptureBarWidgetFillDirectionType:
-  LeftToRight: 1
-  RightToLeft: 0
+  values:
+    LeftToRight: 1
+    RightToLeft: 0
 Causeofdeath:
-  Creature: 3
-  Drowning: 5
-  Falling: 4
-  Fatigue: 6
-  Fire: 9
-  Lava: 8
-  None: 0
-  PlayerDuel: 2
-  PlayerPvP: 1
-  Slime: 7
+  values:
+    Creature: 3
+    Drowning: 5
+    Falling: 4
+    Fatigue: 6
+    Fire: 9
+    Lava: 8
+    None: 0
+    PlayerDuel: 2
+    PlayerPvP: 1
+    Slime: 7
 CauseofdeathFlags:
-  CreatureNameNeeded: 2
-  NoneNeeded: 0
-  PlayerNameNeeded: 1
-  ZoneNameNeeded: 4
+  values:
+    CreatureNameNeeded: 2
+    NoneNeeded: 0
+    PlayerNameNeeded: 1
+    ZoneNameNeeded: 4
 ChallengeModeHistoryFlags:
-  ConfirmedLeaver: 1
-  None: 0
+  values:
+    ConfirmedLeaver: 1
+    None: 0
 ChallengeModeHistoryResult:
-  Leaver: 1
-  Successful: 0
+  values:
+    Leaver: 1
+    Successful: 0
 ChallengeModeHistoryStatus:
-  Leaver: 1
-  Normal: 0
+  values:
+    Leaver: 1
+    Normal: 0
 ChannelPlayerFlags:
-  ChannelPlayerHidden: 8
-  ChannelPlayerModerator: 2
-  ChannelPlayerNone: 0
-  ChannelPlayerOwner: 1
-  ChannelPlayerTextAllow: 4
+  values:
+    ChannelPlayerHidden: 8
+    ChannelPlayerModerator: 2
+    ChannelPlayerNone: 0
+    ChannelPlayerOwner: 1
+    ChannelPlayerTextAllow: 4
 CharacterServiceInfoFlag:
-  AllowMaxLevelBoost: 2
-  RestrictToRecommendedSpecs: 1
+  values:
+    AllowMaxLevelBoost: 2
+    RestrictToRecommendedSpecs: 1
 CharCustomizationType:
-  CustomOptionFacewear: 7
-  CustomOptionHorn: 6
-  CustomOptionTattoo: 5
-  CustomOptionTattooColor: 8
-  Face: 1
-  FacialHair: 4
-  Hair: 2
-  HairColor: 3
-  Skin: 0
+  values:
+    CustomOptionFacewear: 7
+    CustomOptionHorn: 6
+    CustomOptionTattoo: 5
+    CustomOptionTattooColor: 8
+    Face: 1
+    FacialHair: 4
+    Hair: 2
+    HairColor: 3
+    Skin: 0
 ChatChannelRuleset:
-  ChromieTimeBuringCrusade: 4
-  ChromieTimeCataclysm: 3
-  ChromieTimeLegion: 8
-  ChromieTimeMists: 6
-  ChromieTimeWoD: 7
-  ChromieTimeWrath: 5
-  Disabled: 2
-  Mentor: 1
-  None: 0
+  values:
+    ChromieTimeBuringCrusade: 4
+    ChromieTimeCataclysm: 3
+    ChromieTimeLegion: 8
+    ChromieTimeMists: 6
+    ChromieTimeWoD: 7
+    ChromieTimeWrath: 5
+    Disabled: 2
+    Mentor: 1
+    None: 0
 ChatChannelType:
-  Communities: 4
-  Custom: 1
-  None: 0
-  PrivateParty: 2
-  PublicParty: 3
+  values:
+    Communities: 4
+    Custom: 1
+    None: 0
+    PrivateParty: 2
+    PublicParty: 3
 ChatToxityFilterOptOut:
-  ExcludeFilterAll: 4294967295
-  ExcludeFilterFriend: 1
-  ExcludeFilterGuild: 2
-  FilterAll: 0
+  values:
+    ExcludeFilterAll: 4294967295
+    ExcludeFilterFriend: 1
+    ExcludeFilterGuild: 2
+    FilterAll: 0
 ChatWhisperTargetStatus:
-  CanWhisper: 0
-  CanWhisperGuild: 1
-  Offline: 2
-  WrongFaction: 3
+  values:
+    CanWhisper: 0
+    CanWhisperGuild: 1
+    Offline: 2
+    WrongFaction: 3
 ChrCustomizationCategoryFlag:
-  Subcategory: 2
-  UndressModel: 1
+  values:
+    Subcategory: 2
+    UndressModel: 1
 ChrCustomizationOptionType:
-  Checkbox: 1
-  Dropdown: 0
-  Slider: 2
+  values:
+    Checkbox: 1
+    Dropdown: 0
+    Slider: 2
 ChrModelFeatureFlags:
-  Deprecated0: 8
-  Forms: 2
-  HunterPets: 32
-  Identity: 4
-  Mounts: 16
-  None: 0
-  Players: 64
-  Summons: 1
+  values:
+    Deprecated0: 8
+    Forms: 2
+    HunterPets: 32
+    Identity: 4
+    Mounts: 16
+    None: 0
+    Players: 64
+    Summons: 1
 ChrRacesAllianceType:
-  Alliance: 0
-  Horde: 1
-  NeutralOrNpc: 2
+  values:
+    Alliance: 0
+    Horde: 1
+    NeutralOrNpc: 2
 CinematicType:
-  GameCinematicSequence: 3
-  GameClientScene: 2
-  GameMovie: 1
-  GlueMovie: 0
+  values:
+    GameCinematicSequence: 3
+    GameClientScene: 2
+    GameMovie: 1
+    GlueMovie: 0
 ClickBindingInteraction:
-  OpenContextMenu: 2
-  Target: 1
+  values:
+    OpenContextMenu: 2
+    Target: 1
 ClickBindingType:
-  Interaction: 3
-  Macro: 2
-  None: 0
-  PetAction: 4
-  Spell: 1
+  values:
+    Interaction: 3
+    Macro: 2
+    None: 0
+    PetAction: 4
+    Spell: 1
 ClientPlatformType:
-  Macintosh: 1
-  Windows: 0
+  values:
+    Macintosh: 1
+    Windows: 0
 ClientSceneType:
-  DefaultSceneType: 0
-  MinigameSceneType: 1
+  values:
+    DefaultSceneType: 0
+    MinigameSceneType: 1
 ClientSettingsConfigFlag:
-  ClientSettingsConfigBeta: 64
-  ClientSettingsConfigBetaRetail: 128
-  ClientSettingsConfigDebug: 1
-  ClientSettingsConfigGm: 8
-  ClientSettingsConfigInternal: 2
-  ClientSettingsConfigPerf: 4
-  ClientSettingsConfigRetail: 256
-  ClientSettingsConfigTest: 16
-  ClientSettingsConfigTestRetail: 32
+  values:
+    ClientSettingsConfigBeta: 64
+    ClientSettingsConfigBetaRetail: 128
+    ClientSettingsConfigDebug: 1
+    ClientSettingsConfigGm: 8
+    ClientSettingsConfigInternal: 2
+    ClientSettingsConfigPerf: 4
+    ClientSettingsConfigRetail: 256
+    ClientSettingsConfigTest: 16
+    ClientSettingsConfigTestRetail: 32
 ClubActionType:
-  ErrorClubActionAcceptInvitation: 13
-  ErrorClubActionAddBan: 22
-  ErrorClubActionCreate: 1
-  ErrorClubActionCreateMessage: 24
-  ErrorClubActionCreateStream: 15
-  ErrorClubActionCreateTicket: 5
-  ErrorClubActionDeclineInvitation: 14
-  ErrorClubActionDestroy: 3
-  ErrorClubActionDestroyMessage: 26
-  ErrorClubActionDestroyStream: 17
-  ErrorClubActionDestroyTicket: 6
-  ErrorClubActionEdit: 2
-  ErrorClubActionEditMember: 19
-  ErrorClubActionEditMemberNote: 20
-  ErrorClubActionEditMessage: 25
-  ErrorClubActionEditStream: 16
-  ErrorClubActionGetBans: 10
-  ErrorClubActionGetInvitations: 11
-  ErrorClubActionGetTicket: 8
-  ErrorClubActionGetTickets: 9
-  ErrorClubActionInviteMember: 18
-  ErrorClubActionKickMember: 21
-  ErrorClubActionLeave: 4
-  ErrorClubActionRedeemTicket: 7
-  ErrorClubActionRemoveBan: 23
-  ErrorClubActionRevokeInvitation: 12
-  ErrorClubActionSubscribe: 0
+  values:
+    ErrorClubActionAcceptInvitation: 13
+    ErrorClubActionAddBan: 22
+    ErrorClubActionCreate: 1
+    ErrorClubActionCreateMessage: 24
+    ErrorClubActionCreateStream: 15
+    ErrorClubActionCreateTicket: 5
+    ErrorClubActionDeclineInvitation: 14
+    ErrorClubActionDestroy: 3
+    ErrorClubActionDestroyMessage: 26
+    ErrorClubActionDestroyStream: 17
+    ErrorClubActionDestroyTicket: 6
+    ErrorClubActionEdit: 2
+    ErrorClubActionEditMember: 19
+    ErrorClubActionEditMemberNote: 20
+    ErrorClubActionEditMessage: 25
+    ErrorClubActionEditStream: 16
+    ErrorClubActionGetBans: 10
+    ErrorClubActionGetInvitations: 11
+    ErrorClubActionGetTicket: 8
+    ErrorClubActionGetTickets: 9
+    ErrorClubActionInviteMember: 18
+    ErrorClubActionKickMember: 21
+    ErrorClubActionLeave: 4
+    ErrorClubActionRedeemTicket: 7
+    ErrorClubActionRemoveBan: 23
+    ErrorClubActionRevokeInvitation: 12
+    ErrorClubActionSubscribe: 0
 ClubErrorType:
-  ErrorClubAlreadyMember: 19
-  ErrorClubBanAlreadyExists: 35
-  ErrorClubBanCountAtMax: 36
-  ErrorClubDoesntAllowCrossFaction: 40
-  ErrorClubEditHasCrossFactionMembers: 41
-  ErrorClubFull: 16
-  ErrorClubInsufficientPrivileges: 24
-  ErrorClubInvalidRoleID: 23
-  ErrorClubInvitationAlreadyExists: 22
-  ErrorClubMemberHasRequiredRole: 31
-  ErrorClubNoClub: 17
-  ErrorClubNoSuchInvitation: 21
-  ErrorClubNoSuchMember: 20
-  ErrorClubNotMember: 18
-  ErrorClubReceivedInvitationCountAtMax: 33
-  ErrorClubSentInvitationCountAtMax: 32
-  ErrorClubStreamCountAtMax: 30
-  ErrorClubStreamCountAtMin: 29
-  ErrorClubStreamInvalidName: 28
-  ErrorClubStreamNoStream: 27
-  ErrorClubTargetIsBanned: 34
-  ErrorClubTicketCountAtMax: 37
-  ErrorClubTicketHasConsumedAllowedRedeemCount: 39
-  ErrorClubTicketNoSuchTicket: 38
-  ErrorClubTooManyClubsJoined: 25
-  ErrorClubVoiceFull: 26
-  ErrorCommunitiesBadTarget: 4
-  ErrorCommunitiesChatMute: 15
-  ErrorCommunitiesGuild: 8
-  ErrorCommunitiesIgnored: 7
-  ErrorCommunitiesMissingShortName: 11
-  ErrorCommunitiesNeutralFaction: 2
-  ErrorCommunitiesNone: 0
-  ErrorCommunitiesProfanity: 12
-  ErrorCommunitiesRestricted: 6
-  ErrorCommunitiesTrial: 13
-  ErrorCommunitiesUnknown: 1
-  ErrorCommunitiesUnknownRealm: 3
-  ErrorCommunitiesUnknownTicket: 10
-  ErrorCommunitiesVeteranTrial: 14
-  ErrorCommunitiesWrongFaction: 5
-  ErrorCommunitiesWrongRegion: 9
+  values:
+    ErrorClubAlreadyMember: 19
+    ErrorClubBanAlreadyExists: 35
+    ErrorClubBanCountAtMax: 36
+    ErrorClubDoesntAllowCrossFaction: 40
+    ErrorClubEditHasCrossFactionMembers: 41
+    ErrorClubFull: 16
+    ErrorClubInsufficientPrivileges: 24
+    ErrorClubInvalidRoleID: 23
+    ErrorClubInvitationAlreadyExists: 22
+    ErrorClubMemberHasRequiredRole: 31
+    ErrorClubNoClub: 17
+    ErrorClubNoSuchInvitation: 21
+    ErrorClubNoSuchMember: 20
+    ErrorClubNotMember: 18
+    ErrorClubReceivedInvitationCountAtMax: 33
+    ErrorClubSentInvitationCountAtMax: 32
+    ErrorClubStreamCountAtMax: 30
+    ErrorClubStreamCountAtMin: 29
+    ErrorClubStreamInvalidName: 28
+    ErrorClubStreamNoStream: 27
+    ErrorClubTargetIsBanned: 34
+    ErrorClubTicketCountAtMax: 37
+    ErrorClubTicketHasConsumedAllowedRedeemCount: 39
+    ErrorClubTicketNoSuchTicket: 38
+    ErrorClubTooManyClubsJoined: 25
+    ErrorClubVoiceFull: 26
+    ErrorCommunitiesBadTarget: 4
+    ErrorCommunitiesChatMute: 15
+    ErrorCommunitiesGuild: 8
+    ErrorCommunitiesIgnored: 7
+    ErrorCommunitiesMissingShortName: 11
+    ErrorCommunitiesNeutralFaction: 2
+    ErrorCommunitiesNone: 0
+    ErrorCommunitiesProfanity: 12
+    ErrorCommunitiesRestricted: 6
+    ErrorCommunitiesTrial: 13
+    ErrorCommunitiesUnknown: 1
+    ErrorCommunitiesUnknownRealm: 3
+    ErrorCommunitiesUnknownTicket: 10
+    ErrorCommunitiesVeteranTrial: 14
+    ErrorCommunitiesWrongFaction: 5
+    ErrorCommunitiesWrongRegion: 9
 ClubFieldType:
-  ClubBroadcast: 3
-  ClubDescription: 2
-  ClubName: 0
-  ClubShortName: 1
-  ClubStreamName: 4
-  ClubStreamSubject: 5
-  NumTypes: 6
+  values:
+    ClubBroadcast: 3
+    ClubDescription: 2
+    ClubName: 0
+    ClubShortName: 1
+    ClubStreamName: 4
+    ClubStreamSubject: 5
+    NumTypes: 6
 ClubFinderApplicationUpdateType:
-  AcceptInvite: 1
-  Cancel: 3
-  DeclineInvite: 2
-  None: 0
+  values:
+    AcceptInvite: 1
+    Cancel: 3
+    DeclineInvite: 2
+    None: 0
 ClubFinderClubPostingStatusFlags:
-  Banned: 5
-  FakePost: 6
-  ForceDescriptionChange: 2
-  ForceNameChange: 3
-  NeedsCacheUpdate: 1
-  None: 0
-  PendingDelete: 7
-  PostDelisted: 8
-  UnderReview: 4
+  values:
+    Banned: 5
+    FakePost: 6
+    ForceDescriptionChange: 2
+    ForceNameChange: 3
+    NeedsCacheUpdate: 1
+    None: 0
+    PendingDelete: 7
+    PostDelisted: 8
+    UnderReview: 4
 ClubFinderDisableReason:
-  Muted: 0
-  Silenced: 1
-  VeteranTrial: 2
+  values:
+    Muted: 0
+    Silenced: 1
+    VeteranTrial: 2
 ClubFinderPostingReportType:
-  ApplicantsName: 3
-  ClubName: 1
-  JoinNote: 4
-  PostersName: 0
-  PostingDescription: 2
+  values:
+    ApplicantsName: 3
+    ClubName: 1
+    JoinNote: 4
+    PostersName: 0
+    PostingDescription: 2
 ClubFinderRequestType:
-  All: 3
-  Community: 2
-  Guild: 1
-  None: 0
+  values:
+    All: 3
+    Community: 2
+    Guild: 1
+    None: 0
 ClubFinderSettingFlags:
-  AutoAccept: 14
-  Damage: 11
-  Dungeons: 1
-  EnableListing: 12
-  FactionAlliance: 16
-  FactionHorde: 15
-  FactionNeutral: 17
-  Healer: 10
-  LanguageReserved1: 21
-  LanguageReserved2: 22
-  LanguageReserved3: 23
-  LanguageReserved4: 24
-  LanguageReserved5: 25
-  Large: 8
-  MaxLevelOnly: 13
-  Medium: 7
-  None: 0
-  PvP: 3
-  Raids: 2
-  RP: 4
-  Small: 6
-  Social: 5
-  SortMemberCount: 19
-  SortNewest: 20
-  SortRelevance: 18
-  Tank: 9
+  values:
+    AutoAccept: 14
+    Damage: 11
+    Dungeons: 1
+    EnableListing: 12
+    FactionAlliance: 16
+    FactionHorde: 15
+    FactionNeutral: 17
+    Healer: 10
+    LanguageReserved1: 21
+    LanguageReserved2: 22
+    LanguageReserved3: 23
+    LanguageReserved4: 24
+    LanguageReserved5: 25
+    Large: 8
+    MaxLevelOnly: 13
+    Medium: 7
+    None: 0
+    PvP: 3
+    Raids: 2
+    RP: 4
+    Small: 6
+    Social: 5
+    SortMemberCount: 19
+    SortNewest: 20
+    SortRelevance: 18
+    Tank: 9
 ClubInvitationCandidateStatus:
-  AlreadyMember: 2
-  Available: 0
-  InvitePending: 1
+  values:
+    AlreadyMember: 2
+    Available: 0
+    InvitePending: 1
 ClubMemberPresence:
-  Away: 4
-  Busy: 5
-  Offline: 3
-  Online: 1
-  OnlineMobile: 2
-  Unknown: 0
+  values:
+    Away: 4
+    Busy: 5
+    Offline: 3
+    Online: 1
+    OnlineMobile: 2
+    Unknown: 0
 ClubRemovedReason:
-  Banned: 1
-  ClubDestroyed: 3
-  None: 0
-  Removed: 2
+  values:
+    Banned: 1
+    ClubDestroyed: 3
+    None: 0
+    Removed: 2
 ClubRestrictionReason:
-  None: 0
-  Unavailable: 1
+  values:
+    None: 0
+    Unavailable: 1
 ClubRoleIdentifier:
-  Leader: 2
-  Member: 4
-  Moderator: 3
-  Owner: 1
+  values:
+    Leader: 2
+    Member: 4
+    Moderator: 3
+    Owner: 1
 ClubStreamNotificationFilter:
-  All: 2
-  Mention: 1
-  None: 0
+  values:
+    All: 2
+    Mention: 1
+    None: 0
 ClubStreamType:
-  General: 0
-  Guild: 1
-  Officer: 2
-  Other: 3
+  values:
+    General: 0
+    Guild: 1
+    Officer: 2
+    Other: 3
 ClubType:
-  BattleNet: 0
-  Character: 1
-  Guild: 2
-  Other: 3
+  values:
+    BattleNet: 0
+    Character: 1
+    Guild: 2
+    Other: 3
 ColorOverride:
-  ItemQualityAccount: 7
-  ItemQualityArtifact: 6
-  ItemQualityCommon: 1
-  ItemQualityEpic: 4
-  ItemQualityLegendary: 5
-  ItemQualityPoor: 0
-  ItemQualityRare: 3
-  ItemQualityUncommon: 2
+  values:
+    ItemQualityAccount: 7
+    ItemQualityArtifact: 6
+    ItemQualityCommon: 1
+    ItemQualityEpic: 4
+    ItemQualityLegendary: 5
+    ItemQualityPoor: 0
+    ItemQualityRare: 3
+    ItemQualityUncommon: 2
 CombatAudioAlertCastState:
-  Off: 0
-  OnCastEnd: 2
-  OnCastStart: 1
+  values:
+    Off: 0
+    OnCastEnd: 2
+    OnCastStart: 1
 CombatAudioAlertCategory:
-  General: 0
-  PartyHealth: 7
-  PlayerCast: 3
-  PlayerDebuffs: 8
-  PlayerHealth: 1
-  PlayerResource1: 5
-  PlayerResource2: 6
-  TargetCast: 4
-  TargetHealth: 2
+  values:
+    General: 0
+    PartyHealth: 7
+    PlayerCast: 3
+    PlayerDebuffs: 8
+    PlayerHealth: 1
+    PlayerResource1: 5
+    PlayerResource2: 6
+    TargetCast: 4
+    TargetHealth: 2
 CombatAudioAlertDebuffSelfAlertValues:
-  DispelType: 1
-  Off: 0
+  values:
+    DispelType: 1
+    Off: 0
 CombatAudioAlertPartyPercentValues:
-  Off: 0
-  Under100Percent: 1
-  Under10Percent: 10
-  Under20Percent: 9
-  Under30Percent: 8
-  Under40Percent: 7
-  Under50Percent: 6
-  Under60Percent: 5
-  Under70Percent: 4
-  Under80Percent: 3
-  Under90Percent: 2
+  values:
+    Off: 0
+    Under100Percent: 1
+    Under10Percent: 10
+    Under20Percent: 9
+    Under30Percent: 8
+    Under40Percent: 7
+    Under50Percent: 6
+    Under60Percent: 5
+    Under70Percent: 4
+    Under80Percent: 3
+    Under90Percent: 2
 CombatAudioAlertPercentValues:
-  Every10Percent: 1
-  Every20Percent: 2
-  Every30Percent: 3
-  Every40Percent: 4
-  Every50Percent: 5
-  Off: 0
+  values:
+    Every10Percent: 1
+    Every20Percent: 2
+    Every30Percent: 3
+    Every40Percent: 4
+    Every50Percent: 5
+    Off: 0
 CombatAudioAlertPlayerCastFormatValues:
-  Cast: 3
-  Casting: 2
-  CastingSpellname: 0
-  CastSpellname: 1
-  Spellname: 4
+  values:
+    Cast: 3
+    Casting: 2
+    CastingSpellname: 0
+    CastSpellname: 1
+    Spellname: 4
 CombatAudioAlertPlayerDebuffFormatValues:
-  Full: 0
-  NoSpellname: 1
+  values:
+    Full: 0
+    NoSpellname: 1
 CombatAudioAlertPlayerHealthFormatValues:
-  HealthFull: 0
-  HealthNoPercent: 1
-  HealthNoPercentDiv10: 2
-  NoHealthFull: 3
-  NoHealthNoPercent: 4
-  NoHealthNoPercentDiv10: 5
+  values:
+    HealthFull: 0
+    HealthNoPercent: 1
+    HealthNoPercentDiv10: 2
+    NoHealthFull: 3
+    NoHealthNoPercent: 4
+    NoHealthNoPercentDiv10: 5
 CombatAudioAlertPlayerResourceFormatValues:
-  NoResourceFull: 3
-  NoResourceNoPercent: 4
-  NoResourceNoPercentDiv10: 5
-  ResourceFull: 0
-  ResourceNoPercent: 1
-  ResourceNoPercentDiv10: 2
+  values:
+    NoResourceFull: 3
+    NoResourceNoPercent: 4
+    NoResourceNoPercentDiv10: 5
+    ResourceFull: 0
+    ResourceNoPercent: 1
+    ResourceNoPercentDiv10: 2
 CombatAudioAlertSayIfTargetedType:
-  Aggro: 1
-  None: 0
-  Targeted: 2
-  TargetedBy: 3
+  values:
+    Aggro: 1
+    None: 0
+    Targeted: 2
+    TargetedBy: 3
 CombatAudioAlertSpecSetting:
-  Resource1Format: 1
-  Resource1Percent: 0
-  Resource1Voice: 2
-  Resource1Volume: 3
-  Resource2Format: 5
-  Resource2Percent: 4
-  Resource2Voice: 6
-  Resource2Volume: 7
-  SayIfTargeted: 8
+  values:
+    Resource1Format: 1
+    Resource1Percent: 0
+    Resource1Voice: 2
+    Resource1Volume: 3
+    Resource2Format: 5
+    Resource2Percent: 4
+    Resource2Voice: 6
+    Resource2Volume: 7
+    SayIfTargeted: 8
 CombatAudioAlertTargetCastFormatValues:
-  Cast: 5
-  Casting: 4
-  CastingSpellname: 2
-  CastSpellname: 3
-  Spellname: 6
-  TargetCastingSpellname: 0
-  TargetCastSpellname: 1
+  values:
+    Cast: 5
+    Casting: 4
+    CastingSpellname: 2
+    CastSpellname: 3
+    Spellname: 6
+    TargetCastingSpellname: 0
+    TargetCastSpellname: 1
 CombatAudioAlertTargetDeathBehavior:
-  Default: 0
-  SayTargetDead: 1
+  values:
+    Default: 0
+    SayTargetDead: 1
 CombatAudioAlertTargetHealthFormatValues:
-  HealthFull: 3
-  HealthNoPercent: 4
-  HealthNoPercentDiv10: 5
-  NoHealthFull: 0
-  NoHealthNoPercent: 1
-  NoHealthNoPercentDiv10: 2
-  TargetFull: 6
-  TargetNoPercent: 7
-  TargetNoPercentDiv10: 8
+  values:
+    HealthFull: 3
+    HealthNoPercent: 4
+    HealthNoPercentDiv10: 5
+    NoHealthFull: 0
+    NoHealthNoPercent: 1
+    NoHealthNoPercentDiv10: 2
+    TargetFull: 6
+    TargetNoPercent: 7
+    TargetNoPercentDiv10: 8
 CombatAudioAlertThrottle:
-  PlayerCast: 3
-  PlayerHealth: 1
-  PlayerHealthSamePercent: 7
-  PlayerResource1: 5
-  PlayerResource1SamePercent: 9
-  PlayerResource2: 6
-  PlayerResource2SamePercent: 10
-  Sample: 0
-  TargetCast: 4
-  TargetHealth: 2
-  TargetHealthSamePercent: 8
+  values:
+    PlayerCast: 3
+    PlayerHealth: 1
+    PlayerHealthSamePercent: 7
+    PlayerResource1: 5
+    PlayerResource1SamePercent: 9
+    PlayerResource2: 6
+    PlayerResource2SamePercent: 10
+    Sample: 0
+    TargetCast: 4
+    TargetHealth: 2
+    TargetHealthSamePercent: 8
 CombatAudioAlertType:
-  Cast: 1
-  Health: 0
+  values:
+    Cast: 1
+    Health: 0
 CombatAudioAlertUnit:
-  Player: 0
-  Target: 1
+  values:
+    Player: 0
+    Target: 1
 CombatLogMessageOrder:
-  Newest: 0
-  Oldest: 1
+  values:
+    Newest: 0
+    Oldest: 1
 CombatLogObject:
-  AffiliationMine: 1
-  AffiliationOutsider: 8
-  AffiliationParty: 2
-  AffiliationRaid: 4
-  ControlNpc: 512
-  ControlPlayer: 256
-  Empty: 0
-  Focus: 131072
-  Mainassist: 524288
-  Maintank: 262144
-  None: 2147483648
-  ReactionFriendly: 16
-  ReactionHostile: 64
-  ReactionNeutral: 32
-  Target: 65536
-  TypeGuardian: 8192
-  TypeNpc: 2048
-  TypeObject: 16384
-  TypePet: 4096
-  TypePlayer: 1024
+  values:
+    AffiliationMine: 1
+    AffiliationOutsider: 8
+    AffiliationParty: 2
+    AffiliationRaid: 4
+    ControlNpc: 512
+    ControlPlayer: 256
+    Empty: 0
+    Focus: 131072
+    Mainassist: 524288
+    Maintank: 262144
+    None: 2147483648
+    ReactionFriendly: 16
+    ReactionHostile: 64
+    ReactionNeutral: 32
+    Target: 65536
+    TypeGuardian: 8192
+    TypeNpc: 2048
+    TypeObject: 16384
+    TypePet: 4096
+    TypePlayer: 1024
 CombatLogObjectTarget:
-  RaidNone: 2147483648
-  Raidtarget1: 1
-  Raidtarget2: 2
-  Raidtarget3: 4
-  Raidtarget4: 8
-  Raidtarget5: 16
-  Raidtarget6: 32
-  Raidtarget7: 64
-  Raidtarget8: 128
+  values:
+    RaidNone: 2147483648
+    Raidtarget1: 1
+    Raidtarget2: 2
+    Raidtarget3: 4
+    Raidtarget4: 8
+    Raidtarget5: 16
+    Raidtarget6: 32
+    Raidtarget7: 64
+    Raidtarget8: 128
 CombinedQuestLogStatus:
-  Available: 0
-  Complete: 1
-  CompleteDaily: 2
-  CompleteGameReset: 6
-  CompleteMonthly: 4
-  CompleteWeekly: 3
-  CompleteYearly: 5
-  Reset: 7
+  values:
+    Available: 0
+    Complete: 1
+    CompleteDaily: 2
+    CompleteGameReset: 6
+    CompleteMonthly: 4
+    CompleteWeekly: 3
+    CompleteYearly: 5
+    Reset: 7
 CombinedQuestStatus:
-  Completed: 1
-  Invalid: 0
-  NotCompleted: 2
+  values:
+    Completed: 1
+    Invalid: 0
+    NotCompleted: 2
 CommunicationMode:
-  OpenMic: 1
-  PushToTalk: 0
+  values:
+    OpenMic: 1
+    PushToTalk: 0
 CompanionConfigSlotTypes:
-  Combat: 2
-  Role: 0
-  Utility: 1
+  values:
+    Combat: 2
+    Role: 0
+    Utility: 1
 CompanionRoleType:
-  Dps: 0
-  Heal: 1
-  Tank: 2
+  values:
+    Dps: 0
+    Heal: 1
+    Tank: 2
 CompressionLevel:
-  Default: 0
-  OptimizeForSize: 2
-  OptimizeForSpeed: 1
+  values:
+    Default: 0
+    OptimizeForSize: 2
+    OptimizeForSpeed: 1
 CompressionMethod:
-  Deflate: 0
-  Gzip: 2
-  Zlib: 1
+  values:
+    Deflate: 0
+    Gzip: 2
+    Zlib: 1
 ConfirmationPromptUIType:
-  BonusRoll: 1
-  SimpleWarning: 2
-  SimpleWarningAlert: 4
-  StaticText: 0
-  StaticTextAlert: 3
+  values:
+    BonusRoll: 1
+    SimpleWarning: 2
+    SimpleWarningAlert: 4
+    StaticText: 0
+    StaticTextAlert: 3
 ConquestProgressBarDisplayType:
-  AdditionalChest: 1
-  FirstChest: 0
-  Seasonal: 2
+  values:
+    AdditionalChest: 1
+    FirstChest: 0
+    Seasonal: 2
 ConsoleCategory:
-  Combat: 3
-  Console: 2
-  Debug: 0
-  Default: 5
-  Game: 4
-  Gm: 8
-  Graphics: 1
-  Net: 6
-  None: 10
-  Reveal: 9
-  Sound: 7
+  values:
+    Combat: 3
+    Console: 2
+    Debug: 0
+    Default: 5
+    Game: 4
+    Gm: 8
+    Graphics: 1
+    Net: 6
+    None: 10
+    Reveal: 9
+    Sound: 7
 ConsoleColorType:
-  AdminColor: 6
-  BackgroundColor: 8
-  ClickbufferColor: 9
-  DefaultColor: 0
-  DefaultGreen: 11
-  EchoColor: 2
-  ErrorColor: 3
-  GlobalColor: 5
-  HighlightColor: 7
-  InputColor: 1
-  PrivateColor: 10
-  WarningColor: 4
+  values:
+    AdminColor: 6
+    BackgroundColor: 8
+    ClickbufferColor: 9
+    DefaultColor: 0
+    DefaultGreen: 11
+    EchoColor: 2
+    ErrorColor: 3
+    GlobalColor: 5
+    HighlightColor: 7
+    InputColor: 1
+    PrivateColor: 10
+    WarningColor: 4
 ConsoleCommandType:
-  Command: 1
-  Cvar: 0
-  Macro: 2
-  Script: 3
+  values:
+    Command: 1
+    Cvar: 0
+    Macro: 2
+    Script: 3
 ContentTrackingError:
-  AlreadyTracked: 2
-  MaxTracked: 1
-  Untrackable: 0
+  values:
+    AlreadyTracked: 2
+    MaxTracked: 1
+    Untrackable: 0
 ContentTrackingResult:
-  DataPending: 1
-  Failure: 2
-  Success: 0
+  values:
+    DataPending: 1
+    Failure: 2
+    Success: 0
 ContentTrackingStopType:
-  Collected: 1
-  Invalidated: 0
-  Manual: 2
+  values:
+    Collected: 1
+    Invalidated: 0
+    Manual: 2
 ContentTrackingTargetType:
-  Achievement: 2
-  JournalEncounter: 0
-  Profession: 3
-  Quest: 4
-  Vendor: 1
+  values:
+    Achievement: 2
+    JournalEncounter: 0
+    Profession: 3
+    Quest: 4
+    Vendor: 1
 ContentTrackingType:
-  Achievement: 2
-  Appearance: 0
-  Decor: 3
-  Mount: 1
+  values:
+    Achievement: 2
+    Appearance: 0
+    Decor: 3
+    Mount: 1
 ContributionAppearanceFlags:
-  TooltipUseTimeRemaining: 0
+  values:
+    TooltipUseTimeRemaining: 0
 ContributionResult:
-  FailedConditionCheck: 5
-  IncorrectState: 2
-  InternalError: 7
-  InvalidID: 3
-  MustBeNearNpc: 1
-  QuestDataMissing: 4
-  Success: 0
-  UnableToCompleteTurnIn: 6
+  values:
+    FailedConditionCheck: 5
+    IncorrectState: 2
+    InternalError: 7
+    InvalidID: 3
+    MustBeNearNpc: 1
+    QuestDataMissing: 4
+    Success: 0
+    UnableToCompleteTurnIn: 6
 ContributionState:
-  Active: 2
-  Building: 1
-  Destroyed: 4
-  None: 0
-  UnderAttack: 3
+  values:
+    Active: 2
+    Building: 1
+    Destroyed: 4
+    None: 0
+    UnderAttack: 3
 CooldownSetLinkedSpellFlags:
-  UseAsTooltip: 1
+  values:
+    UseAsTooltip: 1
 CooldownSetSpellFlags:
-  HideAura: 1
-  HideByDefault: 2
+  values:
+    HideAura: 1
+    HideByDefault: 2
 CooldownViewerAddAlertStatus:
-  DuplicateAlert: 3
-  InvalidAlertType: 1
-  InvalidEventType: 2
-  Success: 0
+  values:
+    DuplicateAlert: 3
+    InvalidAlertType: 1
+    InvalidEventType: 2
+    Success: 0
 CooldownViewerAlertEventType:
-  Available: 1
-  ChargeGained: 4
-  OnAuraApplied: 5
-  OnAuraRemoved: 6
-  OnCooldown: 3
-  PandemicTime: 2
+  values:
+    Available: 1
+    ChargeGained: 4
+    OnAuraApplied: 5
+    OnAuraRemoved: 6
+    OnCooldown: 3
+    PandemicTime: 2
 CooldownViewerAlertType:
-  Sound: 1
-  Visual: 2
+  values:
+    Sound: 1
+    Visual: 2
 CooldownViewerBarContent:
-  IconAndName: 0
-  IconOnly: 1
-  NameOnly: 2
+  values:
+    IconAndName: 0
+    IconOnly: 1
+    NameOnly: 2
 CooldownViewerCategory:
-  Essential: 0
-  TrackedBar: 3
-  TrackedBuff: 2
-  Utility: 1
+  values:
+    Essential: 0
+    TrackedBar: 3
+    TrackedBuff: 2
+    Utility: 1
 CooldownViewerIconDirection:
-  Left: 0
-  Right: 1
+  values:
+    Left: 0
+    Right: 1
 CooldownViewerOrientation:
-  Horizontal: 0
-  Vertical: 1
+  values:
+    Horizontal: 0
+    Vertical: 1
 CooldownViewerVisibleSetting:
-  Always: 0
-  Hidden: 2
-  InCombat: 1
+  values:
+    Always: 0
+    Hidden: 2
+    InCombat: 1
 CornerstonePurchaseMode:
-  Basic: 0
-  Import: 1
-  Move: 2
+  values:
+    Basic: 0
+    Import: 1
+    Move: 2
 CovenantAbilityType:
-  Class: 0
-  Signature: 1
-  Soulbind: 2
+  values:
+    Class: 0
+    Signature: 1
+    Soulbind: 2
 CovenantSkill:
-  Kyrian: 2730
-  Necrolord: 2733
-  NightFae: 2732
-  Venthyr: 2731
+  values:
+    Kyrian: 2730
+    Necrolord: 2733
+    NightFae: 2732
+    Venthyr: 2731
 CovenantType:
-  Kyrian: 1
-  Necrolord: 4
-  NightFae: 3
-  None: 0
-  Venthyr: 2
+  values:
+    Kyrian: 1
+    Necrolord: 4
+    NightFae: 3
+    None: 0
+    Venthyr: 2
 CraftingOrderCustomerCategoryType:
-  Primary: 0
-  Secondary: 1
-  Tertiary: 2
+  values:
+    Primary: 0
+    Secondary: 1
+    Tertiary: 2
 CraftingOrderDuration:
-  Long: 2
-  Medium: 1
-  Short: 0
+  values:
+    Long: 2
+    Medium: 1
+    Short: 0
 CraftingOrderFlags:
-  HasAllReagents: 8
-  HasNoneReagents: 2
-  HasSomeReagents: 4
-  IsFulfillable: 16
-  IsRecraft: 1
-  None: 0
+  values:
+    HasAllReagents: 8
+    HasNoneReagents: 2
+    HasSomeReagents: 4
+    IsFulfillable: 16
+    IsRecraft: 1
+    None: 0
 CraftingOrderItemFlags:
-  HasEnchantmentData: 2
-  None: 0
-  NpcProvided: 1
+  values:
+    HasEnchantmentData: 2
+    None: 0
+    NpcProvided: 1
 CraftingOrderItemType:
-  CraftedResult: 2
-  Currency: 5
-  Deprecated: 4
-  Item: 0
-  Recraft: 1
-  RemoveReagent: 3
+  values:
+    CraftedResult: 2
+    Currency: 5
+    Deprecated: 4
+    Item: 0
+    Recraft: 1
+    RemoveReagent: 3
 CraftingOrderReagentSource:
-  Any: 0
-  Crafter: 2
-  Customer: 1
-  None: 3
+  values:
+    Any: 0
+    Crafter: 2
+    Customer: 1
+    None: 3
 CraftingOrderReagentsType:
-  All: 0
-  None: 2
-  Some: 1
+  values:
+    All: 0
+    None: 2
+    Some: 1
 CraftingOrderResult:
-  Aborted: 1
-  AlreadyClaimed: 2
-  AlreadyCrafted: 3
-  CannotBeOrdered: 4
-  CannotCancel: 5
-  CannotClaim: 6
-  CannotClaimOwnOrder: 7
-  CannotCraft: 8
-  CannotCreate: 9
-  CannotFulfill: 10
-  CannotRecraft: 11
-  CannotReject: 12
-  CannotRelease: 13
-  CrafterIsIgnored: 14
-  DatabaseError: 15
-  Expired: 16
-  InvalidDuration: 18
-  InvalidMinQuality: 19
-  InvalidNotes: 20
-  InvalidReagent: 21
-  InvalidRealm: 22
-  InvalidRecipe: 23
-  InvalidRecraftItem: 24
-  InvalidSort: 25
-  InvalidTarget: 26
-  InvalidType: 27
-  Locked: 17
-  MaxOrdersReached: 28
-  MissingCraftingTable: 29
-  MissingCurrency: 30
-  MissingItem: 31
-  MissingNpc: 32
-  MissingOrder: 33
-  MissingRecraftItem: 34
-  NoAccountItems: 35
-  NotClaimed: 36
-  NotCrafted: 37
-  NotInGuild: 38
-  NotYetImplemented: 39
-  Ok: 0
-  OutOfPublicOrderCapacity: 40
-  ServerIsNotAvailable: 41
-  TargetCannotCraft: 43
-  TargetLocked: 44
-  ThrottleViolation: 42
-  Timeout: 45
-  TooManyCurrencies: 46
-  TooManyItems: 47
-  WrongVersion: 48
+  values:
+    Aborted: 1
+    AlreadyClaimed: 2
+    AlreadyCrafted: 3
+    CannotBeOrdered: 4
+    CannotCancel: 5
+    CannotClaim: 6
+    CannotClaimOwnOrder: 7
+    CannotCraft: 8
+    CannotCreate: 9
+    CannotFulfill: 10
+    CannotRecraft: 11
+    CannotReject: 12
+    CannotRelease: 13
+    CrafterIsIgnored: 14
+    DatabaseError: 15
+    Expired: 16
+    InvalidDuration: 18
+    InvalidMinQuality: 19
+    InvalidNotes: 20
+    InvalidReagent: 21
+    InvalidRealm: 22
+    InvalidRecipe: 23
+    InvalidRecraftItem: 24
+    InvalidSort: 25
+    InvalidTarget: 26
+    InvalidType: 27
+    Locked: 17
+    MaxOrdersReached: 28
+    MissingCraftingTable: 29
+    MissingCurrency: 30
+    MissingItem: 31
+    MissingNpc: 32
+    MissingOrder: 33
+    MissingRecraftItem: 34
+    NoAccountItems: 35
+    NotClaimed: 36
+    NotCrafted: 37
+    NotInGuild: 38
+    NotYetImplemented: 39
+    Ok: 0
+    OutOfPublicOrderCapacity: 40
+    ServerIsNotAvailable: 41
+    TargetCannotCraft: 43
+    TargetLocked: 44
+    ThrottleViolation: 42
+    Timeout: 45
+    TooManyCurrencies: 46
+    TooManyItems: 47
+    WrongVersion: 48
 CraftingOrderSortType:
-  AveTip: 1
-  ItemName: 0
-  MaxTip: 2
-  Quantity: 3
-  Reagents: 4
-  Status: 7
-  TimeRemaining: 6
-  Tip: 5
+  values:
+    AveTip: 1
+    ItemName: 0
+    MaxTip: 2
+    Quantity: 3
+    Reagents: 4
+    Status: 7
+    TimeRemaining: 6
+    Tip: 5
 CraftingOrderState:
-  Canceled: 13
-  Canceling: 12
-  Claimed: 4
-  Claiming: 3
-  Crafting: 8
-  Created: 2
-  Creating: 1
-  Expired: 15
-  Expiring: 14
-  Fulfilled: 11
-  Fulfilling: 10
-  None: 0
-  Recrafting: 9
-  Rejected: 6
-  Rejecting: 5
-  Releasing: 7
+  values:
+    Canceled: 13
+    Canceling: 12
+    Claimed: 4
+    Claiming: 3
+    Crafting: 8
+    Created: 2
+    Creating: 1
+    Expired: 15
+    Expiring: 14
+    Fulfilled: 11
+    Fulfilling: 10
+    None: 0
+    Recrafting: 9
+    Rejected: 6
+    Rejecting: 5
+    Releasing: 7
 CraftingOrderType:
-  Guild: 1
-  Npc: 3
-  Personal: 2
-  Public: 0
+  values:
+    Guild: 1
+    Npc: 3
+    Personal: 2
+    Public: 0
 CraftingReagentItemFlag:
-  TooltipShowsAsStatModifications: 1
+  values:
+    TooltipShowsAsStatModifications: 1
 CraftingReagentType:
-  Automatic: 3
-  Basic: 1
-  Finishing: 2
-  Modifying: 0
+  values:
+    Automatic: 3
+    Basic: 1
+    Finishing: 2
+    Modifying: 0
 CreateAllAccountData:
-  AccountCurrenciesDone: '0x0000000000200000'
-  AccountDynamicCriteriaDone: '0x0000000001000000'
-  AccountFactionsDone: '0x0000000200000000'
-  AccountItemsDone: '0x0000000400000000'
-  AccountMappingDone: '0x0000008000000000'
-  AccountNotificationsDone: '0x0000000008000000'
-  AccountStateHousingData: '0x0000080000000000'
-  AchievementsDone: '0x0000000000000001'
-  ArchivedPurchasesDone: '0x0000000000000200'
-  AuctionableTokensDone: '0x0000000000002000'
-  BanktabSettingsDone: '0x0000004000000000'
-  BattlepetsDone: '0x0000000000000008'
-  BitVectorsDone: '0x0000000100000000'
-  BpayAddLicenseObjectsDone: '0x0000000000000800'
-  BpayDistributionObjectsDone: '0x0000000000000100'
-  BpayProductitemObjectsDone: '0x0000000000020000'
-  CharacterItemsDone: '0x0000010000000000'
-  CharactersDone: '0x0000000000000040'
-  CombinedQuestLogEntriesDone: '0x0000000800000000'
-  ConsumableTokensDone: '0x0000000000004000'
-  CriteriaDone: '0x0000000000000002'
-  CurrencycapsDone: '0x0000000000000010'
-  CurrencyTransferLogDone: '0x0000020000000000'
-  DataElementsDone: '0x0000001000000000'
-  EventRecordsDone: '0x0000200000000000'
-  ItemCollectionItemsDone: '0x0000000000001000'
-  LgVendorPurchaseDone: '0x0000040000000000'
-  MountsDone: '0x0000000000000004'
-  None: '0x0000000000000000'
-  Object: '0x0000000000100000'
-  PerkHeldItemsDone: '0x0000000040000000'
-  PerkPastRewardsDone: '0x0000000000008000'
-  PerkPendingPurchasesDone: '0x0000000010000000'
-  PerkPendingRewardsDone: '0x0000000080000000'
-  PurchasesDone: '0x0000000000000080'
-  QuestCriteriaDone: '0x0000000000080000'
-  QuestLogDone: '0x0000000000000020'
-  RafActivitiesDone: '0x0000000002000000'
-  RafBalanceDone: '0x0000000000400000'
-  RafRewardsDone: '0x0000000000800000'
-  RevokedRafRewardsDone: '0x0000000004000000'
-  SettingsDone: '0x0000000000000400'
-  TransmogOutfitsLoadedDone: '0x0000400000000000'
-  TrialBoostHistoryDone: '0x0000000000040000'
-  VasTransactionsDone: '0x0000000000010000'
-  WarbandGroupsDone: '0x0000002000000000'
-  WarbandScenesLoadedDone: '0x0000100000000000'
-  WowlabsDataDone: '0x0000000020000000'
+  values:
+    AccountCurrenciesDone: '0x0000000000200000'
+    AccountDynamicCriteriaDone: '0x0000000001000000'
+    AccountFactionsDone: '0x0000000200000000'
+    AccountItemsDone: '0x0000000400000000'
+    AccountMappingDone: '0x0000008000000000'
+    AccountNotificationsDone: '0x0000000008000000'
+    AccountStateHousingData: '0x0000080000000000'
+    AchievementsDone: '0x0000000000000001'
+    ArchivedPurchasesDone: '0x0000000000000200'
+    AuctionableTokensDone: '0x0000000000002000'
+    BanktabSettingsDone: '0x0000004000000000'
+    BattlepetsDone: '0x0000000000000008'
+    BitVectorsDone: '0x0000000100000000'
+    BpayAddLicenseObjectsDone: '0x0000000000000800'
+    BpayDistributionObjectsDone: '0x0000000000000100'
+    BpayProductitemObjectsDone: '0x0000000000020000'
+    CharacterItemsDone: '0x0000010000000000'
+    CharactersDone: '0x0000000000000040'
+    CombinedQuestLogEntriesDone: '0x0000000800000000'
+    ConsumableTokensDone: '0x0000000000004000'
+    CriteriaDone: '0x0000000000000002'
+    CurrencycapsDone: '0x0000000000000010'
+    CurrencyTransferLogDone: '0x0000020000000000'
+    DataElementsDone: '0x0000001000000000'
+    EventRecordsDone: '0x0000200000000000'
+    ItemCollectionItemsDone: '0x0000000000001000'
+    LgVendorPurchaseDone: '0x0000040000000000'
+    MountsDone: '0x0000000000000004'
+    None: '0x0000000000000000'
+    Object: '0x0000000000100000'
+    PerkHeldItemsDone: '0x0000000040000000'
+    PerkPastRewardsDone: '0x0000000000008000'
+    PerkPendingPurchasesDone: '0x0000000010000000'
+    PerkPendingRewardsDone: '0x0000000080000000'
+    PurchasesDone: '0x0000000000000080'
+    QuestCriteriaDone: '0x0000000000080000'
+    QuestLogDone: '0x0000000000000020'
+    RafActivitiesDone: '0x0000000002000000'
+    RafBalanceDone: '0x0000000000400000'
+    RafRewardsDone: '0x0000000000800000'
+    RevokedRafRewardsDone: '0x0000000004000000'
+    SettingsDone: '0x0000000000000400'
+    TransmogOutfitsLoadedDone: '0x0000400000000000'
+    TrialBoostHistoryDone: '0x0000000000040000'
+    VasTransactionsDone: '0x0000000000010000'
+    WarbandGroupsDone: '0x0000002000000000'
+    WarbandScenesLoadedDone: '0x0000100000000000'
+    WowlabsDataDone: '0x0000000020000000'
 CreateNeighborhoodErrorType:
-  None: 0
-  OversizedGuild: 3
-  Profanity: 1
-  UndersizedGuild: 2
+  values:
+    None: 0
+    OversizedGuild: 3
+    Profanity: 1
+    UndersizedGuild: 2
 CurioRarity:
-  Common: 1
-  Epic: 4
-  Rare: 3
-  Uncommon: 2
+  values:
+    Common: 1
+    Epic: 4
+    Rare: 3
+    Uncommon: 2
 CurioType:
-  Combat: 0
-  Utility: 1
+  values:
+    Combat: 0
+    Utility: 1
 CurrencyConversionResult:
-  Conversion: 1
-  NoConversion: 0
-  SkippedAccountCurrency: 2
+  values:
+    Conversion: 1
+    NoConversion: 0
+    SkippedAccountCurrency: 2
 CurrencyDestroyReason:
-  AccountServerConversion: 17
-  AccountTransfer: 14
-  BonusRoll: 9
-  Capped: 6
-  Cheat: 0
-  ConcentrationCast: 13
-  CraftingOrderReagent: 16
-  DroppedToCorpse: 8
-  FactionConversion: 10
-  FulfillCraftingOrder: 11
-  Garrison: 7
-  HonorLoss: 15
-  QuestTurnin: 3
-  Script: 12
-  Spell: 1
-  Trade: 5
-  Vendor: 4
-  VersionUpdate: 2
+  values:
+    AccountServerConversion: 17
+    AccountTransfer: 14
+    BonusRoll: 9
+    Capped: 6
+    Cheat: 0
+    ConcentrationCast: 13
+    CraftingOrderReagent: 16
+    DroppedToCorpse: 8
+    FactionConversion: 10
+    FulfillCraftingOrder: 11
+    Garrison: 7
+    HonorLoss: 15
+    QuestTurnin: 3
+    Script: 12
+    Spell: 1
+    Trade: 5
+    Vendor: 4
+    VersionUpdate: 2
 CurrencyFilterType:
-  DiscoveredAndAllAccountTransferable: 2
-  DiscoveredOnly: 1
-  None: 0
+  values:
+    DiscoveredAndAllAccountTransferable: 2
+    DiscoveredOnly: 1
+    None: 0
 CurrencyFlags:
-  Currency_100_Scaler: 8
-  CurrencyAccountWide: 16777216
-  CurrencyAllowOverflowMailer: 33554432
-  CurrencyAppearsInLootWindow: 2
-  CurrencyComputedWeeklyMaximum: 4
-  CurrencyDeprecated: 131072
-  CurrencyDestroyExtraOnLoot: 2097152
-  CurrencyDoNotCompressChat: 8192
-  CurrencyDoNotLogAcquisitionToBi: 16384
-  CurrencyDoNotToast: 1048576
-  CurrencyDontCoalesceInLootWindow: 8388608
-  CurrencyDontShowTotalInTooltip: 4194304
-  CurrencyDynamicMaximum: 262144
-  CurrencyHasWarmodeBonus: 134217728
-  CurrencyHasWeeklyCatchup: 4096
-  CurrencyHideAsReward: 67108864
-  CurrencyIgnoreMaxQtyOnLoad: 32
-  CurrencyIsAllianceOnly: 268435456
-  CurrencyIsHordeOnly: 536870912
-  CurrencyLimitWarmodeBonusOncePerTooltip: 1073741824
-  CurrencyLogOnWorldChange: 64
-  CurrencyNoLowLevelDrop: 16
-  CurrencyNoRaidDrop: 32768
-  CurrencyNotPersistent: 65536
-  CurrencyResetTrackedQuantity: 256
-  CurrencySingleDropInLoot: 2048
-  CurrencySuppressChatMessageOnVersionChange: 1024
-  CurrencySuppressChatMessages: 524288
-  CurrencyTrackQuantity: 128
-  CurrencyTradable: 1
-  CurrencyUpdateVersionIgnoreMax: 512
-  CurrencyUsesLedgerBalance: 2147483648
+  values:
+    Currency_100_Scaler: 8
+    CurrencyAccountWide: 16777216
+    CurrencyAllowOverflowMailer: 33554432
+    CurrencyAppearsInLootWindow: 2
+    CurrencyComputedWeeklyMaximum: 4
+    CurrencyDeprecated: 131072
+    CurrencyDestroyExtraOnLoot: 2097152
+    CurrencyDoNotCompressChat: 8192
+    CurrencyDoNotLogAcquisitionToBi: 16384
+    CurrencyDoNotToast: 1048576
+    CurrencyDontCoalesceInLootWindow: 8388608
+    CurrencyDontShowTotalInTooltip: 4194304
+    CurrencyDynamicMaximum: 262144
+    CurrencyHasWarmodeBonus: 134217728
+    CurrencyHasWeeklyCatchup: 4096
+    CurrencyHideAsReward: 67108864
+    CurrencyIgnoreMaxQtyOnLoad: 32
+    CurrencyIsAllianceOnly: 268435456
+    CurrencyIsHordeOnly: 536870912
+    CurrencyLimitWarmodeBonusOncePerTooltip: 1073741824
+    CurrencyLogOnWorldChange: 64
+    CurrencyNoLowLevelDrop: 16
+    CurrencyNoRaidDrop: 32768
+    CurrencyNotPersistent: 65536
+    CurrencyResetTrackedQuantity: 256
+    CurrencySingleDropInLoot: 2048
+    CurrencySuppressChatMessageOnVersionChange: 1024
+    CurrencySuppressChatMessages: 524288
+    CurrencyTrackQuantity: 128
+    CurrencyTradable: 1
+    CurrencyUpdateVersionIgnoreMax: 512
+    CurrencyUsesLedgerBalance: 2147483648
 CurrencyFlagsB:
-  CurrencyBAllowReductionByResourcefulness: 1024
-  CurrencyBBattlenetVirtualCurrency: 8
-  CurrencyBDontDisplayIfZero: 32
-  CurrencyBForceMaxQuantityOnConversion: 256
-  CurrencyBNoBonusXP: 2048
-  CurrencyBNoNotificationMailOnOfflineProgress: 4
-  CurrencyBScaleMaxQuantityBySeasonWeeks: 64
-  CurrencyBScaleMaxQuantityByWeeksSinceStart: 128
-  CurrencyBShowQuestXPGainInTooltip: 2
-  CurrencyBUnearnableBeforeMaxQuantityStart: 512
-  CurrencyBUseTotalEarnedForEarned: 1
-  FutureCurrencyFlag: 16
+  values:
+    CurrencyBAllowReductionByResourcefulness: 1024
+    CurrencyBBattlenetVirtualCurrency: 8
+    CurrencyBDontDisplayIfZero: 32
+    CurrencyBForceMaxQuantityOnConversion: 256
+    CurrencyBNoBonusXP: 2048
+    CurrencyBNoNotificationMailOnOfflineProgress: 4
+    CurrencyBScaleMaxQuantityBySeasonWeeks: 64
+    CurrencyBScaleMaxQuantityByWeeksSinceStart: 128
+    CurrencyBShowQuestXPGainInTooltip: 2
+    CurrencyBUnearnableBeforeMaxQuantityStart: 512
+    CurrencyBUseTotalEarnedForEarned: 1
+    FutureCurrencyFlag: 16
 CurrencyGainFlags:
-  Autotracking: 8
-  BonusAward: 1
-  DroppedFromDeath: 2
-  FromAccountServer: 4
-  None: 0
+  values:
+    Autotracking: 8
+    BonusAward: 1
+    DroppedFromDeath: 2
+    FromAccountServer: 4
+    None: 0
 CurrencySource:
-  AccountCopy: 42
-  AccountHwmUpdate: 61
-  AccountServerConversion: 63
-  AccountTransfer: 65
-  AddConduitToCollection: 46
-  Arena: 17
-  AuctionDeposit: 51
-  AzeriteRespec: 34
-  Barbershop: 47
-  BonusRoll: 33
-  CatalystBalancing: 57
-  CatalystCraft: 58
-  Cheat: 4
-  ConvertItemsToCurrencyAndReputation: 62
-  ConvertItemsToCurrencyValue: 48
-  ConvertOldItem: 0
-  ConvertOldPvPCurrency: 1
-  CraftingOrder: 56
-  CurrencyWalletClaim: 29
-  DailyQuestReward: 38
-  DailyQuestWarModeReward: 39
-  DailyReset: 45
-  ExceededMaxQty: 18
-  FactionConversion: 37
-  GarrisonBuilding: 23
-  GarrisonBuildingRefund: 26
-  GarrisonFollowerActivation: 25
-  GarrisonMissionReward: 27
-  GarrisonResourceOverTime: 28
-  GarrisonTalent: 30
-  GarrisonTalentTreeReset: 44
-  GarrisonWorldQuestBonus: 31
-  GuildBankWithdrawal: 21
-  InitiativeReward: 67
-  ItemDeletion: 14
-  ItemRefund: 2
-  LFGReward: 11
-  Loot: 9
-  PhBuffer_53: 53
-  PhBuffer_54: 54
-  PlayerTrait: 52
-  PlayerTraitRefund: 60
-  ProfessionInitialAward: 59
-  Pushloot: 22
-  PvPCompletionBonus: 19
-  PvPDrop: 24
-  PvPHonorReward: 32
-  PvPKillCredit: 6
-  PvPMetaCredit: 7
-  PvPScriptedAward: 8
-  PvPTeamContribution: 49
-  QuestReward: 3
-  RandomBattleground: 16
-  RatedBattleground: 15
-  RenownRepGain: 55
-  RenownRepGainInitialVisibility: 66
-  Script: 20
-  Spell: 13
-  SpellSkipLinkedCurrency: 64
-  Trade: 12
-  Transmogrify: 50
-  UpdatingVersion: 10
-  Vendor: 5
-  WeeklyQuestReward: 40
-  WeeklyQuestWarModeReward: 41
-  WeeklyRewardChest: 43
-  WorldQuestReward: 35
-  WorldQuestRewardIgnoreCapsDeprecated: 36
+  values:
+    AccountCopy: 42
+    AccountHwmUpdate: 61
+    AccountServerConversion: 63
+    AccountTransfer: 65
+    AddConduitToCollection: 46
+    Arena: 17
+    AuctionDeposit: 51
+    AzeriteRespec: 34
+    Barbershop: 47
+    BonusRoll: 33
+    CatalystBalancing: 57
+    CatalystCraft: 58
+    Cheat: 4
+    ConvertItemsToCurrencyAndReputation: 62
+    ConvertItemsToCurrencyValue: 48
+    ConvertOldItem: 0
+    ConvertOldPvPCurrency: 1
+    CraftingOrder: 56
+    CurrencyWalletClaim: 29
+    DailyQuestReward: 38
+    DailyQuestWarModeReward: 39
+    DailyReset: 45
+    ExceededMaxQty: 18
+    FactionConversion: 37
+    GarrisonBuilding: 23
+    GarrisonBuildingRefund: 26
+    GarrisonFollowerActivation: 25
+    GarrisonMissionReward: 27
+    GarrisonResourceOverTime: 28
+    GarrisonTalent: 30
+    GarrisonTalentTreeReset: 44
+    GarrisonWorldQuestBonus: 31
+    GuildBankWithdrawal: 21
+    InitiativeReward: 67
+    ItemDeletion: 14
+    ItemRefund: 2
+    LFGReward: 11
+    Loot: 9
+    PhBuffer_53: 53
+    PhBuffer_54: 54
+    PlayerTrait: 52
+    PlayerTraitRefund: 60
+    ProfessionInitialAward: 59
+    Pushloot: 22
+    PvPCompletionBonus: 19
+    PvPDrop: 24
+    PvPHonorReward: 32
+    PvPKillCredit: 6
+    PvPMetaCredit: 7
+    PvPScriptedAward: 8
+    PvPTeamContribution: 49
+    QuestReward: 3
+    RandomBattleground: 16
+    RatedBattleground: 15
+    RenownRepGain: 55
+    RenownRepGainInitialVisibility: 66
+    Script: 20
+    Spell: 13
+    SpellSkipLinkedCurrency: 64
+    Trade: 12
+    Transmogrify: 50
+    UpdatingVersion: 10
+    Vendor: 5
+    WeeklyQuestReward: 40
+    WeeklyQuestWarModeReward: 41
+    WeeklyRewardChest: 43
+    WorldQuestReward: 35
+    WorldQuestRewardIgnoreCapsDeprecated: 36
 CurrencyTokenCategoryFlags:
-  FlagPlayerItemAssignment: 2
-  FlagSortLast: 1
-  Hidden: 4
-  StartsCollapsed: 16
-  Virtual: 8
+  values:
+    FlagPlayerItemAssignment: 2
+    FlagSortLast: 1
+    Hidden: 4
+    StartsCollapsed: 16
+    Virtual: 8
 CurrencyType:
-  Copper: 0
-  Gold: 2
-  Silver: 1
+  values:
+    Copper: 0
+    Gold: 2
+    Silver: 1
 Cursormode:
-  AttackCursor: 4
-  AttackErrorCursor: 50
-  BroomCursor: 42
-  BroomErrorCursor: 88
-  BuyCursor: 3
-  BuyErrorCursor: 49
-  CampaignQuestCursor: 23
-  CampaignQuestErrorCursor: 69
-  CampaignQuestTurninCursor: 24
-  CampaignQuestTurninErrorCursor: 70
-  CastCursor: 2
-  CastErrorCursor: 48
-  CustomCursor: 91
-  EnchantCursor: 39
-  EnchantErrorCursor: 85
-  GatherCursor: 13
-  GatherErrorCursor: 59
-  GrabbingHandCursor: 44
-  GrabbingHandErrorCursor: 90
-  HoldingHandCursor: 43
-  HoldingHandErrorCursor: 89
-  InnkeeperCursor: 22
-  InnkeeperErrorCursor: 68
-  InspectCursor: 7
-  InspectErrorCursor: 53
-  InteractCursor: 5
-  InteractErrorCursor: 51
-  ItemCursor: 19
-  ItemErrorCursor: 65
-  LockCursor: 14
-  LockErrorCursor: 60
-  LootAllCursor: 16
-  LootAllErrorCursor: 62
-  MailCursor: 15
-  MailErrorCursor: 61
-  MapPinCursor: 37
-  MapPinErrorCursor: 83
-  MineCursor: 11
-  MineErrorCursor: 57
-  NoCursor: 0
-  PaletteCursor: 41
-  PaletteErrorCursor: 87
-  PickupCursor: 8
-  PickupErrorCursor: 54
-  PingCursor: 38
-  PingErrorCursor: 84
-  PointCursor: 1
-  PointErrorCursor: 47
-  QuestCursor: 25
-  QuestErrorCursor: 71
-  QuestImportantCursor: 30
-  QuestImportantErrorCursor: 76
-  QuestImportantTurninCursor: 31
-  QuestImportantTurninErrorCursor: 77
-  QuestLegendaryCursor: 28
-  QuestLegendaryErrorCursor: 74
-  QuestLegendaryTurninCursor: 29
-  QuestLegendaryTurninErrorCursor: 75
-  QuestMetaCursor: 32
-  QuestMetaErrorCursor: 78
-  QuestMetaTurninCursor: 33
-  QuestMetaTurninErrorCursor: 79
-  QuestRecurringCursor: 34
-  QuestRecurringErrorCursor: 80
-  QuestRecurringTurninCursor: 35
-  QuestRecurringTurninErrorCursor: 81
-  QuestRepeatableCursor: 26
-  QuestRepeatableErrorCursor: 72
-  QuestTurninCursor: 27
-  QuestTurninErrorCursor: 73
-  RepairCursor: 17
-  RepairErrorCursor: 63
-  RepairnpcCursor: 18
-  RepairnpcErrorCursor: 64
-  SkinAllianceCursor: 21
-  SkinAllianceErrorCursor: 67
-  SkinCursor: 12
-  SkinErrorCursor: 58
-  SkinHordeCursor: 20
-  SkinHordeErrorCursor: 66
-  SpeakCursor: 6
-  SpeakErrorCursor: 52
-  StablemasterCursor: 40
-  StablemasterErrorCursor: 86
-  TaxiCursor: 9
-  TaxiErrorCursor: 55
-  TrainerCursor: 10
-  TrainerErrorCursor: 56
-  UIMoveCursor: 45
-  UIResizeCursor: 46
-  VehicleCursor: 36
-  VehicleErrorCursor: 82
+  values:
+    AttackCursor: 4
+    AttackErrorCursor: 50
+    BroomCursor: 42
+    BroomErrorCursor: 88
+    BuyCursor: 3
+    BuyErrorCursor: 49
+    CampaignQuestCursor: 23
+    CampaignQuestErrorCursor: 69
+    CampaignQuestTurninCursor: 24
+    CampaignQuestTurninErrorCursor: 70
+    CastCursor: 2
+    CastErrorCursor: 48
+    CustomCursor: 91
+    EnchantCursor: 39
+    EnchantErrorCursor: 85
+    GatherCursor: 13
+    GatherErrorCursor: 59
+    GrabbingHandCursor: 44
+    GrabbingHandErrorCursor: 90
+    HoldingHandCursor: 43
+    HoldingHandErrorCursor: 89
+    InnkeeperCursor: 22
+    InnkeeperErrorCursor: 68
+    InspectCursor: 7
+    InspectErrorCursor: 53
+    InteractCursor: 5
+    InteractErrorCursor: 51
+    ItemCursor: 19
+    ItemErrorCursor: 65
+    LockCursor: 14
+    LockErrorCursor: 60
+    LootAllCursor: 16
+    LootAllErrorCursor: 62
+    MailCursor: 15
+    MailErrorCursor: 61
+    MapPinCursor: 37
+    MapPinErrorCursor: 83
+    MineCursor: 11
+    MineErrorCursor: 57
+    NoCursor: 0
+    PaletteCursor: 41
+    PaletteErrorCursor: 87
+    PickupCursor: 8
+    PickupErrorCursor: 54
+    PingCursor: 38
+    PingErrorCursor: 84
+    PointCursor: 1
+    PointErrorCursor: 47
+    QuestCursor: 25
+    QuestErrorCursor: 71
+    QuestImportantCursor: 30
+    QuestImportantErrorCursor: 76
+    QuestImportantTurninCursor: 31
+    QuestImportantTurninErrorCursor: 77
+    QuestLegendaryCursor: 28
+    QuestLegendaryErrorCursor: 74
+    QuestLegendaryTurninCursor: 29
+    QuestLegendaryTurninErrorCursor: 75
+    QuestMetaCursor: 32
+    QuestMetaErrorCursor: 78
+    QuestMetaTurninCursor: 33
+    QuestMetaTurninErrorCursor: 79
+    QuestRecurringCursor: 34
+    QuestRecurringErrorCursor: 80
+    QuestRecurringTurninCursor: 35
+    QuestRecurringTurninErrorCursor: 81
+    QuestRepeatableCursor: 26
+    QuestRepeatableErrorCursor: 72
+    QuestTurninCursor: 27
+    QuestTurninErrorCursor: 73
+    RepairCursor: 17
+    RepairErrorCursor: 63
+    RepairnpcCursor: 18
+    RepairnpcErrorCursor: 64
+    SkinAllianceCursor: 21
+    SkinAllianceErrorCursor: 67
+    SkinCursor: 12
+    SkinErrorCursor: 58
+    SkinHordeCursor: 20
+    SkinHordeErrorCursor: 66
+    SpeakCursor: 6
+    SpeakErrorCursor: 52
+    StablemasterCursor: 40
+    StablemasterErrorCursor: 86
+    TaxiCursor: 9
+    TaxiErrorCursor: 55
+    TrainerCursor: 10
+    TrainerErrorCursor: 56
+    UIMoveCursor: 45
+    UIResizeCursor: 46
+    VehicleCursor: 36
+    VehicleErrorCursor: 82
 CursorStyle:
-  Crosshair: 1
-  Mouse: 0
+  values:
+    Crosshair: 1
+    Mouse: 0
 CustomBindingType:
-  VoicePushToTalk: 0
+  values:
+    VoicePushToTalk: 0
 Damageclass:
-  All: 127
-  AllMagical: 126
-  AllPhysical: 1
-  Arcane: 6
-  Fire: 2
-  FirstResist: 2
-  Frost: 4
-  Holy: 1
-  LastResist: 6
-  MaskArcane: 64
-  MaskChaos: 124
-  MaskChromatic: 62
-  MaskCosmic: 106
-  MaskDivine: 66
-  MaskElemental: 28
-  MaskFire: 4
-  MaskFirestorm: 12
-  MaskFlamestrike: 5
-  MaskFrost: 16
-  MaskFrostfire: 20
-  MaskFroststorm: 24
-  MaskFroststrike: 17
-  MaskHoly: 2
-  MaskHolyfire: 6
-  MaskHolyfrost: 18
-  MaskHolystorm: 10
-  MaskHolystrike: 3
-  MaskMagical: 126
-  MaskNature: 8
-  MaskNone: 0
-  MaskPhysical: 1
-  MaskShadow: 32
-  MaskShadowflame: 36
-  MaskShadowfrost: 48
-  MaskShadowstorm: 40
-  MaskShadowstrike: 33
-  MaskSpellfire: 68
-  MaskSpellfrost: 80
-  MaskSpellshadow: 96
-  MaskSpellstorm: 72
-  MaskSpellstrike: 65
-  MaskStormstrike: 9
-  MaskTwilight: 34
-  Nature: 3
-  Physical: 0
-  Shadow: 5
+  values:
+    All: 127
+    AllMagical: 126
+    AllPhysical: 1
+    Arcane: 6
+    Fire: 2
+    FirstResist: 2
+    Frost: 4
+    Holy: 1
+    LastResist: 6
+    MaskArcane: 64
+    MaskChaos: 124
+    MaskChromatic: 62
+    MaskCosmic: 106
+    MaskDivine: 66
+    MaskElemental: 28
+    MaskFire: 4
+    MaskFirestorm: 12
+    MaskFlamestrike: 5
+    MaskFrost: 16
+    MaskFrostfire: 20
+    MaskFroststorm: 24
+    MaskFroststrike: 17
+    MaskHoly: 2
+    MaskHolyfire: 6
+    MaskHolyfrost: 18
+    MaskHolystorm: 10
+    MaskHolystrike: 3
+    MaskMagical: 126
+    MaskNature: 8
+    MaskNone: 0
+    MaskPhysical: 1
+    MaskShadow: 32
+    MaskShadowflame: 36
+    MaskShadowfrost: 48
+    MaskShadowstorm: 40
+    MaskShadowstrike: 33
+    MaskSpellfire: 68
+    MaskSpellfrost: 80
+    MaskSpellshadow: 96
+    MaskSpellstorm: 72
+    MaskSpellstrike: 65
+    MaskStormstrike: 9
+    MaskTwilight: 34
+    Nature: 3
+    Physical: 0
+    Shadow: 5
 DamageclassType:
-  Magical: 1
-  Physical: 0
+  values:
+    Magical: 1
+    Physical: 0
 DamageMeterCombineSessionType:
-  Arena: 2
-  ArenaMultiRound: 3
-  ChallengeMode: 1
-  None: 0
+  values:
+    Arena: 2
+    ArenaMultiRound: 3
+    ChallengeMode: 1
+    None: 0
 DamageMeterNumbers:
-  Compact: 1
-  Complete: 2
-  Minimal: 0
+  values:
+    Compact: 1
+    Complete: 2
+    Minimal: 0
 DamageMeterOverrideType:
-  AllowFriendlyFire: 1
-  Ignore: 0
-  IgnoreForAbsorbSpell: 4
-  RedirectSourceToAuraCaster: 3
-  RedirectSourceToOwner: 2
+  values:
+    AllowFriendlyFire: 1
+    Ignore: 0
+    IgnoreForAbsorbSpell: 4
+    RedirectSourceToAuraCaster: 3
+    RedirectSourceToOwner: 2
 DamageMeterSessionType:
-  Current: 1
-  Expired: 2
-  Overall: 0
+  values:
+    Current: 1
+    Expired: 2
+    Overall: 0
 DamageMeterSourceDisplayType:
-  Ally: 1
-  Enemy: 2
-  None: 0
+  values:
+    Ally: 1
+    Enemy: 2
+    None: 0
 DamageMeterSpellDetailsDisplayType:
-  Deaths: 3
-  EnemyDamageTaken: 4
-  SpellAffected: 2
-  SpellCasted: 0
-  UnitSpecificSpellCasted: 1
+  values:
+    Deaths: 3
+    EnemyDamageTaken: 4
+    SpellAffected: 2
+    SpellCasted: 0
+    UnitSpecificSpellCasted: 1
 DamageMeterStorageType:
-  Absorbs: 2
-  AvoidableDamageTaken: 6
-  Damage: 0
-  DamageTaken: 5
-  Deaths: 7
-  Dispels: 4
-  EnemyDamageTaken: 8
-  HealingAndAbsorbs: 1
-  Interrupts: 3
+  values:
+    Absorbs: 2
+    AvoidableDamageTaken: 6
+    Damage: 0
+    DamageTaken: 5
+    Deaths: 7
+    Dispels: 4
+    EnemyDamageTaken: 8
+    HealingAndAbsorbs: 1
+    Interrupts: 3
 DamageMeterStyle:
-  Bordered: 2
-  Default: 0
-  FullBackground: 3
-  Thin: 1
+  values:
+    Bordered: 2
+    Default: 0
+    FullBackground: 3
+    Thin: 1
 DamageMeterType:
-  Absorbs: 4
-  AvoidableDamageTaken: 8
-  DamageDone: 0
-  DamageTaken: 7
-  Deaths: 9
-  Dispels: 6
-  Dps: 1
-  EnemyDamageTaken: 10
-  HealingDone: 2
-  Hps: 3
-  Interrupts: 5
+  values:
+    Absorbs: 4
+    AvoidableDamageTaken: 8
+    DamageDone: 0
+    DamageTaken: 7
+    Deaths: 9
+    Dispels: 6
+    Dps: 1
+    EnemyDamageTaken: 10
+    HealingDone: 2
+    Hps: 3
+    Interrupts: 5
 DamageMeterVisibility:
-  Always: 0
-  Hidden: 2
-  InCombat: 1
-  InGroup: 3
+  values:
+    Always: 0
+    Hidden: 2
+    InCombat: 1
+    InGroup: 3
 DeveloperLogAssertDomain:
-  Art: 1
-  Design: 2
-  Engineering: 4
-  LiveOperations: 64
-  Performance: 32
-  Sound: 8
-  Tools: 16
+  values:
+    Art: 1
+    Design: 2
+    Engineering: 4
+    LiveOperations: 64
+    Performance: 32
+    Sound: 8
+    Tools: 16
 DeveloperLogErrorDomain:
-  Assert: 0
-  AssertData: 1
-  Frame: 2
-  TestSuite: 3
+  values:
+    Assert: 0
+    AssertData: 1
+    Frame: 2
+    TestSuite: 3
 DeveloperLogTrafficType:
-  ClientToServer: 1
-  GameEvent: 2
-  LuaToClient: 3
-  ServerToClient: 0
+  values:
+    ClientToServer: 1
+    GameEvent: 2
+    LuaToClient: 3
+    ServerToClient: 0
 DisableAccountProfilesFlags:
-  DecorsCollections: 32
-  Document: 1
-  ItemsCollections: 16
-  MountsCollections: 4
-  None: 0
-  PetsCollections: 8
-  SharedCollections: 2
+  values:
+    DecorsCollections: 32
+    Document: 1
+    ItemsCollections: 16
+    MountsCollections: 4
+    None: 0
+    PetsCollections: 8
+    SharedCollections: 2
 DurationTextBindingProperty:
-  ElapsedDuration: 2
-  ElapsedPercent: 3
-  EndTime: 6
-  RemainingDuration: 0
-  RemainingPercent: 1
-  StartTime: 5
-  TotalDuration: 4
+  values:
+    ElapsedDuration: 2
+    ElapsedPercent: 3
+    EndTime: 6
+    RemainingDuration: 0
+    RemainingPercent: 1
+    StartTime: 5
+    TotalDuration: 4
 DurationTimeModifier:
-  BaseTime: 1
-  RealTime: 0
+  values:
+    BaseTime: 1
+    RealTime: 0
 EditModeAccountSetting:
-  DeprecatedShowDebuffFrame: 11
-  EnableAdvancedOptions: 23
-  EnableSnap: 22
-  GridSpacing: 1
-  SettingsExpanded: 2
-  ShowArchaeologyBar: 27
-  ShowArenaFrames: 17
-  ShowBossFrames: 16
-  ShowBuffsAndDebuffs: 10
-  ShowCastBar: 7
-  ShowCooldownViewer: 28
-  ShowDamageMeter: 31
-  ShowDurabilityFrame: 21
-  ShowEncounterBar: 8
-  ShowEncounterEvents: 30
-  ShowExternalDefensives: 32
-  ShowExtraAbilities: 9
-  ShowGrid: 0
-  ShowHudTooltip: 19
-  ShowLootFrame: 18
-  ShowPartyFrames: 12
-  ShowPersonalResourceDisplay: 29
-  ShowPetActionBar: 5
-  ShowPetFrame: 24
-  ShowPossessActionBar: 6
-  ShowRaidFrames: 13
-  ShowStanceBar: 4
-  ShowStatusTrackingBar2: 20
-  ShowTalkingHeadFrame: 14
-  ShowTargetAndFocus: 3
-  ShowTimerBars: 25
-  ShowTotemActionBar: 33
-  ShowVehicleLeaveButton: 15
-  ShowVehicleSeatIndicator: 26
+  values:
+    DeprecatedShowDebuffFrame: 11
+    EnableAdvancedOptions: 23
+    EnableSnap: 22
+    GridSpacing: 1
+    SettingsExpanded: 2
+    ShowArchaeologyBar: 27
+    ShowArenaFrames: 17
+    ShowBossFrames: 16
+    ShowBuffsAndDebuffs: 10
+    ShowCastBar: 7
+    ShowCooldownViewer: 28
+    ShowDamageMeter: 31
+    ShowDurabilityFrame: 21
+    ShowEncounterBar: 8
+    ShowEncounterEvents: 30
+    ShowExternalDefensives: 32
+    ShowExtraAbilities: 9
+    ShowGrid: 0
+    ShowHudTooltip: 19
+    ShowLootFrame: 18
+    ShowPartyFrames: 12
+    ShowPersonalResourceDisplay: 29
+    ShowPetActionBar: 5
+    ShowPetFrame: 24
+    ShowPossessActionBar: 6
+    ShowRaidFrames: 13
+    ShowStanceBar: 4
+    ShowStatusTrackingBar2: 20
+    ShowTalkingHeadFrame: 14
+    ShowTargetAndFocus: 3
+    ShowTimerBars: 25
+    ShowTotemActionBar: 33
+    ShowVehicleLeaveButton: 15
+    ShowVehicleSeatIndicator: 26
 EditModeActionBarSetting:
-  AlwaysShowButtons: 9
-  DeprecatedSnapToSide: 7
-  HideBarArt: 6
-  HideBarScrolling: 8
-  IconPadding: 4
-  IconSize: 3
-  NumIcons: 2
-  NumRows: 1
-  Orientation: 0
-  VisibleSetting: 5
+  values:
+    AlwaysShowButtons: 9
+    DeprecatedSnapToSide: 7
+    HideBarArt: 6
+    HideBarScrolling: 8
+    IconPadding: 4
+    IconSize: 3
+    NumIcons: 2
+    NumRows: 1
+    Orientation: 0
+    VisibleSetting: 5
 EditModeActionBarSystemIndices:
-  Bar2: 2
-  Bar3: 3
-  ExtraBar1: 6
-  ExtraBar2: 7
-  ExtraBar3: 8
-  MainBar: 1
-  PetActionBar: 12
-  PossessActionBar: 13
-  RightBar1: 4
-  RightBar2: 5
-  StanceBar: 11
+  values:
+    Bar2: 2
+    Bar3: 3
+    ExtraBar1: 6
+    ExtraBar2: 7
+    ExtraBar3: 8
+    MainBar: 1
+    PetActionBar: 12
+    PossessActionBar: 13
+    RightBar1: 4
+    RightBar2: 5
+    StanceBar: 11
 EditModeArchaeologyBarSetting:
-  Size: 0
+  values:
+    Size: 0
 EditModeAuraFrameSetting:
-  DeprecatedShowFull: 7
-  IconDirection: 2
-  IconLimitBuffFrame: 3
-  IconLimitDebuffFrame: 4
-  IconPadding: 6
-  IconSize: 5
-  IconWrap: 1
-  Opacity: 9
-  Orientation: 0
-  ShowDispelType: 10
-  VisibleSetting: 8
+  values:
+    DeprecatedShowFull: 7
+    IconDirection: 2
+    IconLimitBuffFrame: 3
+    IconLimitDebuffFrame: 4
+    IconPadding: 6
+    IconSize: 5
+    IconWrap: 1
+    Opacity: 9
+    Orientation: 0
+    ShowDispelType: 10
+    VisibleSetting: 8
 EditModeAuraFrameSystemIndices:
-  BuffFrame: 1
-  DebuffFrame: 2
-  ExternalDefensivesFrame: 3
+  values:
+    BuffFrame: 1
+    DebuffFrame: 2
+    ExternalDefensivesFrame: 3
 EditModeBagsSetting:
-  BagSlotPadding: 3
-  Direction: 1
-  Orientation: 0
-  Size: 2
+  values:
+    BagSlotPadding: 3
+    Direction: 1
+    Orientation: 0
+    Size: 2
 EditModeCastBarSetting:
-  BarSize: 0
-  LockToPlayerFrame: 1
-  ShowCastTime: 2
+  values:
+    BarSize: 0
+    LockToPlayerFrame: 1
+    ShowCastTime: 2
 EditModeChatFrameSetting:
-  HeightHundreds: 2
-  HeightTensAndOnes: 3
-  WidthHundreds: 0
-  WidthTensAndOnes: 1
+  values:
+    HeightHundreds: 2
+    HeightTensAndOnes: 3
+    WidthHundreds: 0
+    WidthTensAndOnes: 1
 EditModeCooldownViewerSetting:
-  BarContent: 7
-  BarWidthScale: 11
-  HideWhenInactive: 8
-  IconDirection: 2
-  IconLimit: 1
-  IconPadding: 4
-  IconSize: 3
-  Opacity: 5
-  Orientation: 0
-  ShowTimer: 9
-  ShowTooltips: 10
-  VisibleSetting: 6
+  values:
+    BarContent: 7
+    BarWidthScale: 11
+    HideWhenInactive: 8
+    IconDirection: 2
+    IconLimit: 1
+    IconPadding: 4
+    IconSize: 3
+    Opacity: 5
+    Orientation: 0
+    ShowTimer: 9
+    ShowTooltips: 10
+    VisibleSetting: 6
 EditModeCooldownViewerSystemIndices:
-  BuffBar: 4
-  BuffIcon: 3
-  Essential: 1
-  Utility: 2
+  values:
+    BuffBar: 4
+    BuffIcon: 3
+    Essential: 1
+    Utility: 2
 EditModeDamageMeterSetting:
-  BackgroundTransparency: 12
-  BarHeight: 10
-  FrameHeight: 4
-  FrameWidth: 3
-  Numbers: 2
-  ObsoleteReuse1: 7
-  Padding: 5
-  ShowClassColor: 9
-  ShowSpecIcon: 8
-  Style: 1
-  TextSize: 11
-  Transparency: 6
-  Visibility: 0
+  values:
+    BackgroundTransparency: 12
+    BarHeight: 10
+    FrameHeight: 4
+    FrameWidth: 3
+    Numbers: 2
+    ObsoleteReuse1: 7
+    Padding: 5
+    ShowClassColor: 9
+    ShowSpecIcon: 8
+    Style: 1
+    TextSize: 11
+    Transparency: 6
+    Visibility: 0
 EditModeDurabilityFrameSetting:
-  Size: 0
+  values:
+    Size: 0
 EditModeEncounterEventsSetting:
-  BackgroundTransparency: 5
-  BarWidth: 12
-  FlipHorizontally: 11
-  IconDirection: 1
-  IconSize: 3
-  Orientation: 0
-  OverallSize: 4
-  Padding: 13
-  ShowSpellName: 2
-  ShowTimer: 9
-  TooltipAnchor: 8
-  Transparency: 6
-  ViewType: 10
-  Visibility: 7
+  values:
+    BackgroundTransparency: 5
+    BarWidth: 12
+    FlipHorizontally: 11
+    IconDirection: 1
+    IconSize: 3
+    Orientation: 0
+    OverallSize: 4
+    Padding: 13
+    ShowSpellName: 2
+    ShowTimer: 9
+    TooltipAnchor: 8
+    Transparency: 6
+    ViewType: 10
+    Visibility: 7
 EditModeEncounterEventsSystemIndices:
-  CriticalWarnings: 2
-  MediumWarnings: 3
-  NormalWarnings: 4
-  Timeline: 1
+  values:
+    CriticalWarnings: 2
+    MediumWarnings: 3
+    NormalWarnings: 4
+    Timeline: 1
 EditModeLayoutType:
-  Account: 1
-  Character: 2
-  Override: 3
-  Preset: 0
+  values:
+    Account: 1
+    Character: 2
+    Override: 3
+    Preset: 0
 EditModeMicroMenuSetting:
-  EyeSize: 3
-  Order: 1
-  Orientation: 0
-  Size: 2
+  values:
+    EyeSize: 3
+    Order: 1
+    Orientation: 0
+    Size: 2
 EditModeMinimapSetting:
-  HeaderUnderneath: 0
-  RotateMinimap: 1
-  Size: 2
+  values:
+    HeaderUnderneath: 0
+    RotateMinimap: 1
+    Size: 2
 EditModeObjectiveTrackerSetting:
-  Height: 0
-  Opacity: 1
-  TextSize: 2
+  values:
+    Height: 0
+    Opacity: 1
+    TextSize: 2
 EditModePersonalResourceDisplaySetting:
-  BarWidth: 12
-  DeprecatedOnlyShowInCombat: 1
-  HealthBarHeight: 4
-  HideAltPower: 14
-  HideClassInfo: 3
-  HideClassInfoOnPlayerFrame: 10
-  HideHealth: 0
-  HidePower: 2
-  Opacity: 7
-  Padding: 6
-  PowerBarHeight: 5
-  ShowBarText: 13
-  ShowClassColor: 11
-  Size: 9
-  VisibleSetting: 8
+  values:
+    BarWidth: 12
+    DeprecatedOnlyShowInCombat: 1
+    HealthBarHeight: 4
+    HideAltPower: 14
+    HideClassInfo: 3
+    HideClassInfoOnPlayerFrame: 10
+    HideHealth: 0
+    HidePower: 2
+    Opacity: 7
+    Padding: 6
+    PowerBarHeight: 5
+    ShowBarText: 13
+    ShowClassColor: 11
+    Size: 9
+    VisibleSetting: 8
 EditModePresetLayouts:
-  Classic: 1
-  Modern: 0
+  values:
+    Classic: 1
+    Modern: 0
 EditModeSettingDisplayType:
-  Checkbox: 1
-  Dropdown: 0
-  Slider: 2
+  values:
+    Checkbox: 1
+    Dropdown: 0
+    Slider: 2
 EditModeStatusTrackingBarSetting:
-  Height: 0
-  Size: 3
-  TextSize: 2
-  Width: 1
+  values:
+    Height: 0
+    Size: 3
+    TextSize: 2
+    Width: 1
 EditModeStatusTrackingBarSystemIndices:
-  StatusTrackingBar1: 1
-  StatusTrackingBar2: 2
+  values:
+    StatusTrackingBar1: 1
+    StatusTrackingBar2: 2
 EditModeSystem:
-  ActionBar: 0
-  ArchaeologyBar: 19
-  AuraFrame: 6
-  Bags: 14
-  CastBar: 1
-  ChatFrame: 8
-  CooldownViewer: 20
-  DamageMeter: 23
-  DurabilityFrame: 16
-  EncounterBar: 4
-  EncounterEvents: 22
-  ExtraAbilities: 5
-  HudTooltip: 11
-  LootFrame: 10
-  MicroMenu: 13
-  Minimap: 2
-  ObjectiveTracker: 12
-  PersonalResourceDisplay: 21
-  StatusTrackingBar: 15
-  TalkingHeadFrame: 7
-  TimerBars: 17
-  TotemActionBar: 24
-  UnitFrame: 3
-  VehicleLeaveButton: 9
-  VehicleSeatIndicator: 18
+  values:
+    ActionBar: 0
+    ArchaeologyBar: 19
+    AuraFrame: 6
+    Bags: 14
+    CastBar: 1
+    ChatFrame: 8
+    CooldownViewer: 20
+    DamageMeter: 23
+    DurabilityFrame: 16
+    EncounterBar: 4
+    EncounterEvents: 22
+    ExtraAbilities: 5
+    HudTooltip: 11
+    LootFrame: 10
+    MicroMenu: 13
+    Minimap: 2
+    ObjectiveTracker: 12
+    PersonalResourceDisplay: 21
+    StatusTrackingBar: 15
+    TalkingHeadFrame: 7
+    TimerBars: 17
+    TotemActionBar: 24
+    UnitFrame: 3
+    VehicleLeaveButton: 9
+    VehicleSeatIndicator: 18
 EditModeTimerBarsSetting:
-  Size: 0
+  values:
+    Size: 0
 EditModeUnitFrameSetting:
-  AuraOrganizationType: 18
-  BigDefensiveIconSize: 21
-  BuffsOnTop: 2
-  CastBarOnSide: 7
-  CastBarUnderneath: 1
-  DisplayBorder: 12
-  FrameHeight: 11
-  FrameSize: 16
-  FrameWidth: 10
-  HidePortrait: 0
-  IconSize: 19
-  Opacity: 20
-  RaidGroupDisplayType: 13
-  RowSize: 15
-  ShowCastTime: 8
-  ShowPartyFrameBackground: 5
-  SortPlayersBy: 14
-  UseHorizontalGroups: 6
-  UseLargerFrame: 3
-  UseRaidStylePartyFrames: 4
-  ViewArenaSize: 17
-  ViewRaidSize: 9
+  values:
+    AuraOrganizationType: 18
+    BigDefensiveIconSize: 21
+    BuffsOnTop: 2
+    CastBarOnSide: 7
+    CastBarUnderneath: 1
+    DisplayBorder: 12
+    FrameHeight: 11
+    FrameSize: 16
+    FrameWidth: 10
+    HidePortrait: 0
+    IconSize: 19
+    Opacity: 20
+    RaidGroupDisplayType: 13
+    RowSize: 15
+    ShowCastTime: 8
+    ShowPartyFrameBackground: 5
+    SortPlayersBy: 14
+    UseHorizontalGroups: 6
+    UseLargerFrame: 3
+    UseRaidStylePartyFrames: 4
+    ViewArenaSize: 17
+    ViewRaidSize: 9
 EditModeUnitFrameSystemIndices:
-  Arena: 7
-  Boss: 6
-  Focus: 3
-  Party: 4
-  Pet: 8
-  Player: 1
-  Raid: 5
-  Target: 2
+  values:
+    Arena: 7
+    Boss: 6
+    Focus: 3
+    Party: 4
+    Pet: 8
+    Player: 1
+    Raid: 5
+    Target: 2
 EditModeVehicleSeatIndicatorSetting:
-  Size: 0
+  values:
+    Size: 0
 EncounterEventCastState:
-  Casting: 1
-  Expired: 3
-  NotCasting: 2
+  values:
+    Casting: 1
+    Expired: 3
+    NotCasting: 2
 EncounterEventColorTrigger:
-  TextWarning: 0
-  TimelineEvent: 1
-  TimelineEventHighlight: 2
+  values:
+    TextWarning: 0
+    TimelineEvent: 1
+    TimelineEventHighlight: 2
 EncounterEventIconmask:
-  BleedEffect: 4
-  CurseEffect: 32
-  DeadlyEffect: 1
-  DiseaseEffect: 16
-  DpsRole: 512
-  EnrageEffect: 2
-  HealerRole: 256
-  MagicEffect: 8
-  PoisonEffect: 64
-  TankRole: 128
+  values:
+    BleedEffect: 4
+    CurseEffect: 32
+    DeadlyEffect: 1
+    DiseaseEffect: 16
+    DpsRole: 512
+    EnrageEffect: 2
+    HealerRole: 256
+    MagicEffect: 8
+    PoisonEffect: 64
+    TankRole: 128
 EncounterEventSeverity:
-  High: 2
-  Low: 0
-  Medium: 1
+  values:
+    High: 2
+    Low: 0
+    Medium: 1
 EncounterEventsIconDirection:
-  Bottom: 1
-  Left: 0
-  Right: 1
-  Top: 0
+  values:
+    Bottom: 1
+    Left: 0
+    Right: 1
+    Top: 0
 EncounterEventsOrientation:
-  Horizontal: 0
-  Vertical: 1
+  values:
+    Horizontal: 0
+    Vertical: 1
 EncounterEventSoundTrigger:
-  OnTextWarningShown: 0
-  OnTimelineEventFinished: 1
-  OnTimelineEventHighlight: 2
+  values:
+    OnTextWarningShown: 0
+    OnTimelineEventFinished: 1
+    OnTimelineEventHighlight: 2
 EncounterEventsTooltipAnchor:
-  Cursor: 2
-  Default: 1
-  Hidden: 0
+  values:
+    Cursor: 2
+    Default: 1
+    Hidden: 0
 EncounterEventsViewType:
-  Bars: 1
-  Timeline: 0
+  values:
+    Bars: 1
+    Timeline: 0
 EncounterEventsVisibility:
-  Always: 0
-  DeprecatedHidden: 2
-  InEncounter: 1
+  values:
+    Always: 0
+    DeprecatedHidden: 2
+    InEncounter: 1
 EncounterLootDropRollState:
-  Greed: 3
-  NeedMainSpec: 0
-  NeedOffSpec: 1
-  NoRoll: 4
-  Pass: 5
-  Transmog: 2
+  values:
+    Greed: 3
+    NeedMainSpec: 0
+    NeedOffSpec: 1
+    NoRoll: 4
+    Pass: 5
+    Transmog: 2
 EncounterTimelineEventSortDirection:
-  Ascending: 1
-  Descending: 0
+  values:
+    Ascending: 1
+    Descending: 0
 EncounterTimelineEventSource:
-  EditMode: 2
-  Encounter: 0
-  Script: 1
+  values:
+    EditMode: 2
+    Encounter: 0
+    Script: 1
 EncounterTimelineEventState:
-  Active: 0
-  Canceled: 3
-  Finished: 2
-  Paused: 1
+  values:
+    Active: 0
+    Canceled: 3
+    Finished: 2
+    Paused: 1
 EncounterTimelineIconSet:
-  DamageAlert: 3
-  Deadly: 4
-  Dispel: 5
-  Enrage: 6
-  HealerAlert: 2
-  TankAlert: 1
+  values:
+    DamageAlert: 3
+    Deadly: 4
+    Dispel: 5
+    Enrage: 6
+    HealerAlert: 2
+    TankAlert: 1
 EncounterTimelineTrack:
-  Indeterminate: 4
-  Long: 3
-  Medium: 2
-  Queued: 0
-  Short: 1
+  values:
+    Indeterminate: 4
+    Long: 3
+    Medium: 2
+    Queued: 0
+    Short: 1
 EncounterTimelineTrackType:
-  Hidden: 0
-  Linear: 2
-  Sorted: 1
+  values:
+    Hidden: 0
+    Linear: 2
+    Sorted: 1
 EncounterTimelineViewType:
-  Bars: 2
-  None: 0
-  Timeline: 1
+  values:
+    Bars: 2
+    None: 0
+    Timeline: 1
 EndOfMatchType:
-  None: 0
-  Plunderstorm: 1
+  values:
+    None: 0
+    Plunderstorm: 1
 EnvironmentalDamageFlags:
-  DmgIsPct: 2
-  OneTime: 1
+  values:
+    DmgIsPct: 2
+    OneTime: 1
 Environmentaldamagetype:
-  Drowning: 1
-  Falling: 2
-  Fatigue: 0
-  Fire: 5
-  Lava: 3
-  Slime: 4
+  values:
+    Drowning: 1
+    Falling: 2
+    Fatigue: 0
+    Fire: 5
+    Lava: 3
+    Slime: 4
 EventRealmQueues:
-  None: 0
-  PlunderstormDuo: 2
-  PlunderstormSolo: 1
-  PlunderstormTraining: 8
-  PlunderstormTrio: 4
+  values:
+    None: 0
+    PlunderstormDuo: 2
+    PlunderstormSolo: 1
+    PlunderstormTraining: 8
+    PlunderstormTrio: 4
 EventToastDisplayType:
-  CapstoneUnlocked: 12
-  ChallengeMode: 7
-  FlightpointDiscovered: 11
-  HouseUpgradeAvailable: 15
-  LargeTextWithIcon: 4
-  NormalBlockText: 1
-  NormalSingleLine: 0
-  NormalTextWithIcon: 3
-  NormalTextWithIconAndRarity: 5
-  NormalTitleAndSubTitle: 2
-  Scenario: 6
-  ScenarioClickExpand: 8
-  Scoreboard: 14
-  SingleLineWithIcon: 13
-  WeeklyRewardUnlock: 9
-  WeeklyRewardUpgrade: 10
+  values:
+    CapstoneUnlocked: 12
+    ChallengeMode: 7
+    FlightpointDiscovered: 11
+    HouseUpgradeAvailable: 15
+    LargeTextWithIcon: 4
+    NormalBlockText: 1
+    NormalSingleLine: 0
+    NormalTextWithIcon: 3
+    NormalTextWithIconAndRarity: 5
+    NormalTitleAndSubTitle: 2
+    Scenario: 6
+    ScenarioClickExpand: 8
+    Scoreboard: 14
+    SingleLineWithIcon: 13
+    WeeklyRewardUnlock: 9
+    WeeklyRewardUpgrade: 10
 EventToastEventType:
-  BattlePetLevelChanged: 8
-  BattlePetLevelUpAbility: 9
-  CriteriaUpdated: 19
-  FlightpointDiscovered: 25
-  HouseUpgradeAvailable: 26
-  LevelUp: 0
-  LevelUpDungeon: 2
-  LevelUpOther: 15
-  LevelUpPvP: 4
-  LevelUpRaid: 3
-  LevelUpSpell: 1
-  MythicPlusWeeklyRecord: 11
-  PetBattleCapture: 7
-  PetBattleFinalRound: 6
-  PetBattleNewAbility: 5
-  PlayerAuraAdded: 16
-  PlayerAuraRemoved: 17
-  PvPTierUpdate: 20
-  QuestBossEmote: 10
-  QuestTurnedIn: 12
-  Scenario: 14
-  SpellLearned: 21
-  SpellScript: 18
-  TreasureItem: 22
-  WeeklyRewardUnlock: 23
-  WeeklyRewardUpgrade: 24
-  WorldStateChange: 13
+  values:
+    BattlePetLevelChanged: 8
+    BattlePetLevelUpAbility: 9
+    CriteriaUpdated: 19
+    FlightpointDiscovered: 25
+    HouseUpgradeAvailable: 26
+    LevelUp: 0
+    LevelUpDungeon: 2
+    LevelUpOther: 15
+    LevelUpPvP: 4
+    LevelUpRaid: 3
+    LevelUpSpell: 1
+    MythicPlusWeeklyRecord: 11
+    PetBattleCapture: 7
+    PetBattleFinalRound: 6
+    PetBattleNewAbility: 5
+    PlayerAuraAdded: 16
+    PlayerAuraRemoved: 17
+    PvPTierUpdate: 20
+    QuestBossEmote: 10
+    QuestTurnedIn: 12
+    Scenario: 14
+    SpellLearned: 21
+    SpellScript: 18
+    TreasureItem: 22
+    WeeklyRewardUnlock: 23
+    WeeklyRewardUpgrade: 24
+    WorldStateChange: 13
 EventToastFlags:
-  DisableRightClickDismiss: 1
+  values:
+    DisableRightClickDismiss: 1
 ExcludedCensorSources:
-  All: 255
-  Friends: 1
-  Guild: 2
-  None: 0
-  Reserve1: 4
-  Reserve2: 8
-  Reserve3: 16
-  Reserve4: 32
-  Reserve5: 64
-  Reserve6: 128
+  values:
+    All: 255
+    Friends: 1
+    Guild: 2
+    None: 0
+    Reserve1: 4
+    Reserve2: 8
+    Reserve3: 16
+    Reserve4: 32
+    Reserve5: 64
+    Reserve6: 128
 ExpansionLandingPageType:
-  Midnight: 1
-  None: 0
+  values:
+    Midnight: 1
+    None: 0
 ExpansionLevel:
-  BattleForAzeroth: 7
-  BurningCrusade: 1
-  Cataclysm: 3
-  Draenor: 5
-  Dragonflight: 9
-  LastTitan: 12
-  Legion: 6
-  Midnight: 11
-  MistsOfPandaria: 4
-  None: 0
-  Northrend: 2
-  Shadowlands: 8
-  WarWithin: 10
+  values:
+    BattleForAzeroth: 7
+    BurningCrusade: 1
+    Cataclysm: 3
+    Draenor: 5
+    Dragonflight: 9
+    LastTitan: 12
+    Legion: 6
+    Midnight: 11
+    MistsOfPandaria: 4
+    None: 0
+    Northrend: 2
+    Shadowlands: 8
+    WarWithin: 10
 FlightPathFaction:
-  Alliance: 2
-  Horde: 1
-  Neutral: 0
+  values:
+    Alliance: 2
+    Horde: 1
+    Neutral: 0
 FlightPathState:
-  Current: 0
-  Reachable: 1
-  Unreachable: 2
+  values:
+    Current: 0
+    Reachable: 1
+    Unreachable: 2
 FollowerAbilityCastResult:
-  AlreadyAtMaxDurability: 13
-  CannotTargetLimitedUseFollower: 11
-  CannotTargetNonAutoMissionFollower: 14
-  Failure: 1
-  InvalidFollowerSpell: 4
-  InvalidFollowerType: 9
-  InvalidTarget: 3
-  MustBeUnique: 10
-  MustTargetFollower: 7
-  MustTargetLimitedUseFollower: 12
-  MustTargetTrait: 8
-  NoPendingCast: 2
-  RerollNotAllowed: 5
-  SingleMissionDuration: 6
-  Success: 0
+  values:
+    AlreadyAtMaxDurability: 13
+    CannotTargetLimitedUseFollower: 11
+    CannotTargetNonAutoMissionFollower: 14
+    Failure: 1
+    InvalidFollowerSpell: 4
+    InvalidFollowerType: 9
+    InvalidTarget: 3
+    MustBeUnique: 10
+    MustTargetFollower: 7
+    MustTargetLimitedUseFollower: 12
+    MustTargetTrait: 8
+    NoPendingCast: 2
+    RerollNotAllowed: 5
+    SingleMissionDuration: 6
+    Success: 0
 FontStringScaleAnimationMode:
-  FontSize: 0
-  Vertex: 1
+  values:
+    FontSize: 0
+    Vertex: 1
 FragmentID:
-  Actor: 15
-  CgObject: 2
-  ClientObservablesData: 6
-  DeferredMessages: 9
-  EntityPosition: 1
-  FHousingDecor: 20
-  FHousingDecorActor: 28
-  FHousingDecorProxy: 26
-  FHousingFixture: 34
-  FHousingHouseDecorSet: 24
-  FHousingHouseFixtureSet: 35
-  FHousingHouseRoomSet: 25
-  FHousingPlayerHouse: 23
-  FHousingPlotAreaTrigger: 29
-  FHousingRoom: 21
-  FHousingRoomComponentMesh: 22
-  FHousingStorageMirrorData: 33
-  FJamHousingCornerstone: 27
-  FLootObjectList: 12
-  FMeshObjectData: 19
-  FMirroredPositionData: 31
-  FNeighborhoodMirrorData: 30
-  FNeighborhoodStateData: 38
-  FPathingDoor: 41
-  FPathingDynamicLinks: 40
-  FPersistableJamServers: 10
-  FPhaseShiftData: 16
-  FPlayerHouseInfo: 32
-  FPlayerInitiativeInfo: 37
-  FPlayerJamServers: 11
-  FPlayerOwnershipLink: 13
-  FTransportLink: 5
-  FUnitAIGroupLink: 39
-  FUnitAreaTriggerLink: 14
-  FVendor: 17
-  HeartbeatData: 4
-  JamDispatcher: 3
-  MirroredObjectC: 18
-  MirrorState: 0
-  ReservedArchetypeSeparator: 255
-  TagActiveClientS: 216
-  TagActiveObjectC: 217
-  TagActivePlayer: 215
-  TagAIGroup: 212
-  TagAreaTrigger: 209
-  TagAzeriteEmpoweredItem: 202
-  TagAzeriteItem: 203
-  TagContainer: 201
-  TagConversation: 211
-  TagCorpse: 208
-  TagDynamicObject: 207
-  TagGameObject: 206
-  TagHouseExteriorPiece: 224
-  TagHouseExteriorRoot: 225
-  TagHousingDecorProxyGameObject: 226
-  TagHousingPoolObject: 223
-  TagHousingRoom: 220
-  TagHousingSubdivisionObject: 222
-  TagItem: 200
-  TagLootObject: 214
-  TagMeshObject: 221
-  TagPlayer: 205
-  TagScenario: 213
-  TagSceneObject: 210
-  TagUnit: 204
-  TagUnitVehicle: 219
-  TagVisibleObjectC: 218
-  TestFragment_1: 250
-  TestFragment_2: 251
-  TestFragment_3: 252
-  TestFragment_4: 253
-  TestFragment_5: 254
-  Timer: 36
-  TimerQueues: 7
-  TransferSuspensionData: 8
+  values:
+    Actor: 15
+    CgObject: 2
+    ClientObservablesData: 6
+    DeferredMessages: 9
+    EntityPosition: 1
+    FHousingDecor: 20
+    FHousingDecorActor: 28
+    FHousingDecorProxy: 26
+    FHousingFixture: 34
+    FHousingHouseDecorSet: 24
+    FHousingHouseFixtureSet: 35
+    FHousingHouseRoomSet: 25
+    FHousingPlayerHouse: 23
+    FHousingPlotAreaTrigger: 29
+    FHousingRoom: 21
+    FHousingRoomComponentMesh: 22
+    FHousingStorageMirrorData: 33
+    FJamHousingCornerstone: 27
+    FLootObjectList: 12
+    FMeshObjectData: 19
+    FMirroredPositionData: 31
+    FNeighborhoodMirrorData: 30
+    FNeighborhoodStateData: 38
+    FPathingDoor: 41
+    FPathingDynamicLinks: 40
+    FPersistableJamServers: 10
+    FPhaseShiftData: 16
+    FPlayerHouseInfo: 32
+    FPlayerInitiativeInfo: 37
+    FPlayerJamServers: 11
+    FPlayerOwnershipLink: 13
+    FTransportLink: 5
+    FUnitAIGroupLink: 39
+    FUnitAreaTriggerLink: 14
+    FVendor: 17
+    HeartbeatData: 4
+    JamDispatcher: 3
+    MirroredObjectC: 18
+    MirrorState: 0
+    ReservedArchetypeSeparator: 255
+    TagActiveClientS: 216
+    TagActiveObjectC: 217
+    TagActivePlayer: 215
+    TagAIGroup: 212
+    TagAreaTrigger: 209
+    TagAzeriteEmpoweredItem: 202
+    TagAzeriteItem: 203
+    TagContainer: 201
+    TagConversation: 211
+    TagCorpse: 208
+    TagDynamicObject: 207
+    TagGameObject: 206
+    TagHouseExteriorPiece: 224
+    TagHouseExteriorRoot: 225
+    TagHousingDecorProxyGameObject: 226
+    TagHousingPoolObject: 223
+    TagHousingRoom: 220
+    TagHousingSubdivisionObject: 222
+    TagItem: 200
+    TagLootObject: 214
+    TagMeshObject: 221
+    TagPlayer: 205
+    TagScenario: 213
+    TagSceneObject: 210
+    TagUnit: 204
+    TagUnitVehicle: 219
+    TagVisibleObjectC: 218
+    TestFragment_1: 250
+    TestFragment_2: 251
+    TestFragment_3: 252
+    TestFragment_4: 253
+    TestFragment_5: 254
+    Timer: 36
+    TimerQueues: 7
+    TransferSuspensionData: 8
 FrameTutorialAccount:
-  AccountWideReputation: 9
-  AssistedCombatRotationActionButton: 22
-  AssistedCombatRotationDragSpell: 21
-  BindToAccountUntilEquip: 11
-  CompletedQuestsFilter: 12
-  CompletedQuestsFilterSeen: 13
-  ConcentrationCurrency: 14
-  EditModeManager: 3
-  EnconterJournalTutorialsTabSeen: 33
-  EventSchedulerTabSeen: 20
-  HeirloomJournalLevel: 7
-  HousingCleanupMode: 40
-  HousingDecorCleanup: 23
-  HousingDecorClippingGrid: 25
-  HousingDecorCustomization: 26
-  HousingDecorLayout: 27
-  HousingDecorPlace: 24
-  HousingEndeavorsTabSeen: 48
-  HousingExpertMode: 39
-  HousingHouseFinderMap: 28
-  HousingHouseFinderVisitHouse: 29
-  HousingInvalidCollision: 37
-  HousingItemAcquisition: 30
-  HousingMarketTab: 34
-  HousingModesUnlocked: 38
-  HousingNewPip: 31
-  HousingTeleportButton: 35
-  HudRevampBagChanges: 1
-  LFGList: 6
-  LocalStoriesFilterSeen: 19
-  MapLegendOpened: 15
-  MountCollectionDragonriding: 5
-  NpcCraftingOrderCreateButton: 17
-  NpcCraftingOrders: 16
-  NpcCraftingOrderTabNew: 18
-  PerksProgramActivitiesIntro: 2
-  PerksProgramActivitiesOpen: 32
-  RPETalentStarterBuild: 36
-  RunesOfPower: 49
-  TimerunnersAdvantage: 8
-  TransferableCurrencies: 10
-  TransmogCustomSets: 43
-  TransmogCustomSetsMigration: 47
-  TransmogOutfits: 41
-  TransmogSets: 42
-  TransmogSetsTab: 4
-  TransmogSituations: 44
-  TransmogTrialOfStyle: 46
-  TransmogWeaponOptions: 45
+  values:
+    AccountWideReputation: 9
+    AssistedCombatRotationActionButton: 22
+    AssistedCombatRotationDragSpell: 21
+    BindToAccountUntilEquip: 11
+    CompletedQuestsFilter: 12
+    CompletedQuestsFilterSeen: 13
+    ConcentrationCurrency: 14
+    EditModeManager: 3
+    EnconterJournalTutorialsTabSeen: 33
+    EventSchedulerTabSeen: 20
+    HeirloomJournalLevel: 7
+    HousingCleanupMode: 40
+    HousingDecorCleanup: 23
+    HousingDecorClippingGrid: 25
+    HousingDecorCustomization: 26
+    HousingDecorLayout: 27
+    HousingDecorPlace: 24
+    HousingEndeavorsTabSeen: 48
+    HousingExpertMode: 39
+    HousingHouseFinderMap: 28
+    HousingHouseFinderVisitHouse: 29
+    HousingInvalidCollision: 37
+    HousingItemAcquisition: 30
+    HousingMarketTab: 34
+    HousingModesUnlocked: 38
+    HousingNewPip: 31
+    HousingTeleportButton: 35
+    HudRevampBagChanges: 1
+    LFGList: 6
+    LocalStoriesFilterSeen: 19
+    MapLegendOpened: 15
+    MountCollectionDragonriding: 5
+    NpcCraftingOrderCreateButton: 17
+    NpcCraftingOrders: 16
+    NpcCraftingOrderTabNew: 18
+    PerksProgramActivitiesIntro: 2
+    PerksProgramActivitiesOpen: 32
+    RPETalentStarterBuild: 36
+    RunesOfPower: 49
+    TimerunnersAdvantage: 8
+    TransferableCurrencies: 10
+    TransmogCustomSets: 43
+    TransmogCustomSetsMigration: 47
+    TransmogOutfits: 41
+    TransmogSets: 42
+    TransmogSetsTab: 4
+    TransmogSituations: 44
+    TransmogTrialOfStyle: 46
+    TransmogWeaponOptions: 45
 GameMode:
-  Plunderstorm: 2
-  Standard: 1
-  WoWHack: 3
+  values:
+    Plunderstorm: 2
+    Standard: 1
+    WoWHack: 3
 GamePadPowerLevel:
-  Critical: 0
-  High: 3
-  Low: 1
-  Medium: 2
-  Unknown: 5
-  Wired: 4
+  values:
+    Critical: 0
+    High: 3
+    Low: 1
+    Medium: 2
+    Unknown: 5
+    Wired: 4
 GameRule:
-  AchievementsPanelDisabled: 40
-  ActionbarIconIntroDisabled: 60
-  ActionButtonTypeOverlayStrategy: 165
-  ActionCombatTargetLockEnabled: 87
-  AfterDeathSpectatingUI: 49
-  AllPlayersAreFastMovers: 53
-  AlwaysAllowAlliedRaces: 59
-  AutoAttacksDisabled: 103
-  BagSpaceOverride: 172
-  BagsUIDisabled: 64
-  BlockWhileSheathedAllowed: 88
-  CharacterCreateUseFixedBackgroundModel: 55
-  CharacterlessLogin: 14
-  CharacterPanelDisabled: 37
-  CharNameReservationEnabled: 2
-  CharReservationsPerRealmReopenThreshold: 8
-  ChatLinkLevelToastsDisabled: 63
-  ClearMailOnRealmTransfer: 92
-  CollectionsPanelDisabled: 36
-  CommunitiesPanelDisabled: 41
-  CompactRaidFrameManagerDisabled: 81
-  CustomActionbarOverlayHeightOffset: 33
-  DeleteItemConfirmationDisabled: 62
-  DisableCampsites: 114
-  DisableHonorDecay: 23
-  DisablePct: 9
-  DisableQuickJoin: 162
-  DisableRaidGroups: 163
-  DisableRealmSelection: 113
-  DisableVas: 119
-  DoesNotCountTowardAccountCharacterMax: 142
-  EditModeDisabled: 82
-  EjDungeonsDisabled: 149
-  EjItemSetsDisabled: 151
-  EjJourneysDisabled: 156
-  EjRaidsDisabled: 150
-  EjSuggestedContentDisabled: 148
-  EncounterJournalDisabled: 42
-  EtaRealmLaunchTime: 5
-  ExperienceBarDisabled: 159
-  FastAreaTriggerTick: 52
-  FinderPanelDisabled: 43
-  ForceAlteredFormsOn: 56
-  ForcedChatLanguage: 34
-  ForcedMultiActionBarSetting: 133
-  ForcedPartyFrameScale: 32
-  FrontEndChat: 50
-  FullCharacterCreateDisabled: 84
-  GameMode: 13
-  GdapiCharacterProfileDisabled: 153
-  GroupFinderCapabilities: 98
-  GuildsDisabled: 46
-  HardcoreRuleset: 10
-  HelpPanelDisabled: 45
-  HideAllMultiActionBars: 135
-  HideFaction: 116
-  HideTransmogZeroCost: 161
-  HideUnavailableTransmogSlots: 160
-  HousingDashboardDisabled: 102
-  HousingEnabled: 154
-  IgnoreChrclassDisabledFlag: 54
-  IngameCalendarDisabled: 75
-  IngameFriendsListDisabled: 79
-  IngameMailNotificationDisabled: 74
-  IngameTrackingDisabled: 76
-  IngameWhoListDisabled: 77
-  InstanceDifficultyBannerDisabled: 83
-  LandingPageFactionID: 35
-  LootMethodStyle: 157
-  MacrosDisabled: 80
-  MailGameRule: 132
-  MapPlunderstormCircle: 48
-  MaxAccountCharReservationsPerContentset: 4
-  MaxCharactersPerContentSet: 139
-  MaxCharReservationsPerRealm: 3
-  MaximizeWorldMapDisabled: 67
-  MaxLootDropLevel: 25
-  MaxNameplateDistance: 28
-  MaxUnitNameDistance: 27
-  MerchantFilterDisabled: 101
-  MicrobarScale: 26
-  MinimapDisabled: 146
-  MinUndeleteLevelRequired: 140
-  NameplateCastBarDisabled: 107
-  NoDebuffLimit: 1
-  NonPlayerNameplateScale: 31
-  ObjectiveTrackerDisabled: 104
-  PerksProgramActivityTrackingDisabled: 66
-  PersonalResourceDisplayDisabled: 129
-  PetBattlesDisabled: 65
-  PlayerCastBarDisabled: 105
-  PlayerFrameDisabled: 131
-  PlayerNameplateAlternateHealthColor: 58
-  PlayerNameplateDifficultyIcon: 57
-  PlunderstormAreaSelection: 94
-  PremadeGroupFinderStyle: 93
-  PvPInitialRatingOverride: 190
-  QuestLogMicrobuttonDisabled: 47
-  QuestLogPanelDisabled: 71
-  QuestLogSuperTrackingDisabled: 72
-  RaceAlteredFormsDisabled: 78
-  RecommendLeastPopulatedRealm: 169
-  ReleaseSpiritGhostDisabled: 61
-  RepairArmorDisabled: 147
-  ReplaceAbsentGmSeconds: 11
-  ReplaceGmRankLastOnlineSeconds: 12
-  RestrictedAchievementCategoryID: 155
-  Runecarving: 17
-  SelfFoundAllowed: 22
-  SpellbookPanelDisabled: 38
-  StoreDisabled: 44
-  SummoningStones: 108
-  TalentRespecCostMax: 19
-  TalentRespecCostMin: 18
-  TalentRespecCostStep: 20
-  TalentsPanelDisabled: 39
-  TargetCastBarDisabled: 106
-  TargetFrameBuffsDisabled: 85
-  TargetFrameDisabled: 130
-  TimerunningAllowed: 137
-  TransmogEnabled: 109
-  TrivialGroupXPPercent: 7
-  TutorialFrameDisabled: 73
-  UnflaggedPlayersCanAttackPvPFlaggedPlayers: 173
-  UnitFramePvPContextualDisabled: 86
-  UniversalNameplateOcclusion: 51
-  UseGameTableVariation: 164
-  UserAddonsDisabled: 29
-  UserScriptsDisabled: 30
-  UseSimpleCharacterSelectList: 115
-  VanillaAccountMailInstant: 91
-  VanillaNpcKnockback: 16
-  VanillaRageGenerationModifier: 21
-  WorldMapDisabled: 145
-  WorldMapFrameStrata: 100
-  WorldMapHelpPlateDisabled: 70
-  WorldMapLegendDisabled: 99
-  WorldMapTrackingOptionsDisabled: 68
-  WorldMapTrackingPinDisabled: 69
+  values:
+    AchievementsPanelDisabled: 40
+    ActionbarIconIntroDisabled: 60
+    ActionButtonTypeOverlayStrategy: 165
+    ActionCombatTargetLockEnabled: 87
+    AfterDeathSpectatingUI: 49
+    AllPlayersAreFastMovers: 53
+    AlwaysAllowAlliedRaces: 59
+    AutoAttacksDisabled: 103
+    BagSpaceOverride: 172
+    BagsUIDisabled: 64
+    BlockWhileSheathedAllowed: 88
+    CharacterCreateUseFixedBackgroundModel: 55
+    CharacterlessLogin: 14
+    CharacterPanelDisabled: 37
+    CharNameReservationEnabled: 2
+    CharReservationsPerRealmReopenThreshold: 8
+    ChatLinkLevelToastsDisabled: 63
+    ClearMailOnRealmTransfer: 92
+    CollectionsPanelDisabled: 36
+    CommunitiesPanelDisabled: 41
+    CompactRaidFrameManagerDisabled: 81
+    CustomActionbarOverlayHeightOffset: 33
+    DeleteItemConfirmationDisabled: 62
+    DisableCampsites: 114
+    DisableHonorDecay: 23
+    DisablePct: 9
+    DisableQuickJoin: 162
+    DisableRaidGroups: 163
+    DisableRealmSelection: 113
+    DisableVas: 119
+    DoesNotCountTowardAccountCharacterMax: 142
+    EditModeDisabled: 82
+    EjDungeonsDisabled: 149
+    EjItemSetsDisabled: 151
+    EjJourneysDisabled: 156
+    EjRaidsDisabled: 150
+    EjSuggestedContentDisabled: 148
+    EncounterJournalDisabled: 42
+    EtaRealmLaunchTime: 5
+    ExperienceBarDisabled: 159
+    FastAreaTriggerTick: 52
+    FinderPanelDisabled: 43
+    ForceAlteredFormsOn: 56
+    ForcedChatLanguage: 34
+    ForcedMultiActionBarSetting: 133
+    ForcedPartyFrameScale: 32
+    FrontEndChat: 50
+    FullCharacterCreateDisabled: 84
+    GameMode: 13
+    GdapiCharacterProfileDisabled: 153
+    GroupFinderCapabilities: 98
+    GuildsDisabled: 46
+    HardcoreRuleset: 10
+    HelpPanelDisabled: 45
+    HideAllMultiActionBars: 135
+    HideFaction: 116
+    HideTransmogZeroCost: 161
+    HideUnavailableTransmogSlots: 160
+    HousingDashboardDisabled: 102
+    HousingEnabled: 154
+    IgnoreChrclassDisabledFlag: 54
+    IngameCalendarDisabled: 75
+    IngameFriendsListDisabled: 79
+    IngameMailNotificationDisabled: 74
+    IngameTrackingDisabled: 76
+    IngameWhoListDisabled: 77
+    InstanceDifficultyBannerDisabled: 83
+    LandingPageFactionID: 35
+    LootMethodStyle: 157
+    MacrosDisabled: 80
+    MailGameRule: 132
+    MapPlunderstormCircle: 48
+    MaxAccountCharReservationsPerContentset: 4
+    MaxCharactersPerContentSet: 139
+    MaxCharReservationsPerRealm: 3
+    MaximizeWorldMapDisabled: 67
+    MaxLootDropLevel: 25
+    MaxNameplateDistance: 28
+    MaxUnitNameDistance: 27
+    MerchantFilterDisabled: 101
+    MicrobarScale: 26
+    MinimapDisabled: 146
+    MinUndeleteLevelRequired: 140
+    NameplateCastBarDisabled: 107
+    NoDebuffLimit: 1
+    NonPlayerNameplateScale: 31
+    ObjectiveTrackerDisabled: 104
+    PerksProgramActivityTrackingDisabled: 66
+    PersonalResourceDisplayDisabled: 129
+    PetBattlesDisabled: 65
+    PlayerCastBarDisabled: 105
+    PlayerFrameDisabled: 131
+    PlayerNameplateAlternateHealthColor: 58
+    PlayerNameplateDifficultyIcon: 57
+    PlunderstormAreaSelection: 94
+    PremadeGroupFinderStyle: 93
+    PvPInitialRatingOverride: 190
+    QuestLogMicrobuttonDisabled: 47
+    QuestLogPanelDisabled: 71
+    QuestLogSuperTrackingDisabled: 72
+    RaceAlteredFormsDisabled: 78
+    RecommendLeastPopulatedRealm: 169
+    ReleaseSpiritGhostDisabled: 61
+    RepairArmorDisabled: 147
+    ReplaceAbsentGmSeconds: 11
+    ReplaceGmRankLastOnlineSeconds: 12
+    RestrictedAchievementCategoryID: 155
+    Runecarving: 17
+    SelfFoundAllowed: 22
+    SpellbookPanelDisabled: 38
+    StoreDisabled: 44
+    SummoningStones: 108
+    TalentRespecCostMax: 19
+    TalentRespecCostMin: 18
+    TalentRespecCostStep: 20
+    TalentsPanelDisabled: 39
+    TargetCastBarDisabled: 106
+    TargetFrameBuffsDisabled: 85
+    TargetFrameDisabled: 130
+    TimerunningAllowed: 137
+    TransmogEnabled: 109
+    TrivialGroupXPPercent: 7
+    TutorialFrameDisabled: 73
+    UnflaggedPlayersCanAttackPvPFlaggedPlayers: 173
+    UnitFramePvPContextualDisabled: 86
+    UniversalNameplateOcclusion: 51
+    UseGameTableVariation: 164
+    UserAddonsDisabled: 29
+    UserScriptsDisabled: 30
+    UseSimpleCharacterSelectList: 115
+    VanillaAccountMailInstant: 91
+    VanillaNpcKnockback: 16
+    VanillaRageGenerationModifier: 21
+    WorldMapDisabled: 145
+    WorldMapFrameStrata: 100
+    WorldMapHelpPlateDisabled: 70
+    WorldMapLegendDisabled: 99
+    WorldMapTrackingOptionsDisabled: 68
+    WorldMapTrackingPinDisabled: 69
 GameRuleFlags:
-  AllowClient: 1
-  None: 0
-  RequiresDefault: 2
+  values:
+    AllowClient: 1
+    None: 0
+    RequiresDefault: 2
 GameRuleType:
-  Bool: 2
-  Float: 1
-  Int: 0
+  values:
+    Bool: 2
+    Float: 1
+    Int: 0
 GarrAutoBoardIndex:
-  AllyCenterFront: 3
-  AllyLeftBack: 0
-  AllyLeftFront: 2
-  AllyRightBack: 1
-  AllyRightFront: 4
-  EnemyCenterLeftBack: 10
-  EnemyCenterLeftFront: 6
-  EnemyCenterRightBack: 11
-  EnemyCenterRightFront: 7
-  EnemyLeftBack: 9
-  EnemyLeftFront: 5
-  EnemyRightBack: 12
-  EnemyRightFront: 8
-  None: -1
+  values:
+    AllyCenterFront: 3
+    AllyLeftBack: 0
+    AllyLeftFront: 2
+    AllyRightBack: 1
+    AllyRightFront: 4
+    EnemyCenterLeftBack: 10
+    EnemyCenterLeftFront: 6
+    EnemyCenterRightBack: 11
+    EnemyCenterRightFront: 7
+    EnemyLeftBack: 9
+    EnemyLeftFront: 5
+    EnemyRightBack: 12
+    EnemyRightFront: 8
+    None: -1
 GarrAutoCombatantRole:
-  HealSupport: 4
-  Melee: 1
-  None: 0
-  RangedMagic: 3
-  RangedPhysical: 2
-  Tank: 5
+  values:
+    HealSupport: 4
+    Melee: 1
+    None: 0
+    RangedMagic: 3
+    RangedPhysical: 2
+    Tank: 5
 GarrAutoCombatSpellTutorialFlag:
-  All: 4
-  Column: 2
-  None: 0
-  Row: 3
-  Single: 1
+  values:
+    All: 4
+    Column: 2
+    None: 0
+    Row: 3
+    Single: 1
 GarrAutoCombatTutorial:
-  AttackAll: 256
-  AttackColumn: 64
-  AttackRow: 128
-  AttackSingle: 32
-  BeneficialEffect: 16
-  EnvironmentalEffect: 1024
-  HealCompanion: 4
-  LevelHeal: 8
-  PlaceCompanion: 2
-  SelectMission: 1
-  TroopTutorial: 512
+  values:
+    AttackAll: 256
+    AttackColumn: 64
+    AttackRow: 128
+    AttackSingle: 32
+    BeneficialEffect: 16
+    EnvironmentalEffect: 1024
+    HealCompanion: 4
+    LevelHeal: 8
+    PlaceCompanion: 2
+    SelectMission: 1
+    TroopTutorial: 512
 GarrAutoEventFlags:
-  AutoAttack: 1
-  Environment: 4
-  None: 0
-  Passive: 2
+  values:
+    AutoAttack: 1
+    Environment: 4
+    None: 0
+    Passive: 2
 GarrAutoMissionEventType:
-  ApplyAura: 7
-  Died: 9
-  Heal: 4
-  MeleeDamage: 0
-  PeriodicDamage: 5
-  PeriodicHeal: 6
-  RangeDamage: 1
-  RemoveAura: 8
-  SpellMeleeDamage: 2
-  SpellRangeDamage: 3
+  values:
+    ApplyAura: 7
+    Died: 9
+    Heal: 4
+    MeleeDamage: 0
+    PeriodicDamage: 5
+    PeriodicHeal: 6
+    RangeDamage: 1
+    RemoveAura: 8
+    SpellMeleeDamage: 2
+    SpellRangeDamage: 3
 GarrAutoPreviewTargetType:
-  Buff: 4
-  Damage: 1
-  Debuff: 8
-  Heal: 2
-  None: 0
+  values:
+    Buff: 4
+    Damage: 1
+    Debuff: 8
+    Heal: 2
+    None: 0
 GarrFollowerMissionCompleteState:
-  Alive: 0
-  KilledByMissionFailure: 1
-  OutOfDurability: 3
-  SavedByPreventDeath: 2
+  values:
+    Alive: 0
+    KilledByMissionFailure: 1
+    OutOfDurability: 3
+    SavedByPreventDeath: 2
 GarrFollowerQuality:
-  Common: 1
-  Epic: 4
-  Legendary: 5
-  None: 0
-  Rare: 3
-  Title: 6
-  Uncommon: 2
+  values:
+    Common: 1
+    Epic: 4
+    Legendary: 5
+    None: 0
+    Rare: 3
+    Title: 6
+    Uncommon: 2
 GarrisonFollowerType:
-  FollowerType_6_0_Boat: 2
-  FollowerType_6_0_GarrisonFollower: 1
-  FollowerType_7_0_GarrisonFollower: 4
-  FollowerType_8_0_GarrisonFollower: 22
-  FollowerType_9_0_GarrisonFollower: 123
+  values:
+    FollowerType_6_0_Boat: 2
+    FollowerType_6_0_GarrisonFollower: 1
+    FollowerType_7_0_GarrisonFollower: 4
+    FollowerType_8_0_GarrisonFollower: 22
+    FollowerType_9_0_GarrisonFollower: 123
 GarrisonTalentAvailability:
-  Available: 0
-  Unavailable: 1
-  UnavailableAlreadyHave: 7
-  UnavailableAnotherIsResearching: 2
-  UnavailableNotEnoughGold: 4
-  UnavailableNotEnoughResources: 3
-  UnavailablePlayerCondition: 6
-  UnavailableRequiresPrerequisiteTalent: 8
-  UnavailableTierUnavailable: 5
+  values:
+    Available: 0
+    Unavailable: 1
+    UnavailableAlreadyHave: 7
+    UnavailableAnotherIsResearching: 2
+    UnavailableNotEnoughGold: 4
+    UnavailableNotEnoughResources: 3
+    UnavailablePlayerCondition: 6
+    UnavailableRequiresPrerequisiteTalent: 8
+    UnavailableTierUnavailable: 5
 GarrisonType:
-  Type_6_0_Garrison: 2
-  Type_7_0_Garrison: 3
-  Type_8_0_Garrison: 9
-  Type_9_0_Garrison: 111
+  values:
+    Type_6_0_Garrison: 2
+    Type_7_0_Garrison: 3
+    Type_8_0_Garrison: 9
+    Type_9_0_Garrison: 111
 GarrTalentCostType:
-  Initial: 0
-  MakePermanent: 2
-  Respec: 1
-  TreeReset: 3
+  values:
+    Initial: 0
+    MakePermanent: 2
+    Respec: 1
+    TreeReset: 3
 GarrTalentFeatureSubtype:
-  Ardenweald: 3
-  Bastion: 1
-  Generic: 0
-  Maldraxxus: 4
-  Revendreth: 2
+  values:
+    Ardenweald: 3
+    Bastion: 1
+    Generic: 0
+    Maldraxxus: 4
+    Revendreth: 2
 GarrTalentFeatureType:
-  Adventures: 3
-  AnimaDiversion: 1
-  AnimaDiversionMap: 7
-  Cyphers: 8
-  Generic: 0
-  ReservoirUpgrades: 4
-  SanctumUnique: 5
-  SoulBinds: 6
-  TravelPortals: 2
+  values:
+    Adventures: 3
+    AnimaDiversion: 1
+    AnimaDiversionMap: 7
+    Cyphers: 8
+    Generic: 0
+    ReservoirUpgrades: 4
+    SanctumUnique: 5
+    SoulBinds: 6
+    TravelPortals: 2
 GarrTalentResearchCostSource:
-  Talent: 0
-  Tree: 1
+  values:
+    Talent: 0
+    Tree: 1
 GarrTalentSocketType:
-  Conduit: 2
-  None: 0
-  Spell: 1
+  values:
+    Conduit: 2
+    None: 0
+    Spell: 1
 GarrTalentTreeType:
-  Classic: 1
-  Tiers: 0
+  values:
+    Classic: 1
+    Tiers: 0
 GarrTalentType:
-  Major: 2
-  Minor: 1
-  Socket: 3
-  Standard: 0
+  values:
+    Major: 2
+    Minor: 1
+    Socket: 3
+    Standard: 0
 GarrTalentUI:
-  AnimaDiversionMap: 3
-  CovenantSanctum: 1
-  Generic: 0
-  SoulBinds: 2
+  values:
+    AnimaDiversionMap: 3
+    CovenantSanctum: 1
+    Generic: 0
+    SoulBinds: 2
 GossipNpcOption:
-  AccountBanker: 57
-  AdventureMap: 31
-  ArtifactRespec: 21
-  Auctioneer: 10
-  AzeriteRespec: 35
-  Banker: 6
-  BarbersChoice: 52
-  Battlemaster: 9
-  Binder: 5
-  BlackMarketAuctionHouse: 46
-  CemeterySelect: 22
-  CharacterBanker: 56
-  ChromieTimeNpc: 40
-  ContributionCollector: 33
-  CovenantPreviewNpc: 41
-  CovenantRenownNpc: 45
-  DisableXPGain: 16
-  EnableXPGain: 17
-  ForgeMaster: 55
-  GarrisonArchitect: 26
-  GarrisonMissionNpc: 27
-  GarrisonRecruitment: 30
-  GarrisonTalent: 32
-  GarrisonTradeskillNpc: 29
-  GlyphMaster: 24
-  GuildBanker: 14
-  GuildRename: 62
-  GuildTabardVendor: 8
-  HouseFinder: 65
-  HousingCreateGuildNeighborhood: 60
-  HousingGetNeighborhoodCharter: 61
-  HousingOpenCharterConfirmation: 63
-  IslandsMissionNpc: 36
-  ItemUpgrade: 64
-  LFGDungeon: 20
-  Mailbox: 18
-  MajorFactionRenown: 53
-  NewPlayerGuide: 43
-  None: 0
-  PerksProgramVendor: 47
-  PersonalTabardVendor: 54
-  PetitionVendor: 7
-  PetSpecializationMaster: 13
-  ProfessionRespec: 58
-  ProfessionsCraftingOrder: 48
-  ProfessionsCustomerOrder: 50
-  ProfessionsOpen: 49
-  QueueScenario: 25
-  RenameNeighborhood: 59
-  RuneforgeLegendaryCrafting: 42
-  RuneforgeLegendaryUpgrade: 44
-  ShipmentCrafter: 28
-  Soulbind: 39
-  SpecializationMaster: 23
-  Spellclick: 15
-  SpiritHealer: 4
-  Stablemaster: 12
-  TalentMaster: 11
-  Taxinode: 2
-  TieredEntrance: 66
-  Trainer: 3
-  TraitSystem: 51
-  Transmogrify: 34
-  UIItemInteraction: 37
-  Vendor: 1
-  WorldMap: 38
-  WorldPvPQueue: 19
+  values:
+    AccountBanker: 57
+    AdventureMap: 31
+    ArtifactRespec: 21
+    Auctioneer: 10
+    AzeriteRespec: 35
+    Banker: 6
+    BarbersChoice: 52
+    Battlemaster: 9
+    Binder: 5
+    BlackMarketAuctionHouse: 46
+    CemeterySelect: 22
+    CharacterBanker: 56
+    ChromieTimeNpc: 40
+    ContributionCollector: 33
+    CovenantPreviewNpc: 41
+    CovenantRenownNpc: 45
+    DisableXPGain: 16
+    EnableXPGain: 17
+    ForgeMaster: 55
+    GarrisonArchitect: 26
+    GarrisonMissionNpc: 27
+    GarrisonRecruitment: 30
+    GarrisonTalent: 32
+    GarrisonTradeskillNpc: 29
+    GlyphMaster: 24
+    GuildBanker: 14
+    GuildRename: 62
+    GuildTabardVendor: 8
+    HouseFinder: 65
+    HousingCreateGuildNeighborhood: 60
+    HousingGetNeighborhoodCharter: 61
+    HousingOpenCharterConfirmation: 63
+    IslandsMissionNpc: 36
+    ItemUpgrade: 64
+    LFGDungeon: 20
+    Mailbox: 18
+    MajorFactionRenown: 53
+    NewPlayerGuide: 43
+    None: 0
+    PerksProgramVendor: 47
+    PersonalTabardVendor: 54
+    PetitionVendor: 7
+    PetSpecializationMaster: 13
+    ProfessionRespec: 58
+    ProfessionsCraftingOrder: 48
+    ProfessionsCustomerOrder: 50
+    ProfessionsOpen: 49
+    QueueScenario: 25
+    RenameNeighborhood: 59
+    RuneforgeLegendaryCrafting: 42
+    RuneforgeLegendaryUpgrade: 44
+    ShipmentCrafter: 28
+    Soulbind: 39
+    SpecializationMaster: 23
+    Spellclick: 15
+    SpiritHealer: 4
+    Stablemaster: 12
+    TalentMaster: 11
+    Taxinode: 2
+    TieredEntrance: 66
+    Trainer: 3
+    TraitSystem: 51
+    Transmogrify: 34
+    UIItemInteraction: 37
+    Vendor: 1
+    WorldMap: 38
+    WorldPvPQueue: 19
 GossipNpcOptionDisplayFlags:
-  ForceInteractionOnSingleChoice: 1
+  values:
+    ForceInteractionOnSingleChoice: 1
 GossipOptionRecFlags:
-  HideOptionIDFromClient: 2
-  PlayMovieLabelPrepend: 4
-  QuestLabelPrepend: 1
+  values:
+    HideOptionIDFromClient: 2
+    PlayMovieLabelPrepend: 4
+    QuestLabelPrepend: 1
 GossipOptionRewardType:
-  Currency: 1
-  Item: 0
+  values:
+    Currency: 1
+    Item: 0
 GossipOptionStatus:
-  AlreadyComplete: 3
-  Available: 0
-  Locked: 2
-  Unavailable: 1
+  values:
+    AlreadyComplete: 3
+    Available: 0
+    Locked: 2
+    Unavailable: 1
 GossipOptionUIWidgetSetTypes:
-  Background: 1
-  Modifiers: 0
+  values:
+    Background: 1
+    Modifiers: 0
 GraphicsValidationResult:
-  AmdGpuUnsupported: 36
-  AppleGpuUnsupported: 35
-  CompatMode: 41
-  CpuMem_2: 6
-  CpuMem_4: 7
-  CpuMem_8: 8
-  DualCore: 4
-  Dx11Unsupported: 30
-  Dx12Win7Unsupported: 31
-  GpuDriver: 40
-  Graphics: 3
-  Illegal: 1
-  IntelGpuUnsupported: 37
-  LegacyUnsupported: 29
-  MacOsUnsupported: 27
-  Needs_5_0: 9
-  Needs_6_0: 10
-  NeedsAmdGpu: 15
-  NeedsAppleGpu: 14
-  NeedsDx12: 12
-  NeedsDx12Vrs2: 13
-  NeedsIntelGpu: 16
-  NeedsMacOs_10_13: 19
-  NeedsMacOs_10_14: 20
-  NeedsMacOs_10_15: 21
-  NeedsMacOs_11_0: 22
-  NeedsMacOs_12_0: 23
-  NeedsMacOs_13_0: 24
-  NeedsNvidiaGpu: 17
-  NeedsQualcommGpu: 18
-  NeedsRt: 11
-  NeedsWindows_10: 25
-  NeedsWindows_11: 26
-  NvapiWineUnsupported: 34
-  NvidiaGpuUnsupported: 38
-  QuadCore: 5
-  QualcommGpuUnsupported: 39
-  RemoteDesktopUnsupported: 32
-  Supported: 0
-  Unknown: 42
-  Unsupported: 2
-  WindowsUnsupported: 28
-  WineUnsupported: 33
+  values:
+    AmdGpuUnsupported: 36
+    AppleGpuUnsupported: 35
+    CompatMode: 41
+    CpuMem_2: 6
+    CpuMem_4: 7
+    CpuMem_8: 8
+    DualCore: 4
+    Dx11Unsupported: 30
+    Dx12Win7Unsupported: 31
+    GpuDriver: 40
+    Graphics: 3
+    Illegal: 1
+    IntelGpuUnsupported: 37
+    LegacyUnsupported: 29
+    MacOsUnsupported: 27
+    Needs_5_0: 9
+    Needs_6_0: 10
+    NeedsAmdGpu: 15
+    NeedsAppleGpu: 14
+    NeedsDx12: 12
+    NeedsDx12Vrs2: 13
+    NeedsIntelGpu: 16
+    NeedsMacOs_10_13: 19
+    NeedsMacOs_10_14: 20
+    NeedsMacOs_10_15: 21
+    NeedsMacOs_11_0: 22
+    NeedsMacOs_12_0: 23
+    NeedsMacOs_13_0: 24
+    NeedsNvidiaGpu: 17
+    NeedsQualcommGpu: 18
+    NeedsRt: 11
+    NeedsWindows_10: 25
+    NeedsWindows_11: 26
+    NvapiWineUnsupported: 34
+    NvidiaGpuUnsupported: 38
+    QuadCore: 5
+    QualcommGpuUnsupported: 39
+    RemoteDesktopUnsupported: 32
+    Supported: 0
+    Unknown: 42
+    Unsupported: 2
+    WindowsUnsupported: 28
+    WineUnsupported: 33
 GuildErrorType:
-  AlreadyInGuild: 2
-  BadItem: 29
-  BankNotFound: 43
-  BankTabFull: 28
-  BankTabLocked: 35
-  Busy: 20
-  CantInviteSelf: 41
-  DeleteNoAppropriateLeader: 47
-  GuildBankNotAvailable: 45
-  GuildRepTooLow: 40
-  HasRestriction: 42
-  HousingEvictError: 51
-  Ignored: 19
-  InCooldown: 49
-  InvalidBankTab: 24
-  InvitedToGuild: 4
-  LockedForMove: 39
-  NameAlreadyExists: 7
-  NameInvalid: 6
-  NewLeaderWrongFaction: 44
-  NewLeaderWrongRealm: 46
-  NoPermisson: 8
-  NotEnoughMoney: 26
-  NotInGuild: 9
-  PlayerNotFound: 11
-  RankInUse: 18
-  RankRequiresAuthenticator: 34
-  RanksLocked: 17
-  RealmMismatch: 48
-  ReservationExpired: 50
-  Success: 0
-  TargetAlreadyInGuild: 3
-  TargetInvitedToGuild: 5
-  TargetLevelTooHigh: 22
-  TargetLevelTooLow: 21
-  TargetNotInGuild: 10
-  TargetTooHigh: 13
-  TargetTooLow: 14
-  TeamNotFound: 27
-  TeamsLocked: 30
-  Throttled: 52
-  TooFewRanks: 16
-  TooManyCreate: 33
-  TooManyMembers: 23
-  TooManyRanks: 15
-  TooMuchMoney: 31
-  TrialAccount: 36
-  UndeletableDueToLevel: 38
-  UnknownError: 1
-  VeteranAccount: 37
-  WithdrawLimit: 25
-  WrongBankTab: 32
-  WrongFaction: 12
+  values:
+    AlreadyInGuild: 2
+    BadItem: 29
+    BankNotFound: 43
+    BankTabFull: 28
+    BankTabLocked: 35
+    Busy: 20
+    CantInviteSelf: 41
+    DeleteNoAppropriateLeader: 47
+    GuildBankNotAvailable: 45
+    GuildRepTooLow: 40
+    HasRestriction: 42
+    HousingEvictError: 51
+    Ignored: 19
+    InCooldown: 49
+    InvalidBankTab: 24
+    InvitedToGuild: 4
+    LockedForMove: 39
+    NameAlreadyExists: 7
+    NameInvalid: 6
+    NewLeaderWrongFaction: 44
+    NewLeaderWrongRealm: 46
+    NoPermisson: 8
+    NotEnoughMoney: 26
+    NotInGuild: 9
+    PlayerNotFound: 11
+    RankInUse: 18
+    RankRequiresAuthenticator: 34
+    RanksLocked: 17
+    RealmMismatch: 48
+    ReservationExpired: 50
+    Success: 0
+    TargetAlreadyInGuild: 3
+    TargetInvitedToGuild: 5
+    TargetLevelTooHigh: 22
+    TargetLevelTooLow: 21
+    TargetNotInGuild: 10
+    TargetTooHigh: 13
+    TargetTooLow: 14
+    TeamNotFound: 27
+    TeamsLocked: 30
+    Throttled: 52
+    TooFewRanks: 16
+    TooManyCreate: 33
+    TooManyMembers: 23
+    TooManyRanks: 15
+    TooMuchMoney: 31
+    TrialAccount: 36
+    UndeletableDueToLevel: 38
+    UnknownError: 1
+    VeteranAccount: 37
+    WithdrawLimit: 25
+    WrongBankTab: 32
+    WrongFaction: 12
 HolidayCalendarFlags:
-  Alliance: 1
-  Horde: 2
+  values:
+    Alliance: 1
+    Horde: 2
 HolidayFlags:
-  BeginEventOnlyOnStageChange: 64
-  DontDisplayBanner: 8
-  DontDisplayEnd: 4
-  DontShowInCalendar: 2
-  DurationUseMinutes: 32
-  IsRegionwide: 1
-  NotAvailableClientSide: 16
+  values:
+    BeginEventOnlyOnStageChange: 64
+    DontDisplayBanner: 8
+    DontDisplayEnd: 4
+    DontShowInCalendar: 2
+    DurationUseMinutes: 32
+    IsRegionwide: 1
+    NotAvailableClientSide: 16
 HouseEditingContext:
-  Decor: 1
-  Fixture: 3
-  None: 0
-  Room: 2
+  values:
+    Decor: 1
+    Fixture: 3
+    None: 0
+    Room: 2
 HouseEditorMode:
-  BasicDecor: 1
-  Cleanup: 5
-  Customize: 4
-  ExpertDecor: 2
-  ExteriorCustomization: 6
-  Layout: 3
-  None: 0
+  values:
+    BasicDecor: 1
+    Cleanup: 5
+    Customize: 4
+    ExpertDecor: 2
+    ExteriorCustomization: 6
+    Layout: 3
+    None: 0
 HouseExteriorWMODataFlags:
-  AllowedInAllianceNeighborhoods: 4
-  AllowedInHordeNeighborhoods: 2
-  HiddenUnlessOwned: 8
-  None: 0
-  UnlockedByDefault: 1
+  values:
+    AllowedInAllianceNeighborhoods: 4
+    AllowedInHordeNeighborhoods: 2
+    HiddenUnlessOwned: 8
+    None: 0
+    UnlockedByDefault: 1
 HouseFinderSuggestionReason:
-  BNetFriends: 8
-  CharterInvite: 2
-  Guild: 4
-  HomeOwner: 64
-  None: 0
-  Owner: 1
-  PartySync: 16
-  Random: 32
+  values:
+    BNetFriends: 8
+    CharterInvite: 2
+    Guild: 4
+    HomeOwner: 64
+    None: 0
+    Owner: 1
+    PartySync: 16
+    Random: 32
 HouseLevelRewardType:
-  Object: 1
-  Value: 0
+  values:
+    Object: 1
+    Value: 0
 HouseLevelRewardValueType:
-  ExteriorDecor: 0
-  Fixtures: 3
-  InteriorDecor: 1
-  Rooms: 2
+  values:
+    ExteriorDecor: 0
+    Fixtures: 3
+    InteriorDecor: 1
+    Rooms: 2
 HouseOwnerError:
-  Faction: 1
-  GenericPermission: 3
-  Guild: 2
-  None: 0
+  values:
+    Faction: 1
+    GenericPermission: 3
+    Guild: 2
+    None: 0
 HouseSettingFlags:
-  HouseAccessAnyone: 1
-  HouseAccessFriends: 8
-  HouseAccessGuild: 4
-  HouseAccessNeighbors: 2
-  HouseAccessParty: 16
-  None: 0
-  PlotAccessAnyone: 32
-  PlotAccessFriends: 256
-  PlotAccessGuild: 128
-  PlotAccessNeighbors: 64
-  PlotAccessParty: 512
+  values:
+    HouseAccessAnyone: 1
+    HouseAccessFriends: 8
+    HouseAccessGuild: 4
+    HouseAccessNeighbors: 2
+    HouseAccessParty: 16
+    None: 0
+    PlotAccessAnyone: 32
+    PlotAccessFriends: 256
+    PlotAccessGuild: 128
+    PlotAccessNeighbors: 64
+    PlotAccessParty: 512
 HouseVisitType:
-  Friend: 1
-  Guild: 2
-  Party: 3
-  Unknown: 0
+  values:
+    Friend: 1
+    Guild: 2
+    Party: 3
+    Unknown: 0
 HousingBasicModeTargetType:
-  Decor: 1
-  House: 2
-  None: 0
+  values:
+    Decor: 1
+    House: 2
+    None: 0
 HousingCatalogEntryModelScenePresets:
-  DecorCeiling: 1338
-  DecorDefault: 1317
-  DecorFlat: 1318
-  DecorHorizontalSurface: 1452
-  DecorHuge: 1337
-  DecorLarge: 1336
-  DecorMedium: 1335
-  DecorSmall: 1334
-  DecorTiny: 1333
-  DecorWall: 1339
+  values:
+    DecorCeiling: 1338
+    DecorDefault: 1317
+    DecorFlat: 1318
+    DecorHorizontalSurface: 1452
+    DecorHuge: 1337
+    DecorLarge: 1336
+    DecorMedium: 1335
+    DecorSmall: 1334
+    DecorTiny: 1333
+    DecorWall: 1339
 HousingCatalogEntrySize:
-  Huge: 69
-  Large: 68
-  Medium: 67
-  None: 0
-  Small: 66
-  Tiny: 65
+  values:
+    Huge: 69
+    Large: 68
+    Medium: 67
+    None: 0
+    Small: 66
+    Tiny: 65
 HousingCatalogEntryType:
-  Decor: 1
-  Invalid: 0
-  Room: 2
+  values:
+    Decor: 1
+    Invalid: 0
+    Room: 2
 HousingCatalogSortType:
-  Alphabetical: 1
-  DateAdded: 0
+  values:
+    Alphabetical: 1
+    DateAdded: 0
 HousingCleanupModeTargetType:
-  Decor: 1
-  HouseExterior: 2
-  None: 0
+  values:
+    Decor: 1
+    HouseExterior: 2
+    None: 0
 HousingCustomizeModeTargetType:
-  Decor: 1
-  ExteriorHouse: 3
-  None: 0
-  RoomComponent: 2
+  values:
+    Decor: 1
+    ExteriorHouse: 3
+    None: 0
+    RoomComponent: 2
 HousingDecorActionFlags:
-  Add: 1
-  ClickTarget: 16
-  DragMove: 4
-  HoverTarget: 32
-  IncludeTargetChildren: 512
-  MaintainLastTarget: 256
-  None: 0
-  PrecisionMove: 8
-  PreviewDecor: 2048
-  Remove: 2
-  TargetHouseExterior: 128
-  TargetRoomComponents: 64
-  UsePlacedDecorList: 1024
+  values:
+    Add: 1
+    ClickTarget: 16
+    DragMove: 4
+    HoverTarget: 32
+    IncludeTargetChildren: 512
+    MaintainLastTarget: 256
+    None: 0
+    PrecisionMove: 8
+    PreviewDecor: 2048
+    Remove: 2
+    TargetHouseExterior: 128
+    TargetRoomComponents: 64
+    UsePlacedDecorList: 1024
 HousingDecorModelType:
-  M2: 1
-  None: 0
-  WMO: 2
+  values:
+    M2: 1
+    None: 0
+    WMO: 2
 HousingDecorPlacementRestriction:
-  ChildOutsideBounds: 8
-  InvalidCollision: 32
-  InvalidLightOverlap: 64
-  InvalidTarget: 16
-  OutsidePlotBounds: 4
-  OutsideRoomBounds: 2
-  TooFarAway: 1
+  values:
+    ChildOutsideBounds: 8
+    InvalidCollision: 32
+    InvalidLightOverlap: 64
+    InvalidTarget: 16
+    OutsidePlotBounds: 4
+    OutsideRoomBounds: 2
+    TooFarAway: 1
 HousingDecorTheme:
-  BloodElf: 5
-  Folk: 1
-  Generic: 3
-  NightElf: 4
-  None: 0
-  Rugged: 2
+  values:
+    BloodElf: 5
+    Folk: 1
+    Generic: 3
+    NightElf: 4
+    None: 0
+    Rugged: 2
 HousingDecorType:
-  Ceiling: 3
-  Floor: 1
-  Flooring: 4
-  None: 0
-  Wall: 2
+  values:
+    Ceiling: 3
+    Floor: 1
+    Flooring: 4
+    None: 0
+    Wall: 2
 HousingExpertModeTargetType:
-  Decor: 1
-  House: 2
-  None: 0
+  values:
+    Decor: 1
+    House: 2
+    None: 0
 HousingExpertSubmodeRestriction:
-  NoHouseExteriorScale: 2
-  None: 0
-  NotInExpertMode: 1
-  NoWMOScale: 3
+  values:
+    NoHouseExteriorScale: 2
+    None: 0
+    NotInExpertMode: 1
+    NoWMOScale: 3
 HousingFavorUpdateSource:
-  DecorCollection: 1
-  DeferredRewards: 2
-  InitiativeChest: 6
-  InitiativeTask: 5
-  NewHouseDecorFavor: 4
-  Quest: 7
-  RetroactiveDecor: 3
-  Unknown: 0
+  values:
+    DecorCollection: 1
+    DeferredRewards: 2
+    InitiativeChest: 6
+    InitiativeTask: 5
+    NewHouseDecorFavor: 4
+    Quest: 7
+    RetroactiveDecor: 3
+    Unknown: 0
 HousingFavorUpdateType:
-  Add: 0
-  InitiativeAdd: 1
-  Set: 2
+  values:
+    Add: 0
+    InitiativeAdd: 1
+    Set: 2
 HousingFixtureDecorAction:
-  Detach: 1
-  Store: 0
+  values:
+    Detach: 1
+    Store: 0
 HousingFixtureFlags:
-  IsDefaultFixture: 1
-  None: 0
-  UnlockedByDefault: 2
+  values:
+    IsDefaultFixture: 1
+    None: 0
+    UnlockedByDefault: 2
 HousingFixtureSize:
-  Any: 1
-  Large: 4
-  Medium: 3
-  None: 0
-  Small: 2
+  values:
+    Any: 1
+    Large: 4
+    Medium: 3
+    None: 0
+    Small: 2
 HousingFixtureType:
-  Base: 9
-  Chimney: 16
-  Door: 11
-  None: 0
-  Roof: 10
-  RoofDetail: 13
-  RoofWindow: 14
-  Tower: 15
-  Window: 12
+  values:
+    Base: 9
+    Chimney: 16
+    Door: 11
+    None: 0
+    Roof: 10
+    RoofDetail: 13
+    RoofWindow: 14
+    Tower: 15
+    Window: 12
 HousingIncrementType:
-  Back: 8
-  Down: 32
-  Forward: 4
-  Left: 1
-  Right: 2
-  RotateLeft: 64
-  RotateRight: 128
-  ScaleDown: 512
-  ScaleUp: 256
-  Up: 16
+  values:
+    Back: 8
+    Down: 32
+    Forward: 4
+    Left: 1
+    Right: 2
+    RotateLeft: 64
+    RotateRight: 128
+    ScaleDown: 512
+    ScaleUp: 256
+    Up: 16
 HousingItemToastType:
-  Customization: 2
-  Decor: 3
-  Fixture: 1
-  HouseType: 4
-  Room: 0
+  values:
+    Customization: 2
+    Decor: 3
+    Fixture: 1
+    HouseType: 4
+    Room: 0
 HousingLayoutCameraDirection:
-  Down: 2
-  Left: 4
-  None: 0
-  Right: 8
-  Up: 1
+  values:
+    Down: 2
+    Left: 4
+    None: 0
+    Right: 8
+    Up: 1
 HousingLayoutPinType:
-  Door: 0
-  Room: 1
+  values:
+    Door: 0
+    Room: 1
 HousingLayoutRestriction:
-  IsBaseRoom: 4
-  LastRoom: 7
-  None: 0
-  NotHouseOwner: 3
-  NotInsideHouse: 2
-  RoomNotFound: 1
-  RoomNotLeaf: 5
-  SingleDoor: 9
-  StairwellConnection: 6
-  UnreachableRoom: 8
+  values:
+    IsBaseRoom: 4
+    LastRoom: 7
+    None: 0
+    NotHouseOwner: 3
+    NotInsideHouse: 2
+    RoomNotFound: 1
+    RoomNotLeaf: 5
+    SingleDoor: 9
+    StairwellConnection: 6
+    UnreachableRoom: 8
 HousingLayoutStairDirection:
-  Down: 1
-  Up: 0
+  values:
+    Down: 1
+    Up: 0
 HousingPlotOwnerType:
-  Friend: 2
-  None: 0
-  Self: 3
-  Stranger: 1
+  values:
+    Friend: 2
+    None: 0
+    Self: 3
+    Stranger: 1
 HousingPrecisionSubmode:
-  Rotate: 1
-  Scale: 2
-  Translate: 0
+  values:
+    Rotate: 1
+    Scale: 2
+    Translate: 0
 HousingResult:
-  ActionLockedByCombat: 1
-  BoundsFailureChildren: 2
-  BoundsFailurePlot: 3
-  BoundsFailureRoom: 4
-  BoundToStartingArea: 5
-  CannotAfford: 6
-  CharterComplete: 7
-  CollisionInvalid: 8
-  DbError: 9
-  DecorCannotBeRedeemed: 10
-  DecorItemNotDestroyable: 11
-  DecorNotFound: 12
-  DecorNotFoundInStorage: 13
-  DuplicateCharterSignature: 14
-  FilterRejected: 15
-  FixtureCantDeleteDoor: 16
-  FixtureHookEmpty: 17
-  FixtureHookOccupied: 18
-  FixtureHouseTypeMismatch: 19
-  FixtureNotFound: 20
-  FixtureSizeMismatch: 21
-  FixtureTypeMismatch: 22
-  GenericFailure: 23
-  GuildMoreAccountsNeeded: 24
-  GuildMoreActivePlayersNeeded: 25
-  GuildNotLoaded: 26
-  HookNotChildOfFixture: 35
-  HouseEditLockFailed: 27
-  HouseExteriorAlreadyThatSize: 28
-  HouseExteriorAlreadyThatType: 29
-  HouseExteriorRootNotFound: 30
-  HouseExteriorSizeNotAvailable: 34
-  HouseExteriorTypeNeighborhoodMismatch: 31
-  HouseExteriorTypeNotFound: 32
-  HouseExteriorTypeSizeMismatch: 33
-  HouseNotFound: 36
-  IncorrectFaction: 37
-  InvalidDecorItem: 38
-  InvalidDistance: 39
-  InvalidGuild: 40
-  InvalidHouse: 41
-  InvalidInstance: 42
-  InvalidInteraction: 43
-  InvalidLightOverlap: 44
-  InvalidMap: 45
-  InvalidNeighborhoodName: 46
-  InvalidRoomLayout: 47
-  LockedByOtherPlayer: 48
-  LockOperationFailed: 49
-  MaxDecorReached: 50
-  MaxPreviewDecorReached: 51
-  MissingCoreFixture: 52
-  MissingDye: 53
-  MissingExpansionAccess: 54
-  MissingFactionMap: 55
-  MissingPrivateNeighborhoodInvite: 56
-  MoreHouseSlotsNeeded: 57
-  MoreSignaturesNeeded: 58
-  NeighborhoodNotFound: 59
-  NoNeighborhoodOwnershipRequests: 60
-  NotInDecorEditMode: 61
-  NotInFixtureEditMode: 62
-  NotInLayoutEditMode: 63
-  NotInsideHouse: 64
-  NotOnOwnedPlot: 65
-  OperationAborted: 66
-  OwnerNotInGuild: 67
-  PermissionDenied: 68
-  PlacementTargetInvalid: 69
-  PlayerNotFound: 70
-  PlayerNotInInstance: 71
-  PlotNotFound: 72
-  PlotNotVacant: 73
-  PlotReservationCooldown: 74
-  PlotReserved: 75
-  RoomNotFound: 76
-  RoomUpdateFailed: 77
-  RpcFailure: 78
-  ServiceNotAvailable: 79
-  StaticDataNotFound: 80
-  Success: 0
-  TimeoutLimit: 81
-  TimerunningNotAllowed: 82
-  TokenRequired: 83
-  TooManyRequests: 84
-  TransactionFailure: 85
-  UncollectedExteriorFixture: 86
-  UncollectedHouseType: 87
-  UncollectedRoom: 88
-  UncollectedRoomMaterial: 89
-  UncollectedRoomTheme: 90
-  UnlockOperationFailed: 91
+  values:
+    ActionLockedByCombat: 1
+    BoundsFailureChildren: 2
+    BoundsFailurePlot: 3
+    BoundsFailureRoom: 4
+    BoundToStartingArea: 5
+    CannotAfford: 6
+    CharterComplete: 7
+    CollisionInvalid: 8
+    DbError: 9
+    DecorCannotBeRedeemed: 10
+    DecorItemNotDestroyable: 11
+    DecorNotFound: 12
+    DecorNotFoundInStorage: 13
+    DuplicateCharterSignature: 14
+    FilterRejected: 15
+    FixtureCantDeleteDoor: 16
+    FixtureHookEmpty: 17
+    FixtureHookOccupied: 18
+    FixtureHouseTypeMismatch: 19
+    FixtureNotFound: 20
+    FixtureSizeMismatch: 21
+    FixtureTypeMismatch: 22
+    GenericFailure: 23
+    GuildMoreAccountsNeeded: 24
+    GuildMoreActivePlayersNeeded: 25
+    GuildNotLoaded: 26
+    HookNotChildOfFixture: 35
+    HouseEditLockFailed: 27
+    HouseExteriorAlreadyThatSize: 28
+    HouseExteriorAlreadyThatType: 29
+    HouseExteriorRootNotFound: 30
+    HouseExteriorSizeNotAvailable: 34
+    HouseExteriorTypeNeighborhoodMismatch: 31
+    HouseExteriorTypeNotFound: 32
+    HouseExteriorTypeSizeMismatch: 33
+    HouseNotFound: 36
+    IncorrectFaction: 37
+    InvalidDecorItem: 38
+    InvalidDistance: 39
+    InvalidGuild: 40
+    InvalidHouse: 41
+    InvalidInstance: 42
+    InvalidInteraction: 43
+    InvalidLightOverlap: 44
+    InvalidMap: 45
+    InvalidNeighborhoodName: 46
+    InvalidRoomLayout: 47
+    LockedByOtherPlayer: 48
+    LockOperationFailed: 49
+    MaxDecorReached: 50
+    MaxPreviewDecorReached: 51
+    MissingCoreFixture: 52
+    MissingDye: 53
+    MissingExpansionAccess: 54
+    MissingFactionMap: 55
+    MissingPrivateNeighborhoodInvite: 56
+    MoreHouseSlotsNeeded: 57
+    MoreSignaturesNeeded: 58
+    NeighborhoodNotFound: 59
+    NoNeighborhoodOwnershipRequests: 60
+    NotInDecorEditMode: 61
+    NotInFixtureEditMode: 62
+    NotInLayoutEditMode: 63
+    NotInsideHouse: 64
+    NotOnOwnedPlot: 65
+    OperationAborted: 66
+    OwnerNotInGuild: 67
+    PermissionDenied: 68
+    PlacementTargetInvalid: 69
+    PlayerNotFound: 70
+    PlayerNotInInstance: 71
+    PlotNotFound: 72
+    PlotNotVacant: 73
+    PlotReservationCooldown: 74
+    PlotReserved: 75
+    RoomNotFound: 76
+    RoomUpdateFailed: 77
+    RpcFailure: 78
+    ServiceNotAvailable: 79
+    StaticDataNotFound: 80
+    Success: 0
+    TimeoutLimit: 81
+    TimerunningNotAllowed: 82
+    TokenRequired: 83
+    TooManyRequests: 84
+    TransactionFailure: 85
+    UncollectedExteriorFixture: 86
+    UncollectedHouseType: 87
+    UncollectedRoom: 88
+    UncollectedRoomMaterial: 89
+    UncollectedRoomTheme: 90
+    UnlockOperationFailed: 91
 HousingRoomComponentCeilingType:
-  Flat: 0
-  Vaulted: 1
+  values:
+    Flat: 0
+    Vaulted: 1
 HousingRoomComponentDoorType:
-  Doorway: 1
-  None: 0
-  Threshold: 2
+  values:
+    Doorway: 1
+    None: 0
+    Threshold: 2
 HousingRoomComponentFlags:
-  HiddenInLayoutMode: 1
-  None: 0
+  values:
+    HiddenInLayoutMode: 1
+    None: 0
 HousingRoomComponentFloorType:
-  Floor: 0
+  values:
+    Floor: 0
 HousingRoomComponentOptionFlags:
-  IsDefault: 1
-  None: 0
+  values:
+    IsDefault: 1
+    None: 0
 HousingRoomComponentOptionType:
-  Cosmetic: 0
-  Doorway: 2
-  DoorwayWall: 1
+  values:
+    Cosmetic: 0
+    Doorway: 2
+    DoorwayWall: 1
 HousingRoomComponentStairType:
-  MiddleToEnd: 4
-  MiddleToMiddle: 3
-  None: 0
-  StartToEnd: 1
-  StartToMiddle: 2
+  values:
+    MiddleToEnd: 4
+    MiddleToMiddle: 3
+    None: 0
+    StartToEnd: 1
+    StartToMiddle: 2
 HousingRoomComponentTextureFlags:
-  None: 0
-  UnlockedByDefault: 1
+  values:
+    None: 0
+    UnlockedByDefault: 1
 HousingRoomComponentType:
-  Ceiling: 3
-  Doorway: 7
-  DoorwayWall: 6
-  Floor: 2
-  None: 0
-  Pillar: 5
-  Stairs: 4
-  Wall: 1
+  values:
+    Ceiling: 3
+    Doorway: 7
+    DoorwayWall: 6
+    Floor: 2
+    None: 0
+    Pillar: 5
+    Stairs: 4
+    Wall: 1
 HousingRoomFlags:
-  BaseRoom: 1
-  HasCustomGeometry: 8
-  HasStairs: 2
-  None: 0
-  UnlockedByDefault: 4
+  values:
+    BaseRoom: 1
+    HasCustomGeometry: 8
+    HasStairs: 2
+    None: 0
+    UnlockedByDefault: 4
 HousingTeleportReason:
-  Booted: 3
-  Cheat: 1
-  ExitingHouse: 9
-  Friend: 6
-  GuildMember: 7
-  Homestone: 4
-  None: 0
-  PartyMember: 8
-  Portal: 10
-  Tutorial: 11
-  UnspecifiedSpellcast: 2
-  Visit: 5
+  values:
+    Booted: 3
+    Cheat: 1
+    ExitingHouse: 9
+    Friend: 6
+    GuildMember: 7
+    Homestone: 4
+    None: 0
+    PartyMember: 8
+    Portal: 10
+    Tutorial: 11
+    UnspecifiedSpellcast: 2
+    Visit: 5
 HousingThemeFlags:
-  None: 0
-  ShowInStyleSelector: 2
-  UnlockedByDefault: 1
+  values:
+    None: 0
+    ShowInStyleSelector: 2
+    UnlockedByDefault: 1
 HousingThrottleType:
-  Decoration: 1
-  General: 0
+  values:
+    Decoration: 1
+    General: 0
 IconAndTextShiftTextType:
-  None: 0
-  ShiftText: 1
+  values:
+    None: 0
+    ShiftText: 1
 IconAndTextWidgetState:
-  Hidden: 0
-  Shown: 1
-  ShownWithDynamicIconFlashing: 2
-  ShownWithDynamicIconNotFlashing: 3
+  values:
+    Hidden: 0
+    Shown: 1
+    ShownWithDynamicIconFlashing: 2
+    ShownWithDynamicIconNotFlashing: 3
 IconState:
-  Hidden: 0
-  ShowState1: 1
-  ShowState2: 2
+  values:
+    Hidden: 0
+    ShowState1: 1
+    ShowState2: 2
 ImageSharingResult:
-  AccountDataRequestFailure: 6
-  EncryptionFailure: 11
-  EncryptionSecretNotSet: 14
-  FailedToCreateHeader: 10
-  Failure: 0
-  GetAccountDataRequestFailure: 7
-  InvalidOAuthExpiration: 12
-  InvalidRefreshExpiration: 13
-  MissingFieldApiError: 5
-  NotConfigured: 2
-  PlatformApiError: 4
-  RefreshTokenExpired: 9
-  RetrievedExisting: 3
-  SetAccountDataRequestFailure: 8
-  Success: 1
+  values:
+    AccountDataRequestFailure: 6
+    EncryptionFailure: 11
+    EncryptionSecretNotSet: 14
+    FailedToCreateHeader: 10
+    Failure: 0
+    GetAccountDataRequestFailure: 7
+    InvalidOAuthExpiration: 12
+    InvalidRefreshExpiration: 13
+    MissingFieldApiError: 5
+    NotConfigured: 2
+    PlatformApiError: 4
+    RefreshTokenExpired: 9
+    RetrievedExisting: 3
+    SetAccountDataRequestFailure: 8
+    Success: 1
 InitiativeMilestoneFlags:
-  FinalMilestone: 1
+  values:
+    FinalMilestone: 1
 InitiativeRewardFlags:
-  PermanentWorldState: 1
+  values:
+    PermanentWorldState: 1
 InputContext:
-  GamePad: 3
-  Keyboard: 1
-  Mouse: 2
-  None: 0
+  values:
+    GamePad: 3
+    Keyboard: 1
+    Mouse: 2
+    None: 0
 InvalidPlotScreenshotReason:
-  Facing: 2
-  NoActivePlayer: 4
-  None: 0
-  NoNeighborhoodFound: 3
-  OutOfBounds: 1
+  values:
+    Facing: 2
+    NoActivePlayer: 4
+    None: 0
+    NoNeighborhoodFound: 3
+    OutOfBounds: 1
 InventoryType:
-  Index2HweaponType: 17
-  IndexAmmoType: 24
-  IndexBagType: 18
-  IndexBodyType: 4
-  IndexChestType: 5
-  IndexCloakType: 16
-  IndexEquipablespellDefensiveType: 33
-  IndexEquipablespellOffensiveType: 31
-  IndexEquipablespellUtilityType: 32
-  IndexEquipablespellWeaponType: 34
-  IndexFeetType: 8
-  IndexFingerType: 11
-  IndexHandType: 10
-  IndexHeadType: 1
-  IndexHoldableType: 23
-  IndexLegsType: 7
-  IndexNeckType: 2
-  IndexNonEquipType: 0
-  IndexProfessionGearType: 30
-  IndexProfessionToolType: 29
-  IndexQuiverType: 27
-  IndexRangedrightType: 26
-  IndexRangedType: 15
-  IndexRelicType: 28
-  IndexRobeType: 20
-  IndexShieldType: 14
-  IndexShoulderType: 3
-  IndexTabardType: 19
-  IndexThrownType: 25
-  IndexTrinketType: 12
-  IndexWaistType: 6
-  IndexWeaponmainhandType: 21
-  IndexWeaponoffhandType: 22
-  IndexWeaponType: 13
-  IndexWristType: 9
+  values:
+    Index2HweaponType: 17
+    IndexAmmoType: 24
+    IndexBagType: 18
+    IndexBodyType: 4
+    IndexChestType: 5
+    IndexCloakType: 16
+    IndexEquipablespellDefensiveType: 33
+    IndexEquipablespellOffensiveType: 31
+    IndexEquipablespellUtilityType: 32
+    IndexEquipablespellWeaponType: 34
+    IndexFeetType: 8
+    IndexFingerType: 11
+    IndexHandType: 10
+    IndexHeadType: 1
+    IndexHoldableType: 23
+    IndexLegsType: 7
+    IndexNeckType: 2
+    IndexNonEquipType: 0
+    IndexProfessionGearType: 30
+    IndexProfessionToolType: 29
+    IndexQuiverType: 27
+    IndexRangedrightType: 26
+    IndexRangedType: 15
+    IndexRelicType: 28
+    IndexRobeType: 20
+    IndexShieldType: 14
+    IndexShoulderType: 3
+    IndexTabardType: 19
+    IndexThrownType: 25
+    IndexTrinketType: 12
+    IndexWaistType: 6
+    IndexWeaponmainhandType: 21
+    IndexWeaponoffhandType: 22
+    IndexWeaponType: 13
+    IndexWristType: 9
 ItemArmorSubclass:
-  Cloth: 1
-  Cosmetic: 5
-  Generic: 0
-  Idol: 8
-  Leather: 2
-  Libram: 7
-  Mail: 3
-  Plate: 4
-  Relic: 11
-  Shield: 6
-  Sigil: 10
-  Totem: 9
+  values:
+    Cloth: 1
+    Cosmetic: 5
+    Generic: 0
+    Idol: 8
+    Leather: 2
+    Libram: 7
+    Mail: 3
+    Plate: 4
+    Relic: 11
+    Shield: 6
+    Sigil: 10
+    Totem: 9
 ItemBind:
-  None: 0
-  OnAcquire: 1
-  OnEquip: 2
-  OnUse: 3
-  Quest: 4
-  ToBnetAccount: 8
-  ToBnetAccountUntilEquipped: 9
-  ToWoWAccount: 7
-  Unused1: 5
-  Unused2: 6
+  values:
+    None: 0
+    OnAcquire: 1
+    OnEquip: 2
+    OnUse: 3
+    Quest: 4
+    ToBnetAccount: 8
+    ToBnetAccountUntilEquipped: 9
+    ToWoWAccount: 7
+    Unused1: 5
+    Unused2: 6
 ItemClass:
-  Armor: 4
-  Battlepet: 17
-  Consumable: 0
-  Container: 1
-  CurrencyTokenObsolete: 10
-  Gem: 3
-  Glyph: 16
-  Housing: 20
-  ItemEnhancement: 8
-  Key: 13
-  Miscellaneous: 15
-  PermanentObsolete: 14
-  Profession: 19
-  Projectile: 6
-  Questitem: 12
-  Quiver: 11
-  Reagent: 5
-  Recipe: 9
-  Tradegoods: 7
-  Weapon: 2
-  WoWToken: 18
+  values:
+    Armor: 4
+    Battlepet: 17
+    Consumable: 0
+    Container: 1
+    CurrencyTokenObsolete: 10
+    Gem: 3
+    Glyph: 16
+    Housing: 20
+    ItemEnhancement: 8
+    Key: 13
+    Miscellaneous: 15
+    PermanentObsolete: 14
+    Profession: 19
+    Projectile: 6
+    Questitem: 12
+    Quiver: 11
+    Reagent: 5
+    Recipe: 9
+    Tradegoods: 7
+    Weapon: 2
+    WoWToken: 18
 Itemclassfilterflags:
-  Armor: 16
-  Battlepet: 131072
-  Consumable: 1
-  Container: 2
-  CurrencyTokenObsolete: 1024
-  Gem: 8
-  Glyph: 65536
-  ItemEnhancement: 256
-  Key: 8192
-  Miscellaneous: 32768
-  PermanentObsolete: 16384
-  Projectile: 64
-  Questitemclassfilterflags: 4096
-  Quiver: 2048
-  Reagent: 32
-  Recipe: 512
-  Tradegoods: 128
-  Weapon: 4
+  values:
+    Armor: 16
+    Battlepet: 131072
+    Consumable: 1
+    Container: 2
+    CurrencyTokenObsolete: 1024
+    Gem: 8
+    Glyph: 65536
+    ItemEnhancement: 256
+    Key: 8192
+    Miscellaneous: 32768
+    PermanentObsolete: 16384
+    Projectile: 64
+    Questitemclassfilterflags: 4096
+    Quiver: 2048
+    Reagent: 32
+    Recipe: 512
+    Tradegoods: 128
+    Weapon: 4
 ItemCollectionType:
-  ExteriorFixture: 9
-  Heirloom: 2
-  HouseType: 13
-  None: 0
-  Room: 8
-  RoomMaterial: 11
-  RoomTheme: 10
-  RuneforgeLegendaryAbility: 5
-  Toy: 1
-  Transmog: 3
-  TransmogIllusion: 6
-  TransmogOutfit: 12
-  TransmogSetFavorite: 4
-  WarbandScene: 7
+  values:
+    ExteriorFixture: 9
+    Heirloom: 2
+    HouseType: 13
+    None: 0
+    Room: 8
+    RoomMaterial: 11
+    RoomTheme: 10
+    RuneforgeLegendaryAbility: 5
+    Toy: 1
+    Transmog: 3
+    TransmogIllusion: 6
+    TransmogOutfit: 12
+    TransmogSetFavorite: 4
+    WarbandScene: 7
 ItemCommodityStatus:
-  Commodity: 2
-  Item: 1
-  Unknown: 0
+  values:
+    Commodity: 2
+    Item: 1
+    Unknown: 0
 ItemConsumableSubclass:
-  Bandage: 7
-  CombatCurio: 11
-  Elixir: 2
-  Flasksphials: 3
-  Fooddrink: 5
-  Generic: 0
-  Itemenhancement: 6
-  Other: 8
-  Potion: 1
-  Relic: 12
-  Scroll: 4
-  UtilityCurio: 10
-  VantusRune: 9
+  values:
+    Bandage: 7
+    CombatCurio: 11
+    Elixir: 2
+    Flasksphials: 3
+    Fooddrink: 5
+    Generic: 0
+    Itemenhancement: 6
+    Other: 8
+    Potion: 1
+    Relic: 12
+    Scroll: 4
+    UtilityCurio: 10
+    VantusRune: 9
 ItemCreationContext:
-  BlackMarket: 15
-  ChallengeMode_1: 16
-  ChallengeMode_2: 33
-  ChallengeMode_3: 34
-  ChallengeMode_4: 87
-  ChallengeModeJackpot: 35
-  CharacterBoost_1: 61
-  CharacterBoost_2: 62
-  CharacterBoost_3: 86
-  CorpseRecovery: 80
-  Delves_1: 104
-  Delves_2: 106
-  Delves_3: 107
-  DelvesBonus_1: 129
-  DelvesBonus_10: 138
-  DelvesBonus_2: 130
-  DelvesBonus_3: 131
-  DelvesBonus_4: 132
-  DelvesBonus_5: 133
-  DelvesBonus_6: 134
-  DelvesBonus_7: 135
-  DelvesBonus_8: 136
-  DelvesBonus_9: 137
-  DelvesBounty_1: 117
-  DelvesBounty_2: 118
-  DelvesBounty_3: 119
-  DelvesBounty_4: 120
-  DelvesBounty_5: 121
-  DelvesBounty_6: 122
-  DelvesBounty_7: 123
-  DelvesBounty_8: 124
-  DelvesJackpot: 108
-  DelvesKey_1: 109
-  DelvesKey_2: 110
-  DelvesKey_3: 111
-  DelvesKey_4: 112
-  DelvesKey_5: 113
-  DelvesKey_6: 114
-  DelvesKey_7: 115
-  DelvesKey_8: 116
-  DelvesLevelUp_1: 125
-  DelvesLevelUp_2: 126
-  DelvesLevelUp_3: 127
-  DelvesLevelUp_4: 128
-  DungeonBonus_1: 139
-  DungeonBonus_10: 148
-  DungeonBonus_2: 140
-  DungeonBonus_3: 141
-  DungeonBonus_4: 142
-  DungeonBonus_5: 143
-  DungeonBonus_6: 144
-  DungeonBonus_7: 145
-  DungeonBonus_8: 146
-  DungeonBonus_9: 147
-  DungeonHardMode_1: 159
-  DungeonHardMode_2: 160
-  DungeonHardMode_3: 161
-  DungeonHeroic: 2
-  DungeonHeroicJackpot: 102
-  DungeonLevelUp_1: 17
-  DungeonLevelUp_2: 18
-  DungeonLevelUp_3: 19
-  DungeonLevelUp_4: 20
-  DungeonMythic: 23
-  DungeonMythicJackpot: 103
-  DungeonNormal: 1
-  DungeonNormalJackpot: 101
-  Endeavors: 185
-  ForceNone: 21
-  LegendaryCrafting_1: 63
-  LegendaryCrafting_2: 64
-  LegendaryCrafting_3: 65
-  LegendaryCrafting_4: 66
-  LegendaryCrafting_5: 67
-  LegendaryCrafting_6: 68
-  LegendaryCrafting_7: 69
-  LegendaryCrafting_8: 70
-  LegendaryCrafting_9: 71
-  LegendaryForge: 59
-  MissionReward_1: 31
-  MissionReward_2: 32
-  NewCharacter: 75
-  None: 0
-  PvPBrawl_1: 77
-  PvPBrawl_2: 78
-  PvPHonorReward: 24
-  PvPRanked_1: 8
-  PvPRanked_2: 38
-  PvPRanked_3: 39
-  PvPRanked_4: 40
-  PvPRanked_5: 44
-  PvPRanked_6: 45
-  PvPRanked_7: 46
-  PvPRanked_8: 52
-  PvPRanked_9: 88
-  PvPRankedJackpot: 56
-  PvPUnranked_1: 7
-  PvPUnranked_2: 41
-  PvPUnranked_3: 47
-  PvPUnranked_4: 48
-  PvPUnranked_5: 49
-  PvPUnranked_6: 50
-  PvPUnranked_7: 51
-  QuestBonusLoot: 60
-  QuestReward: 11
-  RaidBonus_1: 149
-  RaidBonus_10: 158
-  RaidBonus_2: 150
-  RaidBonus_3: 151
-  RaidBonus_4: 152
-  RaidBonus_5: 153
-  RaidBonus_6: 154
-  RaidBonus_7: 155
-  RaidBonus_8: 156
-  RaidBonus_9: 157
-  RaidFinder: 4
-  RaidFinderExtended: 83
-  RaidFinderExtended_2: 90
-  RaidFinderExtended_3: 94
-  RaidHeroic: 5
-  RaidHeroicExtended: 84
-  RaidHeroicExtended_2: 91
-  RaidHeroicExtended_3: 95
-  RaidMythic: 6
-  RaidMythicExtended: 85
-  RaidMythicExtended_2: 92
-  RaidMythicExtended_3: 96
-  RaidNormal: 3
-  RaidNormalExtended: 82
-  RaidNormalExtended_2: 89
-  RaidNormalExtended_3: 93
-  Relinquished: 58
-  ScenarioHeroic: 10
-  ScenarioNormal: 9
-  Store: 12
-  TemplateCharacter_1: 97
-  TemplateCharacter_2: 98
-  TemplateCharacter_3: 99
-  TemplateCharacter_4: 100
-  Timerunning: 105
-  TimewalkerLevelUp: 22
-  TimewalkerMaxLevel: 186
-  Torghast: 79
-  TournamentRealm_1: 57
-  TournamentRealm_2: 162
-  TournamentRealm_3: 163
-  TournamentRealm_4: 164
-  TradeSkill: 13
-  Vendor: 14
-  Warbound_1: 165
-  Warbound_10: 174
-  Warbound_11: 175
-  Warbound_12: 176
-  Warbound_13: 177
-  Warbound_14: 178
-  Warbound_15: 179
-  Warbound_16: 180
-  Warbound_17: 181
-  Warbound_18: 182
-  Warbound_19: 183
-  Warbound_2: 166
-  Warbound_20: 184
-  Warbound_3: 167
-  Warbound_4: 168
-  Warbound_5: 169
-  Warbound_6: 170
-  Warbound_7: 171
-  Warbound_8: 172
-  Warbound_9: 173
-  WarMode: 76
-  WeeklyRewardsAdditional: 72
-  WeeklyRewardsConcession: 73
-  WorldBoss: 81
-  WorldQuest_1: 25
-  WorldQuest_10: 43
-  WorldQuest_11: 53
-  WorldQuest_12: 54
-  WorldQuest_13: 55
-  WorldQuest_2: 26
-  WorldQuest_3: 27
-  WorldQuest_4: 28
-  WorldQuest_5: 29
-  WorldQuest_6: 30
-  WorldQuest_7: 36
-  WorldQuest_8: 37
-  WorldQuest_9: 42
-  WorldQuestJackpot: 74
+  values:
+    BlackMarket: 15
+    ChallengeMode_1: 16
+    ChallengeMode_2: 33
+    ChallengeMode_3: 34
+    ChallengeMode_4: 87
+    ChallengeModeJackpot: 35
+    CharacterBoost_1: 61
+    CharacterBoost_2: 62
+    CharacterBoost_3: 86
+    CorpseRecovery: 80
+    Delves_1: 104
+    Delves_2: 106
+    Delves_3: 107
+    DelvesBonus_1: 129
+    DelvesBonus_10: 138
+    DelvesBonus_2: 130
+    DelvesBonus_3: 131
+    DelvesBonus_4: 132
+    DelvesBonus_5: 133
+    DelvesBonus_6: 134
+    DelvesBonus_7: 135
+    DelvesBonus_8: 136
+    DelvesBonus_9: 137
+    DelvesBounty_1: 117
+    DelvesBounty_2: 118
+    DelvesBounty_3: 119
+    DelvesBounty_4: 120
+    DelvesBounty_5: 121
+    DelvesBounty_6: 122
+    DelvesBounty_7: 123
+    DelvesBounty_8: 124
+    DelvesJackpot: 108
+    DelvesKey_1: 109
+    DelvesKey_2: 110
+    DelvesKey_3: 111
+    DelvesKey_4: 112
+    DelvesKey_5: 113
+    DelvesKey_6: 114
+    DelvesKey_7: 115
+    DelvesKey_8: 116
+    DelvesLevelUp_1: 125
+    DelvesLevelUp_2: 126
+    DelvesLevelUp_3: 127
+    DelvesLevelUp_4: 128
+    DungeonBonus_1: 139
+    DungeonBonus_10: 148
+    DungeonBonus_2: 140
+    DungeonBonus_3: 141
+    DungeonBonus_4: 142
+    DungeonBonus_5: 143
+    DungeonBonus_6: 144
+    DungeonBonus_7: 145
+    DungeonBonus_8: 146
+    DungeonBonus_9: 147
+    DungeonHardMode_1: 159
+    DungeonHardMode_2: 160
+    DungeonHardMode_3: 161
+    DungeonHeroic: 2
+    DungeonHeroicJackpot: 102
+    DungeonLevelUp_1: 17
+    DungeonLevelUp_2: 18
+    DungeonLevelUp_3: 19
+    DungeonLevelUp_4: 20
+    DungeonMythic: 23
+    DungeonMythicJackpot: 103
+    DungeonNormal: 1
+    DungeonNormalJackpot: 101
+    Endeavors: 185
+    ForceNone: 21
+    LegendaryCrafting_1: 63
+    LegendaryCrafting_2: 64
+    LegendaryCrafting_3: 65
+    LegendaryCrafting_4: 66
+    LegendaryCrafting_5: 67
+    LegendaryCrafting_6: 68
+    LegendaryCrafting_7: 69
+    LegendaryCrafting_8: 70
+    LegendaryCrafting_9: 71
+    LegendaryForge: 59
+    MissionReward_1: 31
+    MissionReward_2: 32
+    NewCharacter: 75
+    None: 0
+    PvPBrawl_1: 77
+    PvPBrawl_2: 78
+    PvPHonorReward: 24
+    PvPRanked_1: 8
+    PvPRanked_2: 38
+    PvPRanked_3: 39
+    PvPRanked_4: 40
+    PvPRanked_5: 44
+    PvPRanked_6: 45
+    PvPRanked_7: 46
+    PvPRanked_8: 52
+    PvPRanked_9: 88
+    PvPRankedJackpot: 56
+    PvPUnranked_1: 7
+    PvPUnranked_2: 41
+    PvPUnranked_3: 47
+    PvPUnranked_4: 48
+    PvPUnranked_5: 49
+    PvPUnranked_6: 50
+    PvPUnranked_7: 51
+    QuestBonusLoot: 60
+    QuestReward: 11
+    RaidBonus_1: 149
+    RaidBonus_10: 158
+    RaidBonus_2: 150
+    RaidBonus_3: 151
+    RaidBonus_4: 152
+    RaidBonus_5: 153
+    RaidBonus_6: 154
+    RaidBonus_7: 155
+    RaidBonus_8: 156
+    RaidBonus_9: 157
+    RaidFinder: 4
+    RaidFinderExtended: 83
+    RaidFinderExtended_2: 90
+    RaidFinderExtended_3: 94
+    RaidHeroic: 5
+    RaidHeroicExtended: 84
+    RaidHeroicExtended_2: 91
+    RaidHeroicExtended_3: 95
+    RaidMythic: 6
+    RaidMythicExtended: 85
+    RaidMythicExtended_2: 92
+    RaidMythicExtended_3: 96
+    RaidNormal: 3
+    RaidNormalExtended: 82
+    RaidNormalExtended_2: 89
+    RaidNormalExtended_3: 93
+    Relinquished: 58
+    ScenarioHeroic: 10
+    ScenarioNormal: 9
+    Store: 12
+    TemplateCharacter_1: 97
+    TemplateCharacter_2: 98
+    TemplateCharacter_3: 99
+    TemplateCharacter_4: 100
+    Timerunning: 105
+    TimewalkerLevelUp: 22
+    TimewalkerMaxLevel: 186
+    Torghast: 79
+    TournamentRealm_1: 57
+    TournamentRealm_2: 162
+    TournamentRealm_3: 163
+    TournamentRealm_4: 164
+    TradeSkill: 13
+    Vendor: 14
+    Warbound_1: 165
+    Warbound_10: 174
+    Warbound_11: 175
+    Warbound_12: 176
+    Warbound_13: 177
+    Warbound_14: 178
+    Warbound_15: 179
+    Warbound_16: 180
+    Warbound_17: 181
+    Warbound_18: 182
+    Warbound_19: 183
+    Warbound_2: 166
+    Warbound_20: 184
+    Warbound_3: 167
+    Warbound_4: 168
+    Warbound_5: 169
+    Warbound_6: 170
+    Warbound_7: 171
+    Warbound_8: 172
+    Warbound_9: 173
+    WarMode: 76
+    WeeklyRewardsAdditional: 72
+    WeeklyRewardsConcession: 73
+    WorldBoss: 81
+    WorldQuest_1: 25
+    WorldQuest_10: 43
+    WorldQuest_11: 53
+    WorldQuest_12: 54
+    WorldQuest_13: 55
+    WorldQuest_2: 26
+    WorldQuest_3: 27
+    WorldQuest_4: 28
+    WorldQuest_5: 29
+    WorldQuest_6: 30
+    WorldQuest_7: 36
+    WorldQuest_8: 37
+    WorldQuest_9: 42
+    WorldQuestJackpot: 74
 ItemDisplayTextDisplayStyle:
-  ItemNameAndInfoText: 1
-  ItemNameOnlyCentered: 2
-  PlayerChoiceReward: 3
-  WorldQuestReward: 0
+  values:
+    ItemNameAndInfoText: 1
+    ItemNameOnlyCentered: 2
+    PlayerChoiceReward: 3
+    WorldQuestReward: 0
 ItemDisplayTooltipEnabledType:
-  Disabled: 1
-  Enabled: 0
+  values:
+    Disabled: 1
+    Enabled: 0
 ItemGemColor:
-  Arcane: 1024
-  Blood: 128
-  Blue: 8
-  Cogwheel: 32
-  Cypher: 8388608
-  DominationBlood: 1048576
-  DominationFrost: 2097152
-  DominationUnholy: 4194304
-  Fel: 512
-  Fiber: 1073741824
-  Fire: 4096
-  Fragrance: 67108864
-  Frost: 2048
-  Holy: 65536
-  Hydraulic: 16
-  Iron: 64
-  Life: 16384
-  Meta: 1
-  Primordial: 33554432
-  PunchcardBlue: 524288
-  PunchcardRed: 131072
-  PunchcardYellow: 262144
-  Red: 2
-  Shadow: 256
-  SingingSea: 268435456
-  SingingThunder: 134217728
-  SingingWind: 536870912
-  Tinker: 16777216
-  Water: 8192
-  Wind: 32768
-  Yellow: 4
+  values:
+    Arcane: 1024
+    Blood: 128
+    Blue: 8
+    Cogwheel: 32
+    Cypher: 8388608
+    DominationBlood: 1048576
+    DominationFrost: 2097152
+    DominationUnholy: 4194304
+    Fel: 512
+    Fiber: 1073741824
+    Fire: 4096
+    Fragrance: 67108864
+    Frost: 2048
+    Holy: 65536
+    Hydraulic: 16
+    Iron: 64
+    Life: 16384
+    Meta: 1
+    Primordial: 33554432
+    PunchcardBlue: 524288
+    PunchcardRed: 131072
+    PunchcardYellow: 262144
+    Red: 2
+    Shadow: 256
+    SingingSea: 268435456
+    SingingThunder: 134217728
+    SingingWind: 536870912
+    Tinker: 16777216
+    Water: 8192
+    Wind: 32768
+    Yellow: 4
 ItemGemSubclass:
-  Agility: 1
-  Artifactrelic: 11
-  Criticalstrike: 5
-  Haste: 7
-  Intellect: 0
-  Mastery: 6
-  Multiplestats: 10
-  Other: 9
-  Spirit: 4
-  Stamina: 3
-  Strength: 2
-  Versatility: 8
+  values:
+    Agility: 1
+    Artifactrelic: 11
+    Criticalstrike: 5
+    Haste: 7
+    Intellect: 0
+    Mastery: 6
+    Multiplestats: 10
+    Other: 9
+    Spirit: 4
+    Stamina: 3
+    Strength: 2
+    Versatility: 8
 ItemHousingSubclass:
-  Decor: 0
-  Dye: 1
-  ExteriorCustomization: 4
-  Room: 2
-  RoomCustomization: 3
-  ServiceItem: 5
+  values:
+    Decor: 0
+    Dye: 1
+    ExteriorCustomization: 4
+    Room: 2
+    RoomCustomization: 3
+    ServiceItem: 5
 ItemMiscellaneousSubclass:
-  CompanionPet: 2
-  Holiday: 3
-  Junk: 0
-  Mount: 5
-  MountEquipment: 6
-  Other: 4
-  Reagent: 1
+  values:
+    CompanionPet: 2
+    Holiday: 3
+    Junk: 0
+    Mount: 5
+    MountEquipment: 6
+    Other: 4
+    Reagent: 1
 ItemModification:
-  ArtifactAppearanceID: 8
-  ArtifactTier: 24
-  BattlePetBreed: 4
-  BattlePetCreaturedisplayid: 6
-  BattlePetLevel: 5
-  BattlePetSpecies: 3
-  ChangeModifiedCraftingStat_1: 29
-  ChangeModifiedCraftingStat_2: 30
-  ContentTuningID: 28
-  CraftingDataID: 40
-  CraftingQualityID: 38
-  CraftingReagentSlot_0: 43
-  CraftingReagentSlot_1: 44
-  CraftingReagentSlot_10: 53
-  CraftingReagentSlot_11: 54
-  CraftingReagentSlot_12: 55
-  CraftingReagentSlot_13: 56
-  CraftingReagentSlot_14: 57
-  CraftingReagentSlot_2: 45
-  CraftingReagentSlot_3: 46
-  CraftingReagentSlot_4: 47
-  CraftingReagentSlot_5: 48
-  CraftingReagentSlot_6: 49
-  CraftingReagentSlot_7: 50
-  CraftingReagentSlot_8: 51
-  CraftingReagentSlot_9: 52
-  CraftingSkillLineAbilityID: 39
-  CraftingSkillReagents: 41
-  CraftingSkillWatermark: 42
-  CurrencyWalletID: 61
-  CurrencyWalletQuantity: 62
-  CurrencyWalletVersion: 63
-  DbidHigh: 59
-  DbidLow: 60
-  IncrementLevelObsolete: 2
-  KeystoneAffix0: 19
-  KeystoneAffix01: 20
-  KeystoneAffix02: 21
-  KeystoneAffix03: 22
-  KeystoneMapChallengeModeID: 17
-  KeystonePowerLevel: 18
-  LegionArtifactKnowledgeObsolete: 23
-  PvPRating: 26
-  RedirectedBaseStats: 64
-  Reforge: 58
-  SoulbindConduitRank: 37
-  TimewalkerLevel: 9
-  TransmogrifyItemModifiedAppearanceIDSpec_0: 1
-  TransmogrifyItemModifiedAppearanceIDSpec_1: 11
-  TransmogrifyItemModifiedAppearanceIDSpec_2: 13
-  TransmogrifyItemModifiedAppearanceIDSpec_3: 15
-  TransmogrifyItemModifiedAppearanceIDSpec_4: 25
-  TransmogrifyItemModifiedAppearanceIDSpecAll: 0
-  TransmogrifyOverrideEnchantVisualIDSpec_0: 10
-  TransmogrifyOverrideEnchantVisualIDSpec_1: 12
-  TransmogrifyOverrideEnchantVisualIDSpec_2: 14
-  TransmogrifyOverrideEnchantVisualIDSpec_3: 16
-  TransmogrifyOverrideEnchantVisualIDSpec_4: 27
-  TransmogrifyOverrideEnchantVisualIDSpecAll: 7
-  TransmogrifySecondaryItemModifiedAppearanceIDSpec_0: 32
-  TransmogrifySecondaryItemModifiedAppearanceIDSpec_1: 33
-  TransmogrifySecondaryItemModifiedAppearanceIDSpec_2: 34
-  TransmogrifySecondaryItemModifiedAppearanceIDSpec_3: 35
-  TransmogrifySecondaryItemModifiedAppearanceIDSpec_4: 36
-  TransmogrifySecondaryItemModifiedAppearanceIDSpecAll: 31
+  values:
+    ArtifactAppearanceID: 8
+    ArtifactTier: 24
+    BattlePetBreed: 4
+    BattlePetCreaturedisplayid: 6
+    BattlePetLevel: 5
+    BattlePetSpecies: 3
+    ChangeModifiedCraftingStat_1: 29
+    ChangeModifiedCraftingStat_2: 30
+    ContentTuningID: 28
+    CraftingDataID: 40
+    CraftingQualityID: 38
+    CraftingReagentSlot_0: 43
+    CraftingReagentSlot_1: 44
+    CraftingReagentSlot_10: 53
+    CraftingReagentSlot_11: 54
+    CraftingReagentSlot_12: 55
+    CraftingReagentSlot_13: 56
+    CraftingReagentSlot_14: 57
+    CraftingReagentSlot_2: 45
+    CraftingReagentSlot_3: 46
+    CraftingReagentSlot_4: 47
+    CraftingReagentSlot_5: 48
+    CraftingReagentSlot_6: 49
+    CraftingReagentSlot_7: 50
+    CraftingReagentSlot_8: 51
+    CraftingReagentSlot_9: 52
+    CraftingSkillLineAbilityID: 39
+    CraftingSkillReagents: 41
+    CraftingSkillWatermark: 42
+    CurrencyWalletID: 61
+    CurrencyWalletQuantity: 62
+    CurrencyWalletVersion: 63
+    DbidHigh: 59
+    DbidLow: 60
+    IncrementLevelObsolete: 2
+    KeystoneAffix0: 19
+    KeystoneAffix01: 20
+    KeystoneAffix02: 21
+    KeystoneAffix03: 22
+    KeystoneMapChallengeModeID: 17
+    KeystonePowerLevel: 18
+    LegionArtifactKnowledgeObsolete: 23
+    PvPRating: 26
+    RedirectedBaseStats: 64
+    Reforge: 58
+    SoulbindConduitRank: 37
+    TimewalkerLevel: 9
+    TransmogrifyItemModifiedAppearanceIDSpec_0: 1
+    TransmogrifyItemModifiedAppearanceIDSpec_1: 11
+    TransmogrifyItemModifiedAppearanceIDSpec_2: 13
+    TransmogrifyItemModifiedAppearanceIDSpec_3: 15
+    TransmogrifyItemModifiedAppearanceIDSpec_4: 25
+    TransmogrifyItemModifiedAppearanceIDSpecAll: 0
+    TransmogrifyOverrideEnchantVisualIDSpec_0: 10
+    TransmogrifyOverrideEnchantVisualIDSpec_1: 12
+    TransmogrifyOverrideEnchantVisualIDSpec_2: 14
+    TransmogrifyOverrideEnchantVisualIDSpec_3: 16
+    TransmogrifyOverrideEnchantVisualIDSpec_4: 27
+    TransmogrifyOverrideEnchantVisualIDSpecAll: 7
+    TransmogrifySecondaryItemModifiedAppearanceIDSpec_0: 32
+    TransmogrifySecondaryItemModifiedAppearanceIDSpec_1: 33
+    TransmogrifySecondaryItemModifiedAppearanceIDSpec_2: 34
+    TransmogrifySecondaryItemModifiedAppearanceIDSpec_3: 35
+    TransmogrifySecondaryItemModifiedAppearanceIDSpec_4: 36
+    TransmogrifySecondaryItemModifiedAppearanceIDSpecAll: 31
 ItemProfessionSubclass:
-  Alchemy: 2
-  Archaeology: 13
-  Blacksmithing: 0
-  Cooking: 4
-  Enchanting: 8
-  Engineering: 7
-  Fishing: 9
-  Herbalism: 3
-  Inscription: 12
-  Jewelcrafting: 11
-  Leatherworking: 1
-  Mining: 5
-  Skinning: 10
-  Tailoring: 6
+  values:
+    Alchemy: 2
+    Archaeology: 13
+    Blacksmithing: 0
+    Cooking: 4
+    Enchanting: 8
+    Engineering: 7
+    Fishing: 9
+    Herbalism: 3
+    Inscription: 12
+    Jewelcrafting: 11
+    Leatherworking: 1
+    Mining: 5
+    Skinning: 10
+    Tailoring: 6
 ItemQuality:
-  Artifact: 6
-  Common: 1
-  Epic: 4
-  Heirloom: 7
-  Legendary: 5
-  Poor: 0
-  Rare: 3
-  Uncommon: 2
-  WoWToken: 8
+  values:
+    Artifact: 6
+    Common: 1
+    Epic: 4
+    Heirloom: 7
+    Legendary: 5
+    Poor: 0
+    Rare: 3
+    Uncommon: 2
+    WoWToken: 8
 ItemReagentSubclass:
-  ContextToken: 2
-  Keystone: 1
-  Reagent: 0
+  values:
+    ContextToken: 2
+    Keystone: 1
+    Reagent: 0
 ItemRecipeSubclass:
-  Alchemy: 6
-  Blacksmithing: 4
-  Book: 0
-  Cooking: 5
-  Enchanting: 8
-  Engineering: 3
-  FirstAid: 7
-  Fishing: 9
-  Inscription: 11
-  Jewelcrafting: 10
-  Leatherworking: 1
-  Tailoring: 2
+  values:
+    Alchemy: 6
+    Blacksmithing: 4
+    Book: 0
+    Cooking: 5
+    Enchanting: 8
+    Engineering: 3
+    FirstAid: 7
+    Fishing: 9
+    Inscription: 11
+    Jewelcrafting: 10
+    Leatherworking: 1
+    Tailoring: 2
 ItemRecraftFlags:
-  Invalid: 1
+  values:
+    Invalid: 1
 ItemRedundancySlot:
-  Chest: 3
-  Cloak: 11
-  Feet: 6
-  Finger: 9
-  Hand: 8
-  Head: 0
-  Legs: 5
-  MainhandWeapon: 13
-  Neck: 1
-  Offhand: 16
-  OnehandWeapon: 14
-  OnehandWeaponSecond: 15
-  Shoulder: 2
-  Trinket: 10
-  Twohand: 12
-  Waist: 4
-  Wrist: 7
+  values:
+    Chest: 3
+    Cloak: 11
+    Feet: 6
+    Finger: 9
+    Hand: 8
+    Head: 0
+    Legs: 5
+    MainhandWeapon: 13
+    Neck: 1
+    Offhand: 16
+    OnehandWeapon: 14
+    OnehandWeaponSecond: 15
+    Shoulder: 2
+    Trinket: 10
+    Twohand: 12
+    Waist: 4
+    Wrist: 7
 Itemsetflags:
-  Legacy: 1
-  RequiresPvPTalentsActive: 4
-  UseItemHistorySetSlots: 2
+  values:
+    Legacy: 1
+    RequiresPvPTalentsActive: 4
+    UseItemHistorySetSlots: 2
 ItemSlotFilterType:
-  Chest: 4
-  Cloak: 3
-  Feet: 9
-  Finger: 12
-  Hand: 6
-  Head: 0
-  Legs: 8
-  MainHand: 10
-  Neck: 1
-  NoFilter: 15
-  OffHand: 11
-  Other: 14
-  Shoulder: 2
-  Trinket: 13
-  Waist: 7
-  Wrist: 5
+  values:
+    Chest: 4
+    Cloak: 3
+    Feet: 9
+    Finger: 12
+    Hand: 6
+    Head: 0
+    Legs: 8
+    MainHand: 10
+    Neck: 1
+    NoFilter: 15
+    OffHand: 11
+    Other: 14
+    Shoulder: 2
+    Trinket: 13
+    Waist: 7
+    Wrist: 5
 ItemSocketInfoUIType:
-  Default: 0
+  values:
+    Default: 0
 ItemSocketType:
-  Arcane: 12
-  Blood: 9
-  Blue: 4
-  Cogwheel: 6
-  Cypher: 23
-  Domination: 22
-  Fel: 11
-  Fiber: 30
-  Fire: 14
-  Fragrance: 26
-  Frost: 13
-  Holy: 18
-  Hydraulic: 5
-  Iron: 8
-  Life: 16
-  Meta: 1
-  None: 0
-  Primordial: 25
-  Prismatic: 7
-  PunchcardBlue: 21
-  PunchcardRed: 19
-  PunchcardYellow: 20
-  Red: 2
-  Shadow: 10
-  SingingSea: 28
-  SingingThunder: 27
-  SingingWind: 29
-  Tinker: 24
-  Water: 15
-  Wind: 17
-  Yellow: 3
+  values:
+    Arcane: 12
+    Blood: 9
+    Blue: 4
+    Cogwheel: 6
+    Cypher: 23
+    Domination: 22
+    Fel: 11
+    Fiber: 30
+    Fire: 14
+    Fragrance: 26
+    Frost: 13
+    Holy: 18
+    Hydraulic: 5
+    Iron: 8
+    Life: 16
+    Meta: 1
+    None: 0
+    Primordial: 25
+    Prismatic: 7
+    PunchcardBlue: 21
+    PunchcardRed: 19
+    PunchcardYellow: 20
+    Red: 2
+    Shadow: 10
+    SingingSea: 28
+    SingingThunder: 27
+    SingingWind: 29
+    Tinker: 24
+    Water: 15
+    Wind: 17
+    Yellow: 3
 ItemSoundType:
-  Close: 3
-  Drop: 1
-  Pickup: 0
-  Use: 2
+  values:
+    Close: 3
+    Drop: 1
+    Pickup: 0
+    Use: 2
 ItemSubclassDisplay:
-  HideSubclassInAuction: 2
-  HideSubclassInTooltips: 1
-  ShowItemCount: 4
+  values:
+    HideSubclassInAuction: 2
+    HideSubclassInTooltips: 1
+    ShowItemCount: 4
 ItemSubclassFlag:
-  ArmorsubclassLfgscalingarmor: 1024
-  ItemsubclassQuivernotrequired: 64
-  ItemsubclassUsesInvtype: 512
-  WeaponsubclassCanparry: 1
-  WeaponsubclassDeprecatedReuseMe: 256
-  WeaponsubclassIsrifle: 8
-  WeaponsubclassIsthrown: 16
-  WeaponsubclassIsunarmed: 4
-  WeaponsubclassRanged: 128
-  WeaponsubclassRighthandRanged: 32
-  WeaponsubclassSetfingerseq: 2
+  values:
+    ArmorsubclassLfgscalingarmor: 1024
+    ItemsubclassQuivernotrequired: 64
+    ItemsubclassUsesInvtype: 512
+    WeaponsubclassCanparry: 1
+    WeaponsubclassDeprecatedReuseMe: 256
+    WeaponsubclassIsrifle: 8
+    WeaponsubclassIsthrown: 16
+    WeaponsubclassIsunarmed: 4
+    WeaponsubclassRanged: 128
+    WeaponsubclassRighthandRanged: 32
+    WeaponsubclassSetfingerseq: 2
 ItemTryOnReason:
-  DataPending: 3
-  NotEquippable: 2
-  Success: 0
-  WrongRace: 1
+  values:
+    DataPending: 3
+    NotEquippable: 2
+    Success: 0
+    WrongRace: 1
 ItemWeaponSubclass:
-  Axe1H: 0
-  Axe2H: 1
-  Bearclaw: 11
-  Bows: 2
-  Catclaw: 12
-  Crossbow: 18
-  Dagger: 15
-  Fishingpole: 20
-  Generic: 14
-  Guns: 3
-  Mace1H: 4
-  Mace2H: 5
-  Obsolete3: 17
-  Polearm: 6
-  Staff: 10
-  Sword1H: 7
-  Sword2H: 8
-  Thrown: 16
-  Unarmed: 13
-  Wand: 19
-  Warglaive: 9
+  values:
+    Axe1H: 0
+    Axe2H: 1
+    Bearclaw: 11
+    Bows: 2
+    Catclaw: 12
+    Crossbow: 18
+    Dagger: 15
+    Fishingpole: 20
+    Generic: 14
+    Guns: 3
+    Mace1H: 4
+    Mace2H: 5
+    Obsolete3: 17
+    Polearm: 6
+    Staff: 10
+    Sword1H: 7
+    Sword2H: 8
+    Thrown: 16
+    Unarmed: 13
+    Wand: 19
+    Warglaive: 9
 JailersTowerType:
-  AdamantVaults: 11
-  ArkobanHall: 7
-  BossRush: 14
-  Coldheart: 4
-  ForgottenCatacombs: 12
-  FractureChambers: 2
-  Mortregar: 5
-  Ossuary: 13
-  SkoldusHalls: 1
-  Soulforges: 3
-  TormentChamberAnduin: 10
-  TormentChamberJaina: 8
-  TormentChamberThrall: 9
-  TwistingCorridors: 0
-  UpperReaches: 6
+  values:
+    AdamantVaults: 11
+    ArkobanHall: 7
+    BossRush: 14
+    Coldheart: 4
+    ForgottenCatacombs: 12
+    FractureChambers: 2
+    Mortregar: 5
+    Ossuary: 13
+    SkoldusHalls: 1
+    Soulforges: 3
+    TormentChamberAnduin: 10
+    TormentChamberJaina: 8
+    TormentChamberThrall: 9
+    TwistingCorridors: 0
+    UpperReaches: 6
 JournalEncounterFlags:
-  AllianceOnly: 4
-  DoNotDisplayEncounter: 64
-  HordeOnly: 8
-  InternalOnly: 32
-  LimitDifficulties: 2
-  NoMap: 16
-  Obsolete: 1
+  values:
+    AllianceOnly: 4
+    DoNotDisplayEncounter: 64
+    HordeOnly: 8
+    InternalOnly: 32
+    LimitDifficulties: 2
+    NoMap: 16
+    Obsolete: 1
 JournalEncounterIconFlags:
-  Bleed: 8192
-  Curse: 256
-  Deadly: 16
-  Disease: 1024
-  Dps: 2
-  Enrage: 2048
-  Healer: 4
-  Heroic: 8
-  Important: 32
-  Interruptible: 64
-  Magic: 128
-  Mythic: 4096
-  Poison: 512
-  Tank: 1
+  values:
+    Bleed: 8192
+    Curse: 256
+    Deadly: 16
+    Disease: 1024
+    Dps: 2
+    Enrage: 2048
+    Healer: 4
+    Heroic: 8
+    Important: 32
+    Interruptible: 64
+    Magic: 128
+    Mythic: 4096
+    Poison: 512
+    Tank: 1
 JournalEncounterItemFlags:
-  DisplayAsExtremelyRare: 16
-  DisplayAsPerPlayerLoot: 4
-  DisplayAsVeryRare: 8
-  LimitDifficulties: 2
-  Obsolete: 1
+  values:
+    DisplayAsExtremelyRare: 16
+    DisplayAsPerPlayerLoot: 4
+    DisplayAsVeryRare: 8
+    LimitDifficulties: 2
+    Obsolete: 1
 JournalEncounterLocFlags:
-  Primary: 1
+  values:
+    Primary: 1
 JournalEncounterSectionFlags:
-  LimitDifficulties: 2
-  StartExpanded: 1
+  values:
+    LimitDifficulties: 2
+    StartExpanded: 1
 JournalEncounterSecTypes:
-  Ability: 2
-  Creature: 1
-  Generic: 0
-  Overview: 3
+  values:
+    Ability: 2
+    Creature: 1
+    Generic: 0
+    Overview: 3
 JournalInstanceFlags:
-  DoNotDisplayInstance: 4
-  HideUserSelectableDifficulty: 2
-  Timewalker: 1
+  values:
+    DoNotDisplayInstance: 4
+    HideUserSelectableDifficulty: 2
+    Timewalker: 1
 JournalLinkTypes:
-  Encounter: 1
-  Instance: 0
-  Section: 2
-  Tier: 3
+  values:
+    Encounter: 1
+    Instance: 0
+    Section: 2
+    Tier: 3
 LanguageFlag:
-  HiddenFromPlayer: 2
-  HideLanguageNameInChat: 4
-  IsExotic: 1
+  values:
+    HiddenFromPlayer: 2
+    HideLanguageNameInChat: 4
+    IsExotic: 1
 LeavePartyConfirmReason:
-  QuestSync: 0
-  RestrictedChallengeMode: 1
+  values:
+    QuestSync: 0
+    RestrictedChallengeMode: 1
 LFGEntryGeneralPlaystyle:
-  Expert: 4
-  FunRelaxed: 2
-  FunSerious: 3
-  Learning: 1
-  None: 0
+  values:
+    Expert: 4
+    FunRelaxed: 2
+    FunSerious: 3
+    Learning: 1
+    None: 0
 LFGEntryPlaystyle:
-  Casual: 2
-  Hardcore: 3
-  None: 0
-  Standard: 1
+  values:
+    Casual: 2
+    Hardcore: 3
+    None: 0
+    Standard: 1
 LFGListDisplayType:
-  ClassEnumerate: 2
-  Comment: 5
-  HideAll: 3
-  PlayerCount: 4
-  RoleCount: 0
-  RoleEnumerate: 1
+  values:
+    ClassEnumerate: 2
+    Comment: 5
+    HideAll: 3
+    PlayerCount: 4
+    RoleCount: 0
+    RoleEnumerate: 1
 LFGListFilter:
-  CurrentExpansion: 32
-  CurrentSeason: 64
-  NotCurrentSeason: 128
-  NotRecommended: 2
-  PvE: 4
-  PvP: 8
-  Recommended: 1
-  Timerunning: 16
+  values:
+    CurrentExpansion: 32
+    CurrentSeason: 64
+    NotCurrentSeason: 128
+    NotRecommended: 2
+    PvE: 4
+    PvP: 8
+    Recommended: 1
+    Timerunning: 16
 LFGRole:
-  Damage: 2
-  Healer: 1
-  Tank: 0
+  values:
+    Damage: 2
+    Healer: 1
+    Tank: 0
 LFGSlotInvalidReason:
-  AreaNotExplored: 9
-  CannotRunAnyChildDungeon: 14
-  ChromieTime: 16
-  EngagedInPvP: 12
-  ExpansionTooLow: 1
-  GearTooHigh: 5
-  GearTooLow: 4
-  LevelTargetTooHigh: 8
-  LevelTargetTooLow: 7
-  LevelTooHigh: 3
-  LevelTooLow: 2
-  None: 0
-  NoSpec: 13
-  NoValidRoles: 11
-  Npe: 17
-  PlayerConditionFailed: 19
-  RaidLocked: 6
-  Restricted: 15
-  Timerunning: 18
-  WrongFaction: 10
+  values:
+    AreaNotExplored: 9
+    CannotRunAnyChildDungeon: 14
+    ChromieTime: 16
+    EngagedInPvP: 12
+    ExpansionTooLow: 1
+    GearTooHigh: 5
+    GearTooLow: 4
+    LevelTargetTooHigh: 8
+    LevelTargetTooLow: 7
+    LevelTooHigh: 3
+    LevelTooLow: 2
+    None: 0
+    NoSpec: 13
+    NoValidRoles: 11
+    Npe: 17
+    PlayerConditionFailed: 19
+    RaidLocked: 6
+    Restricted: 15
+    Timerunning: 18
+    WrongFaction: 10
 LgVendorPurchaseSettlementState:
-  NotSettled: 1
-  Settled: 0
+  values:
+    NotSettled: 1
+    Settled: 0
 LgVendorPurchaseSqlResults:
-  AlreadyOwned: 102
-  Failed: 0
-  InsufficientFunds: 101
-  InsufficientSpent: 103
-  InvalidState: 107
-  NoRecord: 106
-  NotOwned: 104
-  RefundExpired: 105
-  Success: 100
+  values:
+    AlreadyOwned: 102
+    Failed: 0
+    InsufficientFunds: 101
+    InsufficientSpent: 103
+    InvalidState: 107
+    NoRecord: 106
+    NotOwned: 104
+    RefundExpired: 105
+    Success: 100
 LgVendorPurchaseState:
-  NotOwned: 0
-  Owned: 1
+  values:
+    NotOwned: 0
+    Owned: 1
 LightRadiusIndicatorType:
-  Always: 0
-  Never: 2
-  Overlap: 1
+  values:
+    Always: 0
+    Never: 2
+    Overlap: 1
 LimitedInputType:
-  MouseDown: 1
-  MouseMove: 0
-  MouseUp: 2
-  MouseWheel: 3
+  values:
+    MouseDown: 1
+    MouseMove: 0
+    MouseUp: 2
+    MouseWheel: 3
 LinkedCurrencyFlags:
-  AddIgnoresMax: 8
-  IgnoreAdd: 1
-  IgnoreSubtract: 2
-  SuppressChatLog: 4
+  values:
+    AddIgnoresMax: 8
+    IgnoreAdd: 1
+    IgnoreSubtract: 2
+    SuppressChatLog: 4
 LoadConfigResult:
-  Error: 0
-  LoadInProgress: 2
-  NoChangesNecessary: 1
-  Ready: 3
+  values:
+    Error: 0
+    LoadInProgress: 2
+    NoChangesNecessary: 1
+    Ready: 3
 LogicLogicop:
-  And: 1
-  None: 0
-  Or: 2
-  Xor: 3
+  values:
+    And: 1
+    None: 0
+    Or: 2
+    Xor: 3
 LogicMathop:
-  Div: 4
-  Minus: 2
-  Mod: 5
-  None: 0
-  Plus: 1
-  Times: 3
+  values:
+    Div: 4
+    Minus: 2
+    Mod: 5
+    None: 0
+    Plus: 1
+    Times: 3
 LogicRelop:
-  Equal: 1
-  Gt: 5
-  Gteq: 6
-  Lt: 3
-  Lteq: 4
-  None: 0
-  Notequal: 2
+  values:
+    Equal: 1
+    Gt: 5
+    Gteq: 6
+    Lt: 3
+    Lteq: 4
+    None: 0
+    Notequal: 2
 LogPriority:
-  Debug: 30
-  Error: 2
-  Fatal: 1
-  Normal: 10
-  Spam: 40
-  Warning: 3
+  values:
+    Debug: 30
+    Error: 2
+    Fatal: 1
+    Normal: 10
+    Spam: 40
+    Warning: 3
 LootMethod:
-  Freeforall: 0
-  Group: 3
-  Masterlooter: 2
-  Needbeforegreed: 4
-  Personal: 5
-  Roundrobin: 1
+  values:
+    Freeforall: 0
+    Group: 3
+    Masterlooter: 2
+    Needbeforegreed: 4
+    Personal: 5
+    Roundrobin: 1
 LootMethodStyles:
-  Mainline: 0
-  Vanilla: 1
+  values:
+    Mainline: 0
+    Vanilla: 1
 LootSlotType:
-  Currency: 3
-  Item: 1
-  Money: 2
-  None: 0
+  values:
+    Currency: 3
+    Item: 1
+    Money: 2
+    None: 0
 LuaCurveType:
-  Cosine: 2
-  Cubic: 3
-  Linear: 0
-  Step: 1
+  values:
+    Cosine: 2
+    Cubic: 3
+    Linear: 0
+    Step: 1
 MajorFactionFeatureAbility:
-  Fishing: 1
-  Generic: 0
-  Hunts: 2
+  values:
+    Fishing: 1
+    Generic: 0
+    Hunts: 2
 MajorFactionType:
-  DragonscaleExpedition: 1
-  IskaaraTuskarr: 3
-  MaruukCentaur: 2
-  None: 0
-  ValdrakkenAccord: 4
+  values:
+    DragonscaleExpedition: 1
+    IskaaraTuskarr: 3
+    MaruukCentaur: 2
+    None: 0
+    ValdrakkenAccord: 4
 ManipulatorEventType:
-  Complete: 2
-  Delete: 3
-  Move: 1
-  Start: 0
+  values:
+    Complete: 2
+    Delete: 3
+    Move: 1
+    Start: 0
 MapCanvasPosition:
-  BottomLeft: 1
-  BottomRight: 2
-  None: 0
-  TopLeft: 3
-  TopRight: 4
+  values:
+    BottomLeft: 1
+    BottomRight: 2
+    None: 0
+    TopLeft: 3
+    TopRight: 4
 MapIconUIWidgetSetType:
-  AdventureMapDetails: 2
-  BehindIcon: 1
-  Tooltip: 0
+  values:
+    AdventureMapDetails: 2
+    BehindIcon: 1
+    Tooltip: 0
 MapobjEventTypes:
-  PlayAnim: 0
-  SetAnimSpeed: 1
+  values:
+    PlayAnim: 0
+    SetAnimSpeed: 1
 MapOverlayDisplayLocation:
-  BottomLeft: 1
-  BottomRight: 3
-  Default: 0
-  Hidden: 5
-  TopLeft: 2
-  TopRight: 4
+  values:
+    BottomLeft: 1
+    BottomRight: 3
+    Default: 0
+    Hidden: 5
+    TopLeft: 2
+    TopRight: 4
 MapPinAnimationType:
-  None: 0
-  Pulse: 1
+  values:
+    None: 0
+    Pulse: 1
 MatchDetailType:
-  Kills: 1
-  Placement: 0
-  PlunderAcquired: 2
+  values:
+    Kills: 1
+    Placement: 0
+    PlunderAcquired: 2
 MicroMenuOrder:
-  Default: 0
-  Reverse: 1
+  values:
+    Default: 0
+    Reverse: 1
 MicroMenuOrientation:
-  Horizontal: 0
-  Vertical: 1
+  values:
+    Horizontal: 0
+    Vertical: 1
 MinimapTrackingFilter:
-  AccountBanker: 4194304
-  AccountCompletedQuests: 2097152
-  Auctioneer: 1
-  Banker: 2
-  Barber: 262144
-  Battlemaster: 4
-  Digsites: 131072
-  Focus: 32768
-  Innkeeper: 32
-  ItemUpgrade: 524288
-  Mailbox: 64
-  POI: 8192
-  QuestPOIs: 65536
-  Repair: 512
-  Stablemaster: 2048
-  Target: 16384
-  TaxiNode: 8
-  TrainerProfession: 128
-  Transmogrifier: 4096
-  TrivialQuests: 1024
-  Unfiltered: 0
-  VenderFood: 16
-  VendorPoison: 1048576
-  VendorReagent: 256
+  values:
+    AccountBanker: 4194304
+    AccountCompletedQuests: 2097152
+    Auctioneer: 1
+    Banker: 2
+    Barber: 262144
+    Battlemaster: 4
+    Digsites: 131072
+    Focus: 32768
+    Innkeeper: 32
+    ItemUpgrade: 524288
+    Mailbox: 64
+    POI: 8192
+    QuestPOIs: 65536
+    Repair: 512
+    Stablemaster: 2048
+    Target: 16384
+    TaxiNode: 8
+    TrainerProfession: 128
+    Transmogrifier: 4096
+    TrivialQuests: 1024
+    Unfiltered: 0
+    VenderFood: 16
+    VendorPoison: 1048576
+    VendorReagent: 256
 ModelBlendOperation:
-  Anim: 1
-  None: 0
+  values:
+    Anim: 1
+    None: 0
 ModelLightType:
-  Directional: 0
-  Point: 1
+  values:
+    Directional: 0
+    Point: 1
 ModelSceneSetting:
-  AlignLightToOrbitDelta: 1
+  values:
+    AlignLightToOrbitDelta: 1
 ModelSceneType:
-  ArtifactRelicTalentEffect: 9
-  ArtifactTier2: 5
-  ArtifactTier2ForgingScene: 6
-  ArtifactTier2SlamEffect: 7
-  AzeriteItemLevelUpToast: 13
-  AzeritePowers: 14
-  AzeriteRewardGlow: 15
-  CommentatorVictoryFanfare: 8
-  EncounterJournal: 3
-  HeartOfAzeroth: 16
-  JailersTowerAnimaGlow: 19
-  MountJournal: 0
-  PartyPose: 12
-  PetJournalCard: 1
-  PetJournalLoadout: 4
-  PvPWarModeFire: 11
-  PvPWarModeOrb: 10
-  ShopCard: 2
-  Soulbinds: 18
-  WorldMapThreat: 17
+  values:
+    ArtifactRelicTalentEffect: 9
+    ArtifactTier2: 5
+    ArtifactTier2ForgingScene: 6
+    ArtifactTier2SlamEffect: 7
+    AzeriteItemLevelUpToast: 13
+    AzeritePowers: 14
+    AzeriteRewardGlow: 15
+    CommentatorVictoryFanfare: 8
+    EncounterJournal: 3
+    HeartOfAzeroth: 16
+    JailersTowerAnimaGlow: 19
+    MountJournal: 0
+    PartyPose: 12
+    PetJournalCard: 1
+    PetJournalLoadout: 4
+    PvPWarModeFire: 11
+    PvPWarModeOrb: 10
+    ShopCard: 2
+    Soulbinds: 18
+    WorldMapThreat: 17
 ModelSoundOverrideType:
-  Mute: 2
-  UseOverride: 1
-  UseParent: 0
+  values:
+    Mute: 2
+    UseOverride: 1
+    UseParent: 0
 ModelSoundTagType:
-  Looping: 2
-  Oneshot: 1
+  values:
+    Looping: 2
+    Oneshot: 1
 MountType:
-  Aquatic: 2
-  Dragonriding: 3
-  Flying: 1
-  Ground: 0
-  RideAlong: 4
+  values:
+    Aquatic: 2
+    Dragonriding: 3
+    Flying: 1
+    Ground: 0
+    RideAlong: 4
 MountTypeFlag:
-  IsAquaticMount: 2
-  IsDragonRidingMount: 4
-  IsFlyingMount: 1
-  IsRideAlongMount: 8
+  values:
+    IsAquaticMount: 2
+    IsDragonRidingMount: 4
+    IsFlyingMount: 1
+    IsRideAlongMount: 8
 NamePlateCastBarDisplay:
-  HighlightImportantCasts: 4
-  HighlightWhenCastTarget: 5
-  None: 0
-  SpellIcon: 2
-  SpellName: 1
-  SpellTarget: 3
+  values:
+    HighlightImportantCasts: 4
+    HighlightWhenCastTarget: 5
+    None: 0
+    SpellIcon: 2
+    SpellName: 1
+    SpellTarget: 3
 NamePlateEnemyNpcAuraDisplay:
-  Buffs: 1
-  CrowdControl: 3
-  Debuffs: 2
-  None: 0
+  values:
+    Buffs: 1
+    CrowdControl: 3
+    Debuffs: 2
+    None: 0
 NamePlateEnemyPlayerAuraDisplay:
-  Buffs: 1
-  Debuffs: 2
-  LossOfControl: 3
-  None: 0
+  values:
+    Buffs: 1
+    Debuffs: 2
+    LossOfControl: 3
+    None: 0
 NamePlateFriendlyPlayerAuraDisplay:
-  Buffs: 1
-  Debuffs: 2
-  LossOfControl: 3
-  None: 0
+  values:
+    Buffs: 1
+    Debuffs: 2
+    LossOfControl: 3
+    None: 0
 NamePlateInfoDisplay:
-  CurrentHealthPercent: 1
-  CurrentHealthValue: 2
-  None: 0
-  RarityIcon: 3
+  values:
+    CurrentHealthPercent: 1
+    CurrentHealthValue: 2
+    None: 0
+    RarityIcon: 3
 NamePlateSimplifiedType:
-  FriendlyNpc: 4
-  FriendlyPlayer: 3
-  Minion: 1
-  MinusMob: 2
-  None: 0
+  values:
+    FriendlyNpc: 4
+    FriendlyPlayer: 3
+    Minion: 1
+    MinusMob: 2
+    None: 0
 NamePlateSize:
-  ExtraLarge: 4
-  Huge: 5
-  Large: 3
-  Medium: 2
-  Small: 1
+  values:
+    ExtraLarge: 4
+    Huge: 5
+    Large: 3
+    Medium: 2
+    Small: 1
 NamePlateStackType:
-  Enemy: 1
-  Friendly: 2
-  None: 0
+  values:
+    Enemy: 1
+    Friendly: 2
+    None: 0
 NamePlateStyle:
-  Block: 2
-  CastFocus: 4
-  HealthFocus: 3
-  Legacy: 5
-  Modern: 0
-  Thin: 1
+  values:
+    Block: 2
+    CastFocus: 4
+    HealthFocus: 3
+    Legacy: 5
+    Modern: 0
+    Thin: 1
 NamePlateThreatDisplay:
-  Flash: 2
-  HealthBarColor: 3
-  None: 0
-  Progressive: 1
+  values:
+    Flash: 2
+    HealthBarColor: 3
+    None: 0
+    Progressive: 1
 NamePlateType:
-  Enemy: 1
-  Friendly: 0
+  values:
+    Enemy: 1
+    Friendly: 0
 NavigationState:
-  Disabled: 3
-  InRange: 2
-  Invalid: 0
-  Occluded: 1
+  values:
+    Disabled: 3
+    InRange: 2
+    Invalid: 0
+    Occluded: 1
 NeighborhoodFlags:
-  None: 0
-  OpenToPublic: 2
-  PoolParent: 1
+  values:
+    None: 0
+    OpenToPublic: 2
+    PoolParent: 1
 NeighborhoodInitiativeChestResult:
-  NiNoHouseFound: 2
-  NiNoRewards: 3
-  NiServiceDisabled: 5
-  NiSuccess: 0
-  NiThrottled: 4
-  NiUnspecifiedFailure: 1
+  values:
+    NiNoHouseFound: 2
+    NiNoRewards: 3
+    NiServiceDisabled: 5
+    NiSuccess: 0
+    NiThrottled: 4
+    NiUnspecifiedFailure: 1
 NeighborhoodInitiativeFlags:
-  Disabled: 1
-  NoAbandon: 2
-  NoRepeat: 4
+  values:
+    Disabled: 1
+    NoAbandon: 2
+    NoRepeat: 4
 NeighborhoodInitiativeNeighborhoodTypes:
-  NiNeighborhoodTypePool: 1
-  NiNeighborhoodTypeSingleton: 0
+  values:
+    NiNeighborhoodTypePool: 1
+    NiNeighborhoodTypeSingleton: 0
 NeighborhoodInitiativesCompletionStates:
-  NiCompletionStateNotCompleted: 0
-  NiCompletionStatePlayerCompleted: 1
-  NiCompletionStateSystemAbandoned: 2
+  values:
+    NiCompletionStateNotCompleted: 0
+    NiCompletionStatePlayerCompleted: 1
+    NiCompletionStateSystemAbandoned: 2
 NeighborhoodInitiativeTaskType:
-  RepeatableFinite: 1
-  RepeatableInfinite: 2
-  Single: 0
+  values:
+    RepeatableFinite: 1
+    RepeatableInfinite: 2
+    Single: 0
 NeighborhoodInitiativeUpdateStatus:
-  Completed: 2
-  Failed: 3
-  MilestoneCompleted: 1
-  Started: 0
+  values:
+    Completed: 2
+    Failed: 3
+    MilestoneCompleted: 1
+    Started: 0
 NeighborhoodInviteResult:
-  AlreadyInNeighborhood: 11
-  DbError: 1
-  Faction: 5
-  GenericFailure: 3
-  InviteLimit: 7
-  NotEnoughPlots: 8
-  NotFound: 9
-  PendingInvitation: 6
-  Permission: 4
-  RpcFailure: 2
-  Success: 0
-  TooManyRequests: 10
+  values:
+    AlreadyInNeighborhood: 11
+    DbError: 1
+    Faction: 5
+    GenericFailure: 3
+    InviteLimit: 7
+    NotEnoughPlots: 8
+    NotFound: 9
+    PendingInvitation: 6
+    Permission: 4
+    RpcFailure: 2
+    Success: 0
+    TooManyRequests: 10
 NeighborhoodMapFlags:
-  AlliancePurchasable: 1
-  CanSystemGenerate: 4
-  HordePurchasable: 2
-  None: 0
+  values:
+    AlliancePurchasable: 1
+    CanSystemGenerate: 4
+    HordePurchasable: 2
+    None: 0
 NeighborhoodOwnerType:
-  Charter: 2
-  Guild: 1
-  None: 0
+  values:
+    Charter: 2
+    Guild: 1
+    None: 0
 NeighborhoodType:
-  Open: 0
-  Private: 1
-  Public: 2
+  values:
+    Open: 0
+    Private: 1
+    Public: 2
 NewCharGear:
-  Preview: 1
-  Start: 0
+  values:
+    Preview: 1
+    Start: 0
 NodeOpFailureReason:
-  AccountDataNoMatch: 25
-  DataError: 13
-  EntryNotFound: 19
-  HasMutuallyExclusiveEdge: 4
-  LevelTooLow: 22
-  MaxRank: 12
-  MissingAchievement: 8
-  MissingEdgeConnection: 1
-  MissingQuest: 9
-  MissingRequiredEdge: 3
-  NodeNeverPurchasable: 24
-  NodeNotFound: 18
-  None: 0
-  NotEnoughCurrency: 15
-  NotEnoughCurrencySpent: 6
-  NotEnoughGold: 16
-  NotEnoughGoldSpent: 7
-  NotEnoughRanksInEntry: 26
-  NotEnoughSourcedCurrency: 14
-  NotEnoughSourcedCurrencySpent: 5
-  RequiredForCondition: 20
-  RequiredForEdge: 2
-  SameSelection: 17
-  TreeFlaggedNoRefund: 23
-  WrongSelection: 11
-  WrongSpec: 10
-  WrongTreeID: 21
+  values:
+    AccountDataNoMatch: 25
+    DataError: 13
+    EntryNotFound: 19
+    HasMutuallyExclusiveEdge: 4
+    LevelTooLow: 22
+    MaxRank: 12
+    MissingAchievement: 8
+    MissingEdgeConnection: 1
+    MissingQuest: 9
+    MissingRequiredEdge: 3
+    NodeNeverPurchasable: 24
+    NodeNotFound: 18
+    None: 0
+    NotEnoughCurrency: 15
+    NotEnoughCurrencySpent: 6
+    NotEnoughGold: 16
+    NotEnoughGoldSpent: 7
+    NotEnoughRanksInEntry: 26
+    NotEnoughSourcedCurrency: 14
+    NotEnoughSourcedCurrencySpent: 5
+    RequiredForCondition: 20
+    RequiredForEdge: 2
+    SameSelection: 17
+    TreeFlaggedNoRefund: 23
+    WrongSelection: 11
+    WrongSpec: 10
+    WrongTreeID: 21
 NoRPEReason:
-  BNetToken: 8
-  FactionOrRaceChange: 7
-  HasRPE: 0
-  IneligibleMap: 3
-  LowLevel: 1
-  PlayerLocked: 9
-  RecentlyActive: 4
-  RecentlyBoosted: 5
-  Timerunner: 2
-  UpgradeInProgress: 6
+  values:
+    BNetToken: 8
+    FactionOrRaceChange: 7
+    HasRPE: 0
+    IneligibleMap: 3
+    LowLevel: 1
+    PlayerLocked: 9
+    RecentlyActive: 4
+    RecentlyBoosted: 5
+    Timerunner: 2
+    UpgradeInProgress: 6
 NpcCraftingOrderSetFlags:
-  AllowDuplicate: 2
-  AllowMultiple: 1
+  values:
+    AllowDuplicate: 2
+    AllowMultiple: 1
 NumericRuleFormatRounding:
-  Down: 2
-  Nearest: 0
-  Up: 1
+  values:
+    Down: 2
+    Nearest: 0
+    Up: 1
 PartyPlaylistEntry:
-  DuoGameMode: 1
-  SoloGameMode: 0
-  TrainingGameMode: 3
-  TrioGameMode: 2
+  values:
+    DuoGameMode: 1
+    SoloGameMode: 0
+    TrainingGameMode: 3
+    TrioGameMode: 2
 PartyPoseFlags:
-  HideLeaveInstanceButton: 1
+  values:
+    HideLeaveInstanceButton: 1
 PartyRequestJoinRelation:
-  Club: 3
-  Friend: 1
-  Guild: 2
-  None: 0
-  RecentAllies: 4
+  values:
+    Club: 3
+    Friend: 1
+    Guild: 2
+    None: 0
+    RecentAllies: 4
 PerksVendorCategoryType:
-  Achievement: 23
-  Activity: 21
-  GmAdjustment: 22
-  Illusion: 7
-  Mount: 2
-  Pet: 3
-  RefundUnused: 24
-  Stipend: 20
-  Toy: 5
-  Transmog: 1
-  Transmogset: 8
-  WarbandScene: 9
+  values:
+    Achievement: 23
+    Activity: 21
+    GmAdjustment: 22
+    Illusion: 7
+    Mount: 2
+    Pet: 3
+    RefundUnused: 24
+    Stipend: 20
+    Toy: 5
+    Transmog: 1
+    Transmogset: 8
+    WarbandScene: 9
 PermanentChatChannelType:
-  Communities: 2
-  Custom: 3
-  None: 0
-  Zone: 1
+  values:
+    Communities: 2
+    Custom: 3
+    None: 0
+    Zone: 1
 PersonalResourceDisplayVisibleSetting:
-  Always: 0
-  Hidden: 2
-  InCombat: 1
+  values:
+    Always: 0
+    Hidden: 2
+    InCombat: 1
 PetActionbuttonType:
-  Max: 18
-  Mode: 6
-  None: 0
-  Orders: 7
-  Slot1: 8
-  Slot10: 17
-  Slot1Obsolete: 2
-  Slot2: 9
-  Slot2Obsolete: 3
-  Slot3: 10
-  Slot3Obsolete: 4
-  Slot4: 11
-  Slot4Obsolete: 5
-  Slot5: 12
-  Slot6: 13
-  Slot7: 14
-  Slot8: 15
-  Slot9: 16
-  Spell: 1
-  VehicleAction: 19
+  values:
+    Max: 18
+    Mode: 6
+    None: 0
+    Orders: 7
+    Slot1: 8
+    Slot10: 17
+    Slot1Obsolete: 2
+    Slot2: 9
+    Slot2Obsolete: 3
+    Slot3: 10
+    Slot3Obsolete: 4
+    Slot4: 11
+    Slot4Obsolete: 5
+    Slot5: 12
+    Slot6: 13
+    Slot7: 14
+    Slot8: 15
+    Slot9: 16
+    Spell: 1
+    VehicleAction: 19
 PetActionFeedback:
-  Dead: 1
-  FriendlyTarget: 3
-  InvalidTarget: 2
-  NoPath: 4
-  Success: 0
+  values:
+    Dead: 1
+    FriendlyTarget: 3
+    InvalidTarget: 2
+    NoPath: 4
+    Success: 0
 PetBattleQueueStatus:
-  AlreadyQueued: 3
-  InBattle: 20
-  JoinFailed: 4
-  JoinFailedJournalLock: 6
-  JoinFailedNeutral: 7
-  JoinFailedSlots: 5
-  LostConnection: 16
-  MatchAccepted: 8
-  MatchDeclined: 9
-  Matchmaking: 15
-  MatchOpponentDeclined: 10
-  NoBattlingHere: 21
-  None: 0
-  ProposalTimedOut: 11
-  Queued: 1
-  QueuedUpdate: 2
-  Removed: 12
-  RequeuedAfterInternalError: 13
-  RequeuedAfterOpponentRemoved: 14
-  Shutdown: 17
-  Suspended: 18
-  Unsuspended: 19
+  values:
+    AlreadyQueued: 3
+    InBattle: 20
+    JoinFailed: 4
+    JoinFailedJournalLock: 6
+    JoinFailedNeutral: 7
+    JoinFailedSlots: 5
+    LostConnection: 16
+    MatchAccepted: 8
+    MatchDeclined: 9
+    Matchmaking: 15
+    MatchOpponentDeclined: 10
+    NoBattlingHere: 21
+    None: 0
+    ProposalTimedOut: 11
+    Queued: 1
+    QueuedUpdate: 2
+    Removed: 12
+    RequeuedAfterInternalError: 13
+    RequeuedAfterOpponentRemoved: 14
+    Shutdown: 17
+    Suspended: 18
+    Unsuspended: 19
 PetbattleSlot:
-  Slot_0: 0
-  Slot_1: 1
-  Slot_2: 2
+  values:
+    Slot_0: 0
+    Slot_1: 1
+    Slot_2: 2
 PetbattleState:
-  Created: 0
-  CreatedFailed: 4
-  FinalRound: 5
-  Finished: 6
-  RoundInProgress: 2
-  WaitingForFrontPets: 3
-  WaitingPreBattle: 1
+  values:
+    Created: 0
+    CreatedFailed: 4
+    FinalRound: 5
+    Finished: 6
+    RoundInProgress: 2
+    WaitingForFrontPets: 3
+    WaitingPreBattle: 1
 PetJournalError:
-  InvalidFaction: 3
-  JournalIsLocked: 2
-  NoFavoritesToSummon: 4
-  None: 0
-  NoValidRandomSummon: 5
-  PetIsDead: 1
+  values:
+    InvalidFaction: 3
+    JournalIsLocked: 2
+    NoFavoritesToSummon: 4
+    None: 0
+    NoValidRandomSummon: 5
+    PetIsDead: 1
 PetMode:
-  Aggressive: 2
-  Assist: 3
-  Defensive: 1
-  Passive: 0
+  values:
+    Aggressive: 2
+    Assist: 3
+    Defensive: 1
+    Passive: 0
 PetOrders:
-  Attack: 2
-  Dismiss: 3
-  Follow: 1
-  MoveTo: 4
-  Wait: 0
+  values:
+    Attack: 2
+    Dismiss: 3
+    Follow: 1
+    MoveTo: 4
+    Wait: 0
 PetOverride:
-  AICombatControl: 1
-  AICombatPassive: 2
-  None: 0
-  OwnerMounted: 4
+  values:
+    AICombatControl: 1
+    AICombatPassive: 2
+    None: 0
+    OwnerMounted: 4
 Pettameresult:
-  Anothersummonactive: 5
-  Cantcontrolexotic: 12
-  Creaturealreadyowned: 3
-  Dead: 10
-  EliteToohighlevel: 14
-  Internalerror: 8
-  Invalidcreature: 1
-  Invalidslot: 13
-  Nopetavailable: 7
-  Notdead: 11
-  Nottameable: 4
-  Numresults: 15
-  Ok: 0
-  Toohighlevel: 9
-  Toomany: 2
-  Unitscanttame: 6
+  values:
+    Anothersummonactive: 5
+    Cantcontrolexotic: 12
+    Creaturealreadyowned: 3
+    Dead: 10
+    EliteToohighlevel: 14
+    Internalerror: 8
+    Invalidcreature: 1
+    Invalidslot: 13
+    Nopetavailable: 7
+    Notdead: 11
+    Nottameable: 4
+    Numresults: 15
+    Ok: 0
+    Toohighlevel: 9
+    Toomany: 2
+    Unitscanttame: 6
 PhaseReason:
-  ChromieTime: 3
-  Phasing: 0
-  Sharding: 1
-  TimerunningHwt: 4
-  WarMode: 2
+  values:
+    ChromieTime: 3
+    Phasing: 0
+    Sharding: 1
+    TimerunningHwt: 4
+    WarMode: 2
 PhotoSharingStatus:
-  AADCRestricted: 6
-  Configured: 2
-  Disabled: 0
-  Error: 7
-  Expired: 3
-  FailedToClear: 8
-  NotConfigured: 1
-  ParentalControl: 4
-  TrialOrVeteran: 5
+  values:
+    AADCRestricted: 6
+    Configured: 2
+    Disabled: 0
+    Error: 7
+    Expired: 3
+    FailedToClear: 8
+    NotConfigured: 1
+    ParentalControl: 4
+    TrialOrVeteran: 5
 PhotoSharingUploadStatus:
-  CreatePageApiCallFailed: 13
-  CreatePageBadRequest: 14
-  CreatePageForbidden: 16
-  CreatePageGenericFailure: 19
-  CreatePageNoBoardIDFound: 20
-  CreatePageNotFound: 17
-  CreatePageTooManyRequests: 18
-  CreatePageUnauthorized: 15
-  CreatePostApiCallFailed: 21
-  CreatePostBadRequest: 22
-  CreatePostForbidden: 24
-  CreatePostGenericFailure: 27
-  CreatePostNoIDFound: 28
-  CreatePostNotFound: 25
-  CreatePostThrottled: 29
-  CreatePostTooManyRequests: 26
-  CreatePostUnauthorized: 23
-  Disabled: 0
-  Failed: 1
-  ListPagesApiCallFailed: 4
-  ListPagesBadRequest: 5
-  ListPagesEmptyBoardID: 11
-  ListPagesForbidden: 7
-  ListPagesGenericFailure: 10
-  ListPagesInvalidBookmark: 12
-  ListPagesNotFound: 8
-  ListPagesTooManyRequests: 9
-  ListPagesUnauthorized: 6
-  Locked: 3
-  Success: 2
+  values:
+    CreatePageApiCallFailed: 13
+    CreatePageBadRequest: 14
+    CreatePageForbidden: 16
+    CreatePageGenericFailure: 19
+    CreatePageNoBoardIDFound: 20
+    CreatePageNotFound: 17
+    CreatePageTooManyRequests: 18
+    CreatePageUnauthorized: 15
+    CreatePostApiCallFailed: 21
+    CreatePostBadRequest: 22
+    CreatePostForbidden: 24
+    CreatePostGenericFailure: 27
+    CreatePostNoIDFound: 28
+    CreatePostNotFound: 25
+    CreatePostThrottled: 29
+    CreatePostTooManyRequests: 26
+    CreatePostUnauthorized: 23
+    Disabled: 0
+    Failed: 1
+    ListPagesApiCallFailed: 4
+    ListPagesBadRequest: 5
+    ListPagesEmptyBoardID: 11
+    ListPagesForbidden: 7
+    ListPagesGenericFailure: 10
+    ListPagesInvalidBookmark: 12
+    ListPagesNotFound: 8
+    ListPagesTooManyRequests: 9
+    ListPagesUnauthorized: 6
+    Locked: 3
+    Success: 2
 PingMode:
-  ClickDrag: 1
-  KeyDown: 0
+  values:
+    ClickDrag: 1
+    KeyDown: 0
 PingResult:
-  FailedDisabledByLeader: 3
-  FailedDisabledBySettings: 4
-  FailedGeneric: 1
-  FailedOutOfPingArea: 5
-  FailedSpamming: 2
-  FailedSquelched: 6
-  FailedUnspecified: 7
-  Success: 0
+  values:
+    FailedDisabledByLeader: 3
+    FailedDisabledBySettings: 4
+    FailedGeneric: 1
+    FailedOutOfPingArea: 5
+    FailedSpamming: 2
+    FailedSquelched: 6
+    FailedUnspecified: 7
+    Success: 0
 PingSubjectType:
-  AlertNotThreat: 5
-  AlertThreat: 4
-  Assist: 2
-  Attack: 0
-  OnMyWay: 3
-  Warning: 1
+  values:
+    AlertNotThreat: 5
+    AlertThreat: 4
+    Assist: 2
+    Attack: 0
+    OnMyWay: 3
+    Warning: 1
 PingTextureType:
-  Center: 0
-  Expand: 1
-  Rotation: 2
+  values:
+    Center: 0
+    Expand: 1
+    Rotation: 2
 PingTypeFlags:
-  DefaultPing: 1
+  values:
+    DefaultPing: 1
 PlayerChoiceRarity:
-  Common: 0
-  Epic: 3
-  Rare: 2
-  Uncommon: 1
+  values:
+    Common: 0
+    Epic: 3
+    Rare: 2
+    Uncommon: 1
 PlayerClubRequestStatus:
-  Approved: 4
-  AutoApproved: 2
-  Canceled: 7
-  Declined: 3
-  Joined: 5
-  JoinedAnother: 6
-  None: 0
-  Pending: 1
+  values:
+    Approved: 4
+    AutoApproved: 2
+    Canceled: 7
+    Declined: 3
+    Joined: 5
+    JoinedAnother: 6
+    None: 0
+    Pending: 1
 PlayerCompanionInfoFlags:
-  IgnoreSeasonInScenarios: 1
+  values:
+    IgnoreSeasonInScenarios: 1
 PlayerCurrencyFlags:
-  Incremented: 1
-  Loading: 2
+  values:
+    Incremented: 1
+    Loading: 2
 PlayerCurrencyFlagsDbFlags:
-  IgnoreMaxQtyOnload: 1
-  InBackpack: 4
-  Reuse1: 2
-  Reuse2: 16
-  UnusedInUI: 8
+  values:
+    IgnoreMaxQtyOnload: 1
+    InBackpack: 4
+    Reuse1: 2
+    Reuse2: 16
+    UnusedInUI: 8
 PlayerDataElementType:
-  Float: 1
-  Int: 0
+  values:
+    Float: 1
+    Int: 0
 PlayerInteractionType:
-  AccountBanker: 68
-  AdventureJournal: 54
-  AdventureMap: 28
-  AlliedRaceDetailsGiver: 9
-  AnimaDiversion: 47
-  AreaSpiritHealer: 19
-  ArtifactForge: 38
-  Auctioneer: 21
-  AzeriteForge: 56
-  AzeriteRespec: 42
-  Banker: 8
-  BarbersChoice: 62
-  BattleMaster: 23
-  Binder: 20
-  BlackMarketAuctioneer: 27
-  CharacterBanker: 67
-  ChromieTime: 45
-  ContributionCollector: 41
-  CornerstoneInteraction: 70
-  CovenantPreview: 46
-  CovenantSanctum: 51
-  CreateGuildNeighborhood: 74
-  ForgeMaster: 66
-  GarrArchitect: 30
-  GarrMission: 32
-  GarrRecruitment: 34
-  GarrTalent: 35
-  GarrTradeskill: 31
-  Gossip: 3
-  GuildBanker: 10
-  GuildRename: 76
-  GuildTabardVendor: 14
-  HousingBulletinBoard: 72
-  HousingPedestal: 73
-  IslandQueue: 43
-  Item: 2
-  ItemInteraction: 44
-  ItemUpgrade: 53
-  JailersTowerBuffs: 63
-  LegendaryCrafting: 48
-  LFGDungeon: 25
-  MailInfo: 17
-  MajorFactionRenown: 64
-  Merchant: 5
-  NeighborhoodCharter: 75
-  NewPlayerGuide: 52
-  None: 0
-  ObliterumForge: 39
-  OpenHouseFinder: 78
-  OpenNeighborhoodCharterConfirmation: 77
-  PerksProgramVendor: 57
-  PersonalTabardVendor: 65
-  PetitionVendor: 13
-  PlayerChoice: 37
-  ProfessionRespec: 69
-  Professions: 59
-  ProfessionsCraftingOrder: 58
-  ProfessionsCustomerOrder: 60
-  QuestGiver: 4
-  Registrar: 11
-  RenameNeighborhood: 71
-  Renown: 55
-  ScrappingMachine: 40
-  ShipmentCrafter: 33
-  Soulbind: 50
-  SpecializationMaster: 16
-  SpiritHealer: 18
-  StableMaster: 22
-  TalentMaster: 15
-  TaxiNode: 6
-  TieredEntrance: 79
-  TradePartner: 1
-  Trainer: 7
-  TraitSystem: 61
-  Transmogrifier: 24
-  Trophy: 36
-  Vendor: 12
-  VoidStorageBanker: 26
-  WeeklyRewards: 49
-  WorldMap: 29
+  values:
+    AccountBanker: 68
+    AdventureJournal: 54
+    AdventureMap: 28
+    AlliedRaceDetailsGiver: 9
+    AnimaDiversion: 47
+    AreaSpiritHealer: 19
+    ArtifactForge: 38
+    Auctioneer: 21
+    AzeriteForge: 56
+    AzeriteRespec: 42
+    Banker: 8
+    BarbersChoice: 62
+    BattleMaster: 23
+    Binder: 20
+    BlackMarketAuctioneer: 27
+    CharacterBanker: 67
+    ChromieTime: 45
+    ContributionCollector: 41
+    CornerstoneInteraction: 70
+    CovenantPreview: 46
+    CovenantSanctum: 51
+    CreateGuildNeighborhood: 74
+    ForgeMaster: 66
+    GarrArchitect: 30
+    GarrMission: 32
+    GarrRecruitment: 34
+    GarrTalent: 35
+    GarrTradeskill: 31
+    Gossip: 3
+    GuildBanker: 10
+    GuildRename: 76
+    GuildTabardVendor: 14
+    HousingBulletinBoard: 72
+    HousingPedestal: 73
+    IslandQueue: 43
+    Item: 2
+    ItemInteraction: 44
+    ItemUpgrade: 53
+    JailersTowerBuffs: 63
+    LegendaryCrafting: 48
+    LFGDungeon: 25
+    MailInfo: 17
+    MajorFactionRenown: 64
+    Merchant: 5
+    NeighborhoodCharter: 75
+    NewPlayerGuide: 52
+    None: 0
+    ObliterumForge: 39
+    OpenHouseFinder: 78
+    OpenNeighborhoodCharterConfirmation: 77
+    PerksProgramVendor: 57
+    PersonalTabardVendor: 65
+    PetitionVendor: 13
+    PlayerChoice: 37
+    ProfessionRespec: 69
+    Professions: 59
+    ProfessionsCraftingOrder: 58
+    ProfessionsCustomerOrder: 60
+    QuestGiver: 4
+    Registrar: 11
+    RenameNeighborhood: 71
+    Renown: 55
+    ScrappingMachine: 40
+    ShipmentCrafter: 33
+    Soulbind: 50
+    SpecializationMaster: 16
+    SpiritHealer: 18
+    StableMaster: 22
+    TalentMaster: 15
+    TaxiNode: 6
+    TieredEntrance: 79
+    TradePartner: 1
+    Trainer: 7
+    TraitSystem: 61
+    Transmogrifier: 24
+    Trophy: 36
+    Vendor: 12
+    VoidStorageBanker: 26
+    WeeklyRewards: 49
+    WorldMap: 29
 PlayerMentorshipApplicationResult:
-  AlreadyMentor: 1
-  Ineligible: 2
-  Success: 0
+  values:
+    AlreadyMentor: 1
+    Ineligible: 2
+    Success: 0
 PlayerMentorshipStatus:
-  Mentor: 2
-  Newcomer: 1
-  None: 0
+  values:
+    Mentor: 2
+    Newcomer: 1
+    None: 0
 PlunderstormQueueState:
-  None: 0
-  Proposed: 2
-  Queued: 1
-  Suspended: 3
+  values:
+    None: 0
+    Proposed: 2
+    Queued: 1
+    Suspended: 3
 PowerType:
-  Alternate: 10
-  AlternateEncounter: 24
-  AlternateMount: 25
-  AlternateQuest: 23
-  ArcaneCharges: 16
-  Balance: 26
-  BurningEmbers: 14
-  Chi: 12
-  ComboPoints: 4
-  DemonicFury: 15
-  Energy: 3
-  Essence: 19
-  Focus: 2
-  Fury: 17
-  Happiness: 27
-  HolyPower: 9
-  Insanity: 13
-  LunarPower: 8
-  Maelstrom: 11
-  Mana: 0
-  Pain: 18
-  Rage: 1
-  RuneBlood: 20
-  RuneChromatic: 29
-  RuneFrost: 21
-  Runes: 5
-  RuneUnholy: 22
-  RunicPower: 6
-  ShadowOrbs: 28
-  SoulShards: 7
+  values:
+    Alternate: 10
+    AlternateEncounter: 24
+    AlternateMount: 25
+    AlternateQuest: 23
+    ArcaneCharges: 16
+    Balance: 26
+    BurningEmbers: 14
+    Chi: 12
+    ComboPoints: 4
+    DemonicFury: 15
+    Energy: 3
+    Essence: 19
+    Focus: 2
+    Fury: 17
+    Happiness: 27
+    HolyPower: 9
+    Insanity: 13
+    LunarPower: 8
+    Maelstrom: 11
+    Mana: 0
+    Pain: 18
+    Rage: 1
+    RuneBlood: 20
+    RuneChromatic: 29
+    RuneFrost: 21
+    Runes: 5
+    RuneUnholy: 22
+    RunicPower: 6
+    ShadowOrbs: 28
+    SoulShards: 7
 PowerTypeSign:
-  Negative: 1
-  None: -1
-  Positive: 0
+  values:
+    Negative: 1
+    None: -1
+    Positive: 0
 PowerTypeSlot:
-  Slot_0: 0
-  Slot_1: 1
-  Slot_2: 2
-  Slot_3: 3
-  Slot_4: 4
-  Slot_5: 5
-  Slot_6: 6
-  Slot_7: 7
-  Slot_8: 8
-  Slot_9: 9
+  values:
+    Slot_0: 0
+    Slot_1: 1
+    Slot_2: 2
+    Slot_3: 3
+    Slot_4: 4
+    Slot_5: 5
+    Slot_6: 6
+    Slot_7: 7
+    Slot_8: 8
+    Slot_9: 9
 PremadeGroupFinderStyle:
-  Disabled: 0
-  Mainline: 1
-  Vanilla: 2
+  values:
+    Disabled: 0
+    Mainline: 1
+    Vanilla: 2
 PreyHuntProgressState:
-  Cold: 0
-  Final: 3
-  Hot: 2
-  Warm: 1
+  values:
+    Cold: 0
+    Final: 3
+    Hot: 2
+    Warm: 1
 ProceduralSpawnInteractionMode:
-  Manipulate: 2
-  None: 0
-  Paint: 1
+  values:
+    Manipulate: 2
+    None: 0
+    Paint: 1
 ProceduralSpawnVolumeChunkFlags:
-  AllSubChunksSet: 1
-  None: 0
+  values:
+    AllSubChunksSet: 1
+    None: 0
 Profession:
-  Alchemy: 3
-  Archaeology: 14
-  Blacksmithing: 1
-  Cooking: 5
-  Enchanting: 9
-  Engineering: 8
-  FirstAid: 0
-  Fishing: 10
-  Herbalism: 4
-  Inscription: 13
-  Jewelcrafting: 12
-  Leatherworking: 2
-  Mining: 6
-  Skinning: 11
-  Tailoring: 7
+  values:
+    Alchemy: 3
+    Archaeology: 14
+    Blacksmithing: 1
+    Cooking: 5
+    Enchanting: 9
+    Engineering: 8
+    FirstAid: 0
+    Fishing: 10
+    Herbalism: 4
+    Inscription: 13
+    Jewelcrafting: 12
+    Leatherworking: 2
+    Mining: 6
+    Skinning: 11
+    Tailoring: 7
 ProfessionActionType:
-  Craft: 0
-  Gather: 1
+  values:
+    Craft: 0
+    Gather: 1
 ProfessionEffect:
-  AccumulateRanksByLabel: 25
-  ConcentrationRefund: 30
-  DecreaseDifficulty: 22
-  IncreaseDifficulty: 23
-  ModConcentration: 27
-  ModCraftCritSize: 20
-  ModCraftExtraQuantity: 18
-  ModCraftingSpeed: 14
-  ModCraftReductionQuantity: 21
-  ModDeftness: 12
-  ModFinesse: 11
-  ModGatherExtraQuantity: 19
-  ModIngenuity: 29
-  ModInspiration: 9
-  ModMulticraft: 15
-  ModPerception: 13
-  ModResourcefulness: 10
-  ModSkillGain: 24
-  ModUnused_1: 16
-  ModUnused_2: 17
-  Skill: 0
-  StatCraftingSpeed: 6
-  StatDeftness: 4
-  StatFinesse: 3
-  StatIngenuity: 26
-  StatInspiration: 1
-  StatMulticraft: 7
-  StatPerception: 5
-  StatResourcefulness: 2
-  Tokenizer: 28
-  UnlockReagentSlot: 8
+  values:
+    AccumulateRanksByLabel: 25
+    ConcentrationRefund: 30
+    DecreaseDifficulty: 22
+    IncreaseDifficulty: 23
+    ModConcentration: 27
+    ModCraftCritSize: 20
+    ModCraftExtraQuantity: 18
+    ModCraftingSpeed: 14
+    ModCraftReductionQuantity: 21
+    ModDeftness: 12
+    ModFinesse: 11
+    ModGatherExtraQuantity: 19
+    ModIngenuity: 29
+    ModInspiration: 9
+    ModMulticraft: 15
+    ModPerception: 13
+    ModResourcefulness: 10
+    ModSkillGain: 24
+    ModUnused_1: 16
+    ModUnused_2: 17
+    Skill: 0
+    StatCraftingSpeed: 6
+    StatDeftness: 4
+    StatFinesse: 3
+    StatIngenuity: 26
+    StatInspiration: 1
+    StatMulticraft: 7
+    StatPerception: 5
+    StatResourcefulness: 2
+    Tokenizer: 28
+    UnlockReagentSlot: 8
 ProfessionRating:
-  CraftingSpeed: 5
-  Deftness: 3
-  Finesse: 2
-  Ingenuity: 7
-  Inspiration: 0
-  Multicraft: 6
-  Perception: 4
-  Resourcefulness: 1
-  Unused_2: 8
+  values:
+    CraftingSpeed: 5
+    Deftness: 3
+    Finesse: 2
+    Ingenuity: 7
+    Inspiration: 0
+    Multicraft: 6
+    Perception: 4
+    Resourcefulness: 1
+    Unused_2: 8
 ProfessionRatingType:
-  Craft: 0
-  Gather: 1
+  values:
+    Craft: 0
+    Gather: 1
 ProfessionsSpecPathState:
-  Completed: 2
-  Locked: 0
-  Progressing: 1
+  values:
+    Completed: 2
+    Locked: 0
+    Progressing: 1
 ProfessionsSpecPerkState:
-  Earned: 2
-  Pending: 1
-  Unearned: 0
+  values:
+    Earned: 2
+    Pending: 1
+    Unearned: 0
 ProfessionsSpecTabState:
-  Locked: 0
-  Unlockable: 2
-  Unlocked: 1
+  values:
+    Locked: 0
+    Unlockable: 2
+    Unlocked: 1
 ProfTraitPerkNodeFlags:
-  IsMajorBonus: 2
-  UnlocksSubpath: 1
+  values:
+    IsMajorBonus: 2
+    UnlocksSubpath: 1
 PurchaseEligibility:
-  ExpansionTooHigh: 4
-  ExpansionTooLow: 3
-  MissingRequiredDeliverable: 5
-  Ok: 0
-  Owned: 2
-  PartiallyOwned: 1
+  values:
+    ExpansionTooHigh: 4
+    ExpansionTooLow: 3
+    MissingRequiredDeliverable: 5
+    Ok: 0
+    Owned: 2
+    PartiallyOwned: 1
 PurchaseHouseDisabledReason:
-  CharterLockout: 7
-  GuildLockout: 6
-  MaxHouses: 8
-  NoExpansion: 4
-  NoGameTimeRemaining: 9
-  None: 0
-  NotInvited: 3
-  Reserved: 5
-  WrongFaction: 1
-  WrongGuild: 2
+  values:
+    CharterLockout: 7
+    GuildLockout: 6
+    MaxHouses: 8
+    NoExpansion: 4
+    NoGameTimeRemaining: 9
+    None: 0
+    NotInvited: 3
+    Reserved: 5
+    WrongFaction: 1
+    WrongGuild: 2
 PurchaseResult:
-  ErrorAuthorizingPayment: 37
-  ErrorBattlepayDisabled: 14
-  ErrorBattlepayTemporarilyUnavailable: 13
-  ErrorBattlepayTimeoutMopAndRisk: 11
-  ErrorBattlepayTimeoutValidatePurchase: 56
-  ErrorBattlepayTimeoutValidationHash: 62
-  ErrorBlockedByParentalControls: 33
-  ErrorBuyingProductNotAllowedInGlueScreen: 27
-  ErrorBuyingProductNotAllowedInWorld: 32
-  ErrorCharacterUpgradeOperationInProgress: 51
-  ErrorClientCheckoutCanceledOrFailed: 63
-  ErrorClientCheckoutTimeout: 60
-  ErrorClientDeclined: 4
-  ErrorClientDeclinedChallenge: 41
-  ErrorClientGone: 9
-  ErrorClientRestricted: 66
-  ErrorClientTimeout: 3
-  ErrorClientTimeoutChallenge: 40
-  ErrorCommerceServerDisabled: 48
-  ErrorCouldNotGetValidationHash: 64
-  ErrorCurrencyInvalidInRegion: 12
-  ErrorDistributionObjectAlreadyAssigned: 20
-  ErrorDistributionObjectExpansionBlocked: 45
-  ErrorDistributionObjectInvalidChoice: 35
-  ErrorDistributionObjectInvalidTarget: 42
-  ErrorDistributionObjectNotFound: 19
-  ErrorDistributionObjectTrialBlocked: 44
-  ErrorDistributionObjectWrongGameAccount: 65
-  ErrorFailedOldPurchaseFlow: 59
-  ErrorFailedToCreatePurchaseRecord: 5
-  ErrorFailedToGetPurchaseID: 6
-  ErrorFailedToSaveClientCheckoutStatus: 58
-  ErrorFailedToSaveMopAndRiskResponse: 8
-  ErrorFailedToSaveMopAndRiskStatus: 7
-  ErrorFailedToSavePlaceOrderStatus: 10
-  ErrorFailedToSaveRedeemTokenStatus: 67
-  ErrorFailedToSaveValidatePurchaseResponse: 55
-  ErrorFailedToSaveValidatePurchaseStatus: 54
-  ErrorFailedToSaveValidationHashStatus: 61
-  ErrorFailedToWriteVasLicenseID: 50
-  ErrorFailedToWriteVasPurchaseID: 49
-  ErrorFixedLicenseProductAlreadyExists: 43
-  ErrorInManualReview: 71
-  ErrorInvalidCreditCardExpiryDate: 36
-  ErrorInvalidDeviceID: 53
-  ErrorInvalidPlatform: 52
-  ErrorInvalidProduct: 16
-  ErrorInvalidPurchaseID: 68
-  ErrorInvalidRegionGroupMask: 17
-  ErrorMopAndRiskAmqpRpcFailed: 22
-  ErrorMopAndRiskNotEnoughBalance: 28
-  ErrorMopAndRiskNoValidPaymentMethods: 25
-  ErrorMopAndRiskRpcErrorFromBattlepay: 23
-  ErrorMopAndRiskUnexpectedResponseFromBattlepay: 24
-  ErrorNoStorePurchaseFlagIsSet: 34
-  ErrorOrderCanceledPriceChange: 26
-  ErrorOrderFailed: 2
-  ErrorOverSpendingLimit: 39
-  ErrorOwnsConsumableToken: 46
-  ErrorPaymentProviderDeniedPayment: 38
-  ErrorPlaceOrderNotEnoughBalance: 29
-  ErrorProductInvalidInRegion: 18
-  ErrorProductNotPurchasable: 57
-  ErrorProgrammerManualFail: 30
-  ErrorRiskDenied: 1
-  ErrorRiskResponseMissingScore: 21
-  ErrorServerRestarted: 15
-  ErrorThrottledByUserServer: 31
-  ErrorTokenRedemptionOrderFailed: 69
-  ErrorTooManyTokens: 47
-  ErrorVasTransactionCreateFailed: 70
-  Ok: 0
+  values:
+    ErrorAuthorizingPayment: 37
+    ErrorBattlepayDisabled: 14
+    ErrorBattlepayTemporarilyUnavailable: 13
+    ErrorBattlepayTimeoutMopAndRisk: 11
+    ErrorBattlepayTimeoutValidatePurchase: 56
+    ErrorBattlepayTimeoutValidationHash: 62
+    ErrorBlockedByParentalControls: 33
+    ErrorBuyingProductNotAllowedInGlueScreen: 27
+    ErrorBuyingProductNotAllowedInWorld: 32
+    ErrorCharacterUpgradeOperationInProgress: 51
+    ErrorClientCheckoutCanceledOrFailed: 63
+    ErrorClientCheckoutTimeout: 60
+    ErrorClientDeclined: 4
+    ErrorClientDeclinedChallenge: 41
+    ErrorClientGone: 9
+    ErrorClientRestricted: 66
+    ErrorClientTimeout: 3
+    ErrorClientTimeoutChallenge: 40
+    ErrorCommerceServerDisabled: 48
+    ErrorCouldNotGetValidationHash: 64
+    ErrorCurrencyInvalidInRegion: 12
+    ErrorDistributionObjectAlreadyAssigned: 20
+    ErrorDistributionObjectExpansionBlocked: 45
+    ErrorDistributionObjectInvalidChoice: 35
+    ErrorDistributionObjectInvalidTarget: 42
+    ErrorDistributionObjectNotFound: 19
+    ErrorDistributionObjectTrialBlocked: 44
+    ErrorDistributionObjectWrongGameAccount: 65
+    ErrorFailedOldPurchaseFlow: 59
+    ErrorFailedToCreatePurchaseRecord: 5
+    ErrorFailedToGetPurchaseID: 6
+    ErrorFailedToSaveClientCheckoutStatus: 58
+    ErrorFailedToSaveMopAndRiskResponse: 8
+    ErrorFailedToSaveMopAndRiskStatus: 7
+    ErrorFailedToSavePlaceOrderStatus: 10
+    ErrorFailedToSaveRedeemTokenStatus: 67
+    ErrorFailedToSaveValidatePurchaseResponse: 55
+    ErrorFailedToSaveValidatePurchaseStatus: 54
+    ErrorFailedToSaveValidationHashStatus: 61
+    ErrorFailedToWriteVasLicenseID: 50
+    ErrorFailedToWriteVasPurchaseID: 49
+    ErrorFixedLicenseProductAlreadyExists: 43
+    ErrorInManualReview: 71
+    ErrorInvalidCreditCardExpiryDate: 36
+    ErrorInvalidDeviceID: 53
+    ErrorInvalidPlatform: 52
+    ErrorInvalidProduct: 16
+    ErrorInvalidPurchaseID: 68
+    ErrorInvalidRegionGroupMask: 17
+    ErrorMopAndRiskAmqpRpcFailed: 22
+    ErrorMopAndRiskNotEnoughBalance: 28
+    ErrorMopAndRiskNoValidPaymentMethods: 25
+    ErrorMopAndRiskRpcErrorFromBattlepay: 23
+    ErrorMopAndRiskUnexpectedResponseFromBattlepay: 24
+    ErrorNoStorePurchaseFlagIsSet: 34
+    ErrorOrderCanceledPriceChange: 26
+    ErrorOrderFailed: 2
+    ErrorOverSpendingLimit: 39
+    ErrorOwnsConsumableToken: 46
+    ErrorPaymentProviderDeniedPayment: 38
+    ErrorPlaceOrderNotEnoughBalance: 29
+    ErrorProductInvalidInRegion: 18
+    ErrorProductNotPurchasable: 57
+    ErrorProgrammerManualFail: 30
+    ErrorRiskDenied: 1
+    ErrorRiskResponseMissingScore: 21
+    ErrorServerRestarted: 15
+    ErrorThrottledByUserServer: 31
+    ErrorTokenRedemptionOrderFailed: 69
+    ErrorTooManyTokens: 47
+    ErrorVasTransactionCreateFailed: 70
+    Ok: 0
 PvPFaction:
-  Alliance: 1
-  Horde: 0
+  values:
+    Alliance: 1
+    Horde: 0
 PvPMatchmakingType:
-  Arena: 1
-  Battleground: 0
+  values:
+    Arena: 1
+    Battleground: 0
 PvPMatchState:
-  Complete: 5
-  Engaged: 3
-  Inactive: 0
-  PostRound: 4
-  StartUp: 2
-  Waiting: 1
+  values:
+    Complete: 5
+    Engaged: 3
+    Inactive: 0
+    PostRound: 4
+    StartUp: 2
+    Waiting: 1
 PvPRanks:
-  Rank_1: 5
-  Rank_10: 14
-  Rank_11: 15
-  Rank_12: 16
-  Rank_13: 17
-  Rank_14: 18
-  Rank_2: 6
-  Rank_3: 7
-  Rank_4: 8
-  Rank_5: 9
-  Rank_6: 10
-  Rank_7: 11
-  Rank_8: 12
-  Rank_9: 13
-  RankDishonored: 4
-  RankExiled: 3
-  RankNone: 0
-  RankOutlaw: 2
-  RankPariah: 1
+  values:
+    Rank_1: 5
+    Rank_10: 14
+    Rank_11: 15
+    Rank_12: 16
+    Rank_13: 17
+    Rank_14: 18
+    Rank_2: 6
+    Rank_3: 7
+    Rank_4: 8
+    Rank_5: 9
+    Rank_6: 10
+    Rank_7: 11
+    Rank_8: 12
+    Rank_9: 13
+    RankDishonored: 4
+    RankExiled: 3
+    RankNone: 0
+    RankOutlaw: 2
+    RankPariah: 1
 PvPUnitClassification:
-  AssassinAlliance: 6
-  AssassinHorde: 5
-  CartRunnerAlliance: 4
-  CartRunnerHorde: 3
-  FlagCarrierAlliance: 1
-  FlagCarrierHorde: 0
-  FlagCarrierNeutral: 2
-  OrbCarrierBlue: 7
-  OrbCarrierGreen: 8
-  OrbCarrierOrange: 9
-  OrbCarrierPurple: 10
+  values:
+    AssassinAlliance: 6
+    AssassinHorde: 5
+    CartRunnerAlliance: 4
+    CartRunnerHorde: 3
+    FlagCarrierAlliance: 1
+    FlagCarrierHorde: 0
+    FlagCarrierNeutral: 2
+    OrbCarrierBlue: 7
+    OrbCarrierGreen: 8
+    OrbCarrierOrange: 9
+    OrbCarrierPurple: 10
 QuestClassification:
-  BonusObjective: 8
-  Calling: 3
-  Campaign: 2
-  Important: 0
-  Legendary: 1
-  Meta: 4
-  Normal: 7
-  Questline: 6
-  Recurring: 5
-  Threat: 9
-  WorldQuest: 10
+  values:
+    BonusObjective: 8
+    Calling: 3
+    Campaign: 2
+    Important: 0
+    Legendary: 1
+    Meta: 4
+    Normal: 7
+    Questline: 6
+    Recurring: 5
+    Threat: 9
+    WorldQuest: 10
 QuestCompleteSpellType:
-  Ability: 3
-  Aura: 4
-  Companion: 7
-  Follower: 1
-  LegacyBehavior: 0
-  PossibleReward: 11
-  QuestlineReward: 9
-  QuestlineUnlock: 8
-  QuestlineUnlockPart: 10
-  Spell: 5
-  Tradeskill: 2
-  Unlock: 6
+  values:
+    Ability: 3
+    Aura: 4
+    Companion: 7
+    Follower: 1
+    LegacyBehavior: 0
+    PossibleReward: 11
+    QuestlineReward: 9
+    QuestlineUnlock: 8
+    QuestlineUnlockPart: 10
+    Spell: 5
+    Tradeskill: 2
+    Unlock: 6
 QuestFrequency:
-  Daily: 1
-  Default: 0
-  ResetByScheduler: 3
-  Weekly: 2
+  values:
+    Daily: 1
+    Default: 0
+    ResetByScheduler: 3
+    Weekly: 2
 QuestLineFloorLocation:
-  Above: 0
-  Below: 1
-  Same: 2
+  values:
+    Above: 0
+    Below: 1
+    Same: 2
 QuestRepeatability:
-  Daily: 1
-  None: 0
-  Turnin: 3
-  Weekly: 2
-  World: 4
+  values:
+    Daily: 1
+    None: 0
+    Turnin: 3
+    Weekly: 2
+    World: 4
 QuestRewardContextFlags:
-  FirstCompletionBonus: 1
-  None: 0
-  RepeatCompletionBonus: 2
+  values:
+    FirstCompletionBonus: 1
+    None: 0
+    RepeatCompletionBonus: 2
 QuestSessionCommand:
-  None: 0
-  SessionActiveNoCommand: 3
-  Start: 1
-  Stop: 2
+  values:
+    None: 0
+    SessionActiveNoCommand: 3
+    Start: 1
+    Stop: 2
 QuestSessionResult:
-  AlreadyActive: 3
-  AlreadyJoined: 20
-  AlreadyMember: 17
-  AlreadyOwner: 19
-  Busy: 22
-  Disabled: 8
-  Empty: 25
-  InCombat: 32
-  InPetBattle: 29
-  InRaid: 5
-  InvalidOwner: 2
-  InvalidPublicParty: 30
-  Joined: 11
-  JoinRejected: 23
-  Left: 12
-  Logout: 24
-  MemberInCombat: 33
-  MemberTimeout: 16
-  NotActive: 4
-  NotInParty: 1
-  NotMember: 21
-  NotOwner: 18
-  Ok: 0
-  OwnerLeft: 13
-  OwnerRefused: 6
-  PartyDestroyed: 15
-  QuestNotCompleted: 26
-  ReadyCheckFailed: 14
-  Restricted: 28
-  RestrictedCrossFaction: 34
-  Resync: 27
-  Started: 9
-  Stopped: 10
-  Timeout: 7
-  Unknown: 31
+  values:
+    AlreadyActive: 3
+    AlreadyJoined: 20
+    AlreadyMember: 17
+    AlreadyOwner: 19
+    Busy: 22
+    Disabled: 8
+    Empty: 25
+    InCombat: 32
+    InPetBattle: 29
+    InRaid: 5
+    InvalidOwner: 2
+    InvalidPublicParty: 30
+    Joined: 11
+    JoinRejected: 23
+    Left: 12
+    Logout: 24
+    MemberInCombat: 33
+    MemberTimeout: 16
+    NotActive: 4
+    NotInParty: 1
+    NotMember: 21
+    NotOwner: 18
+    Ok: 0
+    OwnerLeft: 13
+    OwnerRefused: 6
+    PartyDestroyed: 15
+    QuestNotCompleted: 26
+    ReadyCheckFailed: 14
+    Restricted: 28
+    RestrictedCrossFaction: 34
+    Resync: 27
+    Started: 9
+    Stopped: 10
+    Timeout: 7
+    Unknown: 31
 QuestTag:
-  Account: 102
-  CombatAlly: 266
-  Delve: 288
-  Dungeon: 81
-  Group: 1
-  Heroic: 85
-  Legendary: 83
-  PvP: 41
-  Raid: 62
-  Raid10: 88
-  Raid25: 89
-  Scenario: 98
+  values:
+    Account: 102
+    CombatAlly: 266
+    Delve: 288
+    Dungeon: 81
+    Group: 1
+    Heroic: 85
+    Legendary: 83
+    PvP: 41
+    Raid: 62
+    Raid10: 88
+    Raid25: 89
+    Scenario: 98
 QuestTagType:
-  Bounty: 5
-  Capstone: 17
-  Contribution: 9
-  CovenantCalling: 15
-  DragonRiderRacing: 16
-  Dungeon: 6
-  FactionAssault: 12
-  Invasion: 7
-  InvasionWrapper: 11
-  Islands: 13
-  Normal: 2
-  PetBattle: 4
-  Prey: 19
-  Profession: 1
-  PvP: 3
-  Raid: 8
-  RatedReward: 10
-  Tag: 0
-  Threat: 14
-  WorldBoss: 18
+  values:
+    Bounty: 5
+    Capstone: 17
+    Contribution: 9
+    CovenantCalling: 15
+    DragonRiderRacing: 16
+    Dungeon: 6
+    FactionAssault: 12
+    Invasion: 7
+    InvasionWrapper: 11
+    Islands: 13
+    Normal: 2
+    PetBattle: 4
+    Prey: 19
+    Profession: 1
+    PvP: 3
+    Raid: 8
+    RatedReward: 10
+    Tag: 0
+    Threat: 14
+    WorldBoss: 18
 QuestTreasurePickerType:
-  Hidden: 1
-  Select: 2
-  Visible: 0
+  values:
+    Hidden: 1
+    Select: 2
+    Visible: 0
 QuestWatchType:
-  Automatic: 0
-  Manual: 1
+  values:
+    Automatic: 0
+    Manual: 1
 RafLinkType:
-  Both: 3
-  Friend: 2
-  None: 0
-  Recruit: 1
+  values:
+    Both: 3
+    Friend: 2
+    None: 0
+    Recruit: 1
 RafRecruitActivityState:
-  Complete: 1
-  Incomplete: 0
-  RewardClaimed: 2
+  values:
+    Complete: 1
+    Incomplete: 0
+    RewardClaimed: 2
 RafRecruitSubStatus:
-  Active: 1
-  Inactive: 2
-  Trial: 0
+  values:
+    Active: 1
+    Inactive: 2
+    Trial: 0
 RafRewardType:
-  Appearance: 2
-  AppearanceSet: 5
-  GameTime: 4
-  Illusion: 6
-  Invalid: 7
-  Mount: 1
-  Pet: 0
-  Title: 3
+  values:
+    Appearance: 2
+    AppearanceSet: 5
+    GameTime: 4
+    Illusion: 6
+    Invalid: 7
+    Mount: 1
+    Pet: 0
+    Title: 3
 RaidAuraOrganizationType:
-  BuffsRightDebuffsLeft: 2
-  BuffsTopDebuffsBottom: 1
-  Legacy: 0
+  values:
+    BuffsRightDebuffsLeft: 2
+    BuffsTopDebuffsBottom: 1
+    Legacy: 0
 RaidDispelDisplayType:
-  Disabled: 0
-  DispellableByMe: 1
-  DisplayAll: 2
+  values:
+    Disabled: 0
+    DispellableByMe: 1
+    DisplayAll: 2
 RaidGroupDisplayType:
-  CombineGroupsHorizontal: 3
-  CombineGroupsVertical: 2
-  SeparateGroupsHorizontal: 1
-  SeparateGroupsVertical: 0
+  values:
+    CombineGroupsHorizontal: 3
+    CombineGroupsVertical: 2
+    SeparateGroupsHorizontal: 1
+    SeparateGroupsVertical: 0
 RcoCloseReason:
-  Cancel: 2
-  CrafterFulfill: 5
-  Expire: 1
-  Fulfill: 0
-  GmCancel: 4
-  Invalid: 6
-  Reject: 3
+  values:
+    Cancel: 2
+    CrafterFulfill: 5
+    Expire: 1
+    Fulfill: 0
+    GmCancel: 4
+    Invalid: 6
+    Reject: 3
 RecentAllyPinResult:
-  ServerError: 1
-  Success: 0
+  values:
+    ServerError: 1
+    Success: 0
 RecipeRequirementType:
-  Area: 2
-  SpellFocus: 0
-  Totem: 1
+  values:
+    Area: 2
+    SpellFocus: 0
+    Totem: 1
 RecruitAFriendRewardsVersion:
-  InvalidVersion: 0
-  UnusedVersionOne: 1
-  VersionThree: 3
-  VersionTwo: 2
+  values:
+    InvalidVersion: 0
+    UnusedVersionOne: 1
+    VersionThree: 3
+    VersionTwo: 2
 RegisterAddonMessagePrefixResult:
-  DuplicatePrefix: 1
-  InvalidPrefix: 2
-  MaxPrefixes: 3
-  Success: 0
+  values:
+    DuplicatePrefix: 1
+    InvalidPrefix: 2
+    MaxPrefixes: 3
+    Success: 0
 RelativeContentDifficulty:
-  Difficult: 3
-  Easy: 1
-  Fair: 2
-  Impossible: 4
-  Trivial: 0
+  values:
+    Difficult: 3
+    Easy: 1
+    Fair: 2
+    Impossible: 4
+    Trivial: 0
 ReleaseType:
-  Classic: 2
-  Original: 1
+  values:
+    Classic: 2
+    Original: 1
 RenownRewardDisplayType:
-  Currency: 9
-  GarrFollower: 8
-  Item: 1
-  Mount: 3
-  None: 0
-  Spell: 2
-  Title: 7
-  Transmog: 4
-  TransmogIllusion: 6
-  TransmogSet: 5
+  values:
+    Currency: 9
+    GarrFollower: 8
+    Item: 1
+    Mount: 3
+    None: 0
+    Spell: 2
+    Title: 7
+    Transmog: 4
+    TransmogIllusion: 6
+    TransmogSet: 5
 RenownRewardsFlags:
-  AccountUnlock: 8
-  Capstone: 2
-  Hidden: 4
-  Milestone: 1
+  values:
+    AccountUnlock: 8
+    Capstone: 2
+    Hidden: 4
+    Milestone: 1
 ReportEvidenceType:
-  HouseLayoutJson: 2
-  HouseScreenshot: 1
-  Invalid: 0
+  values:
+    HouseLayoutJson: 2
+    HouseScreenshot: 1
+    Invalid: 0
 ReportMajorCategory:
-  Cheating: 2
-  GameplaySabotage: 1
-  InappropriateCommunication: 0
-  InappropriateDecor: 4
-  InappropriateName: 3
+  values:
+    Cheating: 2
+    GameplaySabotage: 1
+    InappropriateCommunication: 0
+    InappropriateDecor: 4
+    InappropriateName: 3
 ReportMinorCategory:
-  Advertisement: 256
-  Afk: 8
-  BlockingProgress: 32
-  Boosting: 2
-  Botting: 128
-  BTag: 512
-  CharacterName: 2048
-  ChildSexualExploitationAndAbuse: 262144
-  Description: 8192
-  Disruption: 65536
-  GroupName: 1024
-  GuildName: 4096
-  Hacking: 64
-  HarmfulToMinors: 32768
-  IntentionallyFeeding: 16
-  Name: 16384
-  NeighborhoodName: 524288
-  Spam: 4
-  TerroristAndViolentExtremistContent: 131072
-  TextChat: 1
+  values:
+    Advertisement: 256
+    Afk: 8
+    BlockingProgress: 32
+    Boosting: 2
+    Botting: 128
+    BTag: 512
+    CharacterName: 2048
+    ChildSexualExploitationAndAbuse: 262144
+    Description: 8192
+    Disruption: 65536
+    GroupName: 1024
+    GuildName: 4096
+    Hacking: 64
+    HarmfulToMinors: 32768
+    IntentionallyFeeding: 16
+    Name: 16384
+    NeighborhoodName: 524288
+    Spam: 4
+    TerroristAndViolentExtremistContent: 131072
+    TextChat: 1
 ReportSubComplaintTypes:
-  Advertising: 1
-  Inappropriate: 0
+  values:
+    Advertising: 1
+    Inappropriate: 0
 ReportThrottleType:
-  Expensive: 2
-  General: 1
-  Invalid: 0
+  values:
+    Expensive: 2
+    General: 1
+    Invalid: 0
 ReportType:
-  BattlePet: 10
-  Calendar: 11
-  Chat: 0
-  ClubFinderApplicant: 3
-  ClubFinderPosting: 2
-  ClubMember: 6
-  CraftingOrder: 16
-  Friend: 8
-  GroupFinderApplicant: 5
-  GroupFinderPosting: 4
-  GroupMember: 7
-  HousingDecor: 18
-  InWorld: 1
-  Mail: 12
-  Neighborhood: 19
-  NeighborhoodRoster: 20
-  Pet: 9
-  PvP: 13
-  PvPGroupMember: 15
-  PvPScoreboard: 14
-  RecentAlly: 17
+  values:
+    BattlePet: 10
+    Calendar: 11
+    Chat: 0
+    ClubFinderApplicant: 3
+    ClubFinderPosting: 2
+    ClubMember: 6
+    CraftingOrder: 16
+    Friend: 8
+    GroupFinderApplicant: 5
+    GroupFinderPosting: 4
+    GroupMember: 7
+    HousingDecor: 18
+    InWorld: 1
+    Mail: 12
+    Neighborhood: 19
+    NeighborhoodRoster: 20
+    Pet: 9
+    PvP: 13
+    PvPGroupMember: 15
+    PvPScoreboard: 14
+    RecentAlly: 17
 ReputationSortType:
-  Account: 1
-  Character: 2
-  None: 0
+  values:
+    Account: 1
+    Character: 2
+    None: 0
 ReservationFlags:
-  Canceled: 2
-  None: 0
-  Plotless: 4
-  Relinquish: 1
+  values:
+    Canceled: 2
+    None: 0
+    Plotless: 4
+    Relinquish: 1
 ResidentType:
-  Manager: 1
-  Owner: 2
-  Resident: 0
+  values:
+    Manager: 1
+    Owner: 2
+    Resident: 0
 RestrictPingsTo:
-  Assist: 2
-  Lead: 1
-  None: 0
-  TankHealer: 3
+  values:
+    Assist: 2
+    Lead: 1
+    None: 0
+    TankHealer: 3
 RetroactiveDecorRewardFlags:
-  AllCriteriaRequired: 1
-  None: 0
+  values:
+    AllCriteriaRequired: 1
+    None: 0
 RolodexContextLevelType:
-  DelveTier: 3
-  Difficulty: 1
-  KeystoneLevel: 2
-  None: 0
+  values:
+    DelveTier: 3
+    Difficulty: 1
+    KeystoneLevel: 2
+    None: 0
 RolodexType:
-  CompleteArena: 16
-  CompleteBg: 17
-  CompleteDelve: 15
-  CompleteDungeon: 12
-  CreatureKill: 11
-  Duel: 18
-  GuildOrderFilledByOther: 9
-  GuildOrderFilledByYou: 10
-  KillLfrBoss: 14
-  KillRaidBoss: 13
-  None: 0
-  PartyMember: 1
-  PersonalOrderFilledByOther: 7
-  PersonalOrderFilledByYou: 8
-  PetBattle: 19
-  PublicOrderFilledByOther: 5
-  PublicOrderFilledByYou: 6
-  PvPKill: 20
-  RaidMember: 2
-  Trade: 3
-  Whisper: 4
+  values:
+    CompleteArena: 16
+    CompleteBg: 17
+    CompleteDelve: 15
+    CompleteDungeon: 12
+    CreatureKill: 11
+    Duel: 18
+    GuildOrderFilledByOther: 9
+    GuildOrderFilledByYou: 10
+    KillLfrBoss: 14
+    KillRaidBoss: 13
+    None: 0
+    PartyMember: 1
+    PersonalOrderFilledByOther: 7
+    PersonalOrderFilledByYou: 8
+    PetBattle: 19
+    PublicOrderFilledByOther: 5
+    PublicOrderFilledByYou: 6
+    PvPKill: 20
+    RaidMember: 2
+    Trade: 3
+    Whisper: 4
 RolodexTypeFlags:
-  HiddenFromHistory: 1
-  None: 0
+  values:
+    HiddenFromHistory: 1
+    None: 0
 RoomConnectionType:
-  All: 1
-  None: 0
+  values:
+    All: 1
+    None: 0
 RuneforgePowerFilter:
-  All: 0
-  Available: 2
-  Relevant: 1
-  Unavailable: 3
+  values:
+    All: 0
+    Available: 2
+    Relevant: 1
+    Unavailable: 3
 RuneforgePowerState:
-  Available: 0
-  Invalid: 2
-  Unavailable: 1
+  values:
+    Available: 0
+    Invalid: 2
+    Unavailable: 1
 ScreenLocationType:
-  Bottom: 4
-  Center: 0
-  Left: 1
-  LeftOutside: 7
-  LeftRight: 9
-  LeftRightOutside: 11
-  Right: 2
-  RightOutside: 8
-  Top: 3
-  TopBottom: 10
-  TopLeft: 5
-  TopRight: 6
+  values:
+    Bottom: 4
+    Center: 0
+    Left: 1
+    LeftOutside: 7
+    LeftRight: 9
+    LeftRightOutside: 11
+    Right: 2
+    RightOutside: 8
+    Top: 3
+    TopBottom: 10
+    TopLeft: 5
+    TopRight: 6
 ScreenshotSource:
-  Automatic: 0
-  Cheat: 2
-  PlayerReport: 1
+  values:
+    Automatic: 0
+    Cheat: 2
+    PlayerReport: 1
 ScriptedAnimationBehavior:
-  None: 0
-  SourceCollideWithTarget: 4
-  SourceRecoil: 3
-  TargetKnockBack: 2
-  TargetShake: 1
-  UIParentShake: 5
+  values:
+    None: 0
+    SourceCollideWithTarget: 4
+    SourceRecoil: 3
+    TargetKnockBack: 2
+    TargetShake: 1
+    UIParentShake: 5
 ScriptedAnimationFlags:
-  UseTargetAsSource: 1
+  values:
+    UseTargetAsSource: 1
 ScriptedAnimationTrajectory:
-  AtSource: 0
-  AtTarget: 1
-  CurveLeft: 3
-  CurveRandom: 5
-  CurveRight: 4
-  HalfwayBetween: 6
-  Straight: 2
+  values:
+    AtSource: 0
+    AtTarget: 1
+    CurveLeft: 3
+    CurveRandom: 5
+    CurveRight: 4
+    HalfwayBetween: 6
+    Straight: 2
 ScrubStringFlags:
-  AllowBarCodes: 2
-  None: 0
-  StripControlCodes: 4
-  TruncateNewLines: 1
+  values:
+    AllowBarCodes: 2
+    None: 0
+    StripControlCodes: 4
+    TruncateNewLines: 1
 SeasonID:
-  Fresh: 11
-  FreshHardcore: 12
-  Hardcore: 3
-  NoSeason: 0
-  SeasonOfDiscovery: 2
-  SeasonOfMastery: 1
+  values:
+    Fresh: 11
+    FreshHardcore: 12
+    Hardcore: 3
+    NoSeason: 0
+    SeasonOfDiscovery: 2
+    SeasonOfMastery: 1
 SecondsFormatterAbbreviation:
-  None: 0
-  OneLetter: 2
-  Truncate: 1
+  values:
+    None: 0
+    OneLetter: 2
+    Truncate: 1
 SecondsFormatterInterval:
-  Days: 3
-  Hours: 2
-  Minutes: 1
-  Seconds: 0
+  values:
+    Days: 3
+    Hours: 2
+    Minutes: 1
+    Seconds: 0
 SecondsFormatterIntervalWhitespace:
-  Preserve: 0
-  Strip: 1
-  StripIgnoreLocale: 2
+  values:
+    Preserve: 0
+    Strip: 1
+    StripIgnoreLocale: 2
 SecrecyLevel:
-  AlwaysSecret: 1
-  ContextuallySecret: 2
-  NeverSecret: 0
+  values:
+    AlwaysSecret: 1
+    ContextuallySecret: 2
+    NeverSecret: 0
 SecretAspect:
-  Alpha: 128
-  Attributes: 1
-  BarValue: 16384
-  ButtonState: 2097152
-  Cooldown: 32768
-  CooldownStyle: 524288
-  Cursor: 1024
-  Desaturation: 4096
-  FrameLevel: 256
-  Hierarchy: 1
-  ID: 2
-  MinimumWidth: 131072
-  ObjectDebug: 1
-  ObjectName: 1
-  ObjectSecrets: 1
-  ObjectSecurity: 1
-  ObjectType: 1
-  Padding: 262144
-  Rotation: 65536
-  Scale: 64
-  ScrollOffset: 4194304
-  ScrollRange: 512
-  SecureText: 16
-  Shown: 32
-  TexCoords: 8192
-  Text: 8
-  TooltipTexture: 1048576
-  Toplevel: 4
-  VertexColor: 2048
+  values:
+    Alpha: 128
+    Attributes: 1
+    BarValue: 16384
+    ButtonState: 2097152
+    Cooldown: 32768
+    CooldownStyle: 524288
+    Cursor: 1024
+    Desaturation: 4096
+    FrameLevel: 256
+    Hierarchy: 1
+    ID: 2
+    MinimumWidth: 131072
+    ObjectDebug: 1
+    ObjectName: 1
+    ObjectSecrets: 1
+    ObjectSecurity: 1
+    ObjectType: 1
+    Padding: 262144
+    Rotation: 65536
+    Scale: 64
+    ScrollOffset: 4194304
+    ScrollRange: 512
+    SecureText: 16
+    Shown: 32
+    TexCoords: 8192
+    Text: 8
+    TooltipTexture: 1048576
+    Toplevel: 4
+    VertexColor: 2048
 SelfResurrectOptionType:
-  Item: 1
-  Spell: 0
+  values:
+    Item: 1
+    Spell: 0
 SendAddonMessageResult:
-  AddOnMessageLockdown: 11
-  AddonMessageThrottle: 3
-  ChannelThrottle: 8
-  GeneralError: 9
-  InvalidChannel: 7
-  InvalidChatType: 4
-  InvalidMessage: 2
-  InvalidPrefix: 1
-  NotInGroup: 5
-  NotInGuild: 10
-  Success: 0
-  TargetOffline: 12
-  TargetRequired: 6
+  values:
+    AddOnMessageLockdown: 11
+    AddonMessageThrottle: 3
+    ChannelThrottle: 8
+    GeneralError: 9
+    InvalidChannel: 7
+    InvalidChatType: 4
+    InvalidMessage: 2
+    InvalidPrefix: 1
+    NotInGroup: 5
+    NotInGuild: 10
+    Success: 0
+    TargetOffline: 12
+    TargetRequired: 6
 SendReportResult:
-  GeneralError: 1
-  RequiresChatLine: 3
-  RequiresChatLineOrVoice: 4
-  RequiresScreenshot: 5
-  Success: 0
-  TooManyReports: 2
+  values:
+    GeneralError: 1
+    RequiresChatLine: 3
+    RequiresChatLineOrVoice: 4
+    RequiresScreenshot: 5
+    Success: 0
+    TooManyReports: 2
 SharedStringFlag:
-  InternalOnly: 1
+  values:
+    InternalOnly: 1
 ShutdownSessionReason:
-  AccountLoginCommand: 4
-  Error: 6
-  ForceLogoutCommand: 2
-  LuaScript: 5
-  RealmSelectCommand: 3
-  RestartSessionCommand: 1
-  SessionEnded: 0
+  values:
+    AccountLoginCommand: 4
+    Error: 6
+    ForceLogoutCommand: 2
+    LuaScript: 5
+    RealmSelectCommand: 3
+    RestartSessionCommand: 1
+    SessionEnded: 0
 Siflag:
-  Affectedbyaltitude: 16
-  Affectedbysanity: 2048
-  AutocreatedByBroadcastText: 4
-  CasterOwnsTargetSound: 128
-  Disablepositionallpf: 1
-  Dontplayindoors: 256
-  Dontplayunderwater: 1024
-  Dontstopondeath: 4096
-  Ignoresuppressors: 64
-  Ignorevopriority: 16384
-  Looping: 512
-  Noduplicates: 32
-  None: 0
-  Onlyplayindoors: 32768
-  Onlyplayunderwater: 65536
-  Playonlyforowner: 8192
-  Playsequential: 8
-  UseModCastSpeed: 2
+  values:
+    Affectedbyaltitude: 16
+    Affectedbysanity: 2048
+    AutocreatedByBroadcastText: 4
+    CasterOwnsTargetSound: 128
+    Disablepositionallpf: 1
+    Dontplayindoors: 256
+    Dontplayunderwater: 1024
+    Dontstopondeath: 4096
+    Ignoresuppressors: 64
+    Ignorevopriority: 16384
+    Looping: 512
+    Noduplicates: 32
+    None: 0
+    Onlyplayindoors: 32768
+    Onlyplayunderwater: 65536
+    Playonlyforowner: 8192
+    Playsequential: 8
+    UseModCastSpeed: 2
 SimpleOrderStatus:
-  Creating: 1
-  Failed: 4
-  InProgress: 2
-  Invalid: 0
-  Success: 3
+  values:
+    Creating: 1
+    Failed: 4
+    InProgress: 2
+    Invalid: 0
+    Success: 3
 SkinningState:
-  Looting: 3
-  None: 0
-  Reserved: 1
-  Skinned: 4
-  Skinning: 2
+  values:
+    Looting: 3
+    None: 0
+    Reserved: 1
+    Skinned: 4
+    Skinning: 2
 SleevesGeoRange:
-  Default: 1
-  Flared: 2
-  None: 0
-  PandaCollar: 4
-  Puffy: 3
+  values:
+    Default: 1
+    Flared: 2
+    None: 0
+    PandaCollar: 4
+    Puffy: 3
 SlotRegion:
-  AccountBank: 5
-  CharacterBank: 4
-  Invalid: 0
-  PlayerBags: 2
-  PlayerEquip: 1
-  PlayerInv: 3
+  values:
+    AccountBank: 5
+    CharacterBank: 4
+    Invalid: 0
+    PlayerBags: 2
+    PlayerEquip: 1
+    PlayerInv: 3
 SlotRegionMask:
-  AccountBank: 64
-  CharacterBank: 16
-  Invalid: 1
-  PlayerBags: 4
-  PlayerEquip: 2
-  PlayerInv: 8
+  values:
+    AccountBank: 64
+    CharacterBank: 16
+    Invalid: 1
+    PlayerBags: 4
+    PlayerEquip: 2
+    PlayerInv: 8
 SocialWhoOrigin:
-  Chat: 2
-  Item: 3
-  Social: 1
-  Unknown: 0
+  values:
+    Chat: 2
+    Item: 3
+    Social: 1
+    Unknown: 0
 SoftTargetEnableFlags:
-  Any: 3
-  Gamepad: 1
-  Kbm: 2
-  None: 0
+  values:
+    Any: 3
+    Gamepad: 1
+    Kbm: 2
+    None: 0
 SortPlayersBy:
-  Alphabetical: 2
-  Group: 1
-  Role: 0
+  values:
+    Alphabetical: 2
+    Group: 1
+    Role: 0
 SoulbindConduitFlags:
-  VisibleToGetallsoulbindconduitScript: 1
+  values:
+    VisibleToGetallsoulbindconduitScript: 1
 SoulbindConduitInstallResult:
-  DuplicateConduit: 4
-  ForgeNotInProximity: 5
-  InvalidConduit: 2
-  InvalidItem: 1
-  InvalidTalent: 3
-  SocketNotEmpty: 6
-  Success: 0
+  values:
+    DuplicateConduit: 4
+    ForgeNotInProximity: 5
+    InvalidConduit: 2
+    InvalidItem: 1
+    InvalidTalent: 3
+    SocketNotEmpty: 6
+    Success: 0
 SoulbindConduitTransactionType:
-  Install: 0
-  Uninstall: 1
+  values:
+    Install: 0
+    Uninstall: 1
 SoulbindConduitType:
-  Endurance: 2
-  Finesse: 0
-  Flex: 3
-  Potency: 1
+  values:
+    Endurance: 2
+    Finesse: 0
+    Flex: 3
+    Potency: 1
 SoulbindNodeState:
-  Selectable: 2
-  Selected: 3
-  Unavailable: 0
-  Unselected: 1
+  values:
+    Selectable: 2
+    Selected: 3
+    Unavailable: 0
+    Unselected: 1
 SoundBusFlag:
-  Disablepositionallpf: 1
+  values:
+    Disablepositionallpf: 1
 SpecializationSystem:
-  ChrSpecialization: 1
-  TalentTab: 0
+  values:
+    ChrSpecialization: 1
+    TalentTab: 0
 SpellAuraVisibilityType:
-  EnemyTarget: 2
-  RaidInCombat: 0
-  RaidOutOfCombat: 1
+  values:
+    EnemyTarget: 2
+    RaidInCombat: 0
+    RaidOutOfCombat: 1
 SpellBookItemType:
-  Flyout: 4
-  FutureSpell: 2
-  None: 0
-  PetAction: 3
-  Spell: 1
+  values:
+    Flyout: 4
+    FutureSpell: 2
+    None: 0
+    PetAction: 3
+    Spell: 1
 SpellBookSkillLineIndex:
-  Class: 2
-  General: 1
-  MainSpec: 3
-  OffSpecStart: 4
+  values:
+    Class: 2
+    General: 1
+    MainSpec: 3
+    OffSpecStart: 4
 SpellBookSpellBank:
-  Pet: 1
-  Player: 0
+  values:
+    Pet: 1
+    Player: 0
 SpellDiminishCategory:
-  AoEKnockback: 3
-  Disarm: 7
-  Disorient: 5
-  Incapacitate: 4
-  Root: 0
-  Silence: 6
-  Stun: 2
-  Taunt: 1
+  values:
+    AoEKnockback: 3
+    Disarm: 7
+    Disorient: 5
+    Incapacitate: 4
+    Root: 0
+    Silence: 6
+    Stun: 2
+    Taunt: 1
 SpellDiminishRuleset:
-  None: 0
-  PvE: 1
-  PvP: 2
+  values:
+    None: 0
+    PvE: 1
+    PvP: 2
 SpellDisplayBorderColor:
-  Black: 1
-  Blue: 8
-  Green: 7
-  None: 0
-  Orange: 5
-  Purple: 6
-  Red: 3
-  White: 2
-  Yellow: 4
+  values:
+    Black: 1
+    Blue: 8
+    Green: 7
+    None: 0
+    Orange: 5
+    Purple: 6
+    Red: 3
+    White: 2
+    Yellow: 4
 SpellDisplayIconDisplayType:
-  Buff: 0
-  Circular: 2
-  Debuff: 1
-  NoBorder: 3
+  values:
+    Buff: 0
+    Circular: 2
+    Debuff: 1
+    NoBorder: 3
 SpellDisplayTextShownStateType:
-  Hidden: 1
-  Shown: 0
+  values:
+    Hidden: 1
+    Shown: 0
 SpellDisplayTint:
-  None: 0
-  Red: 1
+  values:
+    None: 0
+    Red: 1
 SplashScreenType:
-  SeasonRollOver: 1
-  WhatsNew: 0
+  values:
+    SeasonRollOver: 1
+    WhatsNew: 0
 StableResult:
-  AlreadyStabled: 5
-  AlreadySummoned: 6
-  BuySlotSuccess: 14
-  CantControlExotic: 11
-  CheckForLuaHack: 13
-  FavoriteToggle: 15
-  InsufficientFunds: 1
-  InternalError: 12
-  InvalidSlot: 3
-  MaxSlots: 0
-  NoPet: 4
-  NotFound: 7
-  NotStableMaster: 2
-  PetRenamed: 16
-  ReviveSuccess: 10
-  StableSuccess: 8
-  UnstableSuccess: 9
+  values:
+    AlreadyStabled: 5
+    AlreadySummoned: 6
+    BuySlotSuccess: 14
+    CantControlExotic: 11
+    CheckForLuaHack: 13
+    FavoriteToggle: 15
+    InsufficientFunds: 1
+    InternalError: 12
+    InvalidSlot: 3
+    MaxSlots: 0
+    NoPet: 4
+    NotFound: 7
+    NotStableMaster: 2
+    PetRenamed: 16
+    ReviveSuccess: 10
+    StableSuccess: 8
+    UnstableSuccess: 9
 StartTimerType:
-  ChallengeModeCountdown: 1
-  PlayerCountdown: 2
-  PlunderstormCountdown: 3
-  PvPBeginTimer: 0
+  values:
+    ChallengeModeCountdown: 1
+    PlayerCountdown: 2
+    PlunderstormCountdown: 3
+    PvPBeginTimer: 0
 StatusBarColorTintValue:
-  Black: 1
-  Blue: 8
-  Green: 7
-  None: 0
-  Orange: 5
-  Purple: 6
-  Red: 3
-  White: 2
-  Yellow: 4
+  values:
+    Black: 1
+    Blue: 8
+    Green: 7
+    None: 0
+    Orange: 5
+    Purple: 6
+    Red: 3
+    White: 2
+    Yellow: 4
 StatusBarFillStyle:
-  Center: 2
-  Reverse: 3
-  Standard: 0
-  StandardNoRangeFill: 1
+  values:
+    Center: 2
+    Reverse: 3
+    Standard: 0
+    StandardNoRangeFill: 1
 StatusBarInterpolation:
-  ExponentialEaseOut: 1
-  Immediate: 0
+  values:
+    ExponentialEaseOut: 1
+    Immediate: 0
 StatusBarOverrideBarTextShownType:
-  Always: 1
-  Never: 0
-  OnlyNotOnMouseover: 3
-  OnlyOnMouseover: 2
+  values:
+    Always: 1
+    Never: 0
+    OnlyNotOnMouseover: 3
+    OnlyOnMouseover: 2
 StatusBarTimerDirection:
-  ElapsedTime: 0
-  RemainingTime: 1
+  values:
+    ElapsedTime: 0
+    RemainingTime: 1
 StatusBarValueTextType:
-  Hidden: 0
-  Percentage: 1
-  Time: 3
-  TimeShowOneLevelOnly: 4
-  Value: 2
-  ValueOverMax: 5
-  ValueOverMaxNormalized: 6
+  values:
+    Hidden: 0
+    Percentage: 1
+    Time: 3
+    TimeShowOneLevelOnly: 4
+    Value: 2
+    ValueOverMax: 5
+    ValueOverMaxNormalized: 6
 StoreError:
-  AlreadyOwned: 7
-  BattlepayDisabled: 4
-  ClientRestricted: 13
-  ConsumableTokenOwned: 10
-  InsufficientBalance: 5
-  InvalidPaymentMethod: 1
-  ItemUnavailable: 12
-  Other: 6
-  ParentalControlsNoPurchase: 8
-  PaymentFailed: 2
-  PurchaseDenied: 9
-  Success: 0
-  TooManyTokens: 11
-  WrongCurrency: 3
+  values:
+    AlreadyOwned: 7
+    BattlepayDisabled: 4
+    ClientRestricted: 13
+    ConsumableTokenOwned: 10
+    InsufficientBalance: 5
+    InvalidPaymentMethod: 1
+    ItemUnavailable: 12
+    Other: 6
+    ParentalControlsNoPurchase: 8
+    PaymentFailed: 2
+    PurchaseDenied: 9
+    Success: 0
+    TooManyTokens: 11
+    WrongCurrency: 3
 SubcontainerType:
-  AccountBankTabs: 36
-  Auction: 5
-  Bag: 0
-  Bankbag: 3
-  Bankgeneric: 2
-  BuybackSlots: 26
-  CachedReward: 27
-  CharacterBankTabs: 38
-  Childequipmentstorage: 23
-  CraftingOrder: 34
-  CraftingOrderReagents: 35
-  CreatedImmediately: 25
-  CurrencytokenOboslete: 15
-  CurrencyTransfer: 37
-  Equipablespells: 14
-  Equipped: 1
-  EquippedBags: 28
-  EquippedCooking: 31
-  EquippedFishing: 32
-  EquippedProfession1: 29
-  EquippedProfession2: 30
-  EquippedReagentbag: 33
-  GuildBank0: 7
-  GuildBank1: 8
-  GuildBank10: 20
-  GuildBank11: 21
-  GuildBank2: 9
-  GuildBank3: 10
-  GuildBank4: 11
-  GuildBank5: 12
-  GuildBank6: 16
-  GuildBank7: 17
-  GuildBank8: 18
-  GuildBank9: 19
-  GuildOverflow: 13
-  HousingDecorConversion: 39
-  Keyring: 6
-  Mail: 4
-  Quarantine: 24
-  Reagentbank: 22
+  values:
+    AccountBankTabs: 36
+    Auction: 5
+    Bag: 0
+    Bankbag: 3
+    Bankgeneric: 2
+    BuybackSlots: 26
+    CachedReward: 27
+    CharacterBankTabs: 38
+    Childequipmentstorage: 23
+    CraftingOrder: 34
+    CraftingOrderReagents: 35
+    CreatedImmediately: 25
+    CurrencytokenOboslete: 15
+    CurrencyTransfer: 37
+    Equipablespells: 14
+    Equipped: 1
+    EquippedBags: 28
+    EquippedCooking: 31
+    EquippedFishing: 32
+    EquippedProfession1: 29
+    EquippedProfession2: 30
+    EquippedReagentbag: 33
+    GuildBank0: 7
+    GuildBank1: 8
+    GuildBank10: 20
+    GuildBank11: 21
+    GuildBank2: 9
+    GuildBank3: 10
+    GuildBank4: 11
+    GuildBank5: 12
+    GuildBank6: 16
+    GuildBank7: 17
+    GuildBank8: 18
+    GuildBank9: 19
+    GuildOverflow: 13
+    HousingDecorConversion: 39
+    Keyring: 6
+    Mail: 4
+    Quarantine: 24
+    Reagentbank: 22
 SubscriptionInterstitialResponseType:
-  Clicked: 0
-  Closed: 1
-  WebRedirect: 2
+  values:
+    Clicked: 0
+    Closed: 1
+    WebRedirect: 2
 SubscriptionInterstitialType:
-  LeftNpeArea: 1
-  MaxLevel: 2
-  Standard: 0
+  values:
+    LeftNpeArea: 1
+    MaxLevel: 2
+    Standard: 0
 SummonReason:
-  Scenario: 1
-  Spell: 0
+  values:
+    Scenario: 1
+    Spell: 0
 SummonStatus:
-  Accepted: 2
-  Declined: 3
-  None: 0
-  Pending: 1
+  values:
+    Accepted: 2
+    Declined: 3
+    None: 0
+    Pending: 1
 SuperTrackingMapPinType:
-  AreaPOI: 0
-  DigSite: 3
-  HousingPlot: 4
-  QuestOffer: 1
-  TaxiNode: 2
+  values:
+    AreaPOI: 0
+    DigSite: 3
+    HousingPlot: 4
+    QuestOffer: 1
+    TaxiNode: 2
 SuperTrackingType:
-  Content: 4
-  Corpse: 2
-  MapPin: 6
-  PartyMember: 5
-  Quest: 0
-  Scenario: 3
-  UserWaypoint: 1
-  Vignette: 7
+  values:
+    Content: 4
+    Corpse: 2
+    MapPin: 6
+    PartyMember: 5
+    Quest: 0
+    Scenario: 3
+    UserWaypoint: 1
+    Vignette: 7
 SurveyDeliveryFlags:
-  EncounterSucccessOnly: 1
-  None: 0
+  values:
+    EncounterSucccessOnly: 1
+    None: 0
 SurveyDeliveryMoment:
-  ChestLooted: 3
-  EncounterEnd: 5
-  Login: 0
-  MythicPlusCompleted: 4
-  ProfessionTable: 1
-  QuestTurnIn: 2
+  values:
+    ChestLooted: 3
+    EncounterEnd: 5
+    Login: 0
+    MythicPlusCompleted: 4
+    ProfessionTable: 1
+    QuestTurnIn: 2
 TableSecurityOption:
-  DisallowSecretKeys: 1
-  DisallowTaintedAccess: 0
-  SecretWrapContents: 2
+  values:
+    DisallowSecretKeys: 1
+    DisallowTaintedAccess: 0
+    SecretWrapContents: 2
 TieredEntranceRewardType:
-  Currency: 1
-  Item: 0
+  values:
+    Currency: 1
+    Item: 0
 TieredEntranceType:
-  Delve: 1
-  Invalid: 0
-  Sites: 2
-  WorldTier: 3
+  values:
+    Delve: 1
+    Invalid: 0
+    Sites: 2
+    WorldTier: 3
 TimeEventFlag:
-  GlobalLaunch: 4
-  GlueScreenShortcut: 1
-  WeeklyReset: 2
+  values:
+    GlobalLaunch: 4
+    GlueScreenShortcut: 1
+    WeeklyReset: 2
 TitleIconVersion:
-  Large: 2
-  Medium: 1
-  Small: 0
+  values:
+    Large: 2
+    Medium: 1
+    Small: 0
 TooltipComparisonMethod:
-  Single: 0
-  WithBagMainHandItem: 2
-  WithBagOffHandItem: 3
-  WithBothHands: 1
+  values:
+    Single: 0
+    WithBagMainHandItem: 2
+    WithBagOffHandItem: 3
+    WithBothHands: 1
 TooltipDataItemBinding:
-  Account: 1
-  AccountUntilEquipped: 9
-  BindOnEquip: 7
-  BindOnPickup: 6
-  BindOnUse: 8
-  BindToAccount: 4
-  BindToAccountUntilEquipped: 10
-  BindToBnetAccount: 5
-  BnetAccount: 2
-  Quest: 0
-  Soulbound: 3
+  values:
+    Account: 1
+    AccountUntilEquipped: 9
+    BindOnEquip: 7
+    BindOnPickup: 6
+    BindOnUse: 8
+    BindToAccount: 4
+    BindToAccountUntilEquipped: 10
+    BindToBnetAccount: 5
+    BnetAccount: 2
+    Quest: 0
+    Soulbound: 3
 TooltipDataLineType:
-  AzeriteEssencePower: 5
-  AzeriteEssenceSlot: 4
-  AzeriteItemPowerDescription: 9
-  Blank: 1
-  CurrencyTotal: 14
-  DisabledLine: 42
-  EquipSlot: 21
-  ErrorLine: 41
-  FlavorText: 37
-  GemSocket: 3
-  GemSocketEnchantment: 30
-  ItemBinding: 20
-  ItemEnchantmentPermanent: 15
-  ItemLevel: 31
-  ItemName: 22
-  ItemQuality: 35
-  ItemSpellTriggerLearn: 38
-  ItemUpgradeLevel: 32
-  LearnableSpell: 6
-  LearnTransmogIllusion: 40
-  LearnTransmogSet: 39
-  NestedBlock: 19
-  None: 0
-  ProfessionCraftingQuality: 12
-  QuestObjective: 8
-  QuestPlayer: 18
-  QuestTitle: 17
-  RuneforgeLegendaryPowerDescription: 10
-  SellPrice: 11
-  Separator: 23
-  SpellDescription: 34
-  SpellName: 13
-  SpellPassive: 33
-  ToyDescription: 28
-  ToyDuration: 27
-  ToyEffect: 26
-  ToyName: 24
-  ToySource: 29
-  ToyText: 25
-  TradeTimeRemaining: 36
-  UnitName: 2
-  UnitOwner: 16
-  UnitThreat: 7
-  UsageRequirement: 43
+  values:
+    AzeriteEssencePower: 5
+    AzeriteEssenceSlot: 4
+    AzeriteItemPowerDescription: 9
+    Blank: 1
+    CurrencyTotal: 14
+    DisabledLine: 42
+    EquipSlot: 21
+    ErrorLine: 41
+    FlavorText: 37
+    GemSocket: 3
+    GemSocketEnchantment: 30
+    ItemBinding: 20
+    ItemEnchantmentPermanent: 15
+    ItemLevel: 31
+    ItemName: 22
+    ItemQuality: 35
+    ItemSpellTriggerLearn: 38
+    ItemUpgradeLevel: 32
+    LearnableSpell: 6
+    LearnTransmogIllusion: 40
+    LearnTransmogSet: 39
+    NestedBlock: 19
+    None: 0
+    ProfessionCraftingQuality: 12
+    QuestObjective: 8
+    QuestPlayer: 18
+    QuestTitle: 17
+    RuneforgeLegendaryPowerDescription: 10
+    SellPrice: 11
+    Separator: 23
+    SpellDescription: 34
+    SpellName: 13
+    SpellPassive: 33
+    ToyDescription: 28
+    ToyDuration: 27
+    ToyEffect: 26
+    ToyName: 24
+    ToySource: 29
+    ToyText: 25
+    TradeTimeRemaining: 36
+    UnitName: 2
+    UnitOwner: 16
+    UnitThreat: 7
+    UsageRequirement: 43
 TooltipDataType:
-  Achievement: 12
-  AzeriteEssence: 8
-  BattlePet: 6
-  CompanionPet: 9
-  Corpse: 3
-  CorruptionCleanser: 20
-  Currency: 5
-  Debug: 26
-  EnhancedConduit: 13
-  EquipmentSet: 14
-  Flyout: 22
-  InstanceLock: 15
-  Item: 0
-  Macro: 25
-  MinimapMouseover: 21
-  Mount: 10
-  Object: 4
-  Outfit: 27
-  PetAction: 11
-  PvPBrawl: 16
-  Quest: 23
-  QuestPartyProgress: 24
-  RecipeRankInfo: 17
-  Spell: 1
-  Totem: 18
-  Toy: 19
-  Unit: 2
-  UnitAura: 7
+  values:
+    Achievement: 12
+    AzeriteEssence: 8
+    BattlePet: 6
+    CompanionPet: 9
+    Corpse: 3
+    CorruptionCleanser: 20
+    Currency: 5
+    Debug: 26
+    EnhancedConduit: 13
+    EquipmentSet: 14
+    Flyout: 22
+    InstanceLock: 15
+    Item: 0
+    Macro: 25
+    MinimapMouseover: 21
+    Mount: 10
+    Object: 4
+    Outfit: 27
+    PetAction: 11
+    PvPBrawl: 16
+    Quest: 23
+    QuestPartyProgress: 24
+    RecipeRankInfo: 17
+    Spell: 1
+    Totem: 18
+    Toy: 19
+    Unit: 2
+    UnitAura: 7
 TooltipDataUsageRequirementType:
-  Achievement: 7
-  ArenaRating: 11
-  EarnCurrency: 12
-  EquippedItem: 9
-  Faction: 1
-  Guild: 6
-  Level: 5
-  NotAlreadyKnown: 14
-  NotInArena: 15
-  NotInRatedBg: 16
-  PvPMedal: 3
-  PvPRank: 8
-  RaceClass: 0
-  Reputation: 4
-  ShapeshiftForm: 10
-  Skill: 2
-  Specialization: 13
+  values:
+    Achievement: 7
+    ArenaRating: 11
+    EarnCurrency: 12
+    EquippedItem: 9
+    Faction: 1
+    Guild: 6
+    Level: 5
+    NotAlreadyKnown: 14
+    NotInArena: 15
+    NotInRatedBg: 16
+    PvPMedal: 3
+    PvPRank: 8
+    RaceClass: 0
+    Reputation: 4
+    ShapeshiftForm: 10
+    Skill: 2
+    Specialization: 13
 TooltipSide:
-  Bottom: 3
-  Left: 0
-  Right: 1
-  Top: 2
+  values:
+    Bottom: 3
+    Left: 0
+    Right: 1
+    Top: 2
 TooltipTextureAnchor:
-  All: 6
-  LeftBottom: 2
-  LeftCenter: 1
-  LeftTop: 0
-  RightBottom: 5
-  RightCenter: 4
-  RightTop: 3
+  values:
+    All: 6
+    LeftBottom: 2
+    LeftCenter: 1
+    LeftTop: 0
+    RightBottom: 5
+    RightCenter: 4
+    RightTop: 3
 TooltipTextureRelativeRegion:
-  LeftLine: 0
-  RightLine: 1
+  values:
+    LeftLine: 0
+    RightLine: 1
 TrackedSpellCategory:
-  Debuff: 3
-  Defensive: 2
-  None: 0
-  Offensive: 1
-  RacialAbility: 4
+  values:
+    Debuff: 3
+    Defensive: 2
+    None: 0
+    Offensive: 1
+    RacialAbility: 4
 TrackedSpellsResult:
-  MismatchedCooldownInfo: 3
-  NoCooldownInfo: 2
-  PlayerNotFound: 1
-  Success: 0
+  values:
+    MismatchedCooldownInfo: 3
+    NoCooldownInfo: 2
+    PlayerNotFound: 1
+    Success: 0
 TradeskillOrderDuration:
-  Long: 3
-  Medium: 2
-  Short: 1
+  values:
+    Long: 3
+    Medium: 2
+    Short: 1
 TradeskillOrderRecipient:
-  Guild: 2
-  Private: 3
-  Public: 1
+  values:
+    Guild: 2
+    Private: 3
+    Public: 1
 TradeskillOrderStatus:
-  Completed: 3
-  Expired: 4
-  Started: 2
-  Unclaimed: 1
+  values:
+    Completed: 3
+    Expired: 4
+    Started: 2
+    Unclaimed: 1
 TradeskillRecipeType:
-  Enchant: 3
-  Gathering: 4
-  Item: 1
-  Salvage: 2
+  values:
+    Enchant: 3
+    Gathering: 4
+    Item: 1
+    Salvage: 2
 TradeskillRelativeDifficulty:
-  Easy: 2
-  Medium: 1
-  Optimal: 0
-  Trivial: 3
+  values:
+    Easy: 2
+    Medium: 1
+    Optimal: 0
+    Trivial: 3
 TradeskillSlotDataType:
-  Currency: 3
-  ModifiedReagent: 2
-  Reagent: 1
+  values:
+    Currency: 3
+    ModifiedReagent: 2
+    Reagent: 1
 TraitCombatConfigFlags:
-  ActiveForSpec: 1
-  SharedActionBars: 4
-  StarterBuild: 2
+  values:
+    ActiveForSpec: 1
+    SharedActionBars: 4
+    StarterBuild: 2
 TraitCondFlag:
-  IsAlwaysMet: 2
-  IsGate: 1
-  IsSufficient: 4
+  values:
+    IsAlwaysMet: 2
+    IsGate: 1
+    IsSufficient: 4
 TraitConditionType:
-  Available: 0
-  DisplayError: 4
-  Granted: 2
-  Increased: 3
-  RanksAllowed: 5
-  Visible: 1
+  values:
+    Available: 0
+    DisplayError: 4
+    Granted: 2
+    Increased: 3
+    RanksAllowed: 5
+    Visible: 1
 TraitConfigDbState:
-  Created: 1
-  Deleted: 3
-  Ready: 0
-  Removed: 2
+  values:
+    Created: 1
+    Deleted: 3
+    Ready: 0
+    Removed: 2
 TraitConfigType:
-  Combat: 1
-  Generic: 3
-  Invalid: 0
-  Profession: 2
+  values:
+    Combat: 1
+    Generic: 3
+    Invalid: 0
+    Profession: 2
 TraitCurrencyFlag:
-  ShowQuantityAsSpent: 1
-  TraitSourcedShowMax: 2
-  UseClassIcon: 4
-  UseSpecIcon: 8
+  values:
+    ShowQuantityAsSpent: 1
+    TraitSourcedShowMax: 2
+    UseClassIcon: 4
+    UseSpecIcon: 8
 TraitCurrencyType:
-  CurrencyTypesBased: 1
-  Gold: 0
-  TraitSourced: 2
-  TraitSourcedPlayerDataElement: 3
+  values:
+    CurrencyTypesBased: 1
+    Gold: 0
+    TraitSourced: 2
+    TraitSourcedPlayerDataElement: 3
 TraitDefinitionSubType:
-  DragonflightBlack: 4
-  DragonflightBlue: 1
-  DragonflightBronze: 3
-  DragonflightGreen: 2
-  DragonflightRed: 0
+  values:
+    DragonflightBlack: 4
+    DragonflightBlue: 1
+    DragonflightBronze: 3
+    DragonflightGreen: 2
+    DragonflightRed: 0
 TraitEdgeType:
-  DeprecatedRankConnection: 1
-  DeprecatedSelectionOption: 5
-  MutuallyExclusive: 4
-  RequiredForAvailability: 3
-  SufficientForAvailability: 2
-  VisualOnly: 0
+  values:
+    DeprecatedRankConnection: 1
+    DeprecatedSelectionOption: 5
+    MutuallyExclusive: 4
+    RequiredForAvailability: 3
+    SufficientForAvailability: 2
+    VisualOnly: 0
 TraitEdgeVisualStyle:
-  None: 0
-  Straight: 1
+  values:
+    None: 0
+    Straight: 1
 TraitNodeEntryType:
-  ArmorSet: 11
-  DeprecatedSelect: 4
-  DragAndDrop: 5
-  ProfPath: 7
-  ProfPathUnlock: 9
-  ProfPerk: 8
-  RedButton: 10
-  SpendCapstoneCircle: 13
-  SpendCapstoneSquare: 14
-  SpendCircle: 2
-  SpendDiamond: 6
-  SpendHex: 0
-  SpendInfinite: 12
-  SpendSmallCircle: 3
-  SpendSquare: 1
+  values:
+    ArmorSet: 11
+    DeprecatedSelect: 4
+    DragAndDrop: 5
+    ProfPath: 7
+    ProfPathUnlock: 9
+    ProfPerk: 8
+    RedButton: 10
+    SpendCapstoneCircle: 13
+    SpendCapstoneSquare: 14
+    SpendCircle: 2
+    SpendDiamond: 6
+    SpendHex: 0
+    SpendInfinite: 12
+    SpendSmallCircle: 3
+    SpendSquare: 1
 TraitNodeFlag:
-  ActiveAtFirstRank: 16
-  HideMaxRank: 64
-  HighestChosenRank: 128
-  NeverPurchasable: 2
-  ShowExpandedSelection: 32
-  ShowMultipleIcons: 1
-  ShowTierTrack: 256
-  TestGridPositioned: 8
-  TestPositionLocked: 4
+  values:
+    ActiveAtFirstRank: 16
+    HideMaxRank: 64
+    HighestChosenRank: 128
+    NeverPurchasable: 2
+    ShowExpandedSelection: 32
+    ShowMultipleIcons: 1
+    ShowTierTrack: 256
+    TestGridPositioned: 8
+    TestPositionLocked: 4
 TraitNodeGroupFlag:
-  AvailableByDefault: 1
+  values:
+    AvailableByDefault: 1
 TraitNodeType:
-  Selection: 2
-  Single: 0
-  SubTreeSelection: 3
-  Tiered: 1
+  values:
+    Selection: 2
+    Single: 0
+    SubTreeSelection: 3
+    Tiered: 1
 TraitPointsOperationType:
-  Multiply: 1
-  None: -1
-  Set: 0
+  values:
+    Multiply: 1
+    None: -1
+    Set: 0
 TraitSystemFlag:
-  AllowEditInChallengeMode: 8
-  AllowEditInCombat: 4
-  AllowMultipleLoadoutsPerTree: 1
-  ShowSpendConfirmation: 2
+  values:
+    AllowEditInChallengeMode: 8
+    AllowEditInCombat: 4
+    AllowMultipleLoadoutsPerTree: 1
+    ShowSpendConfirmation: 2
 TraitSystemVariationType:
-  None: 0
-  Spec: 1
+  values:
+    None: 0
+    Spec: 1
 TraitTreeFlag:
-  CannotRefund: 1
-  HideSingleRankNumbers: 2
+  values:
+    CannotRefund: 1
+    HideSingleRankNumbers: 2
 TransformManipulatorAxis:
-  X: 1
-  Y: 2
-  Z: 4
+  values:
+    X: 1
+    Y: 2
+    Z: 4
 TransformManipulatorControlState:
-  Default: 0
-  Dimmed: 2
-  ExternallyHighlighted: 3
-  Hidden: 1
-  Hovered: 4
-  Moving: 6
-  Selected: 5
+  values:
+    Default: 0
+    Dimmed: 2
+    ExternallyHighlighted: 3
+    Hidden: 1
+    Hovered: 4
+    Moving: 6
+    Selected: 5
 TransformManipulatorDirection:
-  Negative: 1
-  Positive: 0
+  values:
+    Negative: 1
+    Positive: 0
 TransformManipulatorEvent:
-  Cancel: 3
-  Change: 1
-  Complete: 2
-  Hover: 4
-  MouseDown: 5
-  MouseUp: 6
-  Start: 0
+  values:
+    Cancel: 3
+    Change: 1
+    Complete: 2
+    Hover: 4
+    MouseDown: 5
+    MouseUp: 6
+    Start: 0
 TransformManipulatorMode:
-  Rotate: 1
-  Scale: 2
-  Translate: 0
+  values:
+    Rotate: 1
+    Scale: 2
+    Translate: 0
 TransmogCameraVariation:
-  CloakBackpack: 1
-  None: 0
-  RightShoulder: 1
+  values:
+    CloakBackpack: 1
+    None: 0
+    RightShoulder: 1
 TransmogCollectionType:
-  Back: 3
-  Bow: 25
-  Chest: 4
-  Crossbow: 27
-  Dagger: 16
-  Feet: 11
-  Fist: 17
-  Gun: 26
-  Hands: 8
-  Head: 1
-  Holdable: 19
-  Legs: 10
-  None: 0
-  OneHAxe: 13
-  OneHMace: 15
-  OneHSword: 14
-  Paired: 29
-  Polearm: 24
-  Shield: 18
-  Shirt: 5
-  Shoulder: 2
-  Staff: 23
-  Tabard: 6
-  TwoHAxe: 20
-  TwoHMace: 22
-  TwoHSword: 21
-  Waist: 9
-  Wand: 12
-  Warglaives: 28
-  Wrist: 7
+  values:
+    Back: 3
+    Bow: 25
+    Chest: 4
+    Crossbow: 27
+    Dagger: 16
+    Feet: 11
+    Fist: 17
+    Gun: 26
+    Hands: 8
+    Head: 1
+    Holdable: 19
+    Legs: 10
+    None: 0
+    OneHAxe: 13
+    OneHMace: 15
+    OneHSword: 14
+    Paired: 29
+    Polearm: 24
+    Shield: 18
+    Shirt: 5
+    Shoulder: 2
+    Staff: 23
+    Tabard: 6
+    TwoHAxe: 20
+    TwoHMace: 22
+    TwoHSword: 21
+    Waist: 9
+    Wand: 12
+    Warglaives: 28
+    Wrist: 7
 TransmogIllusionFlags:
-  AllowedRangedShieldsHoldables: 4
-  HideUntilCollected: 1
-  PlayerConditionGrantsOnLogin: 2
+  values:
+    AllowedRangedShieldsHoldables: 4
+    HideUntilCollected: 1
+    PlayerConditionGrantsOnLogin: 2
 TransmogModification:
-  Main: 0
-  Secondary: 1
+  values:
+    Main: 0
+    Secondary: 1
 TransmogOutfitCostModifiersApplied:
-  AuraDiscountApplied: 8
-  DebugOnlyFreeDiscountApplied: 1
-  OutfitCostModifierApplied: 4
-  VoidRacialDiscountApplied: 2
+  values:
+    AuraDiscountApplied: 8
+    DebugOnlyFreeDiscountApplied: 1
+    OutfitCostModifierApplied: 4
+    VoidRacialDiscountApplied: 2
 TransmogOutfitDataFlags:
-  IsCachedLocally: 1
+  values:
+    IsCachedLocally: 1
 TransmogOutfitDisplayType:
-  Assigned: 1
-  Disabled: 4
-  Equipped: 2
-  Hidden: 3
-  Unassigned: 0
+  values:
+    Assigned: 1
+    Disabled: 4
+    Equipped: 2
+    Hidden: 3
+    Unassigned: 0
 TransmogOutfitEntryFlags:
-  AutomaticallyAwardedOnLogin: 1
-  IsDefaultEquipped: 32
-  OnlyAvailableDuringEvent: 4
-  SortedToTopOfList: 8
-  UseOverrideCostModifier: 16
-  UseOverrideName: 2
+  values:
+    AutomaticallyAwardedOnLogin: 1
+    IsDefaultEquipped: 32
+    OnlyAvailableDuringEvent: 4
+    SortedToTopOfList: 8
+    UseOverrideCostModifier: 16
+    UseOverrideName: 2
 TransmogOutfitEntrySource:
-  AutomaticallyAwarded: 1
-  PlayerPurchased: 2
-  StampedSource: 0
+  values:
+    AutomaticallyAwarded: 1
+    PlayerPurchased: 2
+    StampedSource: 0
 TransmogOutfitEquipAction:
-  Equip: 0
-  EquipAndLock: 1
-  Lock: 5
-  Remove: 2
-  RemoveAndLock: 3
-  Unlock: 4
+  values:
+    Equip: 0
+    EquipAndLock: 1
+    Lock: 5
+    Remove: 2
+    RemoveAndLock: 3
+    Unlock: 4
 TransmogOutfitSetType:
-  CustomSet: 2
-  Equipped: 0
-  Outfit: 1
+  values:
+    CustomSet: 2
+    Equipped: 0
+    Outfit: 1
 TransmogOutfitSlot:
-  Back: 3
-  Body: 6
-  Chest: 4
-  Feet: 11
-  Hand: 8
-  Head: 0
-  Legs: 10
-  ShoulderLeft: 2
-  ShoulderRight: 1
-  Tabard: 5
-  Waist: 9
-  WeaponMainHand: 12
-  WeaponOffHand: 13
-  WeaponRanged: 14
-  Wrist: 7
+  values:
+    Back: 3
+    Body: 6
+    Chest: 4
+    Feet: 11
+    Hand: 8
+    Head: 0
+    Legs: 10
+    ShoulderLeft: 2
+    ShoulderRight: 1
+    Tabard: 5
+    Waist: 9
+    WeaponMainHand: 12
+    WeaponOffHand: 13
+    WeaponRanged: 14
+    Wrist: 7
 TransmogOutfitSlotError:
-  CannotUseItem: 10
-  IncompatibleWithMainHand: 14
-  InvalidDestination: 5
-  InvalidItemType: 4
-  InvalidSlotForForm: 13
-  InvalidSlotForRace: 11
-  InvalidSource: 8
-  InvalidSourceQuality: 9
-  Legendary: 3
-  Mismatch: 6
-  NoIllusion: 12
-  NoItem: 1
-  NotSoulbound: 2
-  Ok: 0
-  SameItem: 7
+  values:
+    CannotUseItem: 10
+    IncompatibleWithMainHand: 14
+    InvalidDestination: 5
+    InvalidItemType: 4
+    InvalidSlotForForm: 13
+    InvalidSlotForRace: 11
+    InvalidSource: 8
+    InvalidSourceQuality: 9
+    Legendary: 3
+    Mismatch: 6
+    NoIllusion: 12
+    NoItem: 1
+    NotSoulbound: 2
+    Ok: 0
+    SameItem: 7
 TransmogOutfitSlotFlags:
-  CanHaveIllusions: 2
-  CannotBeHidden: 1
-  IsSecondarySlot: 4
+  values:
+    CanHaveIllusions: 2
+    CannotBeHidden: 1
+    IsSecondarySlot: 4
 TransmogOutfitSlotOption:
-  ArtifactSpecFour: 11
-  ArtifactSpecOne: 8
-  ArtifactSpecThree: 10
-  ArtifactSpecTwo: 9
-  DeprecatedReuseMe: 6
-  FuryTwoHandedWeapon: 7
-  None: 0
-  OffHand: 4
-  OneHandedWeapon: 1
-  RangedWeapon: 3
-  Shield: 5
-  TwoHandedWeapon: 2
+  values:
+    ArtifactSpecFour: 11
+    ArtifactSpecOne: 8
+    ArtifactSpecThree: 10
+    ArtifactSpecTwo: 9
+    DeprecatedReuseMe: 6
+    FuryTwoHandedWeapon: 7
+    None: 0
+    OffHand: 4
+    OneHandedWeapon: 1
+    RangedWeapon: 3
+    Shield: 5
+    TwoHandedWeapon: 2
 TransmogOutfitSlotOptionFlags:
-  DisablesOffhandSlot: 4
-  DynamicOptionName: 2
-  IllusionNotAllowed: 1
+  values:
+    DisablesOffhandSlot: 4
+    DynamicOptionName: 2
+    IllusionNotAllowed: 1
 TransmogOutfitSlotOptionSheatheCategory:
-  Back: 1
-  Default: 0
-  Hide: 3
-  Side: 2
+  values:
+    Back: 1
+    Default: 0
+    Hide: 3
+    Side: 2
 TransmogOutfitSlotPosition:
-  Bottom: 2
-  Left: 0
-  Right: 1
+  values:
+    Bottom: 2
+    Left: 0
+    Right: 1
 TransmogOutfitSlotSaveFlags:
-  AppearanceIsNotValid: 1
+  values:
+    AppearanceIsNotValid: 1
 TransmogOutfitSlotWarning:
-  InvalidEquippedDestinationItem: 1
-  NothingEquipped: 5
-  Ok: 0
-  PendingWeaponChanges: 3
-  WeaponDoesNotSupportIllusions: 4
-  WrongWeaponCategoryEquipped: 2
+  values:
+    InvalidEquippedDestinationItem: 1
+    NothingEquipped: 5
+    Ok: 0
+    PendingWeaponChanges: 3
+    WeaponDoesNotSupportIllusions: 4
+    WrongWeaponCategoryEquipped: 2
 TransmogOutfitTransactionFlags:
-  AddNewOutfitMask: 20
-  AddOutfitAndUpdateSlots: 28
-  CreateAndUpdateOutfitInfoMask: 6
-  CreateOutfitInfo: 4
-  FullOutfitUpdateMask: 27
-  UpdateMetadata: 1
-  UpdateOutfitInfo: 2
-  UpdateSituations: 16
-  UpdateSituationsMask: 18
-  UpdateSlots: 8
+  values:
+    AddNewOutfitMask: 20
+    AddOutfitAndUpdateSlots: 28
+    CreateAndUpdateOutfitInfoMask: 6
+    CreateOutfitInfo: 4
+    FullOutfitUpdateMask: 27
+    UpdateMetadata: 1
+    UpdateOutfitInfo: 2
+    UpdateSituations: 16
+    UpdateSituationsMask: 18
+    UpdateSlots: 8
 TransmogOutfitTransactionType:
-  CreateOutfitInfo: 2
-  UpdateMetadata: 0
-  UpdateOutfitInfo: 1
-  UpdateSituations: 4
-  UpdateSlots: 3
+  values:
+    CreateOutfitInfo: 2
+    UpdateMetadata: 0
+    UpdateOutfitInfo: 1
+    UpdateSituations: 4
+    UpdateSlots: 3
 TransmogPendingType:
-  Apply: 0
-  Revert: 1
-  ToggleOff: 3
-  ToggleOn: 2
+  values:
+    Apply: 0
+    Revert: 1
+    ToggleOff: 3
+    ToggleOn: 2
 TransmogSearchType:
-  BaseSets: 2
-  Items: 1
-  UsableSets: 3
+  values:
+    BaseSets: 2
+    Items: 1
+    UsableSets: 3
 TransmogSituation:
-  AllEquipmentSets: 17
-  AllLocations: 2
-  AllMovement: 12
-  AllRacialForms: 19
-  AllSpecs: 0
-  AllTime: 27
-  AllWeather: 22
-  EquipmentSets: 18
-  FormNative: 20
-  FormNonNative: 21
-  LocationArenas: 10
-  LocationBattlegrounds: 11
-  LocationCharacterSelect: 5
-  LocationDelves: 7
-  LocationDungeons: 8
-  LocationHouse: 4
-  LocationRaids: 9
-  LocationRested: 3
-  LocationWorld: 6
-  MovementFlyingMount: 16
-  MovementGroundMount: 15
-  MovementSwimming: 14
-  MovementUnmounted: 13
-  Spec: 1
-  TimeDay: 29
-  TimeEvening: 30
-  TimeMorning: 28
-  TimeNight: 31
-  WeatherClear: 23
-  WeatherRain: 24
-  WeatherSand: 26
-  WeatherSnow: 25
+  values:
+    AllEquipmentSets: 17
+    AllLocations: 2
+    AllMovement: 12
+    AllRacialForms: 19
+    AllSpecs: 0
+    AllTime: 27
+    AllWeather: 22
+    EquipmentSets: 18
+    FormNative: 20
+    FormNonNative: 21
+    LocationArenas: 10
+    LocationBattlegrounds: 11
+    LocationCharacterSelect: 5
+    LocationDelves: 7
+    LocationDungeons: 8
+    LocationHouse: 4
+    LocationRaids: 9
+    LocationRested: 3
+    LocationWorld: 6
+    MovementFlyingMount: 16
+    MovementGroundMount: 15
+    MovementSwimming: 14
+    MovementUnmounted: 13
+    Spec: 1
+    TimeDay: 29
+    TimeEvening: 30
+    TimeMorning: 28
+    TimeNight: 31
+    WeatherClear: 23
+    WeatherRain: 24
+    WeatherSand: 26
+    WeatherSnow: 25
 TransmogSituationFlags:
-  AllSituation: 4
-  DefaultsToOn: 8
-  DisabledSituation: 64
-  DynamicallyNamed: 16
-  IsPlayerFacing: 1
-  NoneSituation: 32
-  SpecUseTalentLoadout: 2
+  values:
+    AllSituation: 4
+    DefaultsToOn: 8
+    DisabledSituation: 64
+    DynamicallyNamed: 16
+    IsPlayerFacing: 1
+    NoneSituation: 32
+    SpecUseTalentLoadout: 2
 TransmogSituationGroupFlags:
-  DynamicallyCreatesGroups: 1
+  values:
+    DynamicallyCreatesGroups: 1
 TransmogSituationTrigger:
-  EquipmentSet: 6
-  EventOutfit: 8
-  Forms: 7
-  Location: 3
-  Manual: 1
-  Movement: 4
-  None: 0
-  Specialization: 5
-  TimeOfDay: 10
-  TransmogUpdate: 2
-  Weather: 9
+  values:
+    EquipmentSet: 6
+    EventOutfit: 8
+    Forms: 7
+    Location: 3
+    Manual: 1
+    Movement: 4
+    None: 0
+    Specialization: 5
+    TimeOfDay: 10
+    TransmogUpdate: 2
+    Weather: 9
 TransmogSituationTriggerFlags:
-  CanChangeLockedOutfit: 2
-  CanLockOutfit: 1
-  DisabledTrigger: 16
-  IsPlayerFacing: 4
-  SituationsAreExclusive: 8
+  values:
+    CanChangeLockedOutfit: 2
+    CanLockOutfit: 1
+    DisabledTrigger: 16
+    IsPlayerFacing: 4
+    SituationsAreExclusive: 8
 TransmogSituationTriggerType:
-  Automatic: 2
-  Manual: 1
-  None: 0
-  TransmogUpdate: 3
+  values:
+    Automatic: 2
+    Manual: 1
+    None: 0
+    TransmogUpdate: 3
 TransmogSlot:
-  Back: 2
-  Body: 4
-  Chest: 3
-  Feet: 10
-  Hand: 7
-  Head: 0
-  Legs: 9
-  Mainhand: 11
-  Offhand: 12
-  Shoulder: 1
-  Tabard: 5
-  Waist: 8
-  Wrist: 6
+  values:
+    Back: 2
+    Body: 4
+    Chest: 3
+    Feet: 10
+    Hand: 7
+    Head: 0
+    Legs: 9
+    Mainhand: 11
+    Offhand: 12
+    Shoulder: 1
+    Tabard: 5
+    Waist: 8
+    Wrist: 6
 TransmogSource:
-  Achievement: 7
-  CantCollect: 6
-  HiddenUntilCollected: 5
-  JournalEncounter: 1
-  None: 0
-  NotValidForTransmog: 9
-  Profession: 8
-  Quest: 2
-  TradingPost: 10
-  Vendor: 3
-  WorldDrop: 4
+  values:
+    Achievement: 7
+    CantCollect: 6
+    HiddenUntilCollected: 5
+    JournalEncounter: 1
+    None: 0
+    NotValidForTransmog: 9
+    Profession: 8
+    Quest: 2
+    TradingPost: 10
+    Vendor: 3
+    WorldDrop: 4
 TransmogTimeOfDayCategory:
-  Evening: 2
-  Midday: 1
-  Morning: 0
-  Night: 3
+  values:
+    Evening: 2
+    Midday: 1
+    Morning: 0
+    Night: 3
 TransmogType:
-  Appearance: 0
-  Illusion: 1
+  values:
+    Appearance: 0
+    Illusion: 1
 TransmogUseErrorType:
-  Ability: 3
-  Class: 7
-  Faction: 9
-  Holiday: 5
-  HotRecheckFailed: 6
-  ItemProficiency: 10
-  None: 0
-  PlayerCondition: 1
-  Race: 8
-  Reputation: 4
-  Skill: 2
+  values:
+    Ability: 3
+    Class: 7
+    Faction: 9
+    Holiday: 5
+    HotRecheckFailed: 6
+    ItemProficiency: 10
+    None: 0
+    PlayerCondition: 1
+    Race: 8
+    Reputation: 4
+    Skill: 2
 TtsBoolSetting:
-  AddCharacterNameToSpeech: 1
-  AlternateSystemVoice: 3
-  NarrateMyMessages: 4
-  PlayActivitySoundWhenNotFocused: 2
-  PlaySoundSeparatingChatLineBreaks: 0
+  values:
+    AddCharacterNameToSpeech: 1
+    AlternateSystemVoice: 3
+    NarrateMyMessages: 4
+    PlayActivitySoundWhenNotFocused: 2
+    PlaySoundSeparatingChatLineBreaks: 0
 TtsVoiceType:
-  Alternate: 1
-  Standard: 0
+  values:
+    Alternate: 1
+    Standard: 0
 TugOfWarMarkerArrowShownState:
-  Always: 1
-  FlashOnMove: 2
-  Never: 0
+  values:
+    Always: 1
+    FlashOnMove: 2
+    Never: 0
 TugOfWarStyleValue:
-  ArchaeologyBrown: 1
-  DefaultYellow: 0
+  values:
+    ArchaeologyBrown: 1
+    DefaultYellow: 0
 TurnStrafeStyle:
-  Custom: 2
-  Legacy: 1
-  Modern: 0
+  values:
+    Custom: 2
+    Legacy: 1
+    Modern: 0
 UIActionType:
-  DefaultAction: 0
-  Reserved1: 2
-  UpdateMapSystem: 1
+  values:
+    DefaultAction: 0
+    Reserved1: 2
+    UpdateMapSystem: 1
 UICovenantDisplayInfoFlags:
-  DisplayCovenantAsJourney: 1
-  UseJourneyRewardTrack: 2
-  UseJourneyUnlockToastText: 3
+  values:
+    DisplayCovenantAsJourney: 1
+    UseJourneyRewardTrack: 2
+    UseJourneyUnlockToastText: 3
 UICursorType:
-  ActionBar: 6
-  AmmoObsolete: 8
-  BattlePet: 16
-  ConduitCollectionItem: 19
-  Currency: 13
-  Default: 0
-  EquipmentSet: 12
-  Flyout: 14
-  GuildBank: 10
-  GuildBankMoney: 11
-  Item: 1
-  Macro: 7
-  Merchant: 5
-  Money: 2
-  Mount: 17
-  Outfit: 21
-  PerksProgramVendorItem: 20
-  Pet: 9
-  PetAction: 4
-  Spell: 3
-  Toy: 18
-  VoidItem: 15
+  values:
+    ActionBar: 6
+    AmmoObsolete: 8
+    BattlePet: 16
+    ConduitCollectionItem: 19
+    Currency: 13
+    Default: 0
+    EquipmentSet: 12
+    Flyout: 14
+    GuildBank: 10
+    GuildBankMoney: 11
+    Item: 1
+    Macro: 7
+    Merchant: 5
+    Money: 2
+    Mount: 17
+    Outfit: 21
+    PerksProgramVendorItem: 20
+    Pet: 9
+    PetAction: 4
+    Spell: 3
+    Toy: 18
+    VoidItem: 15
 UIFrameType:
-  InterruptTutorial: 1
-  JailersTowerBuffs: 0
+  values:
+    InterruptTutorial: 1
+    JailersTowerBuffs: 0
 UIItemInteractionFlags:
-  AddCurrency: 16
-  ClickShowsFlyout: 8
-  ConfirmationHasDelay: 2
-  ConversionMode: 4
-  DisplayWithInset: 1
-  UsesCharges: 32
+  values:
+    AddCurrency: 16
+    ClickShowsFlyout: 8
+    ConfirmationHasDelay: 2
+    ConversionMode: 4
+    DisplayWithInset: 1
+    UsesCharges: 32
 UIItemInteractionType:
-  CastSpell: 1
-  CleanseCorruption: 2
-  ItemConversion: 4
-  None: 0
-  RunecarverScrapping: 3
+  values:
+    CastSpell: 1
+    CleanseCorruption: 2
+    ItemConversion: 4
+    None: 0
+    RunecarverScrapping: 3
 UIMapFlag:
-  AlwaysAllowTaxiPathing: 131072
-  AlwaysAllowUserWaypoints: 65536
-  DoNotShowOnNavbar: 524288
-  DoNotTranslateBranches: 512
-  FallbackToParentMap: 16
-  FlightMapAutoZoom: 16384
-  FlightMapShowZoomOut: 8192
-  ForceAllOverlayExplored: 4096
-  ForceAllowMapLinks: 262144
-  ForceOnNavbar: 32768
-  GarrisonMap: 8
-  HideArchaeologyDigs: 256
-  HideIcons: 1024
-  HideVignettes: 2048
-  IgnoreInTranslationsToParent: 2097152
-  IsCityMap: 1048576
-  NoHighlight: 1
-  NoHighlightTexture: 32
-  NoWorldPositions: 128
-  ShowOverlays: 2
-  ShowTaskObjectives: 64
-  ShowTaxiNodes: 4
+  values:
+    AlwaysAllowTaxiPathing: 131072
+    AlwaysAllowUserWaypoints: 65536
+    DoNotShowOnNavbar: 524288
+    DoNotTranslateBranches: 512
+    FallbackToParentMap: 16
+    FlightMapAutoZoom: 16384
+    FlightMapShowZoomOut: 8192
+    ForceAllOverlayExplored: 4096
+    ForceAllowMapLinks: 262144
+    ForceOnNavbar: 32768
+    GarrisonMap: 8
+    HideArchaeologyDigs: 256
+    HideIcons: 1024
+    HideVignettes: 2048
+    IgnoreInTranslationsToParent: 2097152
+    IsCityMap: 1048576
+    NoHighlight: 1
+    NoHighlightTexture: 32
+    NoWorldPositions: 128
+    ShowOverlays: 2
+    ShowTaskObjectives: 64
+    ShowTaxiNodes: 4
 UIMapGroupFlag:
-  ShowIconsAcrossFloors: 1
+  values:
+    ShowIconsAcrossFloors: 1
 UIMapSystem:
-  Adventure: 2
-  Minimap: 3
-  Taxi: 1
-  World: 0
+  values:
+    Adventure: 2
+    Minimap: 3
+    Taxi: 1
+    World: 0
 UIMapType:
-  Continent: 2
-  Cosmic: 0
-  Dungeon: 4
-  Micro: 5
-  Orphan: 6
-  World: 1
-  Zone: 3
+  values:
+    Continent: 2
+    Cosmic: 0
+    Dungeon: 4
+    Micro: 5
+    Orphan: 6
+    World: 1
+    Zone: 3
 UIModelSceneActorFlag:
-  Deprecated1: 1
-  UseCenterForOriginX: 2
-  UseCenterForOriginY: 4
-  UseCenterForOriginZ: 8
+  values:
+    Deprecated1: 1
+    UseCenterForOriginX: 2
+    UseCenterForOriginY: 4
+    UseCenterForOriginZ: 8
 UIModelSceneContext:
-  None: -1
-  PerksProgram: 0
+  values:
+    None: -1
+    PerksProgram: 0
 UIModelSceneFlags:
-  Autodress: 4
-  HideWeapon: 2
-  NoCameraSpin: 8
-  SheatheWeapon: 1
+  values:
+    Autodress: 4
+    HideWeapon: 2
+    NoCameraSpin: 8
+    SheatheWeapon: 1
 UISystemType:
-  InGameNavigation: 0
+  values:
+    InGameNavigation: 0
 UITextureSliceMode:
-  Stretched: 0
-  Tiled: 1
+  values:
+    Stretched: 0
+    Tiled: 1
 UIWidgetBlendModeType:
-  Additive: 1
-  Opaque: 0
+  values:
+    Additive: 1
+    Opaque: 0
 UIWidgetButtonEnabledState:
-  Disabled: 0
-  Enabled: 1
+  values:
+    Disabled: 0
+    Enabled: 1
 UIWidgetButtonIconType:
-  Checkmark: 3
-  Exit: 0
-  RedX: 4
-  Speak: 1
-  Undo: 2
+  values:
+    Checkmark: 3
+    Exit: 0
+    RedX: 4
+    Speak: 1
+    Undo: 2
 UIWidgetFlag:
-  UniversalWidget: 1
+  values:
+    UniversalWidget: 1
 UIWidgetFontType:
-  Normal: 0
-  Outline: 2
-  Shadow: 1
+  values:
+    Normal: 0
+    Outline: 2
+    Shadow: 1
 UIWidgetHorizontalDirection:
-  LeftToRight: 0
-  RightToLeft: 1
+  values:
+    LeftToRight: 0
+    RightToLeft: 1
 UIWidgetLayoutDirection:
-  Default: 0
-  Horizontal: 2
-  HorizontalForceNewRow: 4
-  Overlap: 3
-  Vertical: 1
+  values:
+    Default: 0
+    Horizontal: 2
+    HorizontalForceNewRow: 4
+    Overlap: 3
+    Vertical: 1
 UIWidgetModelSceneLayer:
-  Back: 2
-  Front: 1
-  None: 0
+  values:
+    Back: 2
+    Front: 1
+    None: 0
 UIWidgetMotionType:
-  Instant: 0
-  Smooth: 1
+  values:
+    Instant: 0
+    Smooth: 1
 UIWidgetOverrideState:
-  Active: 1
-  Inactive: 0
+  values:
+    Active: 1
+    Inactive: 0
 UIWidgetRewardShownState:
-  Hidden: 0
-  ShownEarned: 1
-  ShownUnearned: 2
+  values:
+    Hidden: 0
+    ShownEarned: 1
+    ShownUnearned: 2
 UIWidgetScale:
-  Eighty: 2
-  Fifty: 5
-  Ninty: 1
-  OneHundred: 0
-  OneHundredEighty: 13
-  OneHundredFifty: 10
-  OneHundredForty: 9
-  OneHundredNinety: 14
-  OneHundredSeventy: 12
-  OneHundredSixty: 11
-  OneHundredTen: 6
-  OneHundredThirty: 8
-  OneHundredTwenty: 7
-  Seventy: 3
-  Sixty: 4
-  TwoHundred: 15
+  values:
+    Eighty: 2
+    Fifty: 5
+    Ninty: 1
+    OneHundred: 0
+    OneHundredEighty: 13
+    OneHundredFifty: 10
+    OneHundredForty: 9
+    OneHundredNinety: 14
+    OneHundredSeventy: 12
+    OneHundredSixty: 11
+    OneHundredTen: 6
+    OneHundredThirty: 8
+    OneHundredTwenty: 7
+    Seventy: 3
+    Sixty: 4
+    TwoHundred: 15
 UIWidgetSetLayoutDirection:
-  Horizontal: 1
-  Overlap: 2
-  Vertical: 0
+  values:
+    Horizontal: 1
+    Overlap: 2
+    Vertical: 0
 UIWidgetSpellButtonCooldownType:
-  HideCooldown: 0
-  ShowCooldown: 1
-  ShowCooldownAndDisableOnCooldown: 2
+  values:
+    HideCooldown: 0
+    ShowCooldown: 1
+    ShowCooldownAndDisableOnCooldown: 2
 UIWidgetTextFormatType:
-  LeadingZeroesWithSixDigits: 3
-  None: 0
-  TimeOneLevel: 1
-  TimeTwoLevel: 2
+  values:
+    LeadingZeroesWithSixDigits: 3
+    None: 0
+    TimeOneLevel: 1
+    TimeTwoLevel: 2
 UIWidgetTextSizeType:
-  Huge27Pt: 3
-  Large20Pt: 8
-  Large24Pt: 2
-  Medium16Pt: 1
-  Medium18Pt: 7
-  Small10Pt: 5
-  Small11Pt: 6
-  Small12Pt: 0
-  Standard14Pt: 4
+  values:
+    Huge27Pt: 3
+    Large20Pt: 8
+    Large24Pt: 2
+    Medium16Pt: 1
+    Medium18Pt: 7
+    Small10Pt: 5
+    Small11Pt: 6
+    Small12Pt: 0
+    Standard14Pt: 4
 UIWidgetTextureAndTextSizeType:
-  Huge: 3
-  Large: 2
-  Medium: 1
-  Medium2: 5
-  Small: 0
-  Standard: 4
+  values:
+    Huge: 3
+    Large: 2
+    Medium: 1
+    Medium2: 5
+    Small: 0
+    Standard: 4
 UIWidgetTooltipLocation:
-  Bottom: 8
-  BottomLeft: 1
-  BottomRight: 7
-  Default: 0
-  Left: 2
-  Right: 6
-  Top: 4
-  TopLeft: 3
-  TopRight: 5
+  values:
+    Bottom: 8
+    BottomLeft: 1
+    BottomRight: 7
+    Default: 0
+    Left: 2
+    Right: 6
+    Top: 4
+    TopLeft: 3
+    TopRight: 5
 UIWidgetUpdateAnimType:
-  Flash: 1
-  FlashAndAnimateNumber: 2
-  None: 0
+  values:
+    Flash: 1
+    FlashAndAnimateNumber: 2
+    None: 0
 UIWidgetVisualizationType:
-  BulletTextList: 10
-  ButtonHeader: 30
-  CaptureBar: 1
-  CaptureZone: 17
-  DiscreteProgressSteps: 19
-  DoubleIconAndText: 5
-  DoubleStateIconRow: 14
-  DoubleStatusBar: 3
-  FillUpFrames: 24
-  HorizontalCurrencies: 9
-  IconAndText: 0
-  IconTextAndBackground: 4
-  IconTextAndCurrencies: 7
-  ItemDisplay: 27
-  MapPinAnimation: 26
-  PreyHuntProgress: 31
-  ScenarioHeaderCurrenciesAndBackground: 11
-  ScenarioHeaderDelves: 29
-  ScenarioHeaderTimer: 20
-  Spacer: 22
-  SpellDisplay: 13
-  StackedResourceTracker: 6
-  StatusBar: 2
-  TextColumnRow: 21
-  TextureAndText: 12
-  TextureAndTextRow: 15
-  TextureWithAnimation: 18
-  TextWithState: 8
-  TextWithSubtext: 25
-  TugOfWar: 28
-  UnitPowerBar: 23
-  ZoneControl: 16
+  values:
+    BulletTextList: 10
+    ButtonHeader: 30
+    CaptureBar: 1
+    CaptureZone: 17
+    DiscreteProgressSteps: 19
+    DoubleIconAndText: 5
+    DoubleStateIconRow: 14
+    DoubleStatusBar: 3
+    FillUpFrames: 24
+    HorizontalCurrencies: 9
+    IconAndText: 0
+    IconTextAndBackground: 4
+    IconTextAndCurrencies: 7
+    ItemDisplay: 27
+    MapPinAnimation: 26
+    PreyHuntProgress: 31
+    ScenarioHeaderCurrenciesAndBackground: 11
+    ScenarioHeaderDelves: 29
+    ScenarioHeaderTimer: 20
+    Spacer: 22
+    SpellDisplay: 13
+    StackedResourceTracker: 6
+    StatusBar: 2
+    TextColumnRow: 21
+    TextureAndText: 12
+    TextureAndTextRow: 15
+    TextureWithAnimation: 18
+    TextWithState: 8
+    TextWithSubtext: 25
+    TugOfWar: 28
+    UnitPowerBar: 23
+    ZoneControl: 16
 UnitAuraSortDirection:
-  Normal: 0
-  Reverse: 1
+  values:
+    Normal: 0
+    Reverse: 1
 UnitAuraSortRule:
-  BigDefensive: 2
-  Default: 1
-  Expiration: 3
-  ExpirationOnly: 4
-  Name: 5
-  NameOnly: 6
-  Unsorted: 0
+  values:
+    BigDefensive: 2
+    Default: 1
+    Expiration: 3
+    ExpirationOnly: 4
+    Name: 5
+    NameOnly: 6
+    Unsorted: 0
 UnitDamageAbsorbClampMode:
-  MaximumHealth: 2
-  MissingHealth: 0
-  MissingHealthWithoutIncomingHeals: 1
+  values:
+    MaximumHealth: 2
+    MissingHealth: 0
+    MissingHealthWithoutIncomingHeals: 1
 UnitHealAbsorbClampMode:
-  CurrentHealth: 0
-  MaximumHealth: 1
+  values:
+    CurrentHealth: 0
+    MaximumHealth: 1
 UnitHealAbsorbMode:
-  ReducedByIncomingHeals: 0
-  Total: 1
+  values:
+    ReducedByIncomingHeals: 0
+    Total: 1
 UnitIncomingHealClampMode:
-  MaximumHealth: 1
-  MissingHealth: 0
+  values:
+    MaximumHealth: 1
+    MissingHealth: 0
 UnitMaximumHealthMode:
-  Default: 0
-  WithAbsorbs: 1
+  values:
+    Default: 0
+    WithAbsorbs: 1
 UnitMirrorPetFlags:
-  Dismissable: 2
-  ExtraPet: 16
-  RecentlyTamed: 4
-  Renameable: 1
-  Stampede: 8
+  values:
+    Dismissable: 2
+    ExtraPet: 16
+    RecentlyTamed: 4
+    Renameable: 1
+    Stampede: 8
 UnitSex:
-  Both: 3
-  Female: 1
-  Male: 0
-  Neutral: 4
-  None: 2
+  values:
+    Both: 3
+    Female: 1
+    Male: 0
+    Neutral: 4
+    None: 2
 UrlTextureResult:
-  Found: 1
-  NotAllowed: 4
-  NotFound: 2
-  Requested: 3
+  values:
+    Found: 1
+    NotAllowed: 4
+    NotFound: 2
+    Requested: 3
 ValidateNameResult:
-  ConsecutiveSpaces: 13
-  DeclensionDoesntMatchBaseName: 16
-  Failure: 1
-  InvalidApostrophe: 9
-  InvalidCharacter: 5
-  InvalidSpace: 12
-  MixedLanguages: 6
-  MultipleApostrophes: 10
-  NoName: 2
-  Profane: 7
-  Reserved: 8
-  RussianConsecutiveSilentCharacters: 14
-  RussianSilentCharacterAtBeginningOrEnd: 15
-  SpacesDisallowed: 17
-  Success: 0
-  ThreeConsecutive: 11
-  TooLong: 4
-  TooShort: 3
+  values:
+    ConsecutiveSpaces: 13
+    DeclensionDoesntMatchBaseName: 16
+    Failure: 1
+    InvalidApostrophe: 9
+    InvalidCharacter: 5
+    InvalidSpace: 12
+    MixedLanguages: 6
+    MultipleApostrophes: 10
+    NoName: 2
+    Profane: 7
+    Reserved: 8
+    RussianConsecutiveSilentCharacters: 14
+    RussianSilentCharacterAtBeginningOrEnd: 15
+    SpacesDisallowed: 17
+    Success: 0
+    ThreeConsecutive: 11
+    TooLong: 4
+    TooShort: 3
 VasPurchaseProgress:
-  ApplyingLicense: 3
-  Complete: 7
-  Invalid: 0
-  PaymentPending: 2
-  PrePurchase: 1
-  ProcessingFactionChange: 6
-  Ready: 5
-  WaitingOnQueue: 4
+  values:
+    ApplyingLicense: 3
+    Complete: 7
+    Invalid: 0
+    PaymentPending: 2
+    PrePurchase: 1
+    ProcessingFactionChange: 6
+    Ready: 5
+    WaitingOnQueue: 4
 VasServiceType:
-  AppearanceChange: 2
-  CharacterTransfer: 4
-  FactionChange: 1
-  FactionTransfer: 5
-  GuildFactionChange: 7
-  GuildFactionTransfer: 9
-  GuildNameChange: 6
-  GuildTransfer: 8
-  NameChange: 0
-  RaceChange: 3
+  values:
+    AppearanceChange: 2
+    CharacterTransfer: 4
+    FactionChange: 1
+    FactionTransfer: 5
+    GuildFactionChange: 7
+    GuildFactionTransfer: 9
+    GuildNameChange: 6
+    GuildTransfer: 8
+    NameChange: 0
+    RaceChange: 3
 VasTransactionPurchaseResult:
-  BeginDbErrors: 20010
-  BeginProxyErrors: 17
-  DbAccountDoesNotOwnCharacter: 20017
-  DbAllianceNotEligible: 20027
-  DbAlreadyRenameFlagged: 20055
-  DbAuthenticatorInsufficient: 20073
-  DbBatchProcessingDisabled: 20028
-  DbBatchStateInvalid: 20067
-  DbBnetAccountNotProvided: 20077
-  DbBoostProcessingDisabled: 20095
-  DbBpayDeliveryPending: 20078
-  DbCagedPetInInventory: 20084
-  DbCannotMoveArenaCaptn: 20064
-  DbCannotMoveGuildmaster: 20012
-  DbCharacterDoesNotExist: 20019
-  DbCharacterWithoutGuild: 20070
-  DbCharLocked: 20026
-  DbCharNotLocked: 20025
-  DbCouldNotObtainCharLock: 20041
-  DbCustomizeAlreadyRequested: 20057
-  DbDeletedGuild: 20071
-  DbDuplicateCharacterName: 20015
-  DbDuplicateSupportRequest: 20063
-  DbEventNotActive: 20068
-  DbEventRealmClosed: 20038
-  DbFactionChangeTooSoon: 20061
-  DbGmSenorityInsufficient: 20072
-  DbGuildLevelInsufficient: 20074
-  DbGuildRankInsufficient: 20069
-  DbHasAuctions: 20033
-  DbHasBpayToken: 20079
-  DbHasCraftingOrders: 20092
-  DbHasHeirloomItem: 20080
-  DbHasMail: 20016
-  DbHasNewPlayerExperienceRestriction: 20091
-  DbHasUnclaimedCacheRewards: 20089
-  DbHouseOwnerRestriction: 20096
-  DbIneligibleMapID: 20076
-  DbIneligibleTargetRealm: 20022
-  DbInvalidName: 20094
-  DbInventoryCorrupt: 20040
-  DbLastCustomizeTooSoon: 20058
-  DbLastRenameTooRecent: 20052
-  DbLastRequestTooSoon: 20054
-  DbLastSaveTooDistant: 20083
-  DbLastSaveTooRecent: 20034
-  DbLockAlreadyRequested: 20044
-  DbLockNotAcknowledged: 20043
-  DbMaxCharactersOnServer: 20013
-  DbMoveInProgress: 20018
-  DbMultipleTransferCn: 20056
-  DbNameChangeSkipped: 20093
-  DbNameNotAvailable: 20051
-  DbNeedsEraChoice: 20090
-  DbNeedsLevelSquish: 20088
-  DbNewLeaderInvalid: 20086
-  DbNewNameTooLong: 20024
-  DbNoCopiesAvailable: 20020
-  DbNoCsiFound: 20065
-  DbNoMixedAlliance: 20014
-  DbNoneBatchQueueID: 20029
-  DbNoneLockID: 20042
-  DbNoneRealmForEvent: 20037
-  DbNoneSupportActionID: 20046
-  DbNoneSupportQueueID: 20045
-  DbNoneTemplateForEvent: 20039
-  DbNotMovebackable: 20048
-  DbNotRollbackable: 20047
-  DbOnBoostCooldown: 20085
-  DbPendingItemAudit: 20066
-  DbPvEPvPTransferNotAllowed: 20087
-  DbRaceClassComboIneligible: 20062
-  DbRealmNotEligible: 20011
-  DbRegionalDbNotFound: 20075
-  DbRenameAlreadyRequested: 20049
-  DbReservationDoesNotMatch: 20053
-  DbReservationExpired: 20050
-  DbResultAccountRestricted: 20082
-  DbResultSourceAccountBanned: 20081
-  DbTooMuchMoneyForLevel: 20032
-  DbTransferDateTooSoon: 20023
-  DbTransferNotCancellable: 20031
-  DbTransferNotFinalized: 20030
-  DbTransferNotLockable: 20035
-  DbTransferNotUnlockable: 20036
-  DbUnableToCustomize: 20060
-  DbUnderMinLevelReq: 20021
-  DbWaitingForPayment: 20059
-  DisallowedDestinationAccount: 9
-  DisallowedSourceAccount: 8
-  EndDbErrors: 20097
-  EndProxyErrors: 56
-  EndServerErrors: 16
-  InvalidBpayDeliverableID: 14
-  InvalidBpayProductID: 13
-  InvalidBpayProductType: 15
-  InvalidDestinationAccount: 6
-  InvalidDestinationRealm: 5
-  InvalidDistribution: 12
-  InvalidSourceAccount: 7
-  LowerBoxLevel: 11
-  None: 0
-  NoneCharacter: 2
-  NoneProduct: 3
-  OnlyOneVasAtATime: 4
-  ProxyAccountDataTooBig: 55
-  ProxyBadDbType: 35
-  ProxyBadObjType: 18
-  ProxyBadRequestContained: 33
-  ProxyBindFailed: 51
-  ProxyCannotDeleteArenaCaptain: 31
-  ProxyCannotDeleteGuildLeader: 30
-  ProxyCannotInsertNull: 45
-  ProxyCannotUndeleteTrialBoostCharacter: 46
-  ProxyCharacterHasWoWToken: 53
-  ProxyCharacterLevelTooHigh: 38
-  ProxyCharacterTransferred: 39
-  ProxyCharacterTransferredNoBoostInProgress: 40
-  ProxyDataInvalid: 22
-  ProxyDbError: 21
-  ProxyDeleteNotSupported: 28
-  ProxyExternalUpdateDetected: 37
-  ProxyGenericError: 44
-  ProxyInsertRequestContainedNoData: 49
-  ProxyInvalidKey: 50
-  ProxyIsReadonly: 34
-  ProxyLockedForToken: 42
-  ProxyLockedForTransfer: 26
-  ProxyLockedForUpgrade: 41
-  ProxyLockedForVas: 43
-  ProxyLocksFailed: 24
-  ProxyLostProxyConnection: 23
-  ProxyMissingResultsPtr: 25
-  ProxyMoneyLimitExceeded: 32
-  ProxyNoReturnValue: 27
-  ProxyObjDropped: 29
-  ProxyObjNotInDb: 19
-  ProxyOperationAlreadyInProgress: 36
-  ProxyPredicateFailed: 47
-  ProxyTooBusyBackOff: 54
-  ProxyTooManyRows: 52
-  ProxyUniqueKey: 20
-  ProxyWeeklyRewardNotFound: 48
-  UnknownError: 10
-  VasPurchaseDisabled: 1
+  values:
+    BeginDbErrors: 20010
+    BeginProxyErrors: 17
+    DbAccountDoesNotOwnCharacter: 20017
+    DbAllianceNotEligible: 20027
+    DbAlreadyRenameFlagged: 20055
+    DbAuthenticatorInsufficient: 20073
+    DbBatchProcessingDisabled: 20028
+    DbBatchStateInvalid: 20067
+    DbBnetAccountNotProvided: 20077
+    DbBoostProcessingDisabled: 20095
+    DbBpayDeliveryPending: 20078
+    DbCagedPetInInventory: 20084
+    DbCannotMoveArenaCaptn: 20064
+    DbCannotMoveGuildmaster: 20012
+    DbCharacterDoesNotExist: 20019
+    DbCharacterWithoutGuild: 20070
+    DbCharLocked: 20026
+    DbCharNotLocked: 20025
+    DbCouldNotObtainCharLock: 20041
+    DbCustomizeAlreadyRequested: 20057
+    DbDeletedGuild: 20071
+    DbDuplicateCharacterName: 20015
+    DbDuplicateSupportRequest: 20063
+    DbEventNotActive: 20068
+    DbEventRealmClosed: 20038
+    DbFactionChangeTooSoon: 20061
+    DbGmSenorityInsufficient: 20072
+    DbGuildLevelInsufficient: 20074
+    DbGuildRankInsufficient: 20069
+    DbHasAuctions: 20033
+    DbHasBpayToken: 20079
+    DbHasCraftingOrders: 20092
+    DbHasHeirloomItem: 20080
+    DbHasMail: 20016
+    DbHasNewPlayerExperienceRestriction: 20091
+    DbHasUnclaimedCacheRewards: 20089
+    DbHouseOwnerRestriction: 20096
+    DbIneligibleMapID: 20076
+    DbIneligibleTargetRealm: 20022
+    DbInvalidName: 20094
+    DbInventoryCorrupt: 20040
+    DbLastCustomizeTooSoon: 20058
+    DbLastRenameTooRecent: 20052
+    DbLastRequestTooSoon: 20054
+    DbLastSaveTooDistant: 20083
+    DbLastSaveTooRecent: 20034
+    DbLockAlreadyRequested: 20044
+    DbLockNotAcknowledged: 20043
+    DbMaxCharactersOnServer: 20013
+    DbMoveInProgress: 20018
+    DbMultipleTransferCn: 20056
+    DbNameChangeSkipped: 20093
+    DbNameNotAvailable: 20051
+    DbNeedsEraChoice: 20090
+    DbNeedsLevelSquish: 20088
+    DbNewLeaderInvalid: 20086
+    DbNewNameTooLong: 20024
+    DbNoCopiesAvailable: 20020
+    DbNoCsiFound: 20065
+    DbNoMixedAlliance: 20014
+    DbNoneBatchQueueID: 20029
+    DbNoneLockID: 20042
+    DbNoneRealmForEvent: 20037
+    DbNoneSupportActionID: 20046
+    DbNoneSupportQueueID: 20045
+    DbNoneTemplateForEvent: 20039
+    DbNotMovebackable: 20048
+    DbNotRollbackable: 20047
+    DbOnBoostCooldown: 20085
+    DbPendingItemAudit: 20066
+    DbPvEPvPTransferNotAllowed: 20087
+    DbRaceClassComboIneligible: 20062
+    DbRealmNotEligible: 20011
+    DbRegionalDbNotFound: 20075
+    DbRenameAlreadyRequested: 20049
+    DbReservationDoesNotMatch: 20053
+    DbReservationExpired: 20050
+    DbResultAccountRestricted: 20082
+    DbResultSourceAccountBanned: 20081
+    DbTooMuchMoneyForLevel: 20032
+    DbTransferDateTooSoon: 20023
+    DbTransferNotCancellable: 20031
+    DbTransferNotFinalized: 20030
+    DbTransferNotLockable: 20035
+    DbTransferNotUnlockable: 20036
+    DbUnableToCustomize: 20060
+    DbUnderMinLevelReq: 20021
+    DbWaitingForPayment: 20059
+    DisallowedDestinationAccount: 9
+    DisallowedSourceAccount: 8
+    EndDbErrors: 20097
+    EndProxyErrors: 56
+    EndServerErrors: 16
+    InvalidBpayDeliverableID: 14
+    InvalidBpayProductID: 13
+    InvalidBpayProductType: 15
+    InvalidDestinationAccount: 6
+    InvalidDestinationRealm: 5
+    InvalidDistribution: 12
+    InvalidSourceAccount: 7
+    LowerBoxLevel: 11
+    None: 0
+    NoneCharacter: 2
+    NoneProduct: 3
+    OnlyOneVasAtATime: 4
+    ProxyAccountDataTooBig: 55
+    ProxyBadDbType: 35
+    ProxyBadObjType: 18
+    ProxyBadRequestContained: 33
+    ProxyBindFailed: 51
+    ProxyCannotDeleteArenaCaptain: 31
+    ProxyCannotDeleteGuildLeader: 30
+    ProxyCannotInsertNull: 45
+    ProxyCannotUndeleteTrialBoostCharacter: 46
+    ProxyCharacterHasWoWToken: 53
+    ProxyCharacterLevelTooHigh: 38
+    ProxyCharacterTransferred: 39
+    ProxyCharacterTransferredNoBoostInProgress: 40
+    ProxyDataInvalid: 22
+    ProxyDbError: 21
+    ProxyDeleteNotSupported: 28
+    ProxyExternalUpdateDetected: 37
+    ProxyGenericError: 44
+    ProxyInsertRequestContainedNoData: 49
+    ProxyInvalidKey: 50
+    ProxyIsReadonly: 34
+    ProxyLockedForToken: 42
+    ProxyLockedForTransfer: 26
+    ProxyLockedForUpgrade: 41
+    ProxyLockedForVas: 43
+    ProxyLocksFailed: 24
+    ProxyLostProxyConnection: 23
+    ProxyMissingResultsPtr: 25
+    ProxyMoneyLimitExceeded: 32
+    ProxyNoReturnValue: 27
+    ProxyObjDropped: 29
+    ProxyObjNotInDb: 19
+    ProxyOperationAlreadyInProgress: 36
+    ProxyPredicateFailed: 47
+    ProxyTooBusyBackOff: 54
+    ProxyTooManyRows: 52
+    ProxyUniqueKey: 20
+    ProxyWeeklyRewardNotFound: 48
+    UnknownError: 10
+    VasPurchaseDisabled: 1
 ViewArenaSize:
-  Three: 1
-  Two: 0
+  values:
+    Three: 1
+    Two: 0
 ViewRaidSize:
-  Forty: 2
-  Ten: 0
-  TwentyFive: 1
+  values:
+    Forty: 2
+    Ten: 0
+    TwentyFive: 1
 VignetteObjectiveType:
-  Defeat: 1
-  DefeatShowRemainingHealth: 2
-  None: 0
+  values:
+    Defeat: 1
+    DefeatShowRemainingHealth: 2
+    None: 0
 VignetteType:
-  FyrakkFlight: 4
-  Normal: 0
-  PvPBounty: 1
-  Torghast: 2
-  Treasure: 3
+  values:
+    FyrakkFlight: 4
+    Normal: 0
+    PvPBounty: 1
+    Torghast: 2
+    Treasure: 3
 Vocalerrorsounds:
-  Abilitycooling: 50
-  Alreadyingroup: 20
-  Alreadyinguild: 21
-  Ammoonlyinbag: 28
-  Bagfull: 29
-  BoundNodrop: 4
-  Cantaffordbankslot: 22
-  CantattackNotarget: 38
-  CantattackNotstandingObsolete: 37
-  Cantattackrongdirection: 36
-  CantcastOutofrange: 46
-  Cantcreate: 18
-  Cantdrinkmore: 6
-  Canteatmore: 7
-  CanteatMoving: 24
-  Cantequip2Hequipped: 42
-  Cantequip2HNoskill: 43
-  Cantequip2HSkill: 41
-  Cantflyhere: 60
-  Cantinvite: 8
-  CantlearnLevel: 13
-  Cantloot: 17
-  CantlootDidntkill: 31
-  CantlootLocked: 33
-  CantlootNotstandingObsolete: 34
-  CantlootToofar: 35
-  CantlootWrongfacing: 32
-  Cantputbag: 26
-  Cantswap: 58
-  CanttaxiNomoney: 54
-  CanttradeSoulbound: 59
-  Cantuseitem: 51
-  Cantuselocked: 55
-  Cantusetoofar: 57
-  Chestinuse: 52
-  Declinegroup: 19
-  ExhaustedObsolete: 67
-  FoodcoolingObsolete: 53
-  Genericnotarget: 45
-  Guildpermissions: 62
-  Invaliditemtarget: 66
-  Invalidtarget: 11
-  Inventoryfull: 0
-  Inviteebusy: 9
-  Itemcooling: 5
-  Itemlocked: 61
-  Itemmaxcount: 30
-  Locked: 14
-  Mustequippitem: 49
-  Noenergy: 64
-  NoequipEver: 3
-  NoequipLevel: 2
-  Noequipslotavailable: 56
-  Noessence: 65
-  Nomana: 15
-  Norage: 63
-  Notabag: 25
-  Notenoughgold: 39
-  Notenoughmoney: 40
-  Notequippable: 44
-  Notwhiledead: 16
-  Outofammo: 1
-  Potioncooling: 47
-  Proficiencyneeded: 48
-  Spellcooling: 12
-  Targettoofar: 10
-  Toomanybankslots: 23
-  Wrongslot: 27
+  values:
+    Abilitycooling: 50
+    Alreadyingroup: 20
+    Alreadyinguild: 21
+    Ammoonlyinbag: 28
+    Bagfull: 29
+    BoundNodrop: 4
+    Cantaffordbankslot: 22
+    CantattackNotarget: 38
+    CantattackNotstandingObsolete: 37
+    Cantattackrongdirection: 36
+    CantcastOutofrange: 46
+    Cantcreate: 18
+    Cantdrinkmore: 6
+    Canteatmore: 7
+    CanteatMoving: 24
+    Cantequip2Hequipped: 42
+    Cantequip2HNoskill: 43
+    Cantequip2HSkill: 41
+    Cantflyhere: 60
+    Cantinvite: 8
+    CantlearnLevel: 13
+    Cantloot: 17
+    CantlootDidntkill: 31
+    CantlootLocked: 33
+    CantlootNotstandingObsolete: 34
+    CantlootToofar: 35
+    CantlootWrongfacing: 32
+    Cantputbag: 26
+    Cantswap: 58
+    CanttaxiNomoney: 54
+    CanttradeSoulbound: 59
+    Cantuseitem: 51
+    Cantuselocked: 55
+    Cantusetoofar: 57
+    Chestinuse: 52
+    Declinegroup: 19
+    ExhaustedObsolete: 67
+    FoodcoolingObsolete: 53
+    Genericnotarget: 45
+    Guildpermissions: 62
+    Invaliditemtarget: 66
+    Invalidtarget: 11
+    Inventoryfull: 0
+    Inviteebusy: 9
+    Itemcooling: 5
+    Itemlocked: 61
+    Itemmaxcount: 30
+    Locked: 14
+    Mustequippitem: 49
+    Noenergy: 64
+    NoequipEver: 3
+    NoequipLevel: 2
+    Noequipslotavailable: 56
+    Noessence: 65
+    Nomana: 15
+    Norage: 63
+    Notabag: 25
+    Notenoughgold: 39
+    Notenoughmoney: 40
+    Notequippable: 44
+    Notwhiledead: 16
+    Outofammo: 1
+    Potioncooling: 47
+    Proficiencyneeded: 48
+    Spellcooling: 12
+    Targettoofar: 10
+    Toomanybankslots: 23
+    Wrongslot: 27
 VoiceChannelErrorReason:
-  IsBattleNetChannel: 1
-  Unknown: 0
+  values:
+    IsBattleNetChannel: 1
+    Unknown: 0
 VoiceChatStatusCode:
-  AlreadyInChannel: 10
-  ChannelAlreadyExists: 9
-  ChannelNameTooLong: 8
-  ChannelNameTooShort: 7
-  ClientAlreadyLoggedIn: 6
-  ClientNotInitialized: 4
-  ClientNotLoggedIn: 5
-  Disabled: 18
-  Failure: 12
-  InvalidCommunityStream: 20
-  InvalidInputDevice: 23
-  InvalidOutputDevice: 24
-  LoginProhibited: 3
-  OperationPending: 1
-  PlayerSilenced: 21
-  PlayerVoiceChatParentalDisabled: 22
-  ProxyConnectionTimeOut: 15
-  ProxyConnectionUnableToConnect: 16
-  ProxyConnectionUnexpectedDisconnect: 17
-  ServiceLost: 13
-  Success: 0
-  TargetNotFound: 11
-  TooManyRequests: 2
-  UnableToLaunchProxy: 14
-  UnsupportedChatChannelType: 19
+  values:
+    AlreadyInChannel: 10
+    ChannelAlreadyExists: 9
+    ChannelNameTooLong: 8
+    ChannelNameTooShort: 7
+    ClientAlreadyLoggedIn: 6
+    ClientNotInitialized: 4
+    ClientNotLoggedIn: 5
+    Disabled: 18
+    Failure: 12
+    InvalidCommunityStream: 20
+    InvalidInputDevice: 23
+    InvalidOutputDevice: 24
+    LoginProhibited: 3
+    OperationPending: 1
+    PlayerSilenced: 21
+    PlayerVoiceChatParentalDisabled: 22
+    ProxyConnectionTimeOut: 15
+    ProxyConnectionUnableToConnect: 16
+    ProxyConnectionUnexpectedDisconnect: 17
+    ServiceLost: 13
+    Success: 0
+    TargetNotFound: 11
+    TooManyRequests: 2
+    UnableToLaunchProxy: 14
+    UnsupportedChatChannelType: 19
 VoiceTtsStatusCode:
-  DestinationQueueFull: 8
-  EngineAllocationFailed: 2
-  EnqueueNotNecessary: 9
-  InputTextEnqueued: 6
-  InternalError: 13
-  InvalidArgument: 12
-  InvalidEngineType: 1
-  ManagerNotFound: 11
-  MaxCharactersExceeded: 4
-  NotSupported: 3
-  SdkNotInitialized: 7
-  Success: 0
-  UtteranceBelowMinimumDuration: 5
-  UtteranceNotFound: 10
+  values:
+    DestinationQueueFull: 8
+    EngineAllocationFailed: 2
+    EnqueueNotNecessary: 9
+    InputTextEnqueued: 6
+    InternalError: 13
+    InvalidArgument: 12
+    InvalidEngineType: 1
+    ManagerNotFound: 11
+    MaxCharactersExceeded: 4
+    NotSupported: 3
+    SdkNotInitialized: 7
+    Success: 0
+    UtteranceBelowMinimumDuration: 5
+    UtteranceNotFound: 10
 WarbandSceneFlags:
-  AwardedAutomatically: 8
-  CannotBeSaved: 4
-  DoNotInclude: 1
-  HiddenUntilCollected: 2
-  IsDefault: 16
+  values:
+    AwardedAutomatically: 8
+    CannotBeSaved: 4
+    DoNotInclude: 1
+    HiddenUntilCollected: 2
+    IsDefault: 16
 WeaponSlot:
-  MainHand: 0
-  OffHand: 1
+  values:
+    MainHand: 0
+    OffHand: 1
 WeeklyRewardChestActivityType:
-  LFGDungeons: 1
-  Scenario: 0
-  World: 2
+  values:
+    LFGDungeons: 1
+    Scenario: 0
+    World: 2
 WeeklyRewardChestClaimRewardResult:
-  CountExceeded: 7
-  DbError: 5
-  InvalidSlot: 3
-  InvalidThreshold: 1
-  LockFailure: 6
-  PlayerNotFound: 2
-  Success: 0
-  TooManyItems: 4
+  values:
+    CountExceeded: 7
+    DbError: 5
+    InvalidSlot: 3
+    InvalidThreshold: 1
+    LockFailure: 6
+    PlayerNotFound: 2
+    Success: 0
+    TooManyItems: 4
 WeeklyRewardChestThresholdType:
-  Activities: 1
-  AlsoReceive: 4
-  Concession: 5
-  None: 0
-  Raid: 3
-  RankedPvP: 2
-  World: 6
+  values:
+    Activities: 1
+    AlsoReceive: 4
+    Concession: 5
+    None: 0
+    Raid: 3
+    RankedPvP: 2
+    World: 6
 WeeklyRewardProgressResult:
-  DbError: 3
-  NoPlayer: 4
-  NoSeason: 1
-  Success: 0
-  TimedOut: 2
+  values:
+    DbError: 3
+    NoPlayer: 4
+    NoSeason: 1
+    Success: 0
+    TimedOut: 2
 WidgetAnimationType:
-  Fade: 1
-  None: 0
+  values:
+    Fade: 1
+    None: 0
 WidgetCurrencyClass:
-  Currency: 0
-  Item: 1
+  values:
+    Currency: 0
+    Item: 1
 WidgetEnabledState:
-  Artifact: 5
-  Black: 6
-  BrightBlue: 7
-  Disabled: 0
-  Green: 4
-  Red: 2
-  White: 3
-  Yellow: 1
+  values:
+    Artifact: 5
+    Black: 6
+    BrightBlue: 7
+    Disabled: 0
+    Green: 4
+    Red: 2
+    White: 3
+    Yellow: 1
 WidgetGlowAnimType:
-  None: 0
-  Pulse: 1
+  values:
+    None: 0
+    Pulse: 1
 WidgetIconSizeType:
-  Large: 2
-  Medium: 1
-  Small: 0
-  Standard: 3
+  values:
+    Large: 2
+    Medium: 1
+    Small: 0
+    Standard: 3
 WidgetIconSourceType:
-  Item: 1
-  Spell: 0
+  values:
+    Item: 1
+    Spell: 0
 WidgetOpacityType:
-  Eighty: 2
-  Fifty: 5
-  Forty: 6
-  Ninety: 1
-  OneHundred: 0
-  Seventy: 3
-  Sixty: 4
-  Ten: 9
-  Thirty: 7
-  Twenty: 8
-  Zero: 10
+  values:
+    Eighty: 2
+    Fifty: 5
+    Forty: 6
+    Ninety: 1
+    OneHundred: 0
+    Seventy: 3
+    Sixty: 4
+    Ten: 9
+    Thirty: 7
+    Twenty: 8
+    Zero: 10
 WidgetShowGlowState:
-  HideGlow: 0
-  ShowGlow: 1
+  values:
+    HideGlow: 0
+    ShowGlow: 1
 WidgetShownState:
-  Hidden: 0
-  Shown: 1
+  values:
+    Hidden: 0
+    Shown: 1
 WidgetTextHorizontalAlignmentType:
-  Center: 1
-  Left: 0
-  Right: 2
+  values:
+    Center: 1
+    Left: 0
+    Right: 2
 WidgetUnitPowerBarFlashMomentType:
-  FlashWhenMax: 0
-  FlashWhenMin: 1
-  NeverFlash: 2
+  values:
+    FlashWhenMax: 0
+    FlashWhenMin: 1
+    NeverFlash: 2
 WorldCursorAnchorType:
-  Cursor: 2
-  Default: 1
-  Nameplate: 3
-  None: 0
+  values:
+    Cursor: 2
+    Default: 1
+    Nameplate: 3
+    None: 0
 WorldElapsedTimerTypes:
-  ChallengeMode: 1
-  None: 0
-  ProvingGround: 2
+  values:
+    ChallengeMode: 1
+    None: 0
+    ProvingGround: 2
 WorldQuestQuality:
-  Common: 0
-  Epic: 2
-  Rare: 1
+  values:
+    Common: 0
+    Epic: 2
+    Rare: 1
 WorldTierDifficulty:
-  Heroic: 2
-  Mythic: 3
-  Normal: 1
+  values:
+    Heroic: 2
+    Mythic: 3
+    Normal: 1
 WoWClientCursorSize:
-  ExtraLarge: 3
-  Large: 2
-  Massive: 4
-  Medium: 1
-  Standard: 0
+  values:
+    ExtraLarge: 3
+    Large: 2
+    Massive: 4
+    Medium: 1
+    Standard: 0
 WoWEntitlementType:
-  Appearance: 4
-  AppearanceSet: 5
-  Battlepet: 2
-  GameTime: 6
-  Illusion: 8
-  Invalid: 9
-  Item: 0
-  Mount: 1
-  Title: 7
-  Toy: 3
+  values:
+    Appearance: 4
+    AppearanceSet: 5
+    Battlepet: 2
+    GameTime: 6
+    Illusion: 8
+    Invalid: 9
+    Item: 0
+    Mount: 1
+    Title: 7
+    Toy: 3
 WoWLabsAreaType:
-  PlunderstormDropDense: 2
-  PlunderstormDropMedium: 1
-  PlunderstormDropSparse: 0
+  values:
+    PlunderstormDropDense: 2
+    PlunderstormDropMedium: 1
+    PlunderstormDropSparse: 0
 ZoneControlActiveState:
-  Active: 1
-  Inactive: 0
+  values:
+    Active: 1
+    Inactive: 0
 ZoneControlDangerFlashType:
-  ShowOnBadStates: 1
-  ShowOnBoth: 2
-  ShowOnGoodStates: 0
-  ShowOnNeither: 3
+  values:
+    ShowOnBadStates: 1
+    ShowOnBoth: 2
+    ShowOnGoodStates: 0
+    ShowOnNeither: 3
 ZoneControlFillType:
-  DoubleFillClockwise: 2
-  DoubleFillCounterClockwise: 3
-  SingleFillClockwise: 0
-  SingleFillCounterClockwise: 1
+  values:
+    DoubleFillClockwise: 2
+    DoubleFillCounterClockwise: 3
+    SingleFillClockwise: 0
+    SingleFillCounterClockwise: 1
 ZoneControlLeadingEdgeType:
-  NoLeadingEdge: 0
-  UseLeadingEdge: 1
+  values:
+    NoLeadingEdge: 0
+    UseLeadingEdge: 1
 ZoneControlMode:
-  BothStatesAreGood: 0
-  NeitherStateIsGood: 3
-  State1IsGood: 1
-  State2IsGood: 2
+  values:
+    BothStatesAreGood: 0
+    NeitherStateIsGood: 3
+    State1IsGood: 1
+    State2IsGood: 2
 ZoneControlState:
-  State1: 0
-  State2: 1
+  values:
+    State1: 0
+    State2: 1

--- a/data/schemas/enums.yaml
+++ b/data/schemas/enums.yaml
@@ -3,6 +3,10 @@ type:
   mapof:
     key: string
     value:
-      mapof:
-        key: string
-        value: enumvalue
+      record:
+        values:
+          required: true
+          type:
+            mapof:
+              key: string
+              value: enumvalue

--- a/spec/data/config_spec.lua
+++ b/spec/data/config_spec.lua
@@ -26,7 +26,7 @@ describe('config', function()
         describe('enum_values_set_in_framexml', function()
           for k, v in pairs(addoncfg.enum_values_set_in_framexml or {}) do
             describe(k, function()
-              local e = enums[k]
+              local e = enums[k].values
               for vk in pairs(v) do
                 describe(vk, function()
                   it('must not exist', function()

--- a/spec/data/docs_spec.lua
+++ b/spec/data/docs_spec.lua
@@ -39,7 +39,7 @@ describe('docs', function()
           for k, v in pairs(lies.enums or {}) do
             describe(k, function()
               it('applies to the declared enum in reverse', function()
-                tedit(enums[k], revedit(v))
+                tedit(enums[k].values, revedit(v))
               end)
             end)
           end

--- a/tools/docs.lua
+++ b/tools/docs.lua
@@ -230,7 +230,7 @@ local function default(x)
   if x.Type == 'luaIndex' and x.Default then
     return x.Default + 1
   end
-  return enum[x.Type] and enum[x.Type][x.Default] or x.Default
+  return enum[x.Type] and enum[x.Type].values[x.Default] or x.Default
 end
 
 local function insig(fn, ns, api)
@@ -375,7 +375,7 @@ local function rewriteEnums(out)
         assert(v.Type == tab.Name, v.Name)
         t[v.Name] = v.EnumValue
       end
-      out[tab.Name] = takelieor(t, lies, tab.Name)
+      out[tab.Name] = { values = takelieor(t, lies, tab.Name) }
     end
   end
   assertTaken('lies.enums', lies)

--- a/tools/errsv.lua
+++ b/tools/errsv.lua
@@ -168,15 +168,24 @@ if data.generated.globals then
     if genum then
       local ef = 'data/products/' .. product .. '/enums.yaml'
       local enums = yaml.parseFile(ef)
+      local flatEnums = {}
+      for k, v in pairs(enums) do
+        flatEnums[k] = v.values
+      end
       for k in pairs(genum) do
         local base = k:match('^(.+)Meta$')
         if base and (enums[base] or genum[base]) then
           genum[k] = nil
         end
       end
-      applyPatterns(enums, genum)
+      applyPatterns(flatEnums, genum)
+      for k, v in pairs(flatEnums) do
+        if not enums[k] then
+          enums[k] = { values = v }
+        end
+      end
       for k in pairs(genum) do
-        local ev = enums[k]
+        local ev = flatEnums[k]
         if type(ev) == 'table' and next(ev) == nil then
           ev.Placeholder = 1
         end

--- a/tools/gentest.lua
+++ b/tools/gentest.lua
@@ -307,7 +307,8 @@ local function attrMembers(p, case)
     end
     return members
   elseif ty.enum then
-    return perproduct(p, 'enums')[ty.enum] or {}
+    local e = perproduct(p, 'enums')[ty.enum]
+    return e and e.values or {}
   end
   error('unsupported template-case attribute type for ' .. case.id)
 end
@@ -394,14 +395,11 @@ local ptablemap = {
   end,
   globals = function(p)
     local t = perproduct(p, 'globals')
-    local enums = perproduct(p, 'enums')
+    local enums = {}
     local metafix = perproduct(p, 'config').runtime.enummetafix
-    local names = {}
-    for name in pairs(enums) do
-      table.insert(names, name)
-    end
-    for _, name in ipairs(names) do
-      enums[name .. 'Meta'] = computeEnumMeta(enums[name], metafix)
+    for name, enum in pairs(perproduct(p, 'enums')) do
+      enums[name] = enum.values
+      enums[name .. 'Meta'] = computeEnumMeta(enum.values, metafix)
     end
     t.Enum = enums
     return 'Globals', t

--- a/tools/prep.lua
+++ b/tools/prep.lua
@@ -26,16 +26,13 @@ local product = args.product
 local globals = parseYaml('data/products/' .. product .. '/globals.yaml')
 local structures = parseYaml('data/products/' .. product .. '/structures.yaml')
 local stringenums = parseYaml('data/products/' .. product .. '/stringenums.yaml')
-local enums = parseYaml('data/products/' .. product .. '/enums.yaml')
 
+local enums = {}
 do
   local metafix = parseYaml('data/products/' .. product .. '/config.yaml').runtime.enummetafix
-  local names = {}
-  for name in pairs(enums) do
-    table.insert(names, name)
-  end
-  for _, name in ipairs(names) do
-    enums[name .. 'Meta'] = computeEnumMeta(enums[name], metafix)
+  for name, enum in pairs(parseYaml('data/products/' .. product .. '/enums.yaml')) do
+    enums[name] = enum.values
+    enums[name .. 'Meta'] = computeEnumMeta(enum.values, metafix)
   end
 end
 globals.Enum = enums


### PR DESCRIPTION
## Summary
- Each enum entry in `data/products/<product>/enums.yaml` is now a record with a `values` field holding the member map, instead of the member map being the entry directly (e.g. `AbbreviationDataError: { values: { InvalidBreakpoint: 1, ... } }`). This makes room for future per-enum configuration fields alongside `values`.
- `data/schemas/enums.yaml` updated to match (`mapof -> record { values: mapof -> enumvalue }`).
- `tools/prep.lua` and `tools/gentest.lua` unwrap `.values` while building `globals.Enum`/`WowlessData.Globals.Enum`, so the actual runtime `Enum` global (and everything downstream: `wowless/modules/xml.lua`, `clog.lua`, the generated test addon) stays flat and unaffected.
- Updated `tools/docs.lua` (`rewriteEnums`, `default()`), `tools/errsv.lua` (auto-repair path), and `spec/data/config_spec.lua`/`spec/data/docs_spec.lua` to read/write the new `values` field.

## Test plan
- [x] `cmake --build --preset default --target test` — clean, no output
- [x] `cmake --build --preset default --target docs-all` — verified byte-identical to the manual data transform for all 8 products
- [x] `pre-commit run -a` — all hooks pass

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

https://claude.ai/code/session_01GfmCAeTpcoNEcFXL82T16M